### PR TITLE
Fix: Insights cost-aware confidence labels (#28)

### DIFF
--- a/frontend/dashboard/src/components/charts.tsx
+++ b/frontend/dashboard/src/components/charts.tsx
@@ -138,6 +138,7 @@ export function CostBarChart({
 export interface CountBarDatum {
   label: string;
   value: number;
+  sublabel?: string;
 }
 
 export function CountBarChart({
@@ -192,13 +193,18 @@ export function CountBarChart({
           content={
             <ChartTooltipContent
               indicator="dot"
-              formatter={(value, name) => (
-                <div className="flex items-center justify-between gap-2">
-                  <span className="text-muted-foreground">{name}</span>
-                  <span className="font-medium tabular-nums text-foreground">
-                    {fmtNum(Number(value))}
-                    {valueLabel ? ` ${valueLabel}` : ""}
-                  </span>
+              formatter={(value, name, item) => (
+                <div className="flex flex-col gap-0.5">
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="text-muted-foreground">{name}</span>
+                    <span className="font-medium tabular-nums text-foreground">
+                      {fmtNum(Number(value))}
+                      {valueLabel ? ` ${valueLabel}` : ""}
+                    </span>
+                  </div>
+                  {item.payload?.sublabel && (
+                    <span className="text-xs text-muted-foreground">{item.payload.sublabel}</span>
+                  )}
                 </div>
               )}
             />

--- a/frontend/dashboard/src/lib/types.ts
+++ b/frontend/dashboard/src/lib/types.ts
@@ -121,7 +121,10 @@ export interface SubagentCostRow {
 export interface ToolRow {
   tool_name: string;
   call_count: number;
-  cost_cents?: number;
+  avg_duration_ms?: number | null;
+  total_duration_ms?: number | null;
+  provider?: string;
+  mcp_server?: string;
 }
 
 export interface SessionRow {

--- a/frontend/dashboard/src/pages/insights.tsx
+++ b/frontend/dashboard/src/pages/insights.tsx
@@ -4,7 +4,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { CostBarChart, CountBarChart, SessionCurveChart } from "@/components/charts";
 import { ErrorState, LoadingState } from "@/components/state";
 import { fetchInsights } from "@/lib/api";
-import { fmtCost, fmtNum } from "@/lib/format";
+import { fmtCost, fmtDurationMs, fmtNum } from "@/lib/format";
 import { useDashboardFilters } from "@/lib/period";
 
 const CONFIDENCE_LABELS: Record<string, string> = {
@@ -12,7 +12,16 @@ const CONFIDENCE_LABELS: Record<string, string> = {
   exact: "Exact",
   exact_cost: "Exact Cost",
   estimated: "Estimated",
+  estimated_unknown_model: "Estimated (Unknown Model)",
+  "n/a": "Not Available",
 };
+
+function confidenceLabel(raw: string): string {
+  if (raw in CONFIDENCE_LABELS) return CONFIDENCE_LABELS[raw];
+  return raw
+    .replace(/_/g, " ")
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
 
 function mcpName(raw: string): string {
   const normalized = raw.replace(/^mcp__/, "");
@@ -51,10 +60,12 @@ export function InsightsPage() {
 
   const data = insightsQuery.data;
 
-  const confidenceRows = data.confidence.map((row) => ({
-    label: CONFIDENCE_LABELS[row.confidence] ?? row.confidence,
-    cost_cents: row.cost_cents,
-  }));
+  const confidenceRows = data.confidence
+    .filter((row) => row.cost_cents > 0)
+    .map((row) => ({
+      label: confidenceLabel(row.confidence),
+      cost_cents: row.cost_cents,
+    }));
 
   const sessionCurveRows = data.sessionCurve.map((row) => ({
     label: `${row.bucket} msgs`,
@@ -82,11 +93,13 @@ export function InsightsPage() {
   const toolsRows = data.tools.map((row) => ({
     label: row.tool_name,
     value: row.call_count,
+    sublabel: row.avg_duration_ms != null ? `Avg: ${fmtDurationMs(row.avg_duration_ms)}` : undefined,
   }));
 
   const mcpRows = data.mcp.map((row) => ({
     label: mcpName(row.tool_name),
     value: row.call_count,
+    sublabel: row.avg_duration_ms != null ? `Avg: ${fmtDurationMs(row.avg_duration_ms)}` : undefined,
   }));
 
   return (


### PR DESCRIPTION
Merging fix/28-insights-cost-aware-confidence-labels into main

Made with [Cursor](https://cursor.com)