### PR TITLE
fix(cli): enforce daemon readiness/version checks across command execution (issue #61)

### DIFF
--- a/SOUL.md
+++ b/SOUL.md
@@ -24,7 +24,7 @@ budi init
 
 **Important**: Install **`budi` and `budi-daemon` from the same build** and keep **only one copy on PATH** (do not mix Homebrew with `~/.local/bin` or another prefix). Version mismatch breaks daemon restarts; `budi init` warns if multiple binaries are found.
 
-After upgrading: restart the daemon (stop the old process, then `budi init` or `budi sync`). On Unix you can use `pkill -f budi-daemon`; on Windows use `taskkill /IM budi-daemon.exe /F` if needed.
+After upgrading: the first CLI command now verifies daemon version and auto-restarts stale daemons when needed. If automatic restart fails, stop the old process manually, then run `budi init` or `budi sync`. On Unix you can use `pkill -f budi-daemon`; on Windows use `taskkill /IM budi-daemon.exe /F` if needed.
 
 ## Platforms
 

--- a/crates/budi-cli/src/client.rs
+++ b/crates/budi-cli/src/client.rs
@@ -4,6 +4,7 @@
 //! the SQLite database.
 
 use std::io::Write;
+use std::path::Path;
 use std::sync::{
     Arc,
     atomic::{AtomicBool, Ordering},
@@ -107,20 +108,43 @@ pub struct DaemonClient {
     client: Client,
 }
 
+fn ensure_daemon_ready<H, E>(
+    repo_root: Option<&Path>,
+    config: &BudiConfig,
+    daemon_is_healthy: H,
+    ensure_running: E,
+) -> Result<()>
+where
+    H: Fn(&BudiConfig) -> bool,
+    E: Fn(Option<&Path>, &BudiConfig) -> Result<()>,
+{
+    let was_healthy = daemon_is_healthy(config);
+    ensure_running(repo_root, config).with_context(|| {
+        if was_healthy {
+            "Failed to validate or restart budi daemon. Run `budi doctor` to diagnose."
+        } else {
+            "Failed to start budi daemon. Run `budi doctor` to diagnose."
+        }
+    })
+}
+
 impl DaemonClient {
     /// Create a new client, auto-starting the daemon if needed.
     pub fn connect() -> Result<Self> {
         let config = Self::load_config();
         let base_url = config.daemon_base_url();
+        let repo_root = std::env::current_dir()
+            .ok()
+            .and_then(|cwd| config::find_repo_root(&cwd).ok());
 
-        if !daemon_health(&config) {
-            // Try to auto-start daemon
-            let repo_root = std::env::current_dir()
-                .ok()
-                .and_then(|cwd| config::find_repo_root(&cwd).ok());
-            ensure_daemon_running(repo_root.as_deref(), &config)
-                .context("Failed to start budi daemon. Run `budi doctor` to diagnose")?;
-        }
+        // Always run readiness checks, even when health is green.
+        // `ensure_daemon_running` also handles version mismatches by restarting stale daemons.
+        ensure_daemon_ready(
+            repo_root.as_deref(),
+            &config,
+            daemon_health,
+            ensure_daemon_running,
+        )?;
 
         let client = Client::builder()
             .timeout(Duration::from_secs(120))
@@ -465,5 +489,77 @@ impl DaemonClient {
             .map_err(describe_send_error)?;
         let resp = check_response(resp)?;
         Ok(resp.json()?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::Cell;
+
+    use super::*;
+
+    #[test]
+    fn ensure_daemon_ready_checks_running_daemon_too() {
+        let config = BudiConfig::default();
+        let ensure_calls = Cell::new(0usize);
+
+        let result = ensure_daemon_ready(
+            None,
+            &config,
+            |_| true,
+            |_, _| {
+                ensure_calls.set(ensure_calls.get() + 1);
+                Ok(())
+            },
+        );
+
+        assert!(result.is_ok());
+        assert_eq!(ensure_calls.get(), 1);
+    }
+
+    #[test]
+    fn ensure_daemon_ready_still_checks_when_daemon_is_down() {
+        let config = BudiConfig::default();
+        let ensure_calls = Cell::new(0usize);
+
+        let result = ensure_daemon_ready(
+            None,
+            &config,
+            |_| false,
+            |_, _| {
+                ensure_calls.set(ensure_calls.get() + 1);
+                Ok(())
+            },
+        );
+
+        assert!(result.is_ok());
+        assert_eq!(ensure_calls.get(), 1);
+    }
+
+    #[test]
+    fn ensure_daemon_ready_uses_startup_error_context_when_unhealthy() {
+        let config = BudiConfig::default();
+        let err = ensure_daemon_ready(None, &config, |_| false, |_, _| anyhow::bail!("boom"))
+            .expect_err("should fail");
+
+        assert!(
+            err.to_string()
+                .contains("Failed to start budi daemon. Run `budi doctor` to diagnose."),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn ensure_daemon_ready_uses_mismatch_error_context_when_healthy() {
+        let config = BudiConfig::default();
+        let err = ensure_daemon_ready(None, &config, |_| true, |_, _| anyhow::bail!("boom"))
+            .expect_err("should fail");
+
+        assert!(
+            err.to_string().contains(
+                "Failed to validate or restart budi daemon. Run `budi doctor` to diagnose."
+            ),
+            "unexpected error: {err}"
+        );
     }
 }

--- a/docs/reviews/issue-61-cli-ux-daemon-orchestration-review.md
+++ b/docs/reviews/issue-61-cli-ux-daemon-orchestration-review.md
@@ -1,0 +1,39 @@
+# Issue #61 Review: CLI Commands, UX, and Daemon Orchestration
+
+## Findings (highest severity first)
+
+### P1 (fixed): most CLI commands could keep talking to an old daemon version after upgrades
+- Area: `crates/budi-cli/src/client.rs` (`DaemonClient::connect`)
+- Risk: when `/health` was green, `connect()` skipped `ensure_daemon_running()`. That bypassed the daemon version mismatch guard, so commands like `budi stats`, `budi sync`, `budi health`, and `budi repair` could hit stale daemon routes/schema behavior until users manually restarted.
+- User impact: post-upgrade confusion and intermittent command failures despite a "healthy" daemon.
+- Fix in this PR: `connect()` now always runs daemon readiness via `ensure_daemon_running()`, so healthy-but-stale daemons are restarted automatically before command traffic.
+
+## Command-by-command weak spots reviewed
+
+- `init`: strong setup flow and recoverability; hidden `--no-daemon`/`--repo-root` remain intentionally internal.
+- `doctor`: good diagnostics depth; currently hook and integration checks are comprehensive but produce long output for mixed partial installs.
+- `sync`: clear messaging for quick/full/force variants; no confirmation for `--force` is acceptable for a power-user command, but worth monitoring.
+- `update`: robust preflight and rollback behavior; now better aligned with command reliability because post-update commands enforce daemon version readiness.
+- `uninstall`: cleanup is broad and safe, but `--keep-data` currently preserves config as well (behavior is consistent in code, wording can be clearer in future docs).
+- `statusline`: prompt-safe timeout behavior is good; fallback behavior is resilient when daemon is unavailable.
+- `integrations`: install/list flows are clear; non-interactive semantics are permissive by design.
+
+## Test gaps addressed in this PR
+
+Added regression tests in `crates/budi-cli/src/client.rs`:
+- `ensure_daemon_ready_checks_running_daemon_too`
+- `ensure_daemon_ready_still_checks_when_daemon_is_down`
+- `ensure_daemon_ready_uses_startup_error_context_when_unhealthy`
+- `ensure_daemon_ready_uses_mismatch_error_context_when_healthy`
+
+These lock in the readiness decision path so we don’t regress to "health-only" checks.
+
+## Documentation drift corrected
+
+- `SOUL.md`: updated upgrade behavior note to reflect automatic daemon version verification/restart on first CLI command, with manual restart as fallback.
+
+## Follow-up candidates (not in this PR)
+
+1. Add an integration test that launches mismatched CLI/daemon binaries and verifies auto-restart across a real command path (`budi stats` or `budi sync`).
+2. Tighten `uninstall --keep-data` wording and/or behavior to clarify whether config is retained intentionally.
+3. Consider a concise/verbose mode toggle for `budi doctor` output to improve UX for routine health checks.


### PR DESCRIPTION
## What I reviewed
- CLI command surface and UX for `init`, `doctor`, `sync`, `update`, `uninstall`, `statusline`, and `integrations`
- Daemon orchestration path used by command execution (`DaemonClient::connect`)
- Command/docs alignment for upgrade and daemon lifecycle behavior

## What I changed
- Fixed CLI daemon orchestration regression in `crates/budi-cli/src/client.rs`:
  - `DaemonClient::connect()` now always runs daemon readiness (`ensure_daemon_running`) even when `/health` is green
  - this enforces version-mismatch restart logic for normal command traffic, not only explicit init/start flows
- Added targeted regression tests in `crates/budi-cli/src/client.rs`:
  - `ensure_daemon_ready_checks_running_daemon_too`
  - `ensure_daemon_ready_still_checks_when_daemon_is_down`
  - `ensure_daemon_ready_uses_startup_error_context_when_unhealthy`
  - `ensure_daemon_ready_uses_mismatch_error_context_when_healthy`
- Added review artifact: `docs/reviews/issue-61-cli-ux-daemon-orchestration-review.md`
- Updated `SOUL.md` upgrade note to reflect automatic daemon version verification/restart behavior

## Notable findings or risks
- Main finding fixed in this PR: commands could continue talking to a stale daemon version after upgrades if health endpoint was still passing
- Residual risk: no end-to-end integration test currently boots intentionally mismatched CLI/daemon binaries and asserts restart on a real command path

## Validation performed
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`

## Remaining follow-ups
- Add integration coverage for mismatched CLI/daemon binaries across a real command path (`budi stats` or `budi sync`)
- Clarify `uninstall --keep-data` wording/behavior for config retention
- Consider a concise/verbose output mode for `budi doctor`

Closes #61
