### PR TITLE
review(#58): fix activity propagation and pipeline/tag docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,8 +133,8 @@ Issue templates are available in the repository to keep reports actionable.
 
 1. Create a struct implementing `pipeline::Enricher` in `crates/budi-core/src/pipeline/enrichers.rs`
 2. `enrich(&mut self, msg: &mut ParsedMessage) -> Vec<Tag>` - mutate the message and/or return tags
-3. Register in `Pipeline::new()` in `crates/budi-core/src/pipeline/mod.rs`
-4. Enricher order matters: Hook -> Identity -> Git -> Cost -> Tag
+3. Register in `Pipeline::default_pipeline()` in `crates/budi-core/src/pipeline/mod.rs`
+4. Enricher order matters: Hook -> Identity -> Git -> Tool -> Cost -> Tag
 
 ## Testing MCP server
 

--- a/README.md
+++ b/README.md
@@ -246,7 +246,11 @@ All data commands support `--period today|week|month|all` and `--format json`.
 
 ## Tags & cost attribution
 
-Every message is automatically tagged with: `provider`, `model`, `ticket_id`, `ticket_prefix`, `activity`, `composer_mode`, `permission_mode`, `duration`, `tool`, `user_email`, `platform`, `machine`, `user`, `git_user`.
+Assistant messages are tagged with core attribution keys: `provider`, `model`, `ticket_id`, `ticket_prefix`, `activity`, `composer_mode`, `permission_mode`, `duration`, `tool`, `tool_use_id`, `user_email`, `platform`, `machine`, `user`, `git_user`.
+
+Conditional tags:
+- `cost_confidence` is added when `cost_cents` is present.
+- `speed` is added only for non-`standard` speed modes.
 
 Identity tag semantics:
 - `platform`: OS platform (`macos`, `linux`, `windows`)

--- a/SOUL.md
+++ b/SOUL.md
@@ -43,7 +43,7 @@ macOS and Linux use the Unix daemon startup path (`lsof`, `ps`, `kill`) to repla
 ```
 Sources (JSONL files, OTEL spans, Cursor API, Hooks)
   -> Providers discover + parse -> ParsedMessage structs
-  -> Pipeline: HookEnricher -> IdentityEnricher -> GitEnricher -> CostEnricher -> TagEnricher
+  -> Pipeline: HookEnricher -> IdentityEnricher -> GitEnricher -> ToolEnricher -> CostEnricher -> TagEnricher
   -> SQLite (messages + tags + derived rollup tables)
   -> Dashboard / CLI stats / Statusline
 ```
@@ -87,7 +87,7 @@ OTEL and JSONL deduplicate: same API call matched by session_id + model + timest
 - `crates/budi-core/src/analytics/health.rs` - Session health vitals, ProviderKind-aware tips, overall-state logic
 - `crates/budi-core/src/analytics/tests.rs` - Analytics + session health unit tests
 - `crates/budi-core/src/pipeline/mod.rs` - Pipeline struct, Enricher trait, default_pipeline()
-- `crates/budi-core/src/pipeline/enrichers.rs` - All 5 enricher implementations
+- `crates/budi-core/src/pipeline/enrichers.rs` - All 6 enricher implementations
 - `crates/budi-core/src/cost.rs` - Cost estimation, ModelPricing, per-provider pricing tables
 - `crates/budi-core/src/hooks.rs` - HookEvent parsing, session upsert, prompt classification
 - `crates/budi-core/src/otel.rs` - OTLP JSON parsing, OTEL->JSONL dedup
@@ -116,7 +116,7 @@ OTEL and JSONL deduplicate: same API call matched by session_id + model + timest
 - CostEnricher is the single source of truth for cost - sets cost_cents during pipeline. Skips if cost already set (API data)
 - `budi init` installs hooks in `~/.claude/settings.json` (CC) and `~/.cursor/hooks.json` (Cursor), plus OTEL env vars and MCP server
 - **MCP server**: `budi mcp-serve` runs an MCP server over stdio. Installed into `~/.claude/settings.json` mcpServers by `budi init`. 15 tools for analytics (cost summary, models, projects, branches, tags, providers, tools, activity), config (get_config, set_tag_rules, set_statusline_config, sync_data, get_status), and health (session_health). Thin HTTP client to daemon - stdout is JSON-RPC only, logging to stderr
-- Tags are auto-detected (provider, model, tool, ticket_id, activity, etc.) + custom rules via `~/.config/budi/tags.toml`
+- Tags are auto-detected (`provider`, `model`, `tool`, `tool_use_id`, `ticket_id`, `activity`, and conditional tags like `cost_confidence` / `speed`) + custom rules via `~/.config/budi/tags.toml`
 - git_branch is a column on messages (not a tag) for fast queries
 - **Session health**: Four vitals computed per session - context growth (context-size growth), cache reuse (cache hit rate), cost acceleration (per-turn or per-reply cost growth), retry loops (tool failure loops from hook_events). Each vital has green/yellow/red state. New sessions start green - the default is always positive; vitals only degrade to yellow/red when there is clear evidence of a problem. Tips are provider-aware via `ProviderKind` enum (Claude Code -> `/compact`/`/clear`, Cursor -> "new composer session", Other -> neutral). When no session ID is provided, health auto-select prefers the latest session with assistant activity, then falls back to session timestamps. Statusline "coach" mode shows health icon + session cost + tip. Dashboard session detail page has a health panel with vitals grid and tips section.
 - **Cursor extension** (`extensions/cursor-budi/`): VS Code extension that shows session health in the status bar (aggregated health circles) and a side panel (session details, vitals, tips, session list). Auto-installed by `budi init` when Cursor CLI is on PATH (`.vsix` embedded in binary via `include_bytes!`). Communicates with daemon via HTTP. Tracks active session via `~/.local/share/budi/cursor-sessions.json` (written by hooks, watched by extension). `budi doctor` and `/health/integrations` both check extension install status.

--- a/crates/budi-core/src/pipeline/mod.rs
+++ b/crates/budi-core/src/pipeline/mod.rs
@@ -165,7 +165,9 @@ fn propagate_session_context(messages: &mut [ParsedMessage]) {
             msg.cwd = Some(c.clone());
         }
         if let Some(cat) = &msg.prompt_category {
-            if !cat.is_empty() && ctx.category.is_none() {
+            if !cat.is_empty() {
+                // Activity classification can change mid-session.
+                // Keep the latest non-empty prompt_category and propagate it forward.
                 ctx.category = Some(cat.clone());
             }
         } else if let Some(ref cat) = ctx.category {
@@ -469,6 +471,63 @@ mod tests {
             all_user_tags.len() <= 1,
             "identity tag 'user' should be deduplicated, found {} occurrences",
             all_user_tags.len()
+        );
+    }
+
+    #[test]
+    fn activity_tag_tracks_latest_prompt_category() {
+        use crate::config::TagsConfig;
+        let mut pipeline = Pipeline::default_pipeline(
+            Some(TagsConfig::default()),
+            std::collections::HashMap::new(),
+        );
+
+        let mut u1 = test_msg();
+        u1.uuid = "u1".into();
+        u1.session_id = Some("sess-1".into());
+        u1.role = "user".into();
+        u1.prompt_category = Some("bugfix".into());
+        u1.timestamp = "2026-03-14T18:13:42Z".parse().unwrap();
+
+        let mut a1 = test_msg();
+        a1.uuid = "a1".into();
+        a1.session_id = Some("sess-1".into());
+        a1.role = "assistant".into();
+        a1.model = Some("claude-opus".into());
+        a1.output_tokens = 100;
+        a1.timestamp = "2026-03-14T18:13:43Z".parse().unwrap();
+
+        let mut u2 = test_msg();
+        u2.uuid = "u2".into();
+        u2.session_id = Some("sess-1".into());
+        u2.role = "user".into();
+        u2.prompt_category = Some("feature".into());
+        u2.timestamp = "2026-03-14T18:14:00Z".parse().unwrap();
+
+        let mut a2 = test_msg();
+        a2.uuid = "a2".into();
+        a2.session_id = Some("sess-1".into());
+        a2.role = "assistant".into();
+        a2.model = Some("claude-opus".into());
+        a2.output_tokens = 200;
+        a2.timestamp = "2026-03-14T18:14:01Z".parse().unwrap();
+
+        let mut msgs = vec![u1, a1, u2, a2];
+        let all_tags = pipeline.process(&mut msgs);
+
+        assert!(
+            all_tags[1]
+                .iter()
+                .any(|t| t.key == "activity" && t.value == "bugfix"),
+            "a1 should keep first activity tag, got: {:?}",
+            all_tags[1]
+        );
+        assert!(
+            all_tags[3]
+                .iter()
+                .any(|t| t.key == "activity" && t.value == "feature"),
+            "a2 should inherit updated activity tag, got: {:?}",
+            all_tags[3]
         );
     }
 

--- a/docs/reviews/issue-58-enrichment-pipeline-review.md
+++ b/docs/reviews/issue-58-enrichment-pipeline-review.md
@@ -1,0 +1,41 @@
+# Issue #58 Review: Enrichment Pipeline, Tagging, and Cost Attribution
+
+## Findings (highest severity first)
+
+### P1 (fixed): `activity` attribution could become stale after the first classified prompt in a session
+- Area: `crates/budi-core/src/pipeline/mod.rs` (`propagate_session_context`)
+- Risk: `prompt_category` propagation only latched the first non-empty category per session. Later user turns with a new category (for example `bugfix` -> `feature`) were ignored, so downstream assistant messages kept the old `activity` tag.
+- Concrete example: `u1(prompt_category=bugfix) -> a1 -> u2(prompt_category=feature) -> a2`. Before fix, `a2` was still tagged `activity=bugfix`.
+- Fix in this PR: update propagation to keep the latest non-empty `prompt_category`, matching the documented "most recent preceding message" semantics.
+
+## Invariant assumptions to encode (tests/docs)
+
+1. Enricher order is semantic and must stay: `Hook -> Identity -> Git -> Tool -> Cost -> Tag`.
+2. Context fields (`git_branch`, `repo_id`, `cwd`, `prompt_category`) propagate from the most recent prior message in-session.
+3. Identity tags are deduplicated per session; context tags can legitimately vary across turns.
+4. `cost_cents.is_some()` on assistant messages requires a non-empty `cost_confidence`.
+5. `repo_id` and `git_branch` remain canonical columns (not duplicated as tags) for query stability.
+
+## Test coverage added
+
+- `activity_tag_tracks_latest_prompt_category` in `crates/budi-core/src/pipeline/mod.rs`
+  - Verifies that when prompt classification changes mid-session, subsequent assistant turns get the updated `activity` tag.
+
+## Documentation drift corrected
+
+- `SOUL.md`
+  - Corrected pipeline order to include `ToolEnricher`.
+  - Updated enricher count from 5 -> 6.
+  - Clarified auto/conditional tag examples (`tool_use_id`, `cost_confidence`, `speed`).
+- `CONTRIBUTING.md`
+  - Fixed registration reference from `Pipeline::new()` -> `Pipeline::default_pipeline()`.
+  - Corrected enricher order to include `ToolEnricher`.
+- `README.md`
+  - Clarified assistant-tag semantics and conditional tags (`cost_confidence`, `speed`).
+  - Added `tool_use_id` to documented core attribution tags.
+
+## Follow-up candidates (not in this PR)
+
+- Add an integration test that asserts `HookEnricher` session metadata and JSONL-derived context merge deterministically when both are present and disagree.
+- Add explicit coverage for `repo_id = "unknown"` repair paths to ensure tag-rule matching is not degraded by stale placeholder values.
+- Add a pipeline-order regression test that fails loudly if `ToolEnricher` or `CostEnricher` move relative to `TagEnricher`.


### PR DESCRIPTION
## What I reviewed
- Enricher ordering and coupling in `crates/budi-core/src/pipeline/mod.rs` and `crates/budi-core/src/pipeline/enrichers.rs`
- Cost attribution behavior and confidence semantics around `CostEnricher`/provider pricing paths
- Session context propagation for `repo_id`, `git_branch`, and `prompt_category`
- Tagging/queryability docs in `SOUL.md`, `README.md`, and `CONTRIBUTING.md`

## What I changed
- Fixed `prompt_category` propagation to keep the latest non-empty value per session (instead of latching first value), so `activity` can change correctly mid-session.
- Added regression test `activity_tag_tracks_latest_prompt_category` to lock this behavior.
- Corrected docs drift:
  - pipeline order now includes `ToolEnricher`
  - contributor guidance references `Pipeline::default_pipeline()` (not `Pipeline::new()`)
  - README/SOUL tag semantics now include conditional tags (`cost_confidence`, `speed`) and `tool_use_id`
- Added findings-first review artifact: `docs/reviews/issue-58-enrichment-pipeline-review.md`

## Notable findings or risks
- Fixed P1: stale `activity` attribution after the first classified prompt in a session.
- Remaining risk: pipeline order is still primarily a convention + comments (follow-up below suggests a louder order-regression test).

## Validation performed
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`

## Remaining follow-ups
- Add an integration test for Hook metadata vs JSONL context precedence when both are present and disagree.
- Add explicit coverage for `repo_id = "unknown"` repair paths and tag-rule matching.
- Add a stronger pipeline-order regression test that fails loudly if `ToolEnricher`/`CostEnricher` move relative to `TagEnricher`.

Closes #58
