### PR TITLE
Add privacy retention and minimized storage for hook/OTEL payloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,6 +394,39 @@ The daemon is the single source of truth — the CLI never opens the database di
 </details>
 
 <details>
+<summary>Privacy & Retention</summary>
+
+budi is local-first, but you can now enforce tighter storage controls for raw payloads and session metadata.
+
+**Privacy mode (`BUDI_PRIVACY_MODE`):**
+
+| Value | Behavior |
+|------|----------|
+| `full` (default) | Store raw values as-is |
+| `hash` | Hash sensitive fields (for example `user_email`, `cwd`, and workspace paths) before storage |
+| `omit` | Do not store sensitive raw/session fields |
+
+**Retention controls:**
+
+| Env var | Default | Scope |
+|--------|---------|-------|
+| `BUDI_RETENTION_RAW_DAYS` | `30` | `hook_events.raw_json`, `otel_events.raw_json`, `sessions.raw_json` |
+| `BUDI_RETENTION_SESSION_METADATA_DAYS` | `90` | `sessions.user_email`, `sessions.workspace_root` |
+
+Use `off` to disable a retention window for a category.
+
+Retention cleanup runs automatically after sync, hook ingestion, and OTEL ingestion.
+
+**At-rest protection (SQLCipher strategy):**
+- Current default uses bundled SQLite (WAL) for broad compatibility and easy installs.
+- If you need encrypted-at-rest local DBs (shared/managed machines), use one of these strategies:
+  - build budi against SQLCipher-enabled SQLite (`libsqlite3-sys` SQLCipher build),
+  - or place the budi data directory on an encrypted volume (FileVault, LUKS, BitLocker).
+- SQLCipher integration is feasible but has tradeoffs (key management UX, packaging complexity, migration path from existing plaintext DBs), so default remains plain SQLite for now.
+
+</details>
+
+<details>
 <summary>Hooks</summary>
 
 Both Claude Code and Cursor support lifecycle hooks that budi uses for real-time event capture. Hooks are installed automatically by `budi init` into `~/.claude/settings.json` and `~/.cursor/hooks.json`. They are non-blocking (`async: true`) and wrapped with `|| true` so that budi can never interfere with your coding agent — even if budi crashes or is uninstalled.

--- a/crates/budi-core/src/analytics/mod.rs
+++ b/crates/budi-core/src/analytics/mod.rs
@@ -143,7 +143,7 @@ fn rebuild_sessions_from_hooks(conn: &Connection) -> Result<()> {
          ORDER BY timestamp ASC",
     )?;
 
-    let rows: Vec<(String, String, String)> = stmt
+    let rows: Vec<(Option<String>, String, String)> = stmt
         .query_map([], |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)))
         .context("Failed to query hook_events for session rebuild")?
         .filter_map(|r| {
@@ -154,6 +154,9 @@ fn rebuild_sessions_from_hooks(conn: &Connection) -> Result<()> {
 
     let mut rebuilt = 0;
     for (raw_json, _provider, stored_ts) in &rows {
+        let Some(raw_json) = raw_json.as_deref() else {
+            continue;
+        };
         let json: serde_json::Value = match serde_json::from_str(raw_json) {
             Ok(v) => v,
             Err(_) => continue,

--- a/crates/budi-core/src/analytics/sync.rs
+++ b/crates/budi-core/src/analytics/sync.rs
@@ -173,6 +173,10 @@ fn sync_with_max_age(
         tracing::info!("Backfilled session titles on {titles_backfilled} sessions");
     }
 
+    if let Err(e) = crate::privacy::enforce_retention(conn) {
+        tracing::warn!("Privacy retention cleanup failed during sync: {e}");
+    }
+
     mark_sync_completed(conn)?;
     Ok((total_files, total_messages, warnings))
 }

--- a/crates/budi-core/src/hooks.rs
+++ b/crates/budi-core/src/hooks.rs
@@ -290,6 +290,16 @@ pub fn resolve_hook_message_link(
 
 /// Insert a hook event into the `hook_events` table.
 pub fn ingest_hook_event(conn: &Connection, event: &HookEvent) -> Result<()> {
+    let policy = crate::privacy::load_privacy_policy();
+    ingest_hook_event_with_policy(conn, event, &policy)
+}
+
+/// Insert a hook event using an explicit privacy policy.
+pub fn ingest_hook_event_with_policy(
+    conn: &Connection,
+    event: &HookEvent,
+    policy: &crate::privacy::PrivacyPolicy,
+) -> Result<()> {
     if let (Some(session_id), Some(tool_use_id)) =
         (event.session_id.as_deref(), event.tool_use_id.as_deref())
         && event.event == "post_tool_use"
@@ -327,6 +337,7 @@ pub fn ingest_hook_event(conn: &Connection, event: &HookEvent) -> Result<()> {
         .clone()
         .filter(|s| !s.trim().is_empty())
         .unwrap_or(link_confidence);
+    let raw_json = crate::privacy::sanitize_hook_raw_json(&event.raw_json, policy.mode);
 
     conn.execute(
         "INSERT INTO hook_events (
@@ -344,7 +355,7 @@ pub fn ingest_hook_event(conn: &Connection, event: &HookEvent) -> Result<()> {
             event.tool_name,
             event.tool_duration_ms,
             event.tool_call_count,
-            event.raw_json,
+            raw_json,
             event.mcp_server,
             message_id,
             event.message_request_id,
@@ -361,9 +372,25 @@ pub fn ingest_hook_event(conn: &Connection, event: &HookEvent) -> Result<()> {
 /// since some providers (e.g. Cursor) may not send session_start at all.
 /// Then applies event-specific updates on top.
 pub fn upsert_session(conn: &Connection, event: &HookEvent) -> Result<()> {
+    let policy = crate::privacy::load_privacy_policy();
+    upsert_session_with_policy(conn, event, &policy)
+}
+
+/// Upsert a session record using an explicit privacy policy.
+pub fn upsert_session_with_policy(
+    conn: &Connection,
+    event: &HookEvent,
+    policy: &crate::privacy::PrivacyPolicy,
+) -> Result<()> {
     let Some(ref sid) = event.session_id else {
         return Ok(()); // No session_id → can't create session
     };
+
+    let workspace_root =
+        crate::privacy::minimize_sensitive_field(event.workspace_root.as_deref(), policy.mode);
+    let user_email =
+        crate::privacy::minimize_sensitive_field(event.user_email.as_deref(), policy.mode);
+    let raw_json = crate::privacy::sanitize_hook_raw_json(&event.raw_json, policy.mode);
 
     // Ensure a session row exists regardless of which event arrives first.
     // Cursor often sends post_tool_use before (or instead of) session_start.
@@ -374,7 +401,7 @@ pub fn upsert_session(conn: &Connection, event: &HookEvent) -> Result<()> {
             sid,
             event.provider,
             event.timestamp.to_rfc3339(),
-            event.workspace_root,
+            workspace_root.as_deref(),
             event.repo_id,
             event.git_branch,
         ],
@@ -399,10 +426,10 @@ pub fn upsert_session(conn: &Connection, event: &HookEvent) -> Result<()> {
                     event.timestamp.to_rfc3339(),
                     event.composer_mode,
                     event.permission_mode,
-                    event.user_email,
-                    event.workspace_root,
+                    user_email,
+                    workspace_root,
                     event.model,
-                    event.raw_json,
+                    raw_json,
                     event.repo_id,
                     event.git_branch,
                 ],
@@ -425,7 +452,7 @@ pub fn upsert_session(conn: &Connection, event: &HookEvent) -> Result<()> {
                     event.duration_ms,
                     event.end_reason,
                     event.model,
-                    event.user_email,
+                    user_email,
                     event.repo_id,
                     event.git_branch,
                 ],
@@ -445,8 +472,8 @@ pub fn upsert_session(conn: &Connection, event: &HookEvent) -> Result<()> {
                     sid,
                     event.timestamp.to_rfc3339(),
                     event.model,
-                    event.user_email,
-                    event.workspace_root,
+                    user_email,
+                    workspace_root,
                     event.repo_id,
                     event.git_branch,
                 ],
@@ -1663,6 +1690,120 @@ mod tests {
             )
             .unwrap();
         assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn upsert_session_with_omit_policy_drops_sensitive_storage_fields() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                provider TEXT NOT NULL DEFAULT 'claude_code',
+                started_at TEXT, ended_at TEXT, duration_ms INTEGER,
+                composer_mode TEXT, permission_mode TEXT, user_email TEXT,
+                workspace_root TEXT, end_reason TEXT, prompt_category TEXT,
+                model TEXT, raw_json TEXT, repo_id TEXT, git_branch TEXT
+            );",
+        )
+        .unwrap();
+
+        let event = HookEvent {
+            provider: "claude_code".to_string(),
+            event: "session_start".to_string(),
+            session_id: Some("sess-privacy".to_string()),
+            timestamp: Utc::now(),
+            model: Some("claude-sonnet-4-6".to_string()),
+            duration_ms: None,
+            composer_mode: None,
+            permission_mode: Some("default".to_string()),
+            workspace_root: Some("/Users/alice/repo".to_string()),
+            user_email: Some("alice@example.com".to_string()),
+            end_reason: None,
+            tool_name: None,
+            tool_duration_ms: None,
+            tool_call_count: None,
+            repo_id: Some("github.com/acme/repo".to_string()),
+            git_branch: Some("main".to_string()),
+            mcp_server: None,
+            message_id: None,
+            message_request_id: None,
+            tool_use_id: None,
+            link_confidence: Some(HOOK_LINK_UNLINKED.to_string()),
+            raw_json: r#"{"user_email":"alice@example.com","cwd":"/Users/alice/repo"}"#.to_string(),
+        };
+        let policy = crate::privacy::PrivacyPolicy {
+            mode: crate::privacy::PrivacyMode::Omit,
+            raw_retention_days: None,
+            session_metadata_retention_days: None,
+        };
+
+        upsert_session_with_policy(&conn, &event, &policy).unwrap();
+
+        let (user_email, workspace_root, raw_json): (
+            Option<String>,
+            Option<String>,
+            Option<String>,
+        ) = conn
+            .query_row(
+                "SELECT user_email, workspace_root, raw_json
+                 FROM sessions WHERE id = 'sess-privacy'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+            )
+            .unwrap();
+        assert!(user_email.is_none());
+        assert!(workspace_root.is_none());
+        assert!(raw_json.is_none());
+    }
+
+    #[test]
+    fn ingest_hook_event_with_hash_policy_sanitizes_raw_json() {
+        let conn = Connection::open_in_memory().unwrap();
+        crate::migration::migrate(&conn).unwrap();
+
+        let event = HookEvent {
+            provider: "claude_code".to_string(),
+            event: "session_start".to_string(),
+            session_id: Some("sess-privacy-raw".to_string()),
+            timestamp: Utc::now(),
+            model: Some("claude-sonnet-4-6".to_string()),
+            duration_ms: None,
+            composer_mode: None,
+            permission_mode: None,
+            workspace_root: Some("/Users/dev/repo".to_string()),
+            user_email: Some("dev@example.com".to_string()),
+            end_reason: None,
+            tool_name: None,
+            tool_duration_ms: None,
+            tool_call_count: None,
+            repo_id: None,
+            git_branch: None,
+            mcp_server: None,
+            message_id: None,
+            message_request_id: None,
+            tool_use_id: None,
+            link_confidence: Some(HOOK_LINK_UNLINKED.to_string()),
+            raw_json: r#"{"user_email":"dev@example.com","cwd":"/Users/dev/repo"}"#.to_string(),
+        };
+        let policy = crate::privacy::PrivacyPolicy {
+            mode: crate::privacy::PrivacyMode::Hash,
+            raw_retention_days: None,
+            session_metadata_retention_days: None,
+        };
+
+        ingest_hook_event_with_policy(&conn, &event, &policy).unwrap();
+
+        let raw_json: Option<String> = conn
+            .query_row(
+                "SELECT raw_json FROM hook_events WHERE session_id = 'sess-privacy-raw'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        let raw_json = raw_json.expect("raw_json should be stored in hash mode");
+        assert!(!raw_json.contains("dev@example.com"));
+        assert!(!raw_json.contains("/Users/dev/repo"));
+        assert!(raw_json.contains("sha256:"));
     }
 
     #[test]

--- a/crates/budi-core/src/lib.rs
+++ b/crates/budi-core/src/lib.rs
@@ -8,6 +8,7 @@ pub mod jsonl;
 pub mod migration;
 pub mod otel;
 pub mod pipeline;
+pub mod privacy;
 pub mod provider;
 pub mod providers;
 pub mod repo_id;

--- a/crates/budi-core/src/otel.rs
+++ b/crates/budi-core/src/otel.rs
@@ -235,21 +235,31 @@ fn otel_uuid(session_id: &str, timestamp_nano: &str) -> String {
     hex::encode(&hash[..16])
 }
 
-fn otel_event_snapshot_json(event: &OtelApiRequest, cost_cents_computed: f64) -> String {
-    serde_json::json!({
-        "session_id": event.session_id,
-        "timestamp": event.timestamp.to_rfc3339(),
-        "timestamp_nano": event.timestamp_nano,
-        "model": event.model,
-        "request_id": event.request_id,
-        "cost_usd_reported": event.cost_usd,
-        "cost_cents_computed": cost_cents_computed,
-        "input_tokens": event.input_tokens,
-        "output_tokens": event.output_tokens,
-        "cache_read_tokens": event.cache_read_tokens,
-        "cache_creation_tokens": event.cache_creation_tokens
-    })
-    .to_string()
+fn otel_event_snapshot_json(
+    event: &OtelApiRequest,
+    cost_cents_computed: f64,
+    policy: &crate::privacy::PrivacyPolicy,
+) -> Option<String> {
+    if policy.mode == crate::privacy::PrivacyMode::Omit {
+        return None;
+    }
+
+    Some(
+        serde_json::json!({
+            "session_id": crate::privacy::minimize_sensitive_field(Some(event.session_id.as_str()), policy.mode),
+            "timestamp": event.timestamp.to_rfc3339(),
+            "timestamp_nano": event.timestamp_nano,
+            "model": event.model,
+            "request_id": crate::privacy::minimize_sensitive_field(event.request_id.as_deref(), policy.mode),
+            "cost_usd_reported": event.cost_usd,
+            "cost_cents_computed": cost_cents_computed,
+            "input_tokens": event.input_tokens,
+            "output_tokens": event.output_tokens,
+            "cache_read_tokens": event.cache_read_tokens,
+            "cache_creation_tokens": event.cache_creation_tokens
+        })
+        .to_string(),
+    )
 }
 
 /// Hex-encode bytes (no extra dependency).
@@ -366,6 +376,16 @@ fn choose_candidate<'a>(
 ///
 /// Returns the number of rows upserted.
 pub fn ingest_otel_events(conn: &mut Connection, events: &[OtelApiRequest]) -> Result<usize> {
+    let policy = crate::privacy::load_privacy_policy();
+    ingest_otel_events_with_policy(conn, events, &policy)
+}
+
+/// Ingest OTEL events using an explicit privacy policy.
+pub fn ingest_otel_events_with_policy(
+    conn: &mut Connection,
+    events: &[OtelApiRequest],
+    policy: &crate::privacy::PrivacyPolicy,
+) -> Result<usize> {
     if events.is_empty() {
         return Ok(0);
     }
@@ -460,7 +480,7 @@ pub fn ingest_otel_events(conn: &mut Connection, events: &[OtelApiRequest]) -> R
                     .map(|(candidate, strategy)| (candidate.id.clone(), *strategy))
             });
 
-        let snapshot_json = otel_event_snapshot_json(event, cost_cents);
+        let snapshot_json = otel_event_snapshot_json(event, cost_cents, policy);
 
         if let Some((existing_uuid, strategy)) = existing_otel_match {
             tracing::debug!(
@@ -480,7 +500,7 @@ pub fn ingest_otel_events(conn: &mut Connection, events: &[OtelApiRequest]) -> R
                 params![
                     event.session_id,
                     ts,
-                    snapshot_json,
+                    snapshot_json.clone(),
                     existing_uuid,
                     event.timestamp_nano,
                     event.model,
@@ -1178,6 +1198,71 @@ mod tests {
         assert_eq!(repo_id.as_deref(), Some("github.com/user/repo"));
         assert_eq!(branch.as_deref(), Some("feature/otel"));
         assert_eq!(cwd.as_deref(), Some("/home/user/repo"));
+    }
+
+    #[test]
+    fn ingest_otel_events_with_omit_policy_drops_raw_snapshot() {
+        let mut conn = setup_db();
+        let events = vec![OtelApiRequest {
+            session_id: "sess-privacy-omit".to_string(),
+            timestamp: DateTime::parse_from_rfc3339("2024-03-27T00:00:00Z")
+                .unwrap()
+                .with_timezone(&Utc),
+            timestamp_nano: "1711500000000000000".to_string(),
+            model: "claude-opus-4-6".to_string(),
+            request_id: Some("msg_abc123".to_string()),
+            cost_usd: 0.05,
+            input_tokens: 1000,
+            output_tokens: 500,
+            cache_read_tokens: 50000,
+            cache_creation_tokens: 5000,
+        }];
+        let policy = crate::privacy::PrivacyPolicy {
+            mode: crate::privacy::PrivacyMode::Omit,
+            raw_retention_days: None,
+            session_metadata_retention_days: None,
+        };
+
+        ingest_otel_events_with_policy(&mut conn, &events, &policy).unwrap();
+
+        let raw_json: Option<String> = conn
+            .query_row("SELECT raw_json FROM otel_events LIMIT 1", [], |r| r.get(0))
+            .unwrap();
+        assert!(raw_json.is_none());
+    }
+
+    #[test]
+    fn ingest_otel_events_with_hash_policy_hashes_sensitive_raw_fields() {
+        let mut conn = setup_db();
+        let events = vec![OtelApiRequest {
+            session_id: "sess-privacy-hash".to_string(),
+            timestamp: DateTime::parse_from_rfc3339("2024-03-27T00:00:00Z")
+                .unwrap()
+                .with_timezone(&Utc),
+            timestamp_nano: "1711500000000000000".to_string(),
+            model: "claude-opus-4-6".to_string(),
+            request_id: Some("msg_secret".to_string()),
+            cost_usd: 0.05,
+            input_tokens: 1000,
+            output_tokens: 500,
+            cache_read_tokens: 50000,
+            cache_creation_tokens: 5000,
+        }];
+        let policy = crate::privacy::PrivacyPolicy {
+            mode: crate::privacy::PrivacyMode::Hash,
+            raw_retention_days: None,
+            session_metadata_retention_days: None,
+        };
+
+        ingest_otel_events_with_policy(&mut conn, &events, &policy).unwrap();
+
+        let raw_json: Option<String> = conn
+            .query_row("SELECT raw_json FROM otel_events LIMIT 1", [], |r| r.get(0))
+            .unwrap();
+        let raw_json = raw_json.expect("raw_json should be present in hash mode");
+        assert!(!raw_json.contains("sess-privacy-hash"));
+        assert!(!raw_json.contains("msg_secret"));
+        assert!(raw_json.contains("sha256:"));
     }
 
     #[test]

--- a/crates/budi-core/src/privacy.rs
+++ b/crates/budi-core/src/privacy.rs
@@ -1,0 +1,438 @@
+use std::env;
+
+use anyhow::Result;
+use rusqlite::{Connection, params};
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+
+const DEFAULT_RAW_RETENTION_DAYS: u32 = 30;
+const DEFAULT_SESSION_METADATA_RETENTION_DAYS: u32 = 90;
+
+/// Privacy behavior for sensitive fields in raw payloads/session metadata.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PrivacyMode {
+    /// Store values as-is.
+    Full,
+    /// Store deterministic hashes instead of raw values.
+    Hash,
+    /// Drop sensitive values entirely.
+    Omit,
+}
+
+impl PrivacyMode {
+    fn from_env(raw: &str) -> Self {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "full" | "off" | "none" => Self::Full,
+            "hash" | "hashed" => Self::Hash,
+            "omit" | "redact" | "strict" => Self::Omit,
+            _ => {
+                tracing::warn!(
+                    "Unknown BUDI_PRIVACY_MODE value '{}'; falling back to 'full'",
+                    raw
+                );
+                Self::Full
+            }
+        }
+    }
+}
+
+/// Runtime policy loaded from environment variables.
+#[derive(Debug, Clone)]
+pub struct PrivacyPolicy {
+    pub mode: PrivacyMode,
+    /// Retention window for raw payload columns (`raw_json`) in days.
+    pub raw_retention_days: Option<u32>,
+    /// Retention window for sensitive session metadata in days.
+    pub session_metadata_retention_days: Option<u32>,
+}
+
+impl Default for PrivacyPolicy {
+    fn default() -> Self {
+        Self {
+            mode: PrivacyMode::Full,
+            raw_retention_days: Some(DEFAULT_RAW_RETENTION_DAYS),
+            session_metadata_retention_days: Some(DEFAULT_SESSION_METADATA_RETENTION_DAYS),
+        }
+    }
+}
+
+/// Read privacy policy from env vars.
+///
+/// Supported env vars:
+/// - `BUDI_PRIVACY_MODE` = `full` | `hash` | `omit` (default: `full`)
+/// - `BUDI_RETENTION_RAW_DAYS` = non-negative integer or `off` (default: 30)
+/// - `BUDI_RETENTION_SESSION_METADATA_DAYS` = non-negative integer or `off` (default: 90)
+pub fn load_privacy_policy() -> PrivacyPolicy {
+    let mut policy = PrivacyPolicy::default();
+
+    if let Ok(mode) = env::var("BUDI_PRIVACY_MODE") {
+        policy.mode = PrivacyMode::from_env(&mode);
+    }
+    policy.raw_retention_days =
+        read_retention_days("BUDI_RETENTION_RAW_DAYS", DEFAULT_RAW_RETENTION_DAYS);
+    policy.session_metadata_retention_days = read_retention_days(
+        "BUDI_RETENTION_SESSION_METADATA_DAYS",
+        DEFAULT_SESSION_METADATA_RETENTION_DAYS,
+    );
+    policy
+}
+
+fn read_retention_days(key: &str, default_days: u32) -> Option<u32> {
+    let Ok(raw) = env::var(key) else {
+        return Some(default_days);
+    };
+    let raw = raw.trim();
+    if raw.eq_ignore_ascii_case("off")
+        || raw.eq_ignore_ascii_case("none")
+        || raw.eq_ignore_ascii_case("disable")
+        || raw.eq_ignore_ascii_case("disabled")
+    {
+        return None;
+    }
+    match raw.parse::<u32>() {
+        Ok(days) => Some(days),
+        Err(_) => {
+            tracing::warn!(
+                "Invalid {key} value '{}'; expected non-negative integer or 'off'. Using default {default_days}.",
+                raw
+            );
+            Some(default_days)
+        }
+    }
+}
+
+fn retention_modifier(days: u32) -> String {
+    format!("-{days} days")
+}
+
+/// Deterministically hash a sensitive value.
+pub fn hash_sensitive_value(value: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(value.as_bytes());
+    let digest = hasher.finalize();
+    let mut out = String::from("sha256:");
+    for b in digest.iter().take(12) {
+        out.push_str(&format!("{b:02x}"));
+    }
+    out
+}
+
+fn normalize_nonempty(value: Option<&str>) -> Option<&str> {
+    value.map(str::trim).filter(|s| !s.is_empty())
+}
+
+/// Minimize a scalar field according to policy mode.
+pub fn minimize_sensitive_field(value: Option<&str>, mode: PrivacyMode) -> Option<String> {
+    let normalized = normalize_nonempty(value);
+    match mode {
+        PrivacyMode::Full => normalized.map(str::to_string),
+        PrivacyMode::Hash => normalized.map(hash_sensitive_value),
+        PrivacyMode::Omit => None,
+    }
+}
+
+fn is_sensitive_key(key: &str) -> bool {
+    matches!(
+        key,
+        "user_email" | "cwd" | "workspace_root" | "workspace_roots" | "project_dir"
+    )
+}
+
+fn sanitize_sensitive_json_value(value: &mut Value, mode: PrivacyMode) {
+    match value {
+        Value::Object(map) => {
+            let keys: Vec<String> = map.keys().cloned().collect();
+            for key in keys {
+                if is_sensitive_key(&key) {
+                    match mode {
+                        PrivacyMode::Full => {}
+                        PrivacyMode::Hash => {
+                            if let Some(field_value) = map.get_mut(&key) {
+                                hash_json_field(field_value);
+                            }
+                        }
+                        PrivacyMode::Omit => {
+                            map.remove(&key);
+                            continue;
+                        }
+                    }
+                }
+                if let Some(field_value) = map.get_mut(&key) {
+                    sanitize_sensitive_json_value(field_value, mode);
+                }
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                sanitize_sensitive_json_value(item, mode);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn hash_json_field(value: &mut Value) {
+    match value {
+        Value::String(s) => {
+            if !s.trim().is_empty() {
+                *s = hash_sensitive_value(s);
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                if let Value::String(s) = item
+                    && !s.trim().is_empty()
+                {
+                    *s = hash_sensitive_value(s);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Sanitize hook raw payload JSON according to policy.
+///
+/// Returns `None` when payload storage should be omitted.
+pub fn sanitize_hook_raw_json(raw_json: &str, mode: PrivacyMode) -> Option<String> {
+    match mode {
+        PrivacyMode::Full => Some(raw_json.to_string()),
+        PrivacyMode::Omit => None,
+        PrivacyMode::Hash => {
+            let mut payload: Value = match serde_json::from_str(raw_json) {
+                Ok(v) => v,
+                Err(e) => {
+                    tracing::warn!("Failed to parse hook raw_json for sanitization: {e}");
+                    return None;
+                }
+            };
+            sanitize_sensitive_json_value(&mut payload, mode);
+            Some(payload.to_string())
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RetentionReport {
+    pub hook_raw_scrubbed: usize,
+    pub otel_raw_scrubbed: usize,
+    pub session_raw_scrubbed: usize,
+    pub session_metadata_scrubbed: usize,
+}
+
+impl RetentionReport {
+    pub fn touched_rows(&self) -> usize {
+        self.hook_raw_scrubbed
+            + self.otel_raw_scrubbed
+            + self.session_raw_scrubbed
+            + self.session_metadata_scrubbed
+    }
+}
+
+/// Apply retention policy to raw payload/session metadata columns.
+pub fn enforce_retention(conn: &Connection) -> Result<RetentionReport> {
+    let policy = load_privacy_policy();
+    enforce_retention_with_policy(conn, &policy)
+}
+
+/// Apply retention using an explicit policy (primarily for tests).
+pub fn enforce_retention_with_policy(
+    conn: &Connection,
+    policy: &PrivacyPolicy,
+) -> Result<RetentionReport> {
+    let mut report = RetentionReport::default();
+
+    if let Some(days) = policy.raw_retention_days {
+        let cutoff = retention_modifier(days);
+        report.hook_raw_scrubbed = conn.execute(
+            "UPDATE hook_events
+             SET raw_json = NULL
+             WHERE raw_json IS NOT NULL
+               AND julianday(timestamp) < julianday('now', ?1)",
+            params![cutoff],
+        )?;
+        report.otel_raw_scrubbed = conn.execute(
+            "UPDATE otel_events
+             SET raw_json = NULL
+             WHERE raw_json IS NOT NULL
+               AND julianday(timestamp) < julianday('now', ?1)",
+            params![cutoff],
+        )?;
+        report.session_raw_scrubbed = conn.execute(
+            "UPDATE sessions
+             SET raw_json = NULL
+             WHERE raw_json IS NOT NULL
+               AND COALESCE(ended_at, started_at) IS NOT NULL
+               AND julianday(COALESCE(ended_at, started_at)) < julianday('now', ?1)",
+            params![cutoff],
+        )?;
+    }
+
+    if let Some(days) = policy.session_metadata_retention_days {
+        let cutoff = retention_modifier(days);
+        report.session_metadata_scrubbed = conn.execute(
+            "UPDATE sessions
+             SET user_email = NULL,
+                 workspace_root = NULL
+             WHERE (user_email IS NOT NULL OR workspace_root IS NOT NULL)
+               AND COALESCE(ended_at, started_at) IS NOT NULL
+               AND julianday(COALESCE(ended_at, started_at)) < julianday('now', ?1)",
+            params![cutoff],
+        )?;
+    }
+
+    if report.touched_rows() > 0 {
+        tracing::info!(
+            "Privacy retention scrubbed {} rows (hook_raw={}, otel_raw={}, session_raw={}, session_metadata={})",
+            report.touched_rows(),
+            report.hook_raw_scrubbed,
+            report.otel_raw_scrubbed,
+            report.session_raw_scrubbed,
+            report.session_metadata_scrubbed
+        );
+    }
+
+    Ok(report)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{Duration, Utc};
+
+    #[test]
+    fn minimize_sensitive_field_hashes_or_omits() {
+        let raw = Some("test@example.com");
+        assert_eq!(
+            minimize_sensitive_field(raw, PrivacyMode::Hash),
+            Some(hash_sensitive_value("test@example.com"))
+        );
+        assert_eq!(minimize_sensitive_field(raw, PrivacyMode::Omit), None);
+        assert_eq!(
+            minimize_sensitive_field(raw, PrivacyMode::Full),
+            Some("test@example.com".to_string())
+        );
+    }
+
+    #[test]
+    fn sanitize_hook_raw_json_hashes_sensitive_keys() {
+        let raw = serde_json::json!({
+            "user_email": "dev@example.com",
+            "cwd": "/Users/dev/repo",
+            "workspace_roots": ["/Users/dev/repo", "/tmp/other"],
+            "safe": "keep"
+        })
+        .to_string();
+
+        let sanitized = sanitize_hook_raw_json(&raw, PrivacyMode::Hash).unwrap();
+        let parsed: Value = serde_json::from_str(&sanitized).unwrap();
+        assert_ne!(
+            parsed.get("user_email").and_then(|v| v.as_str()),
+            Some("dev@example.com")
+        );
+        assert_ne!(
+            parsed.get("cwd").and_then(|v| v.as_str()),
+            Some("/Users/dev/repo")
+        );
+        assert_eq!(parsed.get("safe").and_then(|v| v.as_str()), Some("keep"));
+    }
+
+    #[test]
+    fn sanitize_hook_raw_json_omit_drops_payload() {
+        let raw = r#"{"user_email":"dev@example.com"}"#;
+        assert_eq!(sanitize_hook_raw_json(raw, PrivacyMode::Omit), None);
+    }
+
+    #[test]
+    fn enforce_retention_scrubs_old_raw_payloads_and_metadata() {
+        let conn = Connection::open_in_memory().unwrap();
+        crate::migration::migrate(&conn).unwrap();
+
+        let old_ts = (Utc::now() - Duration::days(45)).to_rfc3339();
+        let fresh_ts = (Utc::now() - Duration::days(2)).to_rfc3339();
+
+        conn.execute(
+            "INSERT INTO hook_events (provider, event, session_id, timestamp, raw_json)
+             VALUES ('claude_code', 'post_tool_use', 's-old', ?1, '{\"old\":true}')",
+            params![old_ts],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO hook_events (provider, event, session_id, timestamp, raw_json)
+             VALUES ('claude_code', 'post_tool_use', 's-new', ?1, '{\"new\":true}')",
+            params![fresh_ts],
+        )
+        .unwrap();
+
+        conn.execute(
+            "INSERT INTO otel_events (event_name, session_id, timestamp, raw_json, processed)
+             VALUES ('claude_code.api_request', 's-old', ?1, '{\"old\":true}', 1)",
+            params![old_ts],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO otel_events (event_name, session_id, timestamp, raw_json, processed)
+             VALUES ('claude_code.api_request', 's-new', ?1, '{\"new\":true}', 1)",
+            params![fresh_ts],
+        )
+        .unwrap();
+
+        conn.execute(
+            "INSERT INTO sessions (id, provider, started_at, user_email, workspace_root, raw_json)
+             VALUES ('s-old', 'claude_code', ?1, 'old@example.com', '/old/path', '{\"old\":true}')",
+            params![old_ts],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO sessions (id, provider, started_at, user_email, workspace_root, raw_json)
+             VALUES ('s-new', 'claude_code', ?1, 'new@example.com', '/new/path', '{\"new\":true}')",
+            params![fresh_ts],
+        )
+        .unwrap();
+
+        let policy = PrivacyPolicy {
+            mode: PrivacyMode::Full,
+            raw_retention_days: Some(30),
+            session_metadata_retention_days: Some(30),
+        };
+        let report = enforce_retention_with_policy(&conn, &policy).unwrap();
+        assert_eq!(report.hook_raw_scrubbed, 1);
+        assert_eq!(report.otel_raw_scrubbed, 1);
+        assert_eq!(report.session_raw_scrubbed, 1);
+        assert_eq!(report.session_metadata_scrubbed, 1);
+
+        let old_hook_raw: Option<String> = conn
+            .query_row(
+                "SELECT raw_json FROM hook_events WHERE session_id='s-old'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        let new_hook_raw: Option<String> = conn
+            .query_row(
+                "SELECT raw_json FROM hook_events WHERE session_id='s-new'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!(old_hook_raw.is_none());
+        assert!(new_hook_raw.is_some());
+
+        let old_user_email: Option<String> = conn
+            .query_row(
+                "SELECT user_email FROM sessions WHERE id='s-old'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        let new_user_email: Option<String> = conn
+            .query_row(
+                "SELECT user_email FROM sessions WHERE id='s-new'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!(old_user_email.is_none());
+        assert_eq!(new_user_email.as_deref(), Some("new@example.com"));
+    }
+}

--- a/crates/budi-daemon/src/routes/hooks.rs
+++ b/crates/budi-daemon/src/routes/hooks.rs
@@ -746,6 +746,9 @@ pub async fn hooks_ingest(
         budi_core::hooks::ingest_hook_event(&tx, &event)?;
 
         tx.commit()?;
+        if let Err(e) = budi_core::privacy::enforce_retention(&conn) {
+            tracing::warn!("Privacy retention cleanup failed after hook ingest: {e}");
+        }
         Ok::<_, anyhow::Error>(())
     })
     .await

--- a/crates/budi-daemon/src/routes/otel.rs
+++ b/crates/budi-daemon/src/routes/otel.rs
@@ -34,6 +34,9 @@ pub async fn otel_logs_ingest(Json(payload): Json<serde_json::Value>) -> StatusC
                     if n > 0 {
                         tracing::debug!("OTEL: ingested {n} api_request events");
                     }
+                    if let Err(e) = budi_core::privacy::enforce_retention(&conn) {
+                        tracing::warn!("Privacy retention cleanup failed after OTEL ingest: {e}");
+                    }
                 }
                 Err(e) => {
                     tracing::warn!("OTEL ingestion error: {e}");


### PR DESCRIPTION
## Summary
- add a new core privacy policy module with configurable minimization modes (`full`, `hash`, `omit`)
- sanitize sensitive session fields and hook raw payload storage at write-time
- add configurable retention cleanup for `hook_events.raw_json`, `otel_events.raw_json`, `sessions.raw_json`, and aged session metadata (`user_email`, `workspace_root`)
- apply retention cleanup after sync, hook ingest, and OTEL ingest
- add tests for minimized-storage behavior and retention cleanup
- document privacy controls, retention windows, and SQLCipher at-rest strategy in README

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- re-ran after syncing with latest `origin/main`:
  - `cargo clippy --workspace --all-targets --locked -- -D warnings`
  - `cargo test --workspace --locked`

Closes #17
