### PR TITLE
Review #57: harden Cursor ingestion sources and adapter resilience

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ budi targets **macOS**, **Linux** (glibc), and **Windows 10+**. Prebuilt release
 | Agent | Status | How |
 |-------|--------|-----|
 | **Claude Code** | Supported | OpenTelemetry (exact cost) + JSONL transcripts + hooks |
-| **Cursor** | Supported | Usage API + hooks |
+| **Cursor** | Supported | Usage API + hooks (local transcript fallback when API/auth unavailable) |
 | **Copilot CLI, Codex CLI, Cline, Aider, Gemini CLI** | Planned | |
 
 ## Contributing
@@ -389,7 +389,7 @@ A lightweight Rust daemon (port 7878) receives real-time OpenTelemetry events, s
   └── OTLP HTTP/JSON ──▶ POST /v1/logs (auto-configured)
 ```
 
-The daemon is the single source of truth — the CLI never opens the database directly. Realtime hooks/OTEL payloads are written to a durable local queue first, then drained into analytics in bounded retries. Each message row is enriched from multiple sources: OTEL provides exact cost, JSONL provides context (parent messages, working directory), and hooks provide session metadata (repo, branch, user).
+The daemon is the single source of truth — the CLI never opens the database directly. Realtime hooks/OTEL payloads are written to a durable local queue first, then drained into analytics in bounded retries. Each message row is enriched from multiple sources: OTEL provides exact cost, JSONL provides context (parent messages, working directory), and hooks provide session metadata (repo, branch, user). For Cursor, Usage API sync is primary, with local transcript parsing as a fallback when API auth/network is unavailable.
 
 **Data model** — eight tables, six data entities + two supporting:
 

--- a/SOUL.md
+++ b/SOUL.md
@@ -93,7 +93,7 @@ OTEL and JSONL deduplicate: same API call matched by session_id + model + timest
 - `crates/budi-core/src/otel.rs` - OTLP JSON parsing, OTEL->JSONL dedup
 - `crates/budi-core/src/jsonl.rs` - JSONL transcript parser, ParsedMessage struct
 - `crates/budi-core/src/providers/claude_code.rs` - Claude Code provider (JSONL discovery, pricing)
-- `crates/budi-core/src/providers/cursor.rs` - Cursor provider (Usage API, auth from state.vscdb)
+- `crates/budi-core/src/providers/cursor.rs` - Cursor provider (Usage API primary, transcript fallback; auth/session context from state.vscdb across macOS/Linux/Windows layouts)
 - `crates/budi-core/src/migration.rs` - Schema v20, all migration paths
 - `crates/budi-core/src/config.rs` - BudiConfig, StatuslineConfig, TagsConfig
 - `crates/budi-cli/build.rs` - Build script: creates empty vsix placeholder if not pre-built

--- a/crates/budi-core/src/providers/cursor.rs
+++ b/crates/budi-core/src/providers/cursor.rs
@@ -91,35 +91,50 @@ impl Provider for CursorProvider {
 // ---------------------------------------------------------------------------
 
 /// Returns all state.vscdb paths found on the system: globalStorage and
-/// every workspace under workspaceStorage, for both macOS and Linux.
+/// every workspace under workspaceStorage, across macOS/Linux/Windows layouts.
 fn all_state_vscdb_paths() -> Vec<PathBuf> {
-    let mut paths = Vec::new();
+    let mut paths: Vec<PathBuf> = Vec::new();
     let home = match crate::config::home_dir() {
         Ok(h) => h,
         Err(_) => return paths,
     };
+    let appdata = std::env::var_os("APPDATA").map(PathBuf::from);
 
-    // macOS globalStorage
-    let mac_global = home.join("Library/Application Support/Cursor/User/globalStorage/state.vscdb");
-    if mac_global.exists() {
-        paths.push(mac_global);
+    for root in cursor_user_state_roots(&home, appdata.as_deref()) {
+        let global = root.join("globalStorage/state.vscdb");
+        if global.exists() {
+            push_unique_path(&mut paths, global);
+        }
+
+        let ws_dir = root.join("workspaceStorage");
+        scan_workspace_dbs(&ws_dir, &mut paths);
     }
-
-    // Linux globalStorage
-    let linux_global = home.join(".config/Cursor/User/globalStorage/state.vscdb");
-    if linux_global.exists() {
-        paths.push(linux_global);
-    }
-
-    // macOS workspaceStorage
-    let mac_ws = home.join("Library/Application Support/Cursor/User/workspaceStorage");
-    scan_workspace_dbs(&mac_ws, &mut paths);
-
-    // Linux workspaceStorage
-    let linux_ws = home.join(".config/Cursor/User/workspaceStorage");
-    scan_workspace_dbs(&linux_ws, &mut paths);
 
     paths
+}
+
+fn push_unique_path(paths: &mut Vec<PathBuf>, candidate: PathBuf) {
+    if !paths.iter().any(|p| p == &candidate) {
+        paths.push(candidate);
+    }
+}
+
+/// Cursor stores state.vscdb under OS-specific "User" roots:
+/// - macOS: ~/Library/Application Support/Cursor/User
+/// - Linux: ~/.config/Cursor/User
+/// - Windows: %APPDATA%/Cursor/User (or ~/AppData/Roaming/Cursor/User fallback)
+fn cursor_user_state_roots(home: &Path, appdata: Option<&Path>) -> Vec<PathBuf> {
+    let mut roots = Vec::new();
+    push_unique_path(
+        &mut roots,
+        home.join("Library/Application Support/Cursor/User"),
+    );
+    push_unique_path(&mut roots, home.join(".config/Cursor/User"));
+    push_unique_path(&mut roots, home.join("AppData/Roaming/Cursor/User"));
+    if let Some(appdata_dir) = appdata {
+        push_unique_path(&mut roots, appdata_dir.join("Cursor/User"));
+    }
+    roots
 }
 
 /// Scan a workspaceStorage directory for `*/state.vscdb` files.
@@ -130,7 +145,7 @@ fn scan_workspace_dbs(ws_dir: &Path, paths: &mut Vec<PathBuf>) {
     for entry in entries.flatten() {
         let db = entry.path().join("state.vscdb");
         if db.exists() {
-            paths.push(db);
+            push_unique_path(paths, db);
         }
     }
 }
@@ -271,14 +286,21 @@ fn extract_cursor_auth() -> Option<CursorAuth> {
     Some(CursorAuth { user_id, jwt })
 }
 
+fn parse_timestamp_ms(value: &Value) -> Option<i64> {
+    let ts = match value {
+        Value::String(s) => s.trim().parse::<i64>().ok(),
+        Value::Number(n) => n
+            .as_i64()
+            .or_else(|| n.as_u64().and_then(|u| i64::try_from(u).ok())),
+        _ => None,
+    }?;
+    (ts > 0).then_some(ts)
+}
+
 /// Parse a single usage event JSON value into a CursorUsageEvent.
 /// Returns None if the event should be skipped.
 fn parse_usage_event(ev: &Value) -> Option<CursorUsageEvent> {
-    let ts: i64 = ev
-        .get("timestamp")
-        .and_then(|v| v.as_str())
-        .and_then(|s| s.parse().ok())
-        .filter(|&t: &i64| t > 0)?;
+    let ts: i64 = ev.get("timestamp").and_then(parse_timestamp_ms)?;
 
     let model = ev
         .get("model")
@@ -357,10 +379,7 @@ fn parse_usage_event(ev: &Value) -> Option<CursorUsageEvent> {
 
 /// Extract usage-event timestamp in milliseconds from raw API JSON.
 fn usage_event_timestamp_ms(ev: &Value) -> Option<i64> {
-    ev.get("timestamp")
-        .and_then(|v| v.as_str())
-        .and_then(|s| s.parse::<i64>().ok())
-        .filter(|&ts| ts > 0)
+    ev.get("timestamp").and_then(parse_timestamp_ms)
 }
 
 struct UsageFetchResult {
@@ -2047,12 +2066,57 @@ mod tests {
         })
     }
 
+    fn usage_event_json_numeric(ts_ms: i64) -> Value {
+        serde_json::json!({
+            "timestamp": ts_ms,
+            "model": "composer-2-fast",
+            "tokenUsage": {
+                "inputTokens": 10,
+                "outputTokens": 5,
+                "cacheWriteTokens": 0,
+                "cacheReadTokens": 0,
+                "totalCents": 0.2
+            }
+        })
+    }
+
+    #[test]
+    fn parse_usage_event_accepts_numeric_timestamp() {
+        let ev = usage_event_json_numeric(1_774_455_909_363);
+        let parsed = parse_usage_event(&ev).expect("numeric timestamp should be accepted");
+        assert_eq!(parsed.timestamp_ms, 1_774_455_909_363);
+        assert_eq!(parsed.model, "composer-2-fast");
+    }
+
     #[test]
     fn quick_sync_paginates_until_existing_watermark() {
         // 200 new events after watermark=1000, spread across two full pages.
         let page1: Vec<Value> = (1101..=1200).rev().map(usage_event_json).collect();
         let page2: Vec<Value> = (1001..=1100).rev().map(usage_event_json).collect();
         let page3: Vec<Value> = (901..=1000).rev().map(usage_event_json).collect();
+        let pages = [page1, page2, page3];
+
+        let fetched = fetch_usage_events_with_page_loader(Some(1000), false, |page| {
+            Ok(pages
+                .get((page.saturating_sub(1)) as usize)
+                .cloned()
+                .unwrap_or_default())
+        })
+        .unwrap();
+
+        assert_eq!(fetched.pages_fetched, 3);
+        assert_eq!(fetched.events.len(), 200);
+        assert_eq!(fetched.events.first().map(|e| e.timestamp_ms), Some(1001));
+        assert_eq!(fetched.events.last().map(|e| e.timestamp_ms), Some(1200));
+    }
+
+    #[test]
+    fn quick_sync_handles_numeric_timestamps() {
+        // Cursor has shipped timestamp as both JSON string and number.
+        // Numeric timestamps must still drive watermark pagination + parsing.
+        let page1: Vec<Value> = (1101..=1200).rev().map(usage_event_json_numeric).collect();
+        let page2: Vec<Value> = (1001..=1100).rev().map(usage_event_json_numeric).collect();
+        let page3: Vec<Value> = (901..=1000).rev().map(usage_event_json_numeric).collect();
         let pages = [page1, page2, page3];
 
         let fetched = fetch_usage_events_with_page_loader(Some(1000), false, |page| {
@@ -2087,5 +2151,23 @@ mod tests {
         assert_eq!(fetched.events.len(), 100);
         assert_eq!(fetched.events.first().map(|e| e.timestamp_ms), Some(1101));
         assert_eq!(fetched.events.last().map(|e| e.timestamp_ms), Some(1200));
+    }
+
+    #[test]
+    fn cursor_user_state_roots_include_windows_variants_without_duplicates() {
+        let home = Path::new("/tmp/home");
+        let appdata = home.join("AppData/Roaming");
+        let roots = cursor_user_state_roots(home, Some(appdata.as_path()));
+
+        assert!(roots.contains(&home.join("Library/Application Support/Cursor/User")));
+        assert!(roots.contains(&home.join(".config/Cursor/User")));
+        assert!(roots.contains(&home.join("AppData/Roaming/Cursor/User")));
+        assert_eq!(
+            roots
+                .iter()
+                .filter(|p| *p == &home.join("AppData/Roaming/Cursor/User"))
+                .count(),
+            1
+        );
     }
 }

--- a/docs/reviews/issue-57-ingestion-provider-review.md
+++ b/docs/reviews/issue-57-ingestion-provider-review.md
@@ -1,0 +1,39 @@
+# Issue #57 Review: Ingestion Sources and Provider Adapters
+
+## Findings (highest severity first)
+
+### P1 (fixed): Cursor API events with numeric timestamps were silently dropped, and quick-sync pagination could stop early
+- Area: `crates/budi-core/src/providers/cursor.rs`
+- Risk: `parse_usage_event` and watermark checks only accepted string `timestamp`, so numeric `timestamp` values were treated as invalid. In quick-sync mode this can also incorrectly mark a page as "all below watermark", stopping pagination early.
+- Reproduction note: feed `fetch_usage_events_with_page_loader(Some(1000), false, ...)` pages whose events use numeric timestamps (`"timestamp": 1200` as JSON number). Before fix, parsing produced no new events and pagination could terminate after page 1.
+- Fix in this PR: accept both string and numeric timestamp encodings in one shared parser (`parse_timestamp_ms`) used by both event parsing and watermark/page-stop checks.
+
+### P2 (fixed): Cursor state DB discovery missed Windows user-data layout
+- Area: `crates/budi-core/src/providers/cursor.rs`
+- Risk: provider discovery and auth extraction only checked macOS/Linux paths. On Windows, `%APPDATA%\\Cursor\\User\\...` is a primary location; missing it can disable Cursor API ingestion and force degraded fallback behavior.
+- Reproduction note: install Cursor on Windows with only `%APPDATA%\\Cursor\\User\\globalStorage\\state.vscdb` present. Prior lookup logic does not discover this DB.
+- Fix in this PR: unify user-state root discovery to include macOS/Linux and Windows (`%APPDATA%` + `~/AppData/Roaming` fallback), and de-duplicate discovered paths.
+
+## Risky edge cases reviewed
+
+- Malformed queued payloads are retried with backoff and eventually dead-lettered after `MAX_ATTEMPTS` (covered by existing queue tests).
+- OTEL↔JSONL dedup has explicit ambiguity guards; ambiguous matches avoid unsafe merges and log warnings.
+- Cursor API outages and expired auth degrade to transcript fallback instead of hard failure.
+
+## Test coverage added
+
+- `parse_usage_event_accepts_numeric_timestamp`
+- `quick_sync_handles_numeric_timestamps`
+- `cursor_user_state_roots_include_windows_variants_without_duplicates`
+
+## Documentation drift fixed
+
+- Updated `README.md` Cursor support summary to mention transcript fallback behavior.
+- Updated architecture text in `README.md` to describe Cursor source-of-truth fallback path.
+- Updated `SOUL.md` Cursor provider description to reflect cross-platform state DB lookup and fallback semantics.
+
+## Follow-up candidates (not in this PR)
+
+- Emit an explicit integration-health warning when Cursor auth lookup fails due unreadable/locked `state.vscdb`, not just silent fallback.
+- Add coverage for mixed timestamp encodings within the same Cursor API page (string + number + malformed) to assert ordering and watermark behavior remain stable.
+- Consider broadening transcript discovery depth (currently shallow under `agent-transcripts`) for non-standard Cursor storage layouts.


### PR DESCRIPTION
## What I reviewed
- Cursor provider ingestion surface (`state.vscdb` discovery, Usage API parsing/watermark pagination)
- Source fallback behavior between Cursor Usage API and local transcript parsing
- Ingestion/replay edge cases and docs alignment for provider adapters

## What I changed
- Hardened Cursor `state.vscdb` discovery to include Windows user-data layouts (`%APPDATA%/Cursor/User` and `~/AppData/Roaming/Cursor/User` fallback), with path de-duplication.
- Fixed Cursor Usage API timestamp parsing to accept both string and numeric timestamp encodings via shared parser logic used by both event parsing and watermark pagination checks.
- Added regression tests:
  - `parse_usage_event_accepts_numeric_timestamp`
  - `quick_sync_handles_numeric_timestamps`
  - `cursor_user_state_roots_include_windows_variants_without_duplicates`
- Added review artifact: `docs/reviews/issue-57-ingestion-provider-review.md` (findings-first summary + risks/test/doc gaps).
- Updated docs for ingestion-source behavior:
  - `README.md` (Cursor support row + architecture fallback note)
  - `SOUL.md` (Cursor provider source/fallback description)

## Notable findings or risks
- Before this patch, numeric Cursor API timestamps could be dropped and quick-sync could stop pagination early under a watermark, causing missed events.
- Before this patch, Cursor auth/session context discovery could miss Windows `state.vscdb` locations despite Windows support claims.

## Validation performed
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`

## Remaining follow-ups
- Add explicit health/integration warnings when `state.vscdb` is unreadable/locked (today this silently falls back).
- Add mixed-encoding timestamp tests (string + number + malformed in one page) to assert ordering/watermark stability.
- Consider deeper transcript discovery for non-standard nested `agent-transcripts` layouts.

Closes #57
