### PR TITLE
review #59: harden config path compatibility and fix migration/config docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ If you install with Homebrew, run `budi init` right after `brew install`.
 
 **One install on PATH.** Do not mix Homebrew with `~/.local/bin` (macOS/Linux) or with `%LOCALAPPDATA%\budi\bin` (Windows): you can end up with different `budi` and `budi-daemon` versions and confusing restarts. Keep a single install directory ahead of others on `PATH` (or remove duplicates). `budi init` warns if it detects multiple binaries.
 
-`budi init` starts the daemon, syncs existing data, and now **prompts you to choose integrations** (Claude hooks/MCP/OTEL/statusline, Cursor hooks/extension, Starship prompt module). In non-interactive mode it uses safe defaults. You can also choose explicitly with flags like `--with`, `--without`, and `--integrations all|none|auto`. **Restart Claude Code and Cursor** after install to activate hook/config changes. The daemon uses port 7878 by default — customize in `~/.config/budi/config.toml` with `daemon_port`.
+`budi init` starts the daemon, syncs existing data, and now **prompts you to choose integrations** (Claude hooks/MCP/OTEL/statusline, Cursor hooks/extension, Starship prompt module). In non-interactive mode it uses safe defaults. You can also choose explicitly with flags like `--with`, `--without`, and `--integrations all|none|auto`. **Restart Claude Code and Cursor** after install to activate hook/config changes. The daemon uses port 7878 by default — customize `daemon_port` in the **repo-local** `config.toml` under `<budi-home>/repos/<repo-id>/config.toml` (run `budi doctor` inside the repo to see the exact path).
 
 To install a specific version, set the `VERSION` environment variable: `VERSION=v7.1.0 curl -fsSL ... | bash` (or `$env:VERSION="v7.1.0"` on PowerShell).
 

--- a/SOUL.md
+++ b/SOUL.md
@@ -94,7 +94,7 @@ OTEL and JSONL deduplicate: same API call matched by session_id + model + timest
 - `crates/budi-core/src/jsonl.rs` - JSONL transcript parser, ParsedMessage struct
 - `crates/budi-core/src/providers/claude_code.rs` - Claude Code provider (JSONL discovery, pricing)
 - `crates/budi-core/src/providers/cursor.rs` - Cursor provider (Usage API primary, transcript fallback; auth/session context from state.vscdb across macOS/Linux/Windows layouts)
-- `crates/budi-core/src/migration.rs` - Schema v20, all migration paths
+- `crates/budi-core/src/migration.rs` - Schema v21, all migration paths
 - `crates/budi-core/src/config.rs` - BudiConfig, StatuslineConfig, TagsConfig
 - `crates/budi-cli/build.rs` - Build script: creates empty vsix placeholder if not pre-built
 - `crates/budi-daemon/src/main.rs` - HTTP server, ~38 routes

--- a/crates/budi-core/src/config.rs
+++ b/crates/budi-core/src/config.rs
@@ -13,19 +13,33 @@ pub(crate) const BUDI_CONFIG_FILE_NAME: &str = "config.toml";
 pub(crate) const BUDI_REPO_ROOT_MARKER_FILE_NAME: &str = "repo-root.txt";
 pub(crate) const BUDI_LOG_DIR_NAME: &str = "logs";
 
+fn parse_env_path(raw: &str) -> Option<PathBuf> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    Some(PathBuf::from(trimmed))
+}
+
 /// Cross-platform home directory detection.
 /// Uses HOME on Unix, USERPROFILE (then HOMEPATH) on Windows.
 pub fn home_dir() -> Result<PathBuf> {
-    if let Ok(home) = env::var("HOME") {
-        return Ok(PathBuf::from(home));
+    if let Ok(home) = env::var("HOME")
+        && let Some(path) = parse_env_path(&home)
+    {
+        return Ok(path);
     }
     #[cfg(windows)]
     {
         if let Ok(profile) = env::var("USERPROFILE") {
-            return Ok(PathBuf::from(profile));
+            if let Some(path) = parse_env_path(&profile) {
+                return Ok(path);
+            }
         }
         if let (Ok(drive), Ok(path)) = (env::var("HOMEDRIVE"), env::var("HOMEPATH")) {
-            return Ok(PathBuf::from(format!("{drive}{path}")));
+            if let Some(path) = parse_env_path(&format!("{drive}{path}")) {
+                return Ok(path);
+            }
         }
     }
     anyhow::bail!("Could not determine home directory (HOME not set)")
@@ -259,8 +273,10 @@ fn resolve_worktree_main_root(git_file: &Path) -> Option<PathBuf> {
 }
 
 pub fn budi_home_dir() -> Result<PathBuf> {
-    if let Ok(override_dir) = env::var(BUDI_HOME_ENV) {
-        return Ok(PathBuf::from(override_dir));
+    if let Ok(override_dir) = env::var(BUDI_HOME_ENV)
+        && let Some(path) = parse_env_path(&override_dir)
+    {
+        return Ok(path);
     }
     #[cfg(windows)]
     {
@@ -425,6 +441,19 @@ mod tests {
         let data_dir = PathBuf::from("/tmp/budi-marker-test");
         let marker_path = repo_root_marker_path(&data_dir);
         assert!(marker_path.ends_with(BUDI_REPO_ROOT_MARKER_FILE_NAME));
+    }
+
+    #[test]
+    fn parse_env_path_rejects_blank_values() {
+        assert!(parse_env_path("").is_none());
+        assert!(parse_env_path("   ").is_none());
+        assert!(parse_env_path("\n\t ").is_none());
+    }
+
+    #[test]
+    fn parse_env_path_trims_whitespace() {
+        let parsed = parse_env_path("  /tmp/budi-home  ").expect("path should parse");
+        assert_eq!(parsed, PathBuf::from("/tmp/budi-home"));
     }
 
     #[test]

--- a/docs/reviews/issue-59-config-migrations-privacy-review.md
+++ b/docs/reviews/issue-59-config-migrations-privacy-review.md
@@ -1,0 +1,39 @@
+# Issue #59 Review: Configuration, Migrations, Privacy, and Compatibility
+
+## Findings (highest severity first)
+
+### P1 (fixed): README pointed daemon config to the wrong path
+- Area: `README.md` install/init guidance
+- Risk: docs said to edit `~/.config/budi/config.toml` for `daemon_port`, but daemon host/port config is repo-local (`<budi-home>/repos/<repo-id>/config.toml`). This could send users to the wrong file and cause failed port changes, confusing daemon restart behavior, and upgrade troubleshooting noise.
+- Fix in this PR: updated README to describe repo-local config location and how to discover the exact file with `budi doctor`.
+
+### P2 (fixed): Empty env overrides could silently redirect config/data paths
+- Area: `crates/budi-core/src/config.rs` (`home_dir`, `budi_home_dir`)
+- Risk: empty/whitespace values for `HOME` or `BUDI_HOME` were accepted as valid paths (`PathBuf::from("")`), which can resolve to cwd-relative locations and unintentionally relocate data/config behavior.
+- Fix in this PR: normalize env-based path inputs, reject blank values, and fall back to standard path resolution.
+
+## Migration/config scenarios that need explicit automated coverage
+
+1. `repair` on schema-v21 DBs with dropped/recreated indexes that keep legacy names but wrong definitions.
+2. Upgrade path validation for versions `<10` with explicit user-facing backup/restore expectations around destructive rebuild.
+3. Mixed-version CLI/daemon startup behavior when repo-local daemon port differs from default and commands run outside a repo.
+4. Explicit compatibility checks for `BUDI_HOME`, `HOME`, and Windows path env variants when values are missing, blank, or whitespace-padded.
+5. Retention policy boundaries around session timestamps exactly at cutoff windows (`julianday('now', '-N days')` edge behavior).
+
+## Test coverage added
+
+- `parse_env_path_rejects_blank_values` in `crates/budi-core/src/config.rs`
+- `parse_env_path_trims_whitespace` in `crates/budi-core/src/config.rs`
+
+## Documentation drift corrected
+
+- `README.md`
+  - Corrected daemon config location for `daemon_port` to repo-local storage (`<budi-home>/repos/<repo-id>/config.toml`), plus discoverability guidance via `budi doctor`.
+- `SOUL.md`
+  - Corrected migration key-file note from schema v20 to schema v21.
+
+## Follow-up candidates (not in this PR)
+
+- Add a `budi config path` command to print active repo-local config and eliminate path ambiguity.
+- Add migration-integrity assertions that validate critical index definitions (not just index-name existence) during `repair`.
+- Expand privacy retention tests for exact-cutoff behavior and disabled (`off`) windows through environment-driven integration tests.


### PR DESCRIPTION
## What I reviewed
- `crates/budi-core/src/config.rs` for config loading/defaulting behavior, especially env override edge cases and repo-local vs global path semantics.
- `crates/budi-core/src/migration.rs` for migration/repair safety assumptions and current schema drift handling coverage.
- `crates/budi-core/src/privacy.rs` and related docs for retention/privacy expectations.
- `README.md`, `SOUL.md`, and `CONTRIBUTING.md` for upgrade/config/privacy compatibility guidance drift.

## What I changed
- Hardened env-path handling in `crates/budi-core/src/config.rs`:
  - Added `parse_env_path` normalization.
  - `home_dir()` now ignores blank/whitespace `HOME` values instead of accepting an empty path.
  - `budi_home_dir()` now ignores blank/whitespace `BUDI_HOME` overrides and falls back safely.
- Added focused config edge-case tests:
  - `parse_env_path_rejects_blank_values`
  - `parse_env_path_trims_whitespace`
- Corrected daemon config-path docs in `README.md`:
  - Replaced incorrect `~/.config/budi/config.toml` guidance with the real repo-local location under `<budi-home>/repos/<repo-id>/config.toml` and discoverability via `budi doctor`.
- Corrected schema reference drift in `SOUL.md` (`migration.rs` now noted as schema v21).
- Added findings-first review artifact:
  - `docs/reviews/issue-59-config-migrations-privacy-review.md`

## Notable findings or risks
- Main finding fixed in this PR: daemon config path docs were inaccurate and could mislead users into editing the wrong file.
- Additional compatibility hardening fixed: blank env overrides could redirect storage/config behavior to unintended cwd-relative paths.
- Remaining risk (follow-up): repair currently validates index existence by name, not full index definition integrity.

## Validation performed
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`

## Remaining follow-ups
- Add repair checks for index-definition integrity (not only index-name existence).
- Add migration-path tests around explicit backup/restore expectations for pre-v10 destructive rebuilds.
- Consider a `budi config path` command for explicit repo-local config discovery.
- Add privacy retention boundary tests for exact-cutoff behavior.

Closes #59
