### PR TITLE
Add durable ingest queue for hooks and OTEL

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,6 +360,10 @@ A lightweight Rust daemon (port 7878) receives real-time OpenTelemetry events, s
 │ Dashboard│ ──────────▶ │  - 30s sync  │ ──────────────────┘
 └──────────┘             │  - analytics │    Extract → Normalize
                          │  - hooks     │      → Enrich → Load
+┌──────────┐             │  - queue     │
+│ ingest   │◀───────────▶│  drainer     │
+│ queue DB │   durable   │              │
+└──────────┘             └──────────────┘
 ┌──────────┐    HTTP     └──────────────┘
 │ MCP      │ ──────────▶ (stdio JSON-RPC, 15 tools)
 │ Server   │  thin client
@@ -378,7 +382,7 @@ A lightweight Rust daemon (port 7878) receives real-time OpenTelemetry events, s
   └── OTLP HTTP/JSON ──▶ POST /v1/logs (auto-configured)
 ```
 
-The daemon is the single source of truth — the CLI never opens the database directly. Each message row is enriched from multiple sources: OTEL provides exact cost, JSONL provides context (parent messages, working directory), and hooks provide session metadata (repo, branch, user).
+The daemon is the single source of truth — the CLI never opens the database directly. Realtime hooks/OTEL payloads are written to a durable local queue first, then drained into analytics in bounded retries. Each message row is enriched from multiple sources: OTEL provides exact cost, JSONL provides context (parent messages, working directory), and hooks provide session metadata (repo, branch, user).
 
 **Data model** — six tables, four data entities + two supporting:
 
@@ -415,7 +419,7 @@ budi is local-first, but you can now enforce tighter storage controls for raw pa
 
 Use `off` to disable a retention window for a category.
 
-Retention cleanup runs automatically after sync, hook ingestion, and OTEL ingestion.
+Retention cleanup runs automatically after sync and queued realtime ingestion processing.
 
 **At-rest protection (SQLCipher strategy):**
 - Current default uses bundled SQLite (WAL) for broad compatibility and easy installs.
@@ -492,11 +496,11 @@ The daemon runs on `http://127.0.0.1:7878` and exposes a REST API.
 | POST | `/sync` | Sync recent data (last 30 days) |
 | POST | `/sync/all` | Load full transcript history |
 | POST | `/sync/reset` | Wipe sync state + full re-sync |
-| GET | `/sync/status` | Syncing flag + last_synced |
+| GET | `/sync/status` | Syncing flag + last_synced + ingest queue backlog/failed metrics |
 | POST | `/hooks/ingest` | Receive hook events |
 | GET | `/health/integrations` | Hooks/MCP/OTEL/statusline status + DB stats |
 | GET | `/health/check-update` | Check for updates via GitHub |
-| POST | `/v1/logs` | OTLP logs ingestion (exact cost from Claude Code) |
+| POST | `/v1/logs` | OTLP logs ingestion (durable-queued, then background processed) |
 | POST | `/v1/metrics` | OTLP metrics ingestion (stub for future use) |
 
 **Analytics:**

--- a/crates/budi-core/src/hooks.rs
+++ b/crates/budi-core/src/hooks.rs
@@ -238,6 +238,30 @@ pub fn parse_hook_event(json: &Value) -> Result<HookEvent> {
     })
 }
 
+/// Parse and ingest one raw hook payload into sessions + hook_events.
+///
+/// Runs in a short transaction and is suitable for queue-drain workers.
+pub fn ingest_hook_payload(conn: &mut Connection, payload: &Value) -> Result<()> {
+    let event = parse_hook_event(payload)?;
+    let tx = conn.transaction()?;
+
+    // If prompt submission, classify and update session category.
+    if matches!(event.event.as_str(), "user_prompt_submit")
+        && let Some(prompt) = payload
+            .get("user_prompt")
+            .or_else(|| payload.get("prompt"))
+            .and_then(|v| v.as_str())
+        && let Some(category) = classify_prompt(prompt)
+    {
+        let _ = update_session_category(&tx, &event, &category);
+    }
+
+    upsert_session(&tx, &event)?;
+    ingest_hook_event(&tx, &event)?;
+    tx.commit()?;
+    Ok(())
+}
+
 pub fn resolve_hook_message_link(
     conn: &Connection,
     session_id: Option<&str>,

--- a/crates/budi-core/src/ingest_queue.rs
+++ b/crates/budi-core/src/ingest_queue.rs
@@ -1,0 +1,545 @@
+//! Durable ingest queue for realtime hook and OTEL payloads.
+//!
+//! Realtime endpoints append raw payloads here first (durable-first), then a
+//! background worker drains the queue into the analytics database in bounded
+//! batches with retry/backoff.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration as StdDuration;
+
+use anyhow::{Context, Result};
+use chrono::{Duration, Utc};
+use rusqlite::{Connection, params};
+use serde_json::Value;
+
+const QUEUE_DB_FILE: &str = "ingest-queue.db";
+const MAX_ATTEMPTS: i64 = 5;
+const MAX_ERROR_CHARS: usize = 600;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IngestSource {
+    Hook,
+    Otel,
+}
+
+impl IngestSource {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Hook => "hook",
+            Self::Otel => "otel",
+        }
+    }
+
+    fn from_str(value: &str) -> Option<Self> {
+        match value {
+            "hook" => Some(Self::Hook),
+            "otel" => Some(Self::Otel),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+pub struct QueueStats {
+    /// Pending rows (includes rows waiting for retry time).
+    pub pending: u64,
+    /// Rows eligible to process right now (`available_at <= now`).
+    pub ready: u64,
+    /// Rows that exhausted retry attempts and are now dropped/dead-lettered.
+    pub failed: u64,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct DrainReport {
+    pub processed: u64,
+    pub retried: u64,
+    pub failed: u64,
+    pub remaining: u64,
+}
+
+#[derive(Debug, Clone)]
+struct QueueRow {
+    id: i64,
+    source: String,
+    payload_json: String,
+    attempts: i64,
+}
+
+/// Resolve the queue database path (`<budi-home>/ingest-queue.db`).
+pub fn queue_db_path() -> Result<PathBuf> {
+    Ok(crate::config::budi_home_dir()?.join(QUEUE_DB_FILE))
+}
+
+/// Ensure queue database exists and schema is created.
+pub fn initialize_queue_db() -> Result<()> {
+    let path = queue_db_path()?;
+    let conn = open_queue_db(&path)?;
+    ensure_schema(&conn)
+}
+
+pub fn enqueue_hook_payload(payload: &Value) -> Result<i64> {
+    enqueue_payload(IngestSource::Hook, payload)
+}
+
+pub fn enqueue_otel_payload(payload: &Value) -> Result<i64> {
+    enqueue_payload(IngestSource::Otel, payload)
+}
+
+pub fn enqueue_payload(source: IngestSource, payload: &Value) -> Result<i64> {
+    let queue_path = queue_db_path()?;
+    enqueue_payload_at(&queue_path, source, payload)
+}
+
+pub fn queue_stats() -> Result<QueueStats> {
+    let queue_path = queue_db_path()?;
+    queue_stats_at(&queue_path)
+}
+
+/// Process one queue batch and return processing counters.
+pub fn process_pending_batch(batch_size: usize) -> Result<DrainReport> {
+    let queue_path = queue_db_path()?;
+    let analytics_path = crate::analytics::db_path()?;
+    process_pending_batch_at(&queue_path, &analytics_path, batch_size, 250)
+}
+
+/// Process up to `max_batches` batches. Stops early when queue becomes idle.
+pub fn process_until_idle(max_batches: usize, batch_size: usize) -> Result<DrainReport> {
+    let queue_path = queue_db_path()?;
+    let analytics_path = crate::analytics::db_path()?;
+
+    let mut total = DrainReport::default();
+    for _ in 0..max_batches {
+        let batch = process_pending_batch_at(&queue_path, &analytics_path, batch_size, 250)?;
+        total.processed += batch.processed;
+        total.retried += batch.retried;
+        total.failed += batch.failed;
+        total.remaining = batch.remaining;
+
+        if batch.processed == 0 && batch.retried == 0 && batch.failed == 0 {
+            break;
+        }
+        if batch.remaining == 0 {
+            break;
+        }
+    }
+
+    Ok(total)
+}
+
+fn enqueue_payload_at(queue_db_path: &Path, source: IngestSource, payload: &Value) -> Result<i64> {
+    let conn = open_queue_db(queue_db_path)?;
+    ensure_schema(&conn)?;
+
+    let now = Utc::now().to_rfc3339();
+    let payload_json =
+        serde_json::to_string(payload).context("Failed to serialize queue payload")?;
+    conn.execute(
+        "INSERT INTO ingest_queue (
+            source, payload_json, received_at, available_at, attempts
+        ) VALUES (?1, ?2, ?3, ?4, 0)",
+        params![source.as_str(), payload_json, now, now],
+    )?;
+    Ok(conn.last_insert_rowid())
+}
+
+fn queue_stats_at(queue_db_path: &Path) -> Result<QueueStats> {
+    let conn = open_queue_db(queue_db_path)?;
+    ensure_schema(&conn)?;
+    queue_stats_from_conn(&conn)
+}
+
+fn process_pending_batch_at(
+    queue_db_path: &Path,
+    analytics_db_path: &Path,
+    batch_size: usize,
+    analytics_busy_timeout_ms: u64,
+) -> Result<DrainReport> {
+    let conn = open_queue_db(queue_db_path)?;
+    ensure_schema(&conn)?;
+
+    let rows = load_ready_rows(&conn, batch_size)?;
+    if rows.is_empty() {
+        let stats = queue_stats_from_conn(&conn)?;
+        return Ok(DrainReport {
+            remaining: stats.pending,
+            ..DrainReport::default()
+        });
+    }
+
+    let mut report = DrainReport::default();
+    for row in rows {
+        match process_row(analytics_db_path, analytics_busy_timeout_ms, &row) {
+            Ok(()) => {
+                mark_processed(&conn, row.id)?;
+                report.processed += 1;
+            }
+            Err(err) => {
+                let attempts = row.attempts + 1;
+                let error_text = truncate_error(&err);
+                if attempts >= MAX_ATTEMPTS {
+                    mark_failed(&conn, row.id, attempts, &error_text)?;
+                    report.failed += 1;
+                } else {
+                    mark_retry(&conn, row.id, attempts, &error_text)?;
+                    report.retried += 1;
+                }
+            }
+        }
+    }
+
+    let stats = queue_stats_from_conn(&conn)?;
+    report.remaining = stats.pending;
+    Ok(report)
+}
+
+fn process_row(
+    analytics_db_path: &Path,
+    analytics_busy_timeout_ms: u64,
+    row: &QueueRow,
+) -> Result<()> {
+    let source = IngestSource::from_str(row.source.as_str())
+        .ok_or_else(|| anyhow::anyhow!("Unknown ingest queue source: {}", row.source))?;
+    let payload: Value = serde_json::from_str(&row.payload_json)
+        .with_context(|| format!("Failed to parse queued payload id={}", row.id))?;
+
+    let mut analytics_conn = crate::analytics::open_db(analytics_db_path)?;
+    analytics_conn.busy_timeout(StdDuration::from_millis(analytics_busy_timeout_ms))?;
+
+    match source {
+        IngestSource::Hook => {
+            crate::hooks::ingest_hook_payload(&mut analytics_conn, &payload)?;
+        }
+        IngestSource::Otel => {
+            let _ = crate::otel::ingest_otel_payload(&mut analytics_conn, &payload)?;
+        }
+    }
+
+    if let Err(e) = crate::privacy::enforce_retention(&analytics_conn) {
+        tracing::warn!(
+            "Privacy retention cleanup failed after queued {} ingest: {e}",
+            source.as_str()
+        );
+    }
+
+    Ok(())
+}
+
+fn load_ready_rows(conn: &Connection, batch_size: usize) -> Result<Vec<QueueRow>> {
+    let now = Utc::now().to_rfc3339();
+    let mut stmt = conn.prepare(
+        "SELECT id, source, payload_json, attempts
+         FROM ingest_queue
+         WHERE processed_at IS NULL
+           AND failed_at IS NULL
+           AND available_at <= ?1
+         ORDER BY id ASC
+         LIMIT ?2",
+    )?;
+    let rows = stmt
+        .query_map(params![now, batch_size as i64], |row| {
+            Ok(QueueRow {
+                id: row.get(0)?,
+                source: row.get(1)?,
+                payload_json: row.get(2)?,
+                attempts: row.get(3)?,
+            })
+        })?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    Ok(rows)
+}
+
+fn mark_processed(conn: &Connection, id: i64) -> Result<()> {
+    let now = Utc::now().to_rfc3339();
+    conn.execute(
+        "UPDATE ingest_queue
+         SET processed_at = ?2, last_error = NULL
+         WHERE id = ?1",
+        params![id, now],
+    )?;
+    Ok(())
+}
+
+fn mark_retry(conn: &Connection, id: i64, attempts: i64, error_text: &str) -> Result<()> {
+    let retry_at = (Utc::now() + retry_backoff(attempts)).to_rfc3339();
+    conn.execute(
+        "UPDATE ingest_queue
+         SET attempts = ?2, available_at = ?3, last_error = ?4
+         WHERE id = ?1",
+        params![id, attempts, retry_at, error_text],
+    )?;
+    Ok(())
+}
+
+fn mark_failed(conn: &Connection, id: i64, attempts: i64, error_text: &str) -> Result<()> {
+    let now = Utc::now().to_rfc3339();
+    conn.execute(
+        "UPDATE ingest_queue
+         SET attempts = ?2, failed_at = ?3, last_error = ?4
+         WHERE id = ?1",
+        params![id, attempts, now, error_text],
+    )?;
+    Ok(())
+}
+
+fn retry_backoff(attempts: i64) -> Duration {
+    match attempts {
+        1 => Duration::seconds(1),
+        2 => Duration::seconds(2),
+        3 => Duration::seconds(5),
+        4 => Duration::seconds(10),
+        _ => Duration::seconds(30),
+    }
+}
+
+fn truncate_error(err: &anyhow::Error) -> String {
+    let text = format!("{err:#}");
+    if text.chars().count() <= MAX_ERROR_CHARS {
+        return text;
+    }
+    let mut out = String::with_capacity(MAX_ERROR_CHARS + 3);
+    for ch in text.chars().take(MAX_ERROR_CHARS) {
+        out.push(ch);
+    }
+    out.push_str("...");
+    out
+}
+
+fn queue_stats_from_conn(conn: &Connection) -> Result<QueueStats> {
+    let now = Utc::now().to_rfc3339();
+    let pending: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM ingest_queue
+         WHERE processed_at IS NULL AND failed_at IS NULL",
+        [],
+        |row| row.get(0),
+    )?;
+    let ready: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM ingest_queue
+         WHERE processed_at IS NULL
+           AND failed_at IS NULL
+           AND available_at <= ?1",
+        params![now],
+        |row| row.get(0),
+    )?;
+    let failed: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM ingest_queue
+         WHERE failed_at IS NOT NULL",
+        [],
+        |row| row.get(0),
+    )?;
+    Ok(QueueStats {
+        pending: pending.max(0) as u64,
+        ready: ready.max(0) as u64,
+        failed: failed.max(0) as u64,
+    })
+}
+
+fn open_queue_db(db_path: &Path) -> Result<Connection> {
+    if let Some(parent) = db_path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("Failed to create dir {}", parent.display()))?;
+    }
+
+    let conn = Connection::open(db_path)?;
+    conn.execute_batch(
+        "PRAGMA journal_mode=WAL;
+         PRAGMA foreign_keys=ON;
+         PRAGMA synchronous=NORMAL;
+         PRAGMA temp_store=MEMORY;
+         PRAGMA busy_timeout=5000;",
+    )?;
+    Ok(conn)
+}
+
+fn ensure_schema(conn: &Connection) -> Result<()> {
+    conn.execute_batch(
+        "
+        CREATE TABLE IF NOT EXISTS ingest_queue (
+            id           INTEGER PRIMARY KEY AUTOINCREMENT,
+            source       TEXT NOT NULL,
+            payload_json TEXT NOT NULL,
+            received_at  TEXT NOT NULL,
+            available_at TEXT NOT NULL,
+            attempts     INTEGER NOT NULL DEFAULT 0,
+            last_error   TEXT,
+            processed_at TEXT,
+            failed_at    TEXT
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_ingest_queue_pending
+            ON ingest_queue(available_at, id)
+            WHERE processed_at IS NULL AND failed_at IS NULL;
+        CREATE INDEX IF NOT EXISTS idx_ingest_queue_failed
+            ON ingest_queue(failed_at)
+            WHERE failed_at IS NOT NULL;
+        ",
+    )?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static TEST_COUNTER: AtomicU64 = AtomicU64::new(1);
+
+    fn temp_test_dir(suffix: &str) -> std::path::PathBuf {
+        let id = TEST_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let nanos = Utc::now().timestamp_nanos_opt().unwrap_or_default();
+        let dir = std::env::temp_dir().join(format!(
+            "budi-ingest-queue-{suffix}-{}-{nanos}-{id}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn setup_analytics_db(path: &Path) {
+        let _conn = crate::analytics::open_db_with_migration(path).unwrap();
+    }
+
+    fn hook_payload() -> Value {
+        serde_json::json!({
+            "hook_event_name": "PostToolUse",
+            "session_id": "sess-queue-hook",
+            "tool_name": "Read",
+            "duration": 12,
+            "cwd": "/tmp/repo"
+        })
+    }
+
+    fn otel_payload() -> Value {
+        serde_json::json!({
+            "resourceLogs": [{
+                "resource": {
+                    "attributes": [
+                        {"key": "session.id", "value": {"stringValue": "sess-queue-otel"}}
+                    ]
+                },
+                "scopeLogs": [{
+                    "logRecords": [{
+                        "timeUnixNano": "1711500000000000000",
+                        "body": {"stringValue": "claude_code.api_request"},
+                        "attributes": [
+                            {"key": "model", "value": {"stringValue": "claude-sonnet-4-6"}},
+                            {"key": "cost_usd", "value": {"doubleValue": 0.01}},
+                            {"key": "input_tokens", "value": {"intValue": "100"}},
+                            {"key": "output_tokens", "value": {"intValue": "20"}},
+                            {"key": "cache_read_tokens", "value": {"intValue": "0"}},
+                            {"key": "cache_creation_tokens", "value": {"intValue": "0"}}
+                        ]
+                    }]
+                }]
+            }]
+        })
+    }
+
+    #[test]
+    fn processes_hook_and_otel_queue_items() {
+        let dir = temp_test_dir("process");
+        let queue_db = dir.join("ingest-queue.db");
+        let analytics_db = dir.join("analytics.db");
+        setup_analytics_db(&analytics_db);
+
+        enqueue_payload_at(&queue_db, IngestSource::Hook, &hook_payload()).unwrap();
+        enqueue_payload_at(&queue_db, IngestSource::Otel, &otel_payload()).unwrap();
+
+        let report = process_pending_batch_at(&queue_db, &analytics_db, 50, 50).unwrap();
+        assert_eq!(report.processed, 2);
+        assert_eq!(report.failed, 0);
+        assert_eq!(report.retried, 0);
+
+        let analytics_conn = crate::analytics::open_db(&analytics_db).unwrap();
+        let hook_events: i64 = analytics_conn
+            .query_row("SELECT COUNT(*) FROM hook_events", [], |row| row.get(0))
+            .unwrap();
+        let otel_events: i64 = analytics_conn
+            .query_row("SELECT COUNT(*) FROM otel_events", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(hook_events, 1);
+        assert_eq!(otel_events, 1);
+
+        let stats = queue_stats_at(&queue_db).unwrap();
+        assert_eq!(stats.pending, 0);
+        assert_eq!(stats.failed, 0);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn retries_when_analytics_database_is_locked() {
+        let dir = temp_test_dir("retry");
+        let queue_db = dir.join("ingest-queue.db");
+        let analytics_db = dir.join("analytics.db");
+        setup_analytics_db(&analytics_db);
+
+        enqueue_payload_at(&queue_db, IngestSource::Hook, &hook_payload()).unwrap();
+
+        let mut lock_conn = crate::analytics::open_db(&analytics_db).unwrap();
+        let tx = lock_conn.transaction().unwrap();
+        tx.execute(
+            "INSERT OR IGNORE INTO sessions (id, provider) VALUES ('lock-session', 'claude_code')",
+            [],
+        )
+        .unwrap();
+
+        let first = process_pending_batch_at(&queue_db, &analytics_db, 10, 1).unwrap();
+        assert_eq!(first.processed, 0);
+        assert_eq!(first.retried, 1);
+
+        drop(tx);
+        let queue_conn = open_queue_db(&queue_db).unwrap();
+        queue_conn
+            .execute(
+                "UPDATE ingest_queue SET available_at = ?1 WHERE processed_at IS NULL AND failed_at IS NULL",
+                params![Utc::now().to_rfc3339()],
+            )
+            .unwrap();
+
+        let second = process_pending_batch_at(&queue_db, &analytics_db, 10, 50).unwrap();
+        assert_eq!(second.processed, 1);
+        assert_eq!(second.failed, 0);
+
+        let stats = queue_stats_at(&queue_db).unwrap();
+        assert_eq!(stats.pending, 0);
+        assert_eq!(stats.failed, 0);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn malformed_payload_eventually_moves_to_failed_bucket() {
+        let dir = temp_test_dir("failed");
+        let queue_db = dir.join("ingest-queue.db");
+        let analytics_db = dir.join("analytics.db");
+        setup_analytics_db(&analytics_db);
+
+        let queue_conn = open_queue_db(&queue_db).unwrap();
+        ensure_schema(&queue_conn).unwrap();
+        queue_conn
+            .execute(
+                "INSERT INTO ingest_queue (source, payload_json, received_at, available_at, attempts)
+                 VALUES ('hook', '{bad-json', ?1, ?1, 0)",
+                params![Utc::now().to_rfc3339()],
+            )
+            .unwrap();
+
+        for _ in 0..MAX_ATTEMPTS {
+            let _ = process_pending_batch_at(&queue_db, &analytics_db, 1, 50).unwrap();
+            let conn = open_queue_db(&queue_db).unwrap();
+            conn.execute(
+                "UPDATE ingest_queue
+                 SET available_at = ?1
+                 WHERE processed_at IS NULL AND failed_at IS NULL",
+                params![Utc::now().to_rfc3339()],
+            )
+            .unwrap();
+        }
+
+        let stats = queue_stats_at(&queue_db).unwrap();
+        assert_eq!(stats.pending, 0);
+        assert_eq!(stats.failed, 1);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/crates/budi-core/src/lib.rs
+++ b/crates/budi-core/src/lib.rs
@@ -3,6 +3,7 @@ pub mod config;
 pub mod cost;
 pub mod hooks;
 pub mod identity;
+pub mod ingest_queue;
 pub mod integrations;
 pub mod jsonl;
 pub mod migration;

--- a/crates/budi-core/src/otel.rs
+++ b/crates/budi-core/src/otel.rs
@@ -222,6 +222,16 @@ pub fn parse_otel_logs(request: &ExportLogsServiceRequest) -> Vec<OtelApiRequest
     events
 }
 
+/// Parse and ingest one OTEL JSON payload into analytics tables.
+pub fn ingest_otel_payload(conn: &mut Connection, payload: &serde_json::Value) -> Result<usize> {
+    let request: ExportLogsServiceRequest = serde_json::from_value(payload.clone())?;
+    let events = parse_otel_logs(&request);
+    if events.is_empty() {
+        return Ok(0);
+    }
+    ingest_otel_events(conn, &events)
+}
+
 // ── Ingestion ─────────────────────────────────────────────────────────
 
 /// Generate a deterministic UUID from session_id + timestamp_nano.

--- a/crates/budi-daemon/src/main.rs
+++ b/crates/budi-daemon/src/main.rs
@@ -191,6 +191,38 @@ async fn main() -> Result<()> {
     {
         tracing::warn!("Failed to initialize database: {e}");
     }
+    if let Err(e) = budi_core::ingest_queue::initialize_queue_db() {
+        tracing::warn!("Failed to initialize ingest queue database: {e}");
+    }
+
+    // Drain queued hook/OTEL payloads continuously in bounded batches.
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(std::time::Duration::from_secs(1));
+        loop {
+            interval.tick().await;
+            match tokio::task::spawn_blocking(|| budi_core::ingest_queue::process_until_idle(4, 64))
+                .await
+            {
+                Ok(Ok(report)) => {
+                    if report.processed > 0 || report.retried > 0 || report.failed > 0 {
+                        tracing::debug!(
+                            processed = report.processed,
+                            retried = report.retried,
+                            failed = report.failed,
+                            remaining = report.remaining,
+                            "Ingest queue batch processed"
+                        );
+                    }
+                }
+                Ok(Err(e)) => {
+                    tracing::warn!("Ingest queue processing failed: {e}");
+                }
+                Err(e) => {
+                    tracing::warn!("Ingest queue worker task failed: {e}");
+                }
+            }
+        }
+    });
 
     // Auto-sync transcripts every 30 seconds to keep analytics fresh.
     tokio::spawn(async move {

--- a/crates/budi-daemon/src/routes/hooks.rs
+++ b/crates/budi-daemon/src/routes/hooks.rs
@@ -26,6 +26,9 @@ pub struct SyncStatusResponse {
     pub syncing: bool,
     pub last_sync_completed_at: Option<String>,
     pub newest_data_at: Option<String>,
+    pub ingest_backlog: u64,
+    pub ingest_ready: u64,
+    pub ingest_failed: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub last_synced: Option<String>,
 }
@@ -524,6 +527,9 @@ pub async fn sync_status(State(state): State<AppState>) -> Json<SyncStatusRespon
     let status = tokio::task::spawn_blocking(|| {
         let db_path = budi_core::analytics::db_path().ok()?;
         let conn = budi_core::analytics::open_db(&db_path).ok()?;
+        let queue = budi_core::ingest_queue::queue_stats()
+            .ok()
+            .unwrap_or_default();
         Some((
             budi_core::analytics::last_sync_completed_at(&conn)
                 .ok()
@@ -531,16 +537,21 @@ pub async fn sync_status(State(state): State<AppState>) -> Json<SyncStatusRespon
             budi_core::analytics::newest_ingested_data_at(&conn)
                 .ok()
                 .flatten(),
+            queue,
         ))
     })
     .await
     .ok()
     .flatten();
-    let (last_sync_completed_at, newest_data_at) = status.unwrap_or((None, None));
+    let (last_sync_completed_at, newest_data_at, queue_stats) =
+        status.unwrap_or((None, None, budi_core::ingest_queue::QueueStats::default()));
     Json(SyncStatusResponse {
         syncing,
         last_sync_completed_at: last_sync_completed_at.clone(),
         newest_data_at,
+        ingest_backlog: queue_stats.pending,
+        ingest_ready: queue_stats.ready,
+        ingest_failed: queue_stats.failed,
         last_synced: last_sync_completed_at,
     })
 }
@@ -711,49 +722,18 @@ pub async fn analytics_history(
 // ---------------------------------------------------------------------------
 // Hook event ingestion
 //
-// This endpoint opens its own SQLite connection via `open_db`, which is safe
-// to run concurrently with the background sync.  SQLite in WAL mode allows
-// concurrent readers, and write serialization is handled by SQLite's internal
-// locking (SQLITE_BUSY with a timeout configured via `busy_timeout`).  The
-// `syncing` AtomicBool only guards against *duplicate* long-running syncs;
-// hook ingestion writes are small and fast, so the SQLite-level lock is
-// sufficient to prevent data corruption.
+// Durable-first path:
+// 1) append raw payload to ingest queue db
+// 2) background worker drains queue into analytics tables in bounded batches
 // ---------------------------------------------------------------------------
 
 pub async fn hooks_ingest(
     Json(payload): Json<Value>,
 ) -> Result<Json<Value>, (StatusCode, Json<serde_json::Value>)> {
-    tokio::task::spawn_blocking(move || {
-        let event = budi_core::hooks::parse_hook_event(&payload)?;
+    tokio::task::spawn_blocking(move || budi_core::ingest_queue::enqueue_hook_payload(&payload))
+        .await
+        .map_err(|e| internal_error(anyhow::anyhow!("{e}")))?
+        .map_err(internal_error)?;
 
-        let db_path = budi_core::analytics::db_path()?;
-        let mut conn = budi_core::analytics::open_db(&db_path)?;
-
-        let tx = conn.transaction()?;
-
-        // If prompt submission, classify and update session
-        if matches!(event.event.as_str(), "user_prompt_submit")
-            && let Some(prompt) = payload
-                .get("user_prompt")
-                .or_else(|| payload.get("prompt"))
-                .and_then(|v| v.as_str())
-            && let Some(category) = budi_core::hooks::classify_prompt(prompt)
-        {
-            let _ = budi_core::hooks::update_session_category(&tx, &event, &category);
-        }
-
-        budi_core::hooks::upsert_session(&tx, &event)?;
-        budi_core::hooks::ingest_hook_event(&tx, &event)?;
-
-        tx.commit()?;
-        if let Err(e) = budi_core::privacy::enforce_retention(&conn) {
-            tracing::warn!("Privacy retention cleanup failed after hook ingest: {e}");
-        }
-        Ok::<_, anyhow::Error>(())
-    })
-    .await
-    .map_err(|e| internal_error(anyhow::anyhow!("{e}")))?
-    .map_err(internal_error)?;
-
-    Ok(Json(json!({"ok": true})))
+    Ok(Json(json!({"ok": true, "queued": true})))
 }

--- a/crates/budi-daemon/src/routes/otel.rs
+++ b/crates/budi-daemon/src/routes/otel.rs
@@ -1,58 +1,31 @@
 //! OpenTelemetry (OTLP) HTTP/JSON ingestion endpoints.
 //!
 //! Receives OTLP logs and metrics from Claude Code's telemetry SDK.
-//! Fire-and-forget: always returns 200 OK to avoid blocking the SDK.
+//! Ingestion is durable-first: payloads are queued, then drained in background.
 
 use axum::Json;
 use axum::http::StatusCode;
 
 /// POST /v1/logs — OTLP logs ingestion.
 ///
-/// Parses `claude_code.api_request` events and upserts into messages table
-/// with `cost_confidence = 'otel_exact'`. Same fire-and-forget pattern as hooks.
+/// Appends raw payload to the durable ingest queue.
+/// Background worker parses and upserts `claude_code.api_request` events.
 pub async fn otel_logs_ingest(Json(payload): Json<serde_json::Value>) -> StatusCode {
-    tokio::task::spawn_blocking(move || {
-        let request: budi_core::otel::ExportLogsServiceRequest =
-            match serde_json::from_value(payload) {
-                Ok(r) => r,
-                Err(e) => {
-                    tracing::debug!("Failed to parse OTLP logs payload: {e}");
-                    return;
-                }
-            };
-
-        let events = budi_core::otel::parse_otel_logs(&request);
-        if events.is_empty() {
-            return;
-        }
-
-        let result = (|| -> Option<()> {
-            let db_path = budi_core::analytics::db_path().ok()?;
-            let mut conn = budi_core::analytics::open_db(&db_path).ok()?;
-            match budi_core::otel::ingest_otel_events(&mut conn, &events) {
-                Ok(n) => {
-                    if n > 0 {
-                        tracing::debug!("OTEL: ingested {n} api_request events");
-                    }
-                    if let Err(e) = budi_core::privacy::enforce_retention(&conn) {
-                        tracing::warn!("Privacy retention cleanup failed after OTEL ingest: {e}");
-                    }
-                }
-                Err(e) => {
-                    tracing::warn!("OTEL ingestion error: {e}");
-                }
-            }
-            Some(())
-        })();
-
-        if result.is_none() {
-            tracing::debug!("OTEL: could not open database");
-        }
+    match tokio::task::spawn_blocking(move || {
+        budi_core::ingest_queue::enqueue_otel_payload(&payload)
     })
     .await
-    .ok();
-
-    StatusCode::OK
+    {
+        Ok(Ok(_)) => StatusCode::OK,
+        Ok(Err(e)) => {
+            tracing::warn!("OTEL queue enqueue failed: {e}");
+            StatusCode::SERVICE_UNAVAILABLE
+        }
+        Err(e) => {
+            tracing::warn!("OTEL queue enqueue task failed: {e}");
+            StatusCode::SERVICE_UNAVAILABLE
+        }
+    }
 }
 
 /// POST /v1/metrics — OTLP metrics ingestion (stub).


### PR DESCRIPTION
## Summary
- add a durable local ingest queue (`ingest-queue.db`) for hook and OTEL payloads
- switch `/hooks/ingest` and `/v1/logs` to enqueue-first behavior instead of writing analytics tables inline
- add a background queue drainer in `budi-daemon` that processes bounded batches with retry/backoff and dead-letter tracking
- expose queue backlog/ready/failed counters in `/sync/status`
- add queue tests covering hook+OTEL processing, retry under analytics lock contention, and dead-letter behavior
- update README architecture/API notes for the queued ingestion flow

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- post-sync parity: fetched/merged latest `origin/main`, then re-ran clippy + tests

Closes #13
