### PR TITLE
[codex] Add incremental analytics rollups for hot aggregate queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,7 +384,7 @@ A lightweight Rust daemon (port 7878) receives real-time OpenTelemetry events, s
 
 The daemon is the single source of truth — the CLI never opens the database directly. Realtime hooks/OTEL payloads are written to a durable local queue first, then drained into analytics in bounded retries. Each message row is enriched from multiple sources: OTEL provides exact cost, JSONL provides context (parent messages, working directory), and hooks provide session metadata (repo, branch, user).
 
-**Data model** — six tables, four data entities + two supporting:
+**Data model** — eight tables, six data entities + two supporting:
 
 | Table | Role |
 |-------|------|
@@ -394,6 +394,10 @@ The daemon is the single source of truth — the CLI never opens the database di
 | **otel_events** | Raw OpenTelemetry event storage for debugging/audit |
 | **tags** | Flexible key-value pairs per message (repo, ticket, activity, user, etc.) |
 | **sync_state** | Tracks incremental ingestion progress per file for progressive sync |
+| **message_rollups_hourly** | Derived hourly aggregates (provider/model/repo/branch/role) for low-latency analytics reads |
+| **message_rollups_daily** | Derived daily aggregates for summary/filter scans |
+
+`messages` remains the source of truth; rollup tables are derived caches maintained incrementally during ingest/update/delete.
 
 </details>
 

--- a/SOUL.md
+++ b/SOUL.md
@@ -44,13 +44,13 @@ macOS and Linux use the Unix daemon startup path (`lsof`, `ps`, `kill`) to repla
 Sources (JSONL files, OTEL spans, Cursor API, Hooks)
   -> Providers discover + parse -> ParsedMessage structs
   -> Pipeline: HookEnricher -> IdentityEnricher -> GitEnricher -> CostEnricher -> TagEnricher
-  -> SQLite (messages + tags tables)
+  -> SQLite (messages + tags + derived rollup tables)
   -> Dashboard / CLI stats / Statusline
 ```
 
 Enricher order is critical - each depends on prior enrichers. Do not reorder.
 
-### Database (SQLite, WAL mode, schema v20)
+### Database (SQLite, WAL mode, schema v21)
 
 Six tables, four data entities + two supporting:
 - **messages** - Single cost entity. One row per API call. All token/cost data lives here. Fields: id, session_id, role, model, provider, timestamp, input/output/cache tokens, cost_cents, cost_confidence, git_branch, repo_id, cwd, request_id
@@ -59,6 +59,8 @@ Six tables, four data entities + two supporting:
 - **otel_events** - Raw OpenTelemetry event storage for debugging/audit
 - **tags** - Flexible key-value pairs per message (repo, ticket_id, activity, user, etc.) using message_id FK to messages(id)
 - **sync_state** - Tracks incremental ingestion progress per file for progressive sync
+- **message_rollups_hourly** - Derived hourly aggregates (provider/model/repo/branch/role dimensions) for low-latency analytics reads
+- **message_rollups_daily** - Derived daily aggregates for coarse-grained summaries and filter option scans
 
 ### Cost sources
 
@@ -73,6 +75,7 @@ OTEL and JSONL deduplicate: same API call matched by session_id + model + timest
 ### Key concepts
 
 - **cost_confidence**: determines `~` prefix in dashboard for non-exact costs
+- **Source of truth vs derived**: `messages` remains canonical; rollup tables are derived caches maintained incrementally via SQLite triggers during ingest/update/delete
 - **Session context propagation**: git_branch/repo_id flow from user -> assistant messages within a session
 - **Progressive sync**: files processed newest-first so dashboard shows recent data quickly
 - **Sync split**: `budi sync` = 30-day window (fast), `budi sync --all` = full history

--- a/crates/budi-core/src/analytics/queries.rs
+++ b/crates/budi-core/src/analytics/queries.rs
@@ -2,12 +2,28 @@
 //! tags, models, providers, cache efficiency, cost curves, and statusline stats.
 
 use anyhow::Result;
+use chrono::{DateTime, NaiveDate, Timelike, Utc};
 use rusqlite::Connection;
 use std::collections::HashSet;
 
 use super::MessageRow;
 
 pub const UNTAGGED_DIMENSION: &str = "(untagged)";
+const ROLLUPS_HOURLY_TABLE: &str = "message_rollups_hourly";
+const ROLLUPS_DAILY_TABLE: &str = "message_rollups_daily";
+
+#[derive(Debug, Clone, Copy)]
+enum RollupLevel {
+    Hourly,
+    Daily,
+}
+
+#[derive(Debug, Clone)]
+struct RollupWindow {
+    level: RollupLevel,
+    since: Option<String>,
+    until: Option<String>,
+}
 
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 pub struct DimensionFilters {
@@ -177,6 +193,115 @@ fn apply_dimension_filters(
     append_in_condition(conditions, param_values, branch_expr, &filters.branches);
 }
 
+fn rollups_available(conn: &Connection) -> bool {
+    let hourly_exists: bool = conn
+        .query_row(
+            "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type='table' AND name = ?1)",
+            [ROLLUPS_HOURLY_TABLE],
+            |row| row.get(0),
+        )
+        .unwrap_or(false);
+    let daily_exists: bool = conn
+        .query_row(
+            "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type='table' AND name = ?1)",
+            [ROLLUPS_DAILY_TABLE],
+            |row| row.get(0),
+        )
+        .unwrap_or(false);
+    hourly_exists && daily_exists
+}
+
+fn parse_timestamp_boundary_utc(value: &str) -> Option<DateTime<Utc>> {
+    if let Ok(dt) = DateTime::parse_from_rfc3339(value) {
+        return Some(dt.with_timezone(&Utc));
+    }
+    if let Ok(day) = NaiveDate::parse_from_str(value, "%Y-%m-%d") {
+        return day
+            .and_hms_opt(0, 0, 0)
+            .map(|naive| DateTime::<Utc>::from_naive_utc_and_offset(naive, Utc));
+    }
+    None
+}
+
+fn is_day_aligned(ts: DateTime<Utc>) -> bool {
+    ts.hour() == 0 && ts.minute() == 0 && ts.second() == 0 && ts.nanosecond() == 0
+}
+
+fn is_hour_aligned(ts: DateTime<Utc>) -> bool {
+    ts.minute() == 0 && ts.second() == 0 && ts.nanosecond() == 0
+}
+
+fn choose_rollup_window(
+    since: Option<&str>,
+    until: Option<&str>,
+    prefer_daily: bool,
+) -> Option<RollupWindow> {
+    let since_ts = since.and_then(parse_timestamp_boundary_utc);
+    let until_ts = until.and_then(parse_timestamp_boundary_utc);
+
+    if since.is_some() && since_ts.is_none() {
+        return None;
+    }
+    if until.is_some() && until_ts.is_none() {
+        return None;
+    }
+    if let (Some(s), Some(u)) = (since_ts, until_ts)
+        && s >= u
+    {
+        return None;
+    }
+
+    let day_aligned = since_ts.is_none_or(is_day_aligned) && until_ts.is_none_or(is_day_aligned);
+    if prefer_daily && day_aligned {
+        return Some(RollupWindow {
+            level: RollupLevel::Daily,
+            since: since_ts.map(|ts| ts.format("%Y-%m-%d").to_string()),
+            until: until_ts.map(|ts| ts.format("%Y-%m-%d").to_string()),
+        });
+    }
+
+    let hour_aligned = since_ts.is_none_or(is_hour_aligned) && until_ts.is_none_or(is_hour_aligned);
+    if hour_aligned {
+        return Some(RollupWindow {
+            level: RollupLevel::Hourly,
+            since: since_ts.map(|ts| ts.format("%Y-%m-%dT%H:00:00Z").to_string()),
+            until: until_ts.map(|ts| ts.format("%Y-%m-%dT%H:00:00Z").to_string()),
+        });
+    }
+
+    None
+}
+
+fn rollup_table(level: RollupLevel) -> &'static str {
+    match level {
+        RollupLevel::Hourly => ROLLUPS_HOURLY_TABLE,
+        RollupLevel::Daily => ROLLUPS_DAILY_TABLE,
+    }
+}
+
+fn rollup_time_column(level: RollupLevel) -> &'static str {
+    match level {
+        RollupLevel::Hourly => "bucket_start",
+        RollupLevel::Daily => "bucket_day",
+    }
+}
+
+fn append_rollup_time_filters(
+    conditions: &mut Vec<String>,
+    params: &mut Vec<String>,
+    window: &RollupWindow,
+) {
+    let time_col = rollup_time_column(window.level);
+    if let Some(s) = &window.since {
+        params.push(s.clone());
+        conditions.push(format!("{time_col} >= ?{}", params.len()));
+    }
+    if let Some(u) = &window.until {
+        params.push(u.clone());
+        conditions.push(format!("{time_col} < ?{}", params.len()));
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Usage Summary
 // ---------------------------------------------------------------------------
@@ -261,6 +386,82 @@ pub fn usage_summary_filtered(
     usage_summary_with_filters(conn, since, until, provider, &filters)
 }
 
+fn usage_summary_from_rollups(
+    conn: &Connection,
+    window: &RollupWindow,
+    provider: Option<&str>,
+    filters: &DimensionFilters,
+) -> Result<UsageSummary> {
+    let mut conditions = Vec::new();
+    let mut params: Vec<String> = Vec::new();
+    append_rollup_time_filters(&mut conditions, &mut params, window);
+
+    if let Some(p) = provider {
+        params.push(p.to_string());
+        conditions.push(format!("provider = ?{}", params.len()));
+    }
+    apply_dimension_filters(
+        &mut conditions,
+        &mut params,
+        filters,
+        "provider",
+        "model",
+        "repo_id",
+        "git_branch",
+    );
+
+    let where_clause = if conditions.is_empty() {
+        String::new()
+    } else {
+        format!("WHERE {}", conditions.join(" AND "))
+    };
+    let sql = format!(
+        "SELECT
+            COALESCE(SUM(message_count), 0),
+            COALESCE(SUM(CASE WHEN role = 'user' THEN message_count ELSE 0 END), 0),
+            COALESCE(SUM(CASE WHEN role = 'assistant' THEN message_count ELSE 0 END), 0),
+            COALESCE(SUM(input_tokens), 0),
+            COALESCE(SUM(output_tokens), 0),
+            COALESCE(SUM(cache_creation_tokens), 0),
+            COALESCE(SUM(cache_read_tokens), 0)
+         FROM {} {where_clause}",
+        rollup_table(window.level)
+    );
+    let param_refs: Vec<&dyn rusqlite::types::ToSql> = params
+        .iter()
+        .map(|s| s as &dyn rusqlite::types::ToSql)
+        .collect();
+    let (
+        total_messages,
+        total_user_messages,
+        total_assistant_messages,
+        total_input,
+        total_output,
+        total_cache_create,
+        total_cache_read,
+    ): (u64, u64, u64, u64, u64, u64, u64) = conn.query_row(&sql, param_refs.as_slice(), |r| {
+        Ok((
+            r.get(0)?,
+            r.get(1)?,
+            r.get(2)?,
+            r.get(3)?,
+            r.get(4)?,
+            r.get(5)?,
+            r.get(6)?,
+        ))
+    })?;
+
+    Ok(UsageSummary {
+        total_messages,
+        total_user_messages,
+        total_assistant_messages,
+        total_input_tokens: total_input,
+        total_output_tokens: total_output,
+        total_cache_creation_tokens: total_cache_create,
+        total_cache_read_tokens: total_cache_read,
+    })
+}
+
 pub fn usage_summary_with_filters(
     conn: &Connection,
     since: Option<&str>,
@@ -268,6 +469,12 @@ pub fn usage_summary_with_filters(
     provider: Option<&str>,
     filters: &DimensionFilters,
 ) -> Result<UsageSummary> {
+    if rollups_available(conn)
+        && let Some(window) = choose_rollup_window(since, until, true)
+    {
+        return usage_summary_from_rollups(conn, &window, provider, filters);
+    }
+
     let mut conditions = Vec::new();
     let mut params: Vec<String> = Vec::new();
 
@@ -528,6 +735,81 @@ pub fn repo_usage(
     repo_usage_with_filters(conn, since, until, &filters, limit)
 }
 
+fn repo_usage_from_rollups(
+    conn: &Connection,
+    window: &RollupWindow,
+    filters: &DimensionFilters,
+    limit: usize,
+) -> Result<Vec<RepoUsage>> {
+    let mut conditions = vec!["role = 'assistant'".to_string()];
+    let mut params: Vec<String> = Vec::new();
+    append_rollup_time_filters(&mut conditions, &mut params, window);
+    apply_dimension_filters(
+        &mut conditions,
+        &mut params,
+        filters,
+        "provider",
+        "model",
+        "repo_id",
+        "git_branch",
+    );
+    params.push(limit.to_string());
+    let limit_idx = params.len();
+    let repo_expr = normalized_project_expr("m.repo_id");
+    let sql = format!(
+        "WITH ranked AS (
+             SELECT repo_id as repo,
+                    COALESCE(SUM(message_count), 0) as cnt,
+                    COALESCE(SUM(input_tokens), 0) as inp,
+                    COALESCE(SUM(output_tokens), 0) as outp,
+                    COALESCE(SUM(cost_cents), 0.0) as cost
+             FROM {}
+             WHERE {}
+             GROUP BY repo
+             ORDER BY cost DESC
+             LIMIT ?{limit_idx}
+         )
+         SELECT ranked.repo,
+                COALESCE(
+                    (
+                        SELECT MIN(m.cwd)
+                        FROM messages m
+                        WHERE m.role = 'assistant'
+                          AND {repo_expr} = ranked.repo
+                    ),
+                    '(untagged)'
+                ) as display_path,
+                ranked.cnt,
+                ranked.inp,
+                ranked.outp,
+                ranked.cost
+         FROM ranked
+         ORDER BY ranked.cost DESC",
+        rollup_table(window.level),
+        conditions.join(" AND ")
+    );
+
+    let param_refs: Vec<&dyn rusqlite::types::ToSql> = params
+        .iter()
+        .map(|s| s as &dyn rusqlite::types::ToSql)
+        .collect();
+    let mut stmt = conn.prepare(&sql)?;
+    let rows: Vec<RepoUsage> = stmt
+        .query_map(param_refs.as_slice(), |row| {
+            Ok(RepoUsage {
+                repo_id: row.get(0)?,
+                display_path: row.get(1)?,
+                message_count: row.get(2)?,
+                input_tokens: row.get(3)?,
+                output_tokens: row.get(4)?,
+                cost_cents: row.get(5)?,
+            })
+        })?
+        .filter_map(|r| r.ok())
+        .collect();
+    Ok(rows)
+}
+
 pub fn repo_usage_with_filters(
     conn: &Connection,
     since: Option<&str>,
@@ -535,6 +817,12 @@ pub fn repo_usage_with_filters(
     filters: &DimensionFilters,
     limit: usize,
 ) -> Result<Vec<RepoUsage>> {
+    if rollups_available(conn)
+        && let Some(window) = choose_rollup_window(since, until, true)
+    {
+        return repo_usage_from_rollups(conn, &window, filters, limit);
+    }
+
     // Build parameterized date + dimension filters.
     let mut conditions = vec!["role = 'assistant'".to_string()];
     let mut param_values: Vec<String> = Vec::new();
@@ -640,6 +928,87 @@ pub fn activity_chart(
     activity_chart_with_filters(conn, since, until, &filters, granularity, tz_offset_min)
 }
 
+fn activity_chart_from_rollups(
+    conn: &Connection,
+    window: &RollupWindow,
+    filters: &DimensionFilters,
+    granularity: &str,
+    tz_offset_min: i32,
+) -> Result<Vec<ActivityBucket>> {
+    let mut conditions = vec!["role = 'assistant'".to_string()];
+    let mut params: Vec<String> = Vec::new();
+    append_rollup_time_filters(&mut conditions, &mut params, window);
+    apply_dimension_filters(
+        &mut conditions,
+        &mut params,
+        filters,
+        "provider",
+        "model",
+        "repo_id",
+        "git_branch",
+    );
+    let where_clause = format!("WHERE {}", conditions.join(" AND "));
+    let time_col = rollup_time_column(window.level);
+
+    let group_expr = match window.level {
+        RollupLevel::Daily => match granularity {
+            "month" => format!("strftime('%Y-%m', {time_col})"),
+            _ => time_col.to_string(),
+        },
+        RollupLevel::Hourly => {
+            let hours = tz_offset_min / 60;
+            let mins = (tz_offset_min % 60).abs();
+            let sign = if tz_offset_min >= 0 { "+" } else { "-" };
+            let tz_adjust = if tz_offset_min != 0 {
+                format!(
+                    "datetime({time_col}, '{}{:02}:{:02}')",
+                    sign,
+                    hours.abs(),
+                    mins
+                )
+            } else {
+                time_col.to_string()
+            };
+            match granularity {
+                "hour" => format!("strftime('%H:00', {})", tz_adjust),
+                "month" => format!("strftime('%Y-%m', {})", tz_adjust),
+                _ => format!("date({})", tz_adjust),
+            }
+        }
+    };
+
+    let sql = format!(
+        "SELECT {group_expr} as bucket,
+                COALESCE(SUM(message_count), 0) as cnt,
+                COALESCE(SUM(input_tokens), 0) as inp,
+                COALESCE(SUM(output_tokens), 0) as outp,
+                COALESCE(SUM(cost_cents), 0.0) as cost
+         FROM {} {where_clause}
+         GROUP BY bucket
+         ORDER BY bucket",
+        rollup_table(window.level)
+    );
+    let param_refs: Vec<&dyn rusqlite::types::ToSql> = params
+        .iter()
+        .map(|s| s as &dyn rusqlite::types::ToSql)
+        .collect();
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt
+        .query_map(param_refs.as_slice(), |row| {
+            Ok(ActivityBucket {
+                label: row.get(0)?,
+                message_count: row.get(1)?,
+                tool_call_count: 0,
+                input_tokens: row.get(2)?,
+                output_tokens: row.get(3)?,
+                cost_cents: row.get(4)?,
+            })
+        })?
+        .filter_map(|r| r.ok())
+        .collect();
+    Ok(rows)
+}
+
 pub fn activity_chart_with_filters(
     conn: &Connection,
     since: Option<&str>,
@@ -648,6 +1017,13 @@ pub fn activity_chart_with_filters(
     granularity: &str,
     tz_offset_min: i32,
 ) -> Result<Vec<ActivityBucket>> {
+    if rollups_available(conn) {
+        let prefer_daily = tz_offset_min == 0 && granularity != "hour";
+        if let Some(window) = choose_rollup_window(since, until, prefer_daily) {
+            return activity_chart_from_rollups(conn, &window, filters, granularity, tz_offset_min);
+        }
+    }
+
     let mut conditions = vec!["role = 'assistant'".to_string()];
     let mut param_values = Vec::new();
     if let Some(s) = since
@@ -1316,6 +1692,67 @@ pub fn model_usage(
     model_usage_with_filters(conn, since, until, &filters, limit)
 }
 
+fn model_usage_from_rollups(
+    conn: &Connection,
+    window: &RollupWindow,
+    filters: &DimensionFilters,
+    limit: usize,
+) -> Result<Vec<ModelUsage>> {
+    let mut conditions = vec!["role = 'assistant'".to_string()];
+    let mut params: Vec<String> = Vec::new();
+    append_rollup_time_filters(&mut conditions, &mut params, window);
+    apply_dimension_filters(
+        &mut conditions,
+        &mut params,
+        filters,
+        "provider",
+        "model",
+        "repo_id",
+        "git_branch",
+    );
+    params.push(limit.to_string());
+    let limit_idx = params.len();
+    let sql = format!(
+        "SELECT model as m,
+                provider as p,
+                COALESCE(SUM(message_count), 0) as cnt,
+                COALESCE(SUM(input_tokens), 0) as total_input,
+                COALESCE(SUM(output_tokens), 0) as total_output,
+                COALESCE(SUM(cache_read_tokens), 0),
+                COALESCE(SUM(cache_creation_tokens), 0),
+                COALESCE(SUM(cost_cents), 0.0)
+         FROM {}
+         WHERE {}
+         GROUP BY m, p
+         ORDER BY 8 DESC
+         LIMIT ?{limit_idx}",
+        rollup_table(window.level),
+        conditions.join(" AND ")
+    );
+    let param_refs: Vec<&dyn rusqlite::types::ToSql> = params
+        .iter()
+        .map(|s| s as &dyn rusqlite::types::ToSql)
+        .collect();
+
+    let mut stmt = conn.prepare(&sql)?;
+    let rows: Vec<ModelUsage> = stmt
+        .query_map(param_refs.as_slice(), |row| {
+            Ok(ModelUsage {
+                model: row.get(0)?,
+                provider: row.get(1)?,
+                message_count: row.get(2)?,
+                input_tokens: row.get(3)?,
+                output_tokens: row.get(4)?,
+                cache_read_tokens: row.get(5)?,
+                cache_creation_tokens: row.get(6)?,
+                cost_cents: row.get(7)?,
+            })
+        })?
+        .filter_map(|r| r.ok())
+        .collect();
+    Ok(rows)
+}
+
 pub fn model_usage_with_filters(
     conn: &Connection,
     since: Option<&str>,
@@ -1323,6 +1760,12 @@ pub fn model_usage_with_filters(
     filters: &DimensionFilters,
     limit: usize,
 ) -> Result<Vec<ModelUsage>> {
+    if rollups_available(conn)
+        && let Some(window) = choose_rollup_window(since, until, true)
+    {
+        return model_usage_from_rollups(conn, &window, filters, limit);
+    }
+
     let mut conditions = vec!["role = 'assistant'".to_string()];
     let mut param_values: Vec<String> = Vec::new();
     if let Some(s) = since
@@ -1436,6 +1879,29 @@ pub struct StatuslineParams {
     pub project_dir: Option<String>,
 }
 
+fn assistant_cost_since_from_rollups(conn: &Connection, since: &str) -> Option<f64> {
+    if !rollups_available(conn) {
+        return None;
+    }
+    let window = choose_rollup_window(Some(since), None, false)?;
+    let mut conditions = vec!["role = 'assistant'".to_string()];
+    let mut params: Vec<String> = Vec::new();
+    append_rollup_time_filters(&mut conditions, &mut params, &window);
+    let sql = format!(
+        "SELECT COALESCE(SUM(cost_cents), 0.0)
+         FROM {}
+         WHERE {}",
+        rollup_table(window.level),
+        conditions.join(" AND ")
+    );
+    let param_refs: Vec<&dyn rusqlite::types::ToSql> = params
+        .iter()
+        .map(|s| s as &dyn rusqlite::types::ToSql)
+        .collect();
+    conn.query_row(&sql, param_refs.as_slice(), |r| r.get::<_, f64>(0))
+        .ok()
+}
+
 /// Compute cost stats for today/week/month, suitable for the CLI status line.
 /// Optionally computes session/branch/project costs when params are provided.
 pub fn statusline_stats(
@@ -1446,12 +1912,15 @@ pub fn statusline_stats(
     params: &StatuslineParams,
 ) -> Result<StatuslineStats> {
     fn cost_since(conn: &Connection, since: &str) -> f64 {
-        conn.query_row(
-            "SELECT COALESCE(SUM(cost_cents), 0.0) FROM messages WHERE timestamp >= ?1 AND role = 'assistant'",
-            [since],
-            |r| r.get::<_, f64>(0),
-        )
-        .unwrap_or(0.0)
+        assistant_cost_since_from_rollups(conn, since)
+            .unwrap_or_else(|| {
+                conn.query_row(
+                    "SELECT COALESCE(SUM(cost_cents), 0.0) FROM messages WHERE timestamp >= ?1 AND role = 'assistant'",
+                    [since],
+                    |r| r.get::<_, f64>(0),
+                )
+                .unwrap_or(0.0)
+            })
             / 100.0
     }
 
@@ -1563,12 +2032,95 @@ pub fn provider_stats(
     provider_stats_with_filters(conn, since, until, &filters)
 }
 
+fn provider_stats_from_rollups(
+    conn: &Connection,
+    window: &RollupWindow,
+    filters: &DimensionFilters,
+) -> Result<Vec<ProviderStats>> {
+    let mut conditions = vec!["role = 'assistant'".to_string()];
+    let mut params: Vec<String> = Vec::new();
+    append_rollup_time_filters(&mut conditions, &mut params, window);
+    apply_dimension_filters(
+        &mut conditions,
+        &mut params,
+        filters,
+        "provider",
+        "model",
+        "repo_id",
+        "git_branch",
+    );
+    let sql = format!(
+        "SELECT provider as p,
+                COALESCE(SUM(message_count), 0) as msgs,
+                COALESCE(SUM(input_tokens), 0),
+                COALESCE(SUM(output_tokens), 0),
+                COALESCE(SUM(cache_creation_tokens), 0),
+                COALESCE(SUM(cache_read_tokens), 0),
+                COALESCE(SUM(cost_cents), 0.0)
+         FROM {}
+         WHERE {}
+         GROUP BY p
+         ORDER BY msgs DESC",
+        rollup_table(window.level),
+        conditions.join(" AND ")
+    );
+    let param_refs: Vec<&dyn rusqlite::types::ToSql> = params
+        .iter()
+        .map(|s| s as &dyn rusqlite::types::ToSql)
+        .collect();
+
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt
+        .query_map(param_refs.as_slice(), |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, u64>(1)?,
+                row.get::<_, u64>(2)?,
+                row.get::<_, u64>(3)?,
+                row.get::<_, u64>(4)?,
+                row.get::<_, u64>(5)?,
+                row.get::<_, f64>(6)?,
+            ))
+        })?
+        .filter_map(|r| r.ok())
+        .collect::<Vec<_>>();
+
+    let providers = crate::provider::all_providers();
+    let mut result = Vec::new();
+    for (prov, messages, input, output, cache_create, cache_read, sum_cost_cents) in rows {
+        let display_name = providers
+            .iter()
+            .find(|p| p.name() == prov)
+            .map(|p| p.display_name().to_string())
+            .unwrap_or_else(|| prov.clone());
+        let estimated_cost = sum_cost_cents.round() / 100.0;
+        result.push(ProviderStats {
+            provider: prov,
+            display_name,
+            message_count: messages,
+            input_tokens: input,
+            output_tokens: output,
+            cache_creation_tokens: cache_create,
+            cache_read_tokens: cache_read,
+            estimated_cost,
+            total_cost_cents: sum_cost_cents,
+        });
+    }
+    Ok(result)
+}
+
 pub fn provider_stats_with_filters(
     conn: &Connection,
     since: Option<&str>,
     until: Option<&str>,
     filters: &DimensionFilters,
 ) -> Result<Vec<ProviderStats>> {
+    if rollups_available(conn)
+        && let Some(window) = choose_rollup_window(since, until, true)
+    {
+        return provider_stats_from_rollups(conn, &window, filters);
+    }
+
     let mut conditions = vec!["role = 'assistant'".to_string()];
     let mut param_values = Vec::new();
     if let Some(s) = since
@@ -2067,6 +2619,12 @@ pub fn filter_options(
     until: Option<&str>,
     limit: Option<usize>,
 ) -> Result<FilterOptions> {
+    if rollups_available(conn)
+        && let Some(window) = choose_rollup_window(since, until, true)
+    {
+        return filter_options_from_rollups(conn, &window, limit);
+    }
+
     let mut conditions = vec!["role = 'assistant'".to_string()];
     let mut params: Vec<String> = Vec::new();
     if let Some(s) = since
@@ -2152,5 +2710,54 @@ pub fn filter_options(
         models: distinct_values(conn, &models_sql, &params, limit)?,
         projects: distinct_values(conn, &projects_sql, &params, limit)?,
         branches: distinct_values(conn, &branches_sql, &params, limit)?,
+    })
+}
+
+fn filter_options_from_rollups(
+    conn: &Connection,
+    window: &RollupWindow,
+    limit: Option<usize>,
+) -> Result<FilterOptions> {
+    fn distinct_rollup_values(
+        conn: &Connection,
+        window: &RollupWindow,
+        value_col: &str,
+        limit: Option<usize>,
+    ) -> Result<Vec<String>> {
+        let mut conditions = vec!["role = 'assistant'".to_string()];
+        let mut params: Vec<String> = Vec::new();
+        append_rollup_time_filters(&mut conditions, &mut params, window);
+        let where_clause = format!("WHERE {}", conditions.join(" AND "));
+        let mut limit_clause = String::new();
+        if let Some(limit_value) = limit {
+            params.push(limit_value.to_string());
+            limit_clause = format!("LIMIT ?{}", params.len());
+        }
+        let sql = format!(
+            "SELECT {value_col} as value
+             FROM {}
+             {where_clause}
+             GROUP BY value
+             ORDER BY SUM(message_count) DESC, value ASC
+             {limit_clause}",
+            rollup_table(window.level)
+        );
+        let param_refs: Vec<&dyn rusqlite::types::ToSql> = params
+            .iter()
+            .map(|s| s as &dyn rusqlite::types::ToSql)
+            .collect();
+        let mut stmt = conn.prepare(&sql)?;
+        let rows = stmt
+            .query_map(param_refs.as_slice(), |row| row.get::<_, String>(0))?
+            .filter_map(|r| r.ok())
+            .collect();
+        Ok(rows)
+    }
+
+    Ok(FilterOptions {
+        agents: distinct_rollup_values(conn, window, "provider", limit)?,
+        models: distinct_rollup_values(conn, window, "model", limit)?,
+        projects: distinct_rollup_values(conn, window, "repo_id", limit)?,
+        branches: distinct_rollup_values(conn, window, "git_branch", limit)?,
     })
 }

--- a/crates/budi-core/src/analytics/tests.rs
+++ b/crates/budi-core/src/analytics/tests.rs
@@ -37,6 +37,8 @@ fn schema_creates_tables() {
     assert!(tables.contains(&"hook_events".to_string()));
     assert!(tables.contains(&"messages".to_string()));
     assert!(tables.contains(&"sync_state".to_string()));
+    assert!(tables.contains(&"message_rollups_hourly".to_string()));
+    assert!(tables.contains(&"message_rollups_daily".to_string()));
 }
 
 #[test]
@@ -114,6 +116,177 @@ fn ingest_and_query() {
     assert_eq!(summary.total_assistant_messages, 1);
     assert_eq!(summary.total_input_tokens, 100);
     assert_eq!(summary.total_output_tokens, 50);
+}
+
+#[test]
+fn rollups_track_message_updates_and_deletes() {
+    let mut conn = test_db();
+    let msg = ParsedMessage {
+        uuid: "rollup-msg-1".to_string(),
+        session_id: Some("rollup-sess".to_string()),
+        timestamp: "2026-03-14T18:14:00Z".parse().unwrap(),
+        cwd: Some("/tmp/proj".to_string()),
+        role: "assistant".to_string(),
+        model: Some("claude-opus-4-6".to_string()),
+        input_tokens: 100,
+        output_tokens: 50,
+        cache_creation_tokens: 10,
+        cache_read_tokens: 20,
+        git_branch: Some("refs/heads/main".to_string()),
+        repo_id: Some("github.com/acme/repo".to_string()),
+        provider: "claude_code".to_string(),
+        cost_cents: Some(2.0),
+        session_title: None,
+        parent_uuid: None,
+        user_name: None,
+        machine_name: None,
+        cost_confidence: "estimated".to_string(),
+        request_id: None,
+        speed: None,
+        cache_creation_1h_tokens: 0,
+        web_search_requests: 0,
+        prompt_category: None,
+        tool_names: Vec::new(),
+        tool_use_ids: Vec::new(),
+    };
+    ingest_messages(&mut conn, &[msg], None).unwrap();
+
+    conn.execute(
+        "UPDATE messages
+         SET output_tokens = 90,
+             cost_cents = 4.5
+         WHERE id = 'rollup-msg-1'",
+        [],
+    )
+    .unwrap();
+
+    let summary =
+        usage_summary_with_filters(&conn, None, None, None, &DimensionFilters::default()).unwrap();
+    assert_eq!(summary.total_output_tokens, 90);
+
+    conn.execute("DELETE FROM messages WHERE id = 'rollup-msg-1'", [])
+        .unwrap();
+    let post_delete =
+        usage_summary_with_filters(&conn, None, None, None, &DimensionFilters::default()).unwrap();
+    assert_eq!(post_delete.total_messages, 0);
+}
+
+#[test]
+fn rollups_are_used_only_for_hour_aligned_ranges() {
+    let mut conn = test_db();
+    let msg = ParsedMessage {
+        uuid: "rollup-range-msg".to_string(),
+        session_id: Some("rollup-range-sess".to_string()),
+        timestamp: "2026-03-14T10:30:00Z".parse().unwrap(),
+        cwd: Some("/tmp/proj".to_string()),
+        role: "assistant".to_string(),
+        model: Some("claude-opus-4-6".to_string()),
+        input_tokens: 10,
+        output_tokens: 5,
+        cache_creation_tokens: 0,
+        cache_read_tokens: 0,
+        git_branch: Some("main".to_string()),
+        repo_id: Some("repo-a".to_string()),
+        provider: "claude_code".to_string(),
+        cost_cents: Some(1.0),
+        session_title: None,
+        parent_uuid: None,
+        user_name: None,
+        machine_name: None,
+        cost_confidence: "estimated".to_string(),
+        request_id: None,
+        speed: None,
+        cache_creation_1h_tokens: 0,
+        web_search_requests: 0,
+        prompt_category: None,
+        tool_names: Vec::new(),
+        tool_use_ids: Vec::new(),
+    };
+    ingest_messages(&mut conn, &[msg], None).unwrap();
+
+    // Poison the rollup row to detect whether the query path reads rollups.
+    conn.execute(
+        "UPDATE message_rollups_hourly SET message_count = 9, output_tokens = 99
+         WHERE bucket_start = '2026-03-14T10:00:00Z'",
+        [],
+    )
+    .unwrap();
+
+    let aligned = usage_summary_with_filters(
+        &conn,
+        Some("2026-03-14T10:00:00Z"),
+        None,
+        None,
+        &DimensionFilters::default(),
+    )
+    .unwrap();
+    assert_eq!(aligned.total_messages, 9);
+    assert_eq!(aligned.total_output_tokens, 99);
+
+    let non_aligned = usage_summary_with_filters(
+        &conn,
+        Some("2026-03-14T10:15:00Z"),
+        Some("2026-03-14T11:00:00Z"),
+        None,
+        &DimensionFilters::default(),
+    )
+    .unwrap();
+    // Non-hour-aligned range should fall back to raw messages for correctness.
+    assert_eq!(non_aligned.total_messages, 1);
+    assert_eq!(non_aligned.total_output_tokens, 5);
+}
+
+#[test]
+fn rollup_summary_latency_smoke_on_large_dataset() {
+    let mut conn = test_db();
+    let mut messages = Vec::new();
+    for i in 0..5000 {
+        let hour = i % 24;
+        let day = (i % 28) + 1;
+        messages.push(ParsedMessage {
+            uuid: format!("bench-{i}"),
+            session_id: Some(format!("bench-sess-{}", i % 50)),
+            timestamp: format!("2026-03-{day:02}T{hour:02}:00:00Z")
+                .parse()
+                .unwrap(),
+            cwd: Some("/tmp/bench".to_string()),
+            role: "assistant".to_string(),
+            model: Some("claude-sonnet-4-6".to_string()),
+            input_tokens: 200,
+            output_tokens: 80,
+            cache_creation_tokens: 20,
+            cache_read_tokens: 40,
+            git_branch: Some("main".to_string()),
+            repo_id: Some("repo-bench".to_string()),
+            provider: "claude_code".to_string(),
+            cost_cents: Some(1.2),
+            session_title: None,
+            parent_uuid: None,
+            user_name: None,
+            machine_name: None,
+            cost_confidence: "estimated".to_string(),
+            request_id: None,
+            speed: None,
+            cache_creation_1h_tokens: 0,
+            web_search_requests: 0,
+            prompt_category: None,
+            tool_names: Vec::new(),
+            tool_use_ids: Vec::new(),
+        });
+    }
+    ingest_messages(&mut conn, &messages, None).unwrap();
+
+    let started = std::time::Instant::now();
+    let summary =
+        usage_summary_with_filters(&conn, None, None, None, &DimensionFilters::default()).unwrap();
+    let elapsed = started.elapsed();
+
+    assert_eq!(summary.total_messages, 5000);
+    assert!(
+        elapsed < std::time::Duration::from_secs(2),
+        "rollup summary latency smoke exceeded budget: {:?}",
+        elapsed
+    );
 }
 
 #[test]

--- a/crates/budi-core/src/migration.rs
+++ b/crates/budi-core/src/migration.rs
@@ -12,7 +12,7 @@ use chrono::{DateTime, Utc};
 use rusqlite::Connection;
 
 /// Expected schema version for the current binary.
-pub const SCHEMA_VERSION: u32 = 20;
+pub const SCHEMA_VERSION: u32 = 21;
 
 /// Result of running schema repair.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -133,6 +133,9 @@ fn run_version_migrations(conn: &Connection) -> Result<()> {
     if current_version(conn) == 19 {
         migrate_v19_to_v20(conn)?;
     }
+    if current_version(conn) == 20 {
+        migrate_v20_to_v21(conn)?;
+    }
     Ok(())
 }
 
@@ -192,6 +195,7 @@ fn create_current_schema(conn: &Connection) -> Result<()> {
     )?;
     create_sessions_and_hook_events(conn)?;
     create_otel_events(conn)?;
+    ensure_rollup_schema(conn, false)?;
     create_indexes(conn)?;
     Ok(())
 }
@@ -675,6 +679,607 @@ fn migrate_v19_to_v20(conn: &Connection) -> Result<()> {
     Ok(())
 }
 
+/// Incremental migration from v20 to v21: add incremental analytics rollup tables.
+fn migrate_v20_to_v21(conn: &Connection) -> Result<()> {
+    tracing::info!(
+        "Migrating schema v20 → v21: adding hourly/daily analytics rollups with incremental triggers"
+    );
+    ensure_rollup_schema(conn, true)?;
+    create_indexes(conn)?;
+    conn.pragma_update(None, "user_version", 21u32)?;
+    Ok(())
+}
+
+fn ensure_rollup_schema(conn: &Connection, backfill: bool) -> Result<()> {
+    create_rollup_tables(conn)?;
+    create_rollup_triggers(conn)?;
+    if backfill {
+        backfill_rollup_tables(conn)?;
+    }
+    Ok(())
+}
+
+fn create_rollup_tables(conn: &Connection) -> Result<()> {
+    conn.execute_batch(
+        "
+        CREATE TABLE IF NOT EXISTS message_rollups_hourly (
+            bucket_start           TEXT NOT NULL,
+            role                   TEXT NOT NULL,
+            provider               TEXT NOT NULL,
+            model                  TEXT NOT NULL,
+            repo_id                TEXT NOT NULL,
+            git_branch             TEXT NOT NULL,
+            message_count          INTEGER NOT NULL DEFAULT 0,
+            input_tokens           INTEGER NOT NULL DEFAULT 0,
+            output_tokens          INTEGER NOT NULL DEFAULT 0,
+            cache_creation_tokens  INTEGER NOT NULL DEFAULT 0,
+            cache_read_tokens      INTEGER NOT NULL DEFAULT 0,
+            cost_cents             REAL NOT NULL DEFAULT 0,
+            PRIMARY KEY(bucket_start, role, provider, model, repo_id, git_branch)
+        );
+
+        CREATE TABLE IF NOT EXISTS message_rollups_daily (
+            bucket_day             TEXT NOT NULL,
+            role                   TEXT NOT NULL,
+            provider               TEXT NOT NULL,
+            model                  TEXT NOT NULL,
+            repo_id                TEXT NOT NULL,
+            git_branch             TEXT NOT NULL,
+            message_count          INTEGER NOT NULL DEFAULT 0,
+            input_tokens           INTEGER NOT NULL DEFAULT 0,
+            output_tokens          INTEGER NOT NULL DEFAULT 0,
+            cache_creation_tokens  INTEGER NOT NULL DEFAULT 0,
+            cache_read_tokens      INTEGER NOT NULL DEFAULT 0,
+            cost_cents             REAL NOT NULL DEFAULT 0,
+            PRIMARY KEY(bucket_day, role, provider, model, repo_id, git_branch)
+        );
+        ",
+    )?;
+    Ok(())
+}
+
+fn create_rollup_triggers(conn: &Connection) -> Result<()> {
+    conn.execute_batch(
+        "
+        DROP TRIGGER IF EXISTS trg_messages_rollup_insert;
+        DROP TRIGGER IF EXISTS trg_messages_rollup_delete;
+        DROP TRIGGER IF EXISTS trg_messages_rollup_update;
+
+        CREATE TRIGGER IF NOT EXISTS trg_messages_rollup_insert
+        AFTER INSERT ON messages
+        BEGIN
+            INSERT INTO message_rollups_hourly (
+                bucket_start, role, provider, model, repo_id, git_branch,
+                message_count, input_tokens, output_tokens,
+                cache_creation_tokens, cache_read_tokens, cost_cents
+            )
+            VALUES (
+                strftime('%Y-%m-%dT%H:00:00Z', NEW.timestamp),
+                COALESCE(NULLIF(NEW.role, ''), 'assistant'),
+                COALESCE(NULLIF(NEW.provider, ''), 'claude_code'),
+                CASE
+                    WHEN NEW.model IS NULL OR NEW.model = '' OR SUBSTR(NEW.model, 1, 1) = '<'
+                    THEN '(untagged)'
+                    ELSE NEW.model
+                END,
+                COALESCE(NULLIF(NULLIF(NEW.repo_id, ''), 'unknown'), '(untagged)'),
+                COALESCE(
+                    NULLIF(
+                        CASE
+                            WHEN COALESCE(NEW.git_branch, '') LIKE 'refs/heads/%'
+                            THEN SUBSTR(COALESCE(NEW.git_branch, ''), 12)
+                            ELSE COALESCE(NEW.git_branch, '')
+                        END,
+                        ''
+                    ),
+                    '(untagged)'
+                ),
+                1,
+                COALESCE(NEW.input_tokens, 0),
+                COALESCE(NEW.output_tokens, 0),
+                COALESCE(NEW.cache_creation_tokens, 0),
+                COALESCE(NEW.cache_read_tokens, 0),
+                COALESCE(NEW.cost_cents, 0.0)
+            )
+            ON CONFLICT(bucket_start, role, provider, model, repo_id, git_branch) DO UPDATE SET
+                message_count = message_count + excluded.message_count,
+                input_tokens = input_tokens + excluded.input_tokens,
+                output_tokens = output_tokens + excluded.output_tokens,
+                cache_creation_tokens = cache_creation_tokens + excluded.cache_creation_tokens,
+                cache_read_tokens = cache_read_tokens + excluded.cache_read_tokens,
+                cost_cents = cost_cents + excluded.cost_cents;
+
+            INSERT INTO message_rollups_daily (
+                bucket_day, role, provider, model, repo_id, git_branch,
+                message_count, input_tokens, output_tokens,
+                cache_creation_tokens, cache_read_tokens, cost_cents
+            )
+            VALUES (
+                strftime('%Y-%m-%d', NEW.timestamp),
+                COALESCE(NULLIF(NEW.role, ''), 'assistant'),
+                COALESCE(NULLIF(NEW.provider, ''), 'claude_code'),
+                CASE
+                    WHEN NEW.model IS NULL OR NEW.model = '' OR SUBSTR(NEW.model, 1, 1) = '<'
+                    THEN '(untagged)'
+                    ELSE NEW.model
+                END,
+                COALESCE(NULLIF(NULLIF(NEW.repo_id, ''), 'unknown'), '(untagged)'),
+                COALESCE(
+                    NULLIF(
+                        CASE
+                            WHEN COALESCE(NEW.git_branch, '') LIKE 'refs/heads/%'
+                            THEN SUBSTR(COALESCE(NEW.git_branch, ''), 12)
+                            ELSE COALESCE(NEW.git_branch, '')
+                        END,
+                        ''
+                    ),
+                    '(untagged)'
+                ),
+                1,
+                COALESCE(NEW.input_tokens, 0),
+                COALESCE(NEW.output_tokens, 0),
+                COALESCE(NEW.cache_creation_tokens, 0),
+                COALESCE(NEW.cache_read_tokens, 0),
+                COALESCE(NEW.cost_cents, 0.0)
+            )
+            ON CONFLICT(bucket_day, role, provider, model, repo_id, git_branch) DO UPDATE SET
+                message_count = message_count + excluded.message_count,
+                input_tokens = input_tokens + excluded.input_tokens,
+                output_tokens = output_tokens + excluded.output_tokens,
+                cache_creation_tokens = cache_creation_tokens + excluded.cache_creation_tokens,
+                cache_read_tokens = cache_read_tokens + excluded.cache_read_tokens,
+                cost_cents = cost_cents + excluded.cost_cents;
+        END;
+
+        CREATE TRIGGER IF NOT EXISTS trg_messages_rollup_delete
+        AFTER DELETE ON messages
+        BEGIN
+            INSERT INTO message_rollups_hourly (
+                bucket_start, role, provider, model, repo_id, git_branch,
+                message_count, input_tokens, output_tokens,
+                cache_creation_tokens, cache_read_tokens, cost_cents
+            )
+            VALUES (
+                strftime('%Y-%m-%dT%H:00:00Z', OLD.timestamp),
+                COALESCE(NULLIF(OLD.role, ''), 'assistant'),
+                COALESCE(NULLIF(OLD.provider, ''), 'claude_code'),
+                CASE
+                    WHEN OLD.model IS NULL OR OLD.model = '' OR SUBSTR(OLD.model, 1, 1) = '<'
+                    THEN '(untagged)'
+                    ELSE OLD.model
+                END,
+                COALESCE(NULLIF(NULLIF(OLD.repo_id, ''), 'unknown'), '(untagged)'),
+                COALESCE(
+                    NULLIF(
+                        CASE
+                            WHEN COALESCE(OLD.git_branch, '') LIKE 'refs/heads/%'
+                            THEN SUBSTR(COALESCE(OLD.git_branch, ''), 12)
+                            ELSE COALESCE(OLD.git_branch, '')
+                        END,
+                        ''
+                    ),
+                    '(untagged)'
+                ),
+                -1,
+                -COALESCE(OLD.input_tokens, 0),
+                -COALESCE(OLD.output_tokens, 0),
+                -COALESCE(OLD.cache_creation_tokens, 0),
+                -COALESCE(OLD.cache_read_tokens, 0),
+                -COALESCE(OLD.cost_cents, 0.0)
+            )
+            ON CONFLICT(bucket_start, role, provider, model, repo_id, git_branch) DO UPDATE SET
+                message_count = message_count + excluded.message_count,
+                input_tokens = input_tokens + excluded.input_tokens,
+                output_tokens = output_tokens + excluded.output_tokens,
+                cache_creation_tokens = cache_creation_tokens + excluded.cache_creation_tokens,
+                cache_read_tokens = cache_read_tokens + excluded.cache_read_tokens,
+                cost_cents = cost_cents + excluded.cost_cents;
+
+            DELETE FROM message_rollups_hourly
+             WHERE bucket_start = strftime('%Y-%m-%dT%H:00:00Z', OLD.timestamp)
+               AND role = COALESCE(NULLIF(OLD.role, ''), 'assistant')
+               AND provider = COALESCE(NULLIF(OLD.provider, ''), 'claude_code')
+               AND model = CASE
+                    WHEN OLD.model IS NULL OR OLD.model = '' OR SUBSTR(OLD.model, 1, 1) = '<'
+                    THEN '(untagged)'
+                    ELSE OLD.model
+               END
+               AND repo_id = COALESCE(NULLIF(NULLIF(OLD.repo_id, ''), 'unknown'), '(untagged)')
+               AND git_branch = COALESCE(
+                    NULLIF(
+                        CASE
+                            WHEN COALESCE(OLD.git_branch, '') LIKE 'refs/heads/%'
+                            THEN SUBSTR(COALESCE(OLD.git_branch, ''), 12)
+                            ELSE COALESCE(OLD.git_branch, '')
+                        END,
+                        ''
+                    ),
+                    '(untagged)'
+               )
+               AND message_count <= 0;
+
+            INSERT INTO message_rollups_daily (
+                bucket_day, role, provider, model, repo_id, git_branch,
+                message_count, input_tokens, output_tokens,
+                cache_creation_tokens, cache_read_tokens, cost_cents
+            )
+            VALUES (
+                strftime('%Y-%m-%d', OLD.timestamp),
+                COALESCE(NULLIF(OLD.role, ''), 'assistant'),
+                COALESCE(NULLIF(OLD.provider, ''), 'claude_code'),
+                CASE
+                    WHEN OLD.model IS NULL OR OLD.model = '' OR SUBSTR(OLD.model, 1, 1) = '<'
+                    THEN '(untagged)'
+                    ELSE OLD.model
+                END,
+                COALESCE(NULLIF(NULLIF(OLD.repo_id, ''), 'unknown'), '(untagged)'),
+                COALESCE(
+                    NULLIF(
+                        CASE
+                            WHEN COALESCE(OLD.git_branch, '') LIKE 'refs/heads/%'
+                            THEN SUBSTR(COALESCE(OLD.git_branch, ''), 12)
+                            ELSE COALESCE(OLD.git_branch, '')
+                        END,
+                        ''
+                    ),
+                    '(untagged)'
+                ),
+                -1,
+                -COALESCE(OLD.input_tokens, 0),
+                -COALESCE(OLD.output_tokens, 0),
+                -COALESCE(OLD.cache_creation_tokens, 0),
+                -COALESCE(OLD.cache_read_tokens, 0),
+                -COALESCE(OLD.cost_cents, 0.0)
+            )
+            ON CONFLICT(bucket_day, role, provider, model, repo_id, git_branch) DO UPDATE SET
+                message_count = message_count + excluded.message_count,
+                input_tokens = input_tokens + excluded.input_tokens,
+                output_tokens = output_tokens + excluded.output_tokens,
+                cache_creation_tokens = cache_creation_tokens + excluded.cache_creation_tokens,
+                cache_read_tokens = cache_read_tokens + excluded.cache_read_tokens,
+                cost_cents = cost_cents + excluded.cost_cents;
+
+            DELETE FROM message_rollups_daily
+             WHERE bucket_day = strftime('%Y-%m-%d', OLD.timestamp)
+               AND role = COALESCE(NULLIF(OLD.role, ''), 'assistant')
+               AND provider = COALESCE(NULLIF(OLD.provider, ''), 'claude_code')
+               AND model = CASE
+                    WHEN OLD.model IS NULL OR OLD.model = '' OR SUBSTR(OLD.model, 1, 1) = '<'
+                    THEN '(untagged)'
+                    ELSE OLD.model
+               END
+               AND repo_id = COALESCE(NULLIF(NULLIF(OLD.repo_id, ''), 'unknown'), '(untagged)')
+               AND git_branch = COALESCE(
+                    NULLIF(
+                        CASE
+                            WHEN COALESCE(OLD.git_branch, '') LIKE 'refs/heads/%'
+                            THEN SUBSTR(COALESCE(OLD.git_branch, ''), 12)
+                            ELSE COALESCE(OLD.git_branch, '')
+                        END,
+                        ''
+                    ),
+                    '(untagged)'
+               )
+               AND message_count <= 0;
+        END;
+
+        CREATE TRIGGER IF NOT EXISTS trg_messages_rollup_update
+        AFTER UPDATE ON messages
+        BEGIN
+            INSERT INTO message_rollups_hourly (
+                bucket_start, role, provider, model, repo_id, git_branch,
+                message_count, input_tokens, output_tokens,
+                cache_creation_tokens, cache_read_tokens, cost_cents
+            )
+            VALUES (
+                strftime('%Y-%m-%dT%H:00:00Z', OLD.timestamp),
+                COALESCE(NULLIF(OLD.role, ''), 'assistant'),
+                COALESCE(NULLIF(OLD.provider, ''), 'claude_code'),
+                CASE
+                    WHEN OLD.model IS NULL OR OLD.model = '' OR SUBSTR(OLD.model, 1, 1) = '<'
+                    THEN '(untagged)'
+                    ELSE OLD.model
+                END,
+                COALESCE(NULLIF(NULLIF(OLD.repo_id, ''), 'unknown'), '(untagged)'),
+                COALESCE(
+                    NULLIF(
+                        CASE
+                            WHEN COALESCE(OLD.git_branch, '') LIKE 'refs/heads/%'
+                            THEN SUBSTR(COALESCE(OLD.git_branch, ''), 12)
+                            ELSE COALESCE(OLD.git_branch, '')
+                        END,
+                        ''
+                    ),
+                    '(untagged)'
+                ),
+                -1,
+                -COALESCE(OLD.input_tokens, 0),
+                -COALESCE(OLD.output_tokens, 0),
+                -COALESCE(OLD.cache_creation_tokens, 0),
+                -COALESCE(OLD.cache_read_tokens, 0),
+                -COALESCE(OLD.cost_cents, 0.0)
+            )
+            ON CONFLICT(bucket_start, role, provider, model, repo_id, git_branch) DO UPDATE SET
+                message_count = message_count + excluded.message_count,
+                input_tokens = input_tokens + excluded.input_tokens,
+                output_tokens = output_tokens + excluded.output_tokens,
+                cache_creation_tokens = cache_creation_tokens + excluded.cache_creation_tokens,
+                cache_read_tokens = cache_read_tokens + excluded.cache_read_tokens,
+                cost_cents = cost_cents + excluded.cost_cents;
+
+            DELETE FROM message_rollups_hourly
+             WHERE bucket_start = strftime('%Y-%m-%dT%H:00:00Z', OLD.timestamp)
+               AND role = COALESCE(NULLIF(OLD.role, ''), 'assistant')
+               AND provider = COALESCE(NULLIF(OLD.provider, ''), 'claude_code')
+               AND model = CASE
+                    WHEN OLD.model IS NULL OR OLD.model = '' OR SUBSTR(OLD.model, 1, 1) = '<'
+                    THEN '(untagged)'
+                    ELSE OLD.model
+               END
+               AND repo_id = COALESCE(NULLIF(NULLIF(OLD.repo_id, ''), 'unknown'), '(untagged)')
+               AND git_branch = COALESCE(
+                    NULLIF(
+                        CASE
+                            WHEN COALESCE(OLD.git_branch, '') LIKE 'refs/heads/%'
+                            THEN SUBSTR(COALESCE(OLD.git_branch, ''), 12)
+                            ELSE COALESCE(OLD.git_branch, '')
+                        END,
+                        ''
+                    ),
+                    '(untagged)'
+               )
+               AND message_count <= 0;
+
+            INSERT INTO message_rollups_daily (
+                bucket_day, role, provider, model, repo_id, git_branch,
+                message_count, input_tokens, output_tokens,
+                cache_creation_tokens, cache_read_tokens, cost_cents
+            )
+            VALUES (
+                strftime('%Y-%m-%d', OLD.timestamp),
+                COALESCE(NULLIF(OLD.role, ''), 'assistant'),
+                COALESCE(NULLIF(OLD.provider, ''), 'claude_code'),
+                CASE
+                    WHEN OLD.model IS NULL OR OLD.model = '' OR SUBSTR(OLD.model, 1, 1) = '<'
+                    THEN '(untagged)'
+                    ELSE OLD.model
+                END,
+                COALESCE(NULLIF(NULLIF(OLD.repo_id, ''), 'unknown'), '(untagged)'),
+                COALESCE(
+                    NULLIF(
+                        CASE
+                            WHEN COALESCE(OLD.git_branch, '') LIKE 'refs/heads/%'
+                            THEN SUBSTR(COALESCE(OLD.git_branch, ''), 12)
+                            ELSE COALESCE(OLD.git_branch, '')
+                        END,
+                        ''
+                    ),
+                    '(untagged)'
+                ),
+                -1,
+                -COALESCE(OLD.input_tokens, 0),
+                -COALESCE(OLD.output_tokens, 0),
+                -COALESCE(OLD.cache_creation_tokens, 0),
+                -COALESCE(OLD.cache_read_tokens, 0),
+                -COALESCE(OLD.cost_cents, 0.0)
+            )
+            ON CONFLICT(bucket_day, role, provider, model, repo_id, git_branch) DO UPDATE SET
+                message_count = message_count + excluded.message_count,
+                input_tokens = input_tokens + excluded.input_tokens,
+                output_tokens = output_tokens + excluded.output_tokens,
+                cache_creation_tokens = cache_creation_tokens + excluded.cache_creation_tokens,
+                cache_read_tokens = cache_read_tokens + excluded.cache_read_tokens,
+                cost_cents = cost_cents + excluded.cost_cents;
+
+            DELETE FROM message_rollups_daily
+             WHERE bucket_day = strftime('%Y-%m-%d', OLD.timestamp)
+               AND role = COALESCE(NULLIF(OLD.role, ''), 'assistant')
+               AND provider = COALESCE(NULLIF(OLD.provider, ''), 'claude_code')
+               AND model = CASE
+                    WHEN OLD.model IS NULL OR OLD.model = '' OR SUBSTR(OLD.model, 1, 1) = '<'
+                    THEN '(untagged)'
+                    ELSE OLD.model
+               END
+               AND repo_id = COALESCE(NULLIF(NULLIF(OLD.repo_id, ''), 'unknown'), '(untagged)')
+               AND git_branch = COALESCE(
+                    NULLIF(
+                        CASE
+                            WHEN COALESCE(OLD.git_branch, '') LIKE 'refs/heads/%'
+                            THEN SUBSTR(COALESCE(OLD.git_branch, ''), 12)
+                            ELSE COALESCE(OLD.git_branch, '')
+                        END,
+                        ''
+                    ),
+                    '(untagged)'
+               )
+               AND message_count <= 0;
+
+            INSERT INTO message_rollups_hourly (
+                bucket_start, role, provider, model, repo_id, git_branch,
+                message_count, input_tokens, output_tokens,
+                cache_creation_tokens, cache_read_tokens, cost_cents
+            )
+            VALUES (
+                strftime('%Y-%m-%dT%H:00:00Z', NEW.timestamp),
+                COALESCE(NULLIF(NEW.role, ''), 'assistant'),
+                COALESCE(NULLIF(NEW.provider, ''), 'claude_code'),
+                CASE
+                    WHEN NEW.model IS NULL OR NEW.model = '' OR SUBSTR(NEW.model, 1, 1) = '<'
+                    THEN '(untagged)'
+                    ELSE NEW.model
+                END,
+                COALESCE(NULLIF(NULLIF(NEW.repo_id, ''), 'unknown'), '(untagged)'),
+                COALESCE(
+                    NULLIF(
+                        CASE
+                            WHEN COALESCE(NEW.git_branch, '') LIKE 'refs/heads/%'
+                            THEN SUBSTR(COALESCE(NEW.git_branch, ''), 12)
+                            ELSE COALESCE(NEW.git_branch, '')
+                        END,
+                        ''
+                    ),
+                    '(untagged)'
+                ),
+                1,
+                COALESCE(NEW.input_tokens, 0),
+                COALESCE(NEW.output_tokens, 0),
+                COALESCE(NEW.cache_creation_tokens, 0),
+                COALESCE(NEW.cache_read_tokens, 0),
+                COALESCE(NEW.cost_cents, 0.0)
+            )
+            ON CONFLICT(bucket_start, role, provider, model, repo_id, git_branch) DO UPDATE SET
+                message_count = message_count + excluded.message_count,
+                input_tokens = input_tokens + excluded.input_tokens,
+                output_tokens = output_tokens + excluded.output_tokens,
+                cache_creation_tokens = cache_creation_tokens + excluded.cache_creation_tokens,
+                cache_read_tokens = cache_read_tokens + excluded.cache_read_tokens,
+                cost_cents = cost_cents + excluded.cost_cents;
+
+            INSERT INTO message_rollups_daily (
+                bucket_day, role, provider, model, repo_id, git_branch,
+                message_count, input_tokens, output_tokens,
+                cache_creation_tokens, cache_read_tokens, cost_cents
+            )
+            VALUES (
+                strftime('%Y-%m-%d', NEW.timestamp),
+                COALESCE(NULLIF(NEW.role, ''), 'assistant'),
+                COALESCE(NULLIF(NEW.provider, ''), 'claude_code'),
+                CASE
+                    WHEN NEW.model IS NULL OR NEW.model = '' OR SUBSTR(NEW.model, 1, 1) = '<'
+                    THEN '(untagged)'
+                    ELSE NEW.model
+                END,
+                COALESCE(NULLIF(NULLIF(NEW.repo_id, ''), 'unknown'), '(untagged)'),
+                COALESCE(
+                    NULLIF(
+                        CASE
+                            WHEN COALESCE(NEW.git_branch, '') LIKE 'refs/heads/%'
+                            THEN SUBSTR(COALESCE(NEW.git_branch, ''), 12)
+                            ELSE COALESCE(NEW.git_branch, '')
+                        END,
+                        ''
+                    ),
+                    '(untagged)'
+                ),
+                1,
+                COALESCE(NEW.input_tokens, 0),
+                COALESCE(NEW.output_tokens, 0),
+                COALESCE(NEW.cache_creation_tokens, 0),
+                COALESCE(NEW.cache_read_tokens, 0),
+                COALESCE(NEW.cost_cents, 0.0)
+            )
+            ON CONFLICT(bucket_day, role, provider, model, repo_id, git_branch) DO UPDATE SET
+                message_count = message_count + excluded.message_count,
+                input_tokens = input_tokens + excluded.input_tokens,
+                output_tokens = output_tokens + excluded.output_tokens,
+                cache_creation_tokens = cache_creation_tokens + excluded.cache_creation_tokens,
+                cache_read_tokens = cache_read_tokens + excluded.cache_read_tokens,
+                cost_cents = cost_cents + excluded.cost_cents;
+        END;
+        ",
+    )?;
+    Ok(())
+}
+
+fn backfill_rollup_tables(conn: &Connection) -> Result<()> {
+    conn.execute_batch(
+        "
+        DELETE FROM message_rollups_hourly;
+        DELETE FROM message_rollups_daily;
+
+        WITH normalized AS (
+            SELECT
+                strftime('%Y-%m-%dT%H:00:00Z', timestamp) AS bucket_hour,
+                strftime('%Y-%m-%d', timestamp) AS bucket_day,
+                COALESCE(NULLIF(role, ''), 'assistant') AS role,
+                COALESCE(NULLIF(provider, ''), 'claude_code') AS provider,
+                CASE
+                    WHEN model IS NULL OR model = '' OR SUBSTR(model, 1, 1) = '<' THEN '(untagged)'
+                    ELSE model
+                END AS model,
+                COALESCE(NULLIF(NULLIF(repo_id, ''), 'unknown'), '(untagged)') AS repo_id,
+                COALESCE(
+                    NULLIF(
+                        CASE
+                            WHEN COALESCE(git_branch, '') LIKE 'refs/heads/%'
+                            THEN SUBSTR(COALESCE(git_branch, ''), 12)
+                            ELSE COALESCE(git_branch, '')
+                        END,
+                        ''
+                    ),
+                    '(untagged)'
+                ) AS git_branch,
+                COALESCE(input_tokens, 0) AS input_tokens,
+                COALESCE(output_tokens, 0) AS output_tokens,
+                COALESCE(cache_creation_tokens, 0) AS cache_creation_tokens,
+                COALESCE(cache_read_tokens, 0) AS cache_read_tokens,
+                COALESCE(cost_cents, 0.0) AS cost_cents
+            FROM messages
+        )
+        INSERT INTO message_rollups_hourly (
+            bucket_start, role, provider, model, repo_id, git_branch,
+            message_count, input_tokens, output_tokens,
+            cache_creation_tokens, cache_read_tokens, cost_cents
+        )
+        SELECT
+            bucket_hour, role, provider, model, repo_id, git_branch,
+            COUNT(*) AS message_count,
+            COALESCE(SUM(input_tokens), 0),
+            COALESCE(SUM(output_tokens), 0),
+            COALESCE(SUM(cache_creation_tokens), 0),
+            COALESCE(SUM(cache_read_tokens), 0),
+            COALESCE(SUM(cost_cents), 0.0)
+        FROM normalized
+        GROUP BY bucket_hour, role, provider, model, repo_id, git_branch;
+
+        WITH normalized AS (
+            SELECT
+                strftime('%Y-%m-%d', timestamp) AS bucket_day,
+                COALESCE(NULLIF(role, ''), 'assistant') AS role,
+                COALESCE(NULLIF(provider, ''), 'claude_code') AS provider,
+                CASE
+                    WHEN model IS NULL OR model = '' OR SUBSTR(model, 1, 1) = '<' THEN '(untagged)'
+                    ELSE model
+                END AS model,
+                COALESCE(NULLIF(NULLIF(repo_id, ''), 'unknown'), '(untagged)') AS repo_id,
+                COALESCE(
+                    NULLIF(
+                        CASE
+                            WHEN COALESCE(git_branch, '') LIKE 'refs/heads/%'
+                            THEN SUBSTR(COALESCE(git_branch, ''), 12)
+                            ELSE COALESCE(git_branch, '')
+                        END,
+                        ''
+                    ),
+                    '(untagged)'
+                ) AS git_branch,
+                COALESCE(input_tokens, 0) AS input_tokens,
+                COALESCE(output_tokens, 0) AS output_tokens,
+                COALESCE(cache_creation_tokens, 0) AS cache_creation_tokens,
+                COALESCE(cache_read_tokens, 0) AS cache_read_tokens,
+                COALESCE(cost_cents, 0.0) AS cost_cents
+            FROM messages
+        )
+        INSERT INTO message_rollups_daily (
+            bucket_day, role, provider, model, repo_id, git_branch,
+            message_count, input_tokens, output_tokens,
+            cache_creation_tokens, cache_read_tokens, cost_cents
+        )
+        SELECT
+            bucket_day, role, provider, model, repo_id, git_branch,
+            COUNT(*) AS message_count,
+            COALESCE(SUM(input_tokens), 0),
+            COALESCE(SUM(output_tokens), 0),
+            COALESCE(SUM(cache_creation_tokens), 0),
+            COALESCE(SUM(cache_read_tokens), 0),
+            COALESCE(SUM(cost_cents), 0.0)
+        FROM normalized
+        GROUP BY bucket_day, role, provider, model, repo_id, git_branch;
+        ",
+    )?;
+    Ok(())
+}
+
 fn parse_hook_row_ids(raw_json: Option<&str>) -> (Option<String>, Option<String>) {
     let Some(raw) = raw_json else {
         return (None, None);
@@ -1117,6 +1722,24 @@ fn create_indexes(conn: &Connection) -> Result<()> {
         ))?;
     }
 
+    if table_exists(conn, "message_rollups_hourly")? {
+        conn.execute_batch(
+            "
+            CREATE INDEX IF NOT EXISTS idx_rollups_hourly_bucket ON message_rollups_hourly(bucket_start);
+            CREATE INDEX IF NOT EXISTS idx_rollups_hourly_dims ON message_rollups_hourly(provider, model, repo_id, git_branch, role);
+            ",
+        )?;
+    }
+
+    if table_exists(conn, "message_rollups_daily")? {
+        conn.execute_batch(
+            "
+            CREATE INDEX IF NOT EXISTS idx_rollups_daily_bucket ON message_rollups_daily(bucket_day);
+            CREATE INDEX IF NOT EXISTS idx_rollups_daily_dims ON message_rollups_daily(provider, model, repo_id, git_branch, role);
+            ",
+        )?;
+    }
+
     Ok(())
 }
 
@@ -1161,6 +1784,15 @@ struct SchemaReconcileReport {
 fn index_exists(conn: &Connection, name: &str) -> Result<bool> {
     let exists: bool = conn.query_row(
         "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type='index' AND name = ?1)",
+        [name],
+        |row| row.get(0),
+    )?;
+    Ok(exists)
+}
+
+fn trigger_exists(conn: &Connection, name: &str) -> Result<bool> {
+    let exists: bool = conn.query_row(
+        "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type='trigger' AND name = ?1)",
         [name],
         |row| row.get(0),
     )?;
@@ -1230,6 +1862,16 @@ fn expected_reconcile_indexes(conn: &Connection) -> Result<Vec<String>> {
     if table_exists(conn, "messages")? && table_exists(conn, "tags")? {
         indexes.push("idx_message_tags_pair".to_string());
         indexes.push("idx_messages_primary_id".to_string());
+    }
+
+    if table_exists(conn, "message_rollups_hourly")? {
+        indexes.push("idx_rollups_hourly_bucket".to_string());
+        indexes.push("idx_rollups_hourly_dims".to_string());
+    }
+
+    if table_exists(conn, "message_rollups_daily")? {
+        indexes.push("idx_rollups_daily_bucket".to_string());
+        indexes.push("idx_rollups_daily_dims".to_string());
     }
 
     Ok(indexes)
@@ -1357,6 +1999,35 @@ fn reconcile_schema(conn: &Connection) -> Result<SchemaReconcileReport> {
         "cost_cents_computed REAL",
     )? {
         added_columns.push("otel_events.cost_cents_computed".to_string());
+    }
+
+    let has_hourly_rollups = table_exists(conn, "message_rollups_hourly")?;
+    let has_daily_rollups = table_exists(conn, "message_rollups_daily")?;
+    let has_rollup_insert_trigger = trigger_exists(conn, "trg_messages_rollup_insert")?;
+    let has_rollup_delete_trigger = trigger_exists(conn, "trg_messages_rollup_delete")?;
+    let has_rollup_update_trigger = trigger_exists(conn, "trg_messages_rollup_update")?;
+    let needs_rollup_repair = !has_hourly_rollups
+        || !has_daily_rollups
+        || !has_rollup_insert_trigger
+        || !has_rollup_delete_trigger
+        || !has_rollup_update_trigger;
+    if needs_rollup_repair {
+        ensure_rollup_schema(conn, true)?;
+        if !has_hourly_rollups {
+            added_columns.push("message_rollups_hourly".to_string());
+        }
+        if !has_daily_rollups {
+            added_columns.push("message_rollups_daily".to_string());
+        }
+        if !has_rollup_insert_trigger {
+            added_columns.push("trg_messages_rollup_insert".to_string());
+        }
+        if !has_rollup_delete_trigger {
+            added_columns.push("trg_messages_rollup_delete".to_string());
+        }
+        if !has_rollup_update_trigger {
+            added_columns.push("trg_messages_rollup_update".to_string());
+        }
     }
 
     let added_indexes = missing_reconcile_indexes(conn)?;
@@ -2038,6 +2709,9 @@ mod tests {
         migrate_v19_to_v20(&conn).unwrap();
         assert_eq!(current_version(&conn), 20, "v19→v20 must set version to 20");
 
+        migrate_v20_to_v21(&conn).unwrap();
+        assert_eq!(current_version(&conn), 21, "v20→v21 must set version to 21");
+
         assert_eq!(current_version(&conn), SCHEMA_VERSION);
     }
 
@@ -2609,5 +3283,79 @@ mod tests {
         assert_eq!(kept_message_id, "msg-v19");
         assert_eq!(kept_session_id, "sess-v19");
         assert_eq!(kept_tag_message_id, "msg-v19");
+    }
+
+    #[test]
+    fn migrate_v20_to_v21_builds_rollups_from_existing_messages() {
+        let conn = Connection::open_in_memory().unwrap();
+        migrate(&conn).unwrap();
+
+        conn.execute_batch(
+            "
+            DROP TRIGGER IF EXISTS trg_messages_rollup_insert;
+            DROP TRIGGER IF EXISTS trg_messages_rollup_delete;
+            DROP TRIGGER IF EXISTS trg_messages_rollup_update;
+            DROP TABLE IF EXISTS message_rollups_hourly;
+            DROP TABLE IF EXISTS message_rollups_daily;
+            ",
+        )
+        .unwrap();
+        conn.pragma_update(None, "user_version", 20u32).unwrap();
+
+        conn.execute(
+            "INSERT INTO sessions (id, provider, started_at)
+             VALUES ('sess-v20', 'claude_code', '2026-04-02T10:00:00Z')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO messages (id, session_id, role, timestamp, model, provider, repo_id, git_branch, input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens, cost_cents, cost_confidence)
+             VALUES ('msg-v20', 'sess-v20', 'assistant', '2026-04-02T10:10:00Z', 'claude-sonnet-4-6', 'claude_code', 'github.com/acme/repo', 'refs/heads/main', 100, 40, 0, 0, 1.25, 'estimated')",
+            [],
+        )
+        .unwrap();
+
+        migrate(&conn).unwrap();
+        assert_eq!(current_version(&conn), SCHEMA_VERSION);
+
+        let hourly_rows: i64 = conn
+            .query_row("SELECT COUNT(*) FROM message_rollups_hourly", [], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        let daily_rows: i64 = conn
+            .query_row("SELECT COUNT(*) FROM message_rollups_daily", [], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        assert!(hourly_rows > 0);
+        assert!(daily_rows > 0);
+
+        let assistant_rollup_count: i64 = conn
+            .query_row(
+                "SELECT COALESCE(SUM(message_count), 0) FROM message_rollups_hourly WHERE role = 'assistant'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(assistant_rollup_count, 1);
+    }
+
+    #[test]
+    fn repair_recreates_missing_rollup_triggers() {
+        let conn = Connection::open_in_memory().unwrap();
+        migrate(&conn).unwrap();
+
+        conn.execute_batch("DROP TRIGGER IF EXISTS trg_messages_rollup_update;")
+            .unwrap();
+        assert!(!trigger_exists(&conn, "trg_messages_rollup_update").unwrap());
+
+        let report = repair(&conn).unwrap();
+        assert!(trigger_exists(&conn, "trg_messages_rollup_update").unwrap());
+        assert!(
+            report
+                .added_columns
+                .contains(&"trg_messages_rollup_update".to_string())
+        );
     }
 }


### PR DESCRIPTION
## Summary
- add schema v21 with derived `message_rollups_hourly` and `message_rollups_daily` tables
- maintain rollups incrementally via SQLite triggers on `messages` insert/update/delete, with migration backfill for existing data
- route hot analytics aggregates (summary, projects, models, providers, activity, filter options, statusline cost windows) through rollups when time ranges are rollup-safe, with fallback to raw `messages` for non-hour-aligned ranges
- preserve repo display-path behavior while using rollup-backed ranking
- add migration/tests coverage for rollup schema, trigger repair, rollup correctness, rollup path selection, and latency smoke
- document source-of-truth (`messages`) vs derived rollup behavior in README/SOUL

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`

Closes #16