### PR TITLE
[codex] Clarify identity tag taxonomy for platform, machine, and git user

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,13 @@ All data commands support `--period today|week|month|all` and `--format json`.
 
 ## Tags & cost attribution
 
-Every message is automatically tagged with: `provider`, `model`, `ticket_id`, `ticket_prefix`, `activity`, `composer_mode`, `permission_mode`, `duration`, `tool`, `user_email`.
+Every message is automatically tagged with: `provider`, `model`, `ticket_id`, `ticket_prefix`, `activity`, `composer_mode`, `permission_mode`, `duration`, `tool`, `user_email`, `platform`, `machine`, `user`, `git_user`.
+
+Identity tag semantics:
+- `platform`: OS platform (`macos`, `linux`, `windows`)
+- `machine`: host/machine name
+- `user`: local OS username
+- `git_user`: Git identity (`user.name`/`user.email` fallback)
 
 `repo_id` and `git_branch` are stored as canonical message/session fields (not tags), so repo/branch analytics stay single-source and do not double-count.
 

--- a/crates/budi-core/src/analytics/tests.rs
+++ b/crates/budi-core/src/analytics/tests.rs
@@ -2426,6 +2426,37 @@ fn session_tags_filter_internal_linkage_and_redundant_keys() {
 }
 
 #[test]
+fn session_tags_include_explicit_identity_keys() {
+    let mut conn = test_db();
+    let msg = assistant_msg("st-identity-1", "sess-tags-identity", 1.0);
+    let tags = vec![vec![
+        Tag {
+            key: "platform".to_string(),
+            value: "macos".to_string(),
+        },
+        Tag {
+            key: "machine".to_string(),
+            value: "workstation-01".to_string(),
+        },
+        Tag {
+            key: "user".to_string(),
+            value: "local-user".to_string(),
+        },
+        Tag {
+            key: "git_user".to_string(),
+            value: "Alice Dev".to_string(),
+        },
+    ]];
+    ingest_messages(&mut conn, &[msg], Some(&tags)).unwrap();
+
+    let result = session_tags(&conn, "sess-tags-identity").unwrap();
+    assert!(result.contains(&("platform".to_string(), "macos".to_string())));
+    assert!(result.contains(&("machine".to_string(), "workstation-01".to_string())));
+    assert!(result.contains(&("user".to_string(), "local-user".to_string())));
+    assert!(result.contains(&("git_user".to_string(), "Alice Dev".to_string())));
+}
+
+#[test]
 fn session_tags_does_not_alias_prefixed_session_id() {
     let mut conn = test_db();
     let canonical = "d99dfe22-d05c-4c78-8698-015d06e5dabb";

--- a/crates/budi-core/src/pipeline/enrichers.rs
+++ b/crates/budi-core/src/pipeline/enrichers.rs
@@ -116,12 +116,14 @@ impl Enricher for ToolEnricher {
 }
 
 // ---------------------------------------------------------------------------
-// IdentityEnricher — sets user_name and machine_name
+// IdentityEnricher — emits explicit local identity tags
 // ---------------------------------------------------------------------------
 
 pub struct IdentityEnricher {
     user_name: String,
     machine_name: String,
+    platform: String,
+    git_user: String,
 }
 
 impl Default for IdentityEnricher {
@@ -136,9 +138,13 @@ impl IdentityEnricher {
             .or_else(|_| std::env::var("USERNAME"))
             .unwrap_or_default();
         let machine_name = get_hostname();
+        let platform = std::env::consts::OS.to_string();
+        let git_user = get_git_user_identity();
         Self {
             user_name,
             machine_name,
+            platform,
+            git_user,
         }
     }
 }
@@ -171,6 +177,38 @@ fn get_hostname() -> String {
         .unwrap_or_default()
 }
 
+fn read_git_config(args: &[&str]) -> Option<String> {
+    std::process::Command::new("git")
+        .args(args)
+        .output()
+        .ok()
+        .and_then(|output| {
+            if output.status.success() {
+                let value = String::from_utf8_lossy(&output.stdout).trim().to_string();
+                if value.is_empty() { None } else { Some(value) }
+            } else {
+                None
+            }
+        })
+}
+
+fn non_empty_env(var_name: &str) -> Option<String> {
+    std::env::var(var_name)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn get_git_user_identity() -> String {
+    non_empty_env("GIT_AUTHOR_NAME")
+        .or_else(|| read_git_config(&["config", "--get", "user.name"]))
+        .or_else(|| read_git_config(&["config", "--global", "--get", "user.name"]))
+        .or_else(|| non_empty_env("GIT_AUTHOR_EMAIL"))
+        .or_else(|| read_git_config(&["config", "--get", "user.email"]))
+        .or_else(|| read_git_config(&["config", "--global", "--get", "user.email"]))
+        .unwrap_or_default()
+}
+
 impl Enricher for IdentityEnricher {
     fn enrich(&mut self, msg: &mut ParsedMessage) -> Vec<Tag> {
         let mut tags = Vec::new();
@@ -187,6 +225,18 @@ impl Enricher for IdentityEnricher {
             tags.push(Tag {
                 key: tk::MACHINE.to_string(),
                 value: machine.to_string(),
+            });
+        }
+        if !self.platform.is_empty() {
+            tags.push(Tag {
+                key: tk::PLATFORM.to_string(),
+                value: self.platform.clone(),
+            });
+        }
+        if !self.git_user.is_empty() {
+            tags.push(Tag {
+                key: tk::GIT_USER.to_string(),
+                value: self.git_user.clone(),
             });
         }
 
@@ -430,13 +480,48 @@ mod tests {
         let mut enricher = IdentityEnricher::new();
         let mut msg = test_msg();
         let tags = enricher.enrich(&mut msg);
-        // Should produce user and machine tags (values depend on environment)
+        // Should produce identity tags (values depend on environment)
         if !enricher.user_name.is_empty() {
             assert!(tags.iter().any(|t| t.key == "user"));
         }
         if !enricher.machine_name.is_empty() {
             assert!(tags.iter().any(|t| t.key == "machine"));
         }
+        if !enricher.platform.is_empty() {
+            assert!(tags.iter().any(|t| t.key == "platform"));
+        }
+        if !enricher.git_user.is_empty() {
+            assert!(tags.iter().any(|t| t.key == "git_user"));
+        }
+    }
+
+    #[test]
+    fn identity_enricher_emits_explicit_platform_machine_and_git_user() {
+        let mut enricher = IdentityEnricher {
+            user_name: "local-user".to_string(),
+            machine_name: "workstation-01".to_string(),
+            platform: "macos".to_string(),
+            git_user: "Alice Dev".to_string(),
+        };
+        let mut msg = test_msg();
+        let tags = enricher.enrich(&mut msg);
+
+        assert!(
+            tags.iter()
+                .any(|t| t.key == "user" && t.value == "local-user")
+        );
+        assert!(
+            tags.iter()
+                .any(|t| t.key == "machine" && t.value == "workstation-01")
+        );
+        assert!(
+            tags.iter()
+                .any(|t| t.key == "platform" && t.value == "macos")
+        );
+        assert!(
+            tags.iter()
+                .any(|t| t.key == "git_user" && t.value == "Alice Dev")
+        );
     }
 
     #[test]

--- a/crates/budi-core/src/pipeline/mod.rs
+++ b/crates/budi-core/src/pipeline/mod.rs
@@ -28,7 +28,7 @@ impl Pipeline {
     ) -> Self {
         // Enricher order is critical — do not reorder without understanding dependencies:
         //   1. HookEnricher  — populates session-level metadata (composer_mode, etc.)
-        //   2. IdentityEnricher — populates user/machine tags
+        //   2. IdentityEnricher — populates local identity tags (user/platform/machine/git_user)
         //   3. GitEnricher   — sets repo_id for glob_match (MUST run before TagEnricher)
         //   4. ToolEnricher  — emits per-message tool tags from parsed tool calls
         //   5. CostEnricher  — calculates cost_cents and cost_confidence
@@ -48,7 +48,7 @@ impl Pipeline {
     /// Returns a parallel Vec of tags for each message.
     ///
     /// Two kinds of tags:
-    /// - **Identity tags** (user, machine, composer_mode, …): constant for the
+    /// - **Identity tags** (user, platform, machine, git_user, composer_mode, …): constant for the
     ///   whole session → deduplicated, emitted once on the first assistant msg.
     /// - **Context tags** (ticket_id, activity, tool, …): can change mid-session
     ///   → emitted on every assistant message so cost attribution is accurate.
@@ -459,7 +459,7 @@ mod tests {
             );
         }
 
-        // Identity tags (user, machine) should appear only once across all messages.
+        // Identity tags should appear only once across all messages.
         let all_user_tags: Vec<_> = all_tags
             .iter()
             .flat_map(|t| t.iter())

--- a/crates/budi-core/src/tag_keys.rs
+++ b/crates/budi-core/src/tag_keys.rs
@@ -8,6 +8,8 @@ pub const TICKET_ID: &str = "ticket_id";
 pub const TICKET_PREFIX: &str = "ticket_prefix";
 pub const USER: &str = "user";
 pub const MACHINE: &str = "machine";
+pub const PLATFORM: &str = "platform";
+pub const GIT_USER: &str = "git_user";
 pub const SESSION_TITLE: &str = "session_title";
 pub const PROVIDER: &str = "provider";
 pub const MODEL: &str = "model";
@@ -26,6 +28,8 @@ pub const TOOL_USE_ID: &str = "tool_use_id";
 pub const SESSION_IDENTITY_KEYS: &[&str] = &[
     USER,
     MACHINE,
+    PLATFORM,
+    GIT_USER,
     USER_EMAIL,
     COMPOSER_MODE,
     PERMISSION_MODE,


### PR DESCRIPTION
## Summary
- add explicit identity tags in the pipeline: `platform` (OS), `machine` (host name), `user` (local OS user), and `git_user` (git identity)
- keep identity tags deduplicated at session scope by extending `SESSION_IDENTITY_KEYS`
- add regression coverage for identity taxonomy in both enricher tests and analytics session tag tests
- document the updated tag taxonomy and semantics in the README

## Why
`machine` alone was ambiguous (platform vs host identity), and there was no separate git identity tag. This change makes platform vs machine semantics explicit and adds git user attribution while preserving existing behavior.

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- post-sync parity rerun:
  - `cargo clippy --workspace --all-targets --locked -- -D warnings`
  - `cargo test --workspace --locked`

Closes #29
