### PR TITLE
review #60: harden daemon privileged routes and align API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,15 +502,16 @@ Messages with `otel_exact` or `exact` confidence show exact cost in the dashboar
 <summary>Daemon API</summary>
 
 The daemon runs on `http://127.0.0.1:7878` and exposes a REST API.
+Privileged routes are loopback-only (`127.0.0.1` / `::1`): all `/admin/*` endpoints plus `POST /sync`, `POST /sync/all`, and `POST /sync/reset`.
 
 **System:**
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
 | GET | `/health` | Health check |
-| POST | `/sync` | Sync recent data (last 30 days) |
-| POST | `/sync/all` | Load full transcript history |
-| POST | `/sync/reset` | Wipe sync state + full re-sync |
+| POST | `/sync` | Sync recent data (last 30 days, loopback-only) |
+| POST | `/sync/all` | Load full transcript history (loopback-only) |
+| POST | `/sync/reset` | Wipe sync state + full re-sync (loopback-only) |
 | GET | `/sync/status` | Syncing flag + last_synced + ingest queue backlog/failed metrics |
 | POST | `/hooks/ingest` | Receive hook events |
 | GET | `/health/integrations` | Hooks/MCP/OTEL/statusline status + DB stats |
@@ -523,7 +524,9 @@ The daemon runs on `http://127.0.0.1:7878` and exposes a REST API.
 | Method | Endpoint | Description |
 |--------|----------|-------------|
 | GET | `/analytics/summary` | Cost and token totals |
+| GET | `/analytics/filter-options` | Filter values for providers/models/projects/branches |
 | GET | `/analytics/messages` | Message list (paginated, searchable) |
+| GET | `/analytics/messages/{message_uuid}/detail` | Full detail for a specific message |
 | GET | `/analytics/projects` | Repos ranked by usage |
 | GET | `/analytics/branches` | Cost per git branch |
 | GET | `/analytics/branches/{branch}` | Cost for a specific branch |
@@ -540,13 +543,19 @@ The daemon runs on `http://127.0.0.1:7878` and exposes a REST API.
 | GET | `/analytics/cost-confidence` | Breakdown by cost confidence level |
 | GET | `/analytics/subagent-cost` | Subagent vs main agent cost |
 | GET | `/analytics/sessions` | Session list (paginated, searchable) |
+| GET | `/analytics/sessions/{id}` | Session metadata and aggregate stats |
 | GET | `/analytics/sessions/{id}/messages` | Messages for a specific session |
+| GET | `/analytics/sessions/{id}/curve` | Session input token growth curve |
+| GET | `/analytics/sessions/{id}/hook-events` | Hook events linked to a session |
+| GET | `/analytics/sessions/{id}/otel-events` | OTEL events linked to a session |
 | GET | `/analytics/sessions/{id}/tags` | Tags for a specific session |
 | GET | `/analytics/session-health` | Session health vitals and tips |
-| GET | `/admin/providers` | Registered providers |
-| GET | `/admin/schema` | Database schema version |
-| POST | `/admin/migrate` | Run database migration |
-| POST | `/admin/repair` | Repair schema drift + run migration |
+| GET | `/analytics/session-audit` | Session attribution/linking audit stats |
+| GET | `/admin/providers` | Registered providers (loopback-only) |
+| GET | `/admin/schema` | Database schema version (loopback-only) |
+| POST | `/admin/migrate` | Run database migration (loopback-only) |
+| POST | `/admin/repair` | Repair schema drift + run migration (loopback-only) |
+| POST | `/admin/integrations/install` | Install/update integrations from daemon (loopback-only) |
 
 Most endpoints accept `?since=<ISO>&until=<ISO>` for date filtering.
 

--- a/SOUL.md
+++ b/SOUL.md
@@ -98,9 +98,9 @@ OTEL and JSONL deduplicate: same API call matched by session_id + model + timest
 - `crates/budi-core/src/config.rs` - BudiConfig, StatuslineConfig, TagsConfig
 - `crates/budi-cli/build.rs` - Build script: creates empty vsix placeholder if not pre-built
 - `crates/budi-daemon/src/main.rs` - HTTP server, ~38 routes
-- `crates/budi-daemon/src/routes/hooks.rs` - /hooks/ingest, /sync, /sync/all, /sync/reset, /sync/status, /health, /health/integrations, /health/check-update endpoints
+- `crates/budi-daemon/src/routes/hooks.rs` - /hooks/ingest, /sync, /sync/all, /sync/reset, /sync/status, /health, /health/integrations, /health/check-update, /admin/integrations/install endpoints
 - `crates/budi-daemon/src/routes/analytics.rs` - All analytics + admin endpoints (summary, messages, projects, cost, models, activity, branches, tags, providers, statusline, tools, mcp, cache-efficiency, session-cost-curve, cost-confidence, subagent-cost, sessions, session-health, session-audit, admin/providers, admin/schema, admin/migrate, admin/repair)
-- `crates/budi-daemon/src/routes/otel.rs` - /v1/logs OTLP ingestion
+- `crates/budi-daemon/src/routes/otel.rs` - /v1/logs and /v1/metrics OTLP ingestion endpoints
 - `crates/budi-cli/src/commands/statusline.rs` - Statusline rendering (coach mode with health tips) + installation
 - `crates/budi-cli/src/mcp.rs` - MCP server handler (15 tools: analytics + config + health)
 - `crates/budi-cli/src/commands/mcp.rs` - `mcp-serve` subcommand (stdio transport)
@@ -126,7 +126,8 @@ OTEL and JSONL deduplicate: same API call matched by session_id + model + timest
   - `/dashboard/sessions` - Session list with sort/search/pagination, drill-down to `/dashboard/sessions/:id` with session meta, tags, health panel (vitals + tips), input token growth chart, message table
   - `/dashboard/settings` - Status, integrations, database info, paths, actions (sync/re-sync/migrate/check updates), help links
 - Dashboard frontend sources live in `frontend/dashboard/`; built assets are embedded from `crates/budi-daemon/static/dashboard-dist` (served at `/static/dashboard/*`)
-- Analytics endpoints: `/analytics/summary`, `/analytics/messages`, `/analytics/projects`, `/analytics/cost`, `/analytics/models`, `/analytics/activity`, `/analytics/branches`, `/analytics/branches/{branch}`, `/analytics/tags`, `/analytics/providers`, `/analytics/statusline`, `/analytics/tools`, `/analytics/mcp`, `/analytics/cache-efficiency`, `/analytics/session-cost-curve`, `/analytics/cost-confidence`, `/analytics/subagent-cost`, `/analytics/sessions`, `/analytics/sessions/{id}/messages`, `/analytics/sessions/{id}/tags`, `/analytics/session-health`, `/analytics/session-audit` (session attribution stats for debugging ingestion - not used by dashboard/MCP)
-- Admin endpoints: `/admin/providers` (registered providers), `/admin/schema` (schema version), `/admin/migrate` (run migration), `/admin/repair` (repair schema drift + run migration)
-- Sync endpoints: `/sync` (30-day), `/sync/all` (full history), `/sync/reset` (wipe sync state + full re-sync), `/sync/status` (syncing flag + last_synced)
+- Analytics endpoints: `/analytics/summary`, `/analytics/filter-options`, `/analytics/messages`, `/analytics/messages/{message_uuid}/detail`, `/analytics/projects`, `/analytics/cost`, `/analytics/models`, `/analytics/activity`, `/analytics/branches`, `/analytics/branches/{branch}`, `/analytics/tags`, `/analytics/providers`, `/analytics/statusline`, `/analytics/tools`, `/analytics/mcp`, `/analytics/cache-efficiency`, `/analytics/session-cost-curve`, `/analytics/cost-confidence`, `/analytics/subagent-cost`, `/analytics/sessions`, `/analytics/sessions/{id}`, `/analytics/sessions/{id}/messages`, `/analytics/sessions/{id}/curve`, `/analytics/sessions/{id}/hook-events`, `/analytics/sessions/{id}/otel-events`, `/analytics/sessions/{id}/tags`, `/analytics/session-health`, `/analytics/session-audit` (session attribution stats for debugging ingestion - not used by dashboard/MCP)
+- Admin endpoints (loopback-only): `/admin/providers` (registered providers), `/admin/schema` (schema version), `/admin/migrate` (run migration), `/admin/repair` (repair schema drift + run migration), `/admin/integrations/install` (integration installer orchestration)
+- Sync mutation endpoints (loopback-only): `/sync` (30-day), `/sync/all` (full history), `/sync/reset` (wipe sync state + full re-sync)
+- Sync status endpoint: `/sync/status` (syncing flag + last_synced)
 - Health endpoints: `/health` (ok + version), `/health/integrations` (hooks/MCP/OTEL/statusline status + DB stats + paths), `/health/check-update` (GitHub releases)

--- a/crates/budi-daemon/src/main.rs
+++ b/crates/budi-daemon/src/main.rs
@@ -3,6 +3,7 @@ use std::net::SocketAddr;
 use anyhow::Result;
 use axum::Router;
 use axum::extract::DefaultBodyLimit;
+use axum::middleware::from_fn;
 use axum::routing::{get, post};
 use budi_core::analytics;
 use budi_core::config::{DEFAULT_DAEMON_HOST, DEFAULT_DAEMON_PORT};
@@ -53,7 +54,21 @@ impl Drop for BusyFlagGuard {
 }
 
 fn build_router(app_state: AppState) -> Router {
-    use routes::{analytics as a, dashboard as d, hooks as h, otel as o};
+    use routes::{analytics as a, dashboard as d, hooks as h, otel as o, require_loopback};
+
+    let protected_routes = Router::new()
+        .route("/sync", post(h::analytics_sync))
+        .route("/sync/all", post(h::analytics_history))
+        .route("/sync/reset", post(h::analytics_sync_reset))
+        .route("/admin/providers", get(a::analytics_registered_providers))
+        .route("/admin/schema", get(a::analytics_schema_version))
+        .route("/admin/migrate", post(a::analytics_migrate))
+        .route("/admin/repair", post(a::analytics_repair))
+        .route(
+            "/admin/integrations/install",
+            post(h::admin_install_integrations),
+        )
+        .route_layer(from_fn(require_loopback));
 
     Router::new()
         .route("/favicon.ico", get(d::favicon))
@@ -68,9 +83,6 @@ fn build_router(app_state: AppState) -> Router {
             "/v1/metrics",
             post(o::otel_metrics_ingest).layer(DefaultBodyLimit::max(16 * 1024 * 1024)),
         )
-        .route("/sync", post(h::analytics_sync))
-        .route("/sync/all", post(h::analytics_history))
-        .route("/sync/reset", post(h::analytics_sync_reset))
         .route("/sync/status", get(h::sync_status))
         .route("/analytics/summary", get(a::analytics_summary))
         .route("/analytics/messages", get(a::analytics_messages))
@@ -90,14 +102,6 @@ fn build_router(app_state: AppState) -> Router {
         )
         .route("/analytics/providers", get(a::analytics_providers))
         .route("/analytics/statusline", get(a::analytics_statusline))
-        .route("/admin/providers", get(a::analytics_registered_providers))
-        .route("/admin/schema", get(a::analytics_schema_version))
-        .route("/admin/migrate", post(a::analytics_migrate))
-        .route("/admin/repair", post(a::analytics_repair))
-        .route(
-            "/admin/integrations/install",
-            post(h::admin_install_integrations),
-        )
         .route("/analytics/tools", get(a::analytics_tools))
         .route("/analytics/mcp", get(a::analytics_mcp))
         .route(
@@ -152,6 +156,7 @@ fn build_router(app_state: AppState) -> Router {
         .route("/dashboard", get(d::dashboard))
         .route("/dashboard/{*rest}", get(d::dashboard))
         .route("/static/dashboard/{*path}", get(d::dashboard_asset))
+        .merge(protected_routes)
         .layer(DefaultBodyLimit::max(2 * 1024 * 1024))
         .with_state(app_state)
 }
@@ -263,7 +268,11 @@ async fn main() -> Result<()> {
     let addr: SocketAddr = format!("{}:{}", host, port).parse()?;
     let listener = tokio::net::TcpListener::bind(addr).await?;
     tracing::info!("budi-daemon listening on {}", addr);
-    axum::serve(listener, app).await?;
+    axum::serve(
+        listener,
+        app.into_make_service_with_connect_info::<SocketAddr>(),
+    )
+    .await?;
     Ok(())
 }
 
@@ -372,6 +381,7 @@ fn kill_existing_daemon(_port: u16) {}
 mod tests {
     use super::*;
     use axum::body::Body;
+    use axum::extract::ConnectInfo;
     use axum::http::{Request, StatusCode};
     use http_body_util::BodyExt;
     use tower::ServiceExt;
@@ -457,5 +467,53 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn protected_admin_route_requires_connect_info() {
+        let app = test_app();
+        let resp = app
+            .oneshot(
+                Request::get("/admin/providers")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn protected_admin_route_allows_loopback_client() {
+        let app = test_app();
+        let mut req = Request::get("/admin/providers")
+            .body(Body::empty())
+            .unwrap();
+        req.extensions_mut()
+            .insert(ConnectInfo(SocketAddr::from(([127, 0, 0, 1], 54545))));
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn protected_admin_route_blocks_non_loopback_client() {
+        let app = test_app();
+        let mut req = Request::get("/admin/providers")
+            .body(Body::empty())
+            .unwrap();
+        req.extensions_mut()
+            .insert(ConnectInfo(SocketAddr::from(([192, 168, 1, 10], 54545))));
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn sync_mutation_route_blocks_non_loopback_client() {
+        let app = test_app();
+        let mut req = Request::post("/sync").body(Body::empty()).unwrap();
+        req.extensions_mut()
+            .insert(ConnectInfo(SocketAddr::from(([10, 0, 0, 4], 43434))));
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
     }
 }

--- a/crates/budi-daemon/src/routes/mod.rs
+++ b/crates/budi-daemon/src/routes/mod.rs
@@ -3,8 +3,13 @@ pub mod dashboard;
 pub mod hooks;
 pub mod otel;
 
+use std::net::SocketAddr;
+
 use axum::Json;
+use axum::extract::{ConnectInfo, Request};
 use axum::http::StatusCode;
+use axum::middleware::Next;
+use axum::response::Response;
 
 pub fn internal_error(err: anyhow::Error) -> (StatusCode, Json<serde_json::Value>) {
     tracing::error!("{err:#}");
@@ -26,4 +31,33 @@ pub fn not_found(msg: impl std::fmt::Display) -> (StatusCode, Json<serde_json::V
         StatusCode::NOT_FOUND,
         Json(serde_json::json!({ "ok": false, "error": format!("{msg}") })),
     )
+}
+
+pub fn forbidden(msg: impl std::fmt::Display) -> (StatusCode, Json<serde_json::Value>) {
+    (
+        StatusCode::FORBIDDEN,
+        Json(serde_json::json!({ "ok": false, "error": format!("{msg}") })),
+    )
+}
+
+pub async fn require_loopback(
+    req: Request,
+    next: Next,
+) -> Result<Response, (StatusCode, Json<serde_json::Value>)> {
+    let remote_addr = req
+        .extensions()
+        .get::<ConnectInfo<SocketAddr>>()
+        .map(|info| info.0);
+
+    match remote_addr {
+        Some(addr) if addr.ip().is_loopback() => Ok(next.run(req).await),
+        Some(addr) => {
+            tracing::warn!(remote_addr = %addr, "blocked non-loopback access to protected route");
+            Err(forbidden("this endpoint is available only via loopback"))
+        }
+        None => {
+            tracing::warn!("missing peer address on protected route");
+            Err(forbidden("missing peer address for loopback validation"))
+        }
+    }
 }

--- a/docs/reviews/issue-60-daemon-api-orchestration-review.md
+++ b/docs/reviews/issue-60-daemon-api-orchestration-review.md
@@ -1,0 +1,41 @@
+# Issue #60 Review: Daemon API Surface and Background Orchestration
+
+## Findings (highest severity first)
+
+### P1 (fixed): privileged daemon routes were reachable from non-loopback clients when externally bound
+- Area: `crates/budi-daemon/src/main.rs`, `crates/budi-daemon/src/routes/mod.rs`
+- Risk: admin and sync mutation endpoints had no transport-level guard. If daemon host was configured as non-loopback (for example `0.0.0.0`), remote clients could invoke migration/repair/install or force sync jobs.
+- Fix in this PR:
+  - added loopback-only middleware (`require_loopback`) for privileged routes
+  - applied guard to all `/admin/*` endpoints and sync mutation routes (`POST /sync`, `POST /sync/all`, `POST /sync/reset`)
+  - switched server startup to `into_make_service_with_connect_info::<SocketAddr>()` so peer address checks are enforced in runtime, not just tests
+
+### P2 (fixed): daemon route docs drifted from implemented contract
+- Area: `README.md`, `SOUL.md`
+- Risk: missing endpoint docs can cause frontend/client integration mismatches and incomplete operational runbooks.
+- Fix in this PR:
+  - documented missing analytics routes (`/analytics/filter-options`, `/analytics/messages/{message_uuid}/detail`, `/analytics/sessions/{id}`, `/analytics/sessions/{id}/curve`, `/analytics/sessions/{id}/hook-events`, `/analytics/sessions/{id}/otel-events`, `/analytics/session-audit`)
+  - documented `/admin/integrations/install`
+  - clarified loopback-only behavior for privileged routes
+  - corrected OTEL route summary to include both `/v1/logs` and `/v1/metrics`
+
+## Runtime behavior and contract checks added
+
+- `protected_admin_route_requires_connect_info`
+- `protected_admin_route_allows_loopback_client`
+- `protected_admin_route_blocks_non_loopback_client`
+- `sync_mutation_route_blocks_non_loopback_client`
+
+All were added in `crates/budi-daemon/src/main.rs` and assert loopback policy at the router boundary.
+
+## Remaining daemon-level coverage suggestions
+
+1. Add integration tests that assert privileged route behavior through a real bound socket (not only `oneshot`) for both IPv4 and IPv6 loopback addresses.
+2. Add a startup smoke test for daemon replacement behavior (`kill_existing_daemon`) to ensure no false-positive process termination on shared ports.
+3. Add queue worker lifecycle coverage for graceful shutdown semantics so background jobs stop cleanly during daemon exit/restart.
+4. Add API contract tests asserting error payload shape consistency across `hooks`, `otel`, `sync`, and `admin` routes.
+
+## Follow-up candidates (not in this PR)
+
+- Consider introducing explicit auth (token or signed local session) for privileged routes as defense-in-depth beyond loopback transport checks.
+- Decide and document whether `/sync/status` should remain remotely readable when daemon host is non-loopback.


### PR DESCRIPTION
## What I reviewed
- Daemon runtime boundary in `crates/budi-daemon/src/main.rs` and route modules (`routes/mod.rs`, `routes/hooks.rs`, `routes/otel.rs`, `routes/analytics.rs`, `routes/dashboard.rs`)
- API contract and docs alignment in `README.md` and `SOUL.md`
- Daemon route tests to verify privileged-route behavior

## What I changed
- Added a loopback-only middleware guard (`require_loopback`) for privileged daemon routes.
- Applied that guard to:
  - all `/admin/*` endpoints
  - sync mutation endpoints: `POST /sync`, `POST /sync/all`, `POST /sync/reset`
- Updated server startup to use `into_make_service_with_connect_info::<SocketAddr>()` so peer-address checks are enforced at runtime.
- Added daemon tests for route access control:
  - missing peer address -> forbidden on protected admin route
  - loopback peer -> allowed on protected admin route
  - non-loopback peer -> forbidden on protected admin route
  - non-loopback peer -> forbidden on sync mutation route
- Updated daemon API docs in `README.md` and `SOUL.md` to include missing endpoints and loopback-only constraints.
- Added review artifact: `docs/reviews/issue-60-daemon-api-orchestration-review.md`.

## Notable findings / risks
- High-risk finding fixed: privileged routes were previously callable from remote clients if daemon host was set to non-loopback.
- Residual risk: loopback guard is transport-level hardening; defense-in-depth auth for privileged routes is still a follow-up candidate.

## Validation performed
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`

## Remaining follow-ups
- Add socket-level integration tests for loopback policy (IPv4 + IPv6).
- Add graceful-shutdown coverage for queue/sync background workers.
- Evaluate explicit auth/token for privileged routes as defense in depth.

Closes #60
