### PR TITLE
Fix Cursor extension reliability and health UX refresh flow (review #64)

### DIFF
--- a/README.md
+++ b/README.md
@@ -592,6 +592,12 @@ Windows equivalent:
 1. Restart Claude Code after `budi init`
 2. Check: `budi statusline` should output cost data
 
+**Cursor extension shows offline or stale session:**
+1. Run `budi doctor` to verify daemon + Cursor hooks
+2. In Cursor, run **Budi: Refresh Status**
+3. If needed, reload Cursor window (`Developer: Reload Window`) after `budi init` or daemon URL changes
+4. Use **Budi: Select Session** when passively switching tabs (hooks track most recently interacted-with session)
+
 ## Uninstall
 
 ```bash

--- a/docs/reviews/issue-64-cursor-extension-reliability-health-ux-review.md
+++ b/docs/reviews/issue-64-cursor-extension-reliability-health-ux-review.md
@@ -1,0 +1,37 @@
+## Issue #64 review: Cursor extension reliability and health UX
+
+### Findings (ordered by severity)
+
+1. **Stale daemon URL in file-watch refresh path**
+   - The session-file watcher captured `daemonUrl` at activation, so updates to `budi.daemonUrl` could keep using an old URL for event-driven refreshes.
+   - Impact: status/panel could appear intermittently stale or offline after config updates.
+   - Fix: rebuild session watchers on config change and queue an immediate refresh using the latest daemon URL.
+
+2. **No watch attach when session file appears after startup**
+   - If `cursor-sessions.json` did not exist during activation, no file watcher was attached.
+   - Impact: delayed or missing auto-session updates until polling/manual refresh.
+   - Fix: watch both parent directory and file, and attach file watcher as soon as the file appears.
+
+3. **Refresh races across polling/manual/file-watch triggers**
+   - Concurrent refresh calls could overlap and apply out-of-order states.
+   - Impact: transient status flicker and stale session context.
+   - Fix: add serialized refresh queueing so only one refresh runs at a time and newest daemon URL wins.
+
+4. **Inline webview handler interpolation for dynamic IDs/URLs**
+   - Session IDs and URLs were directly injected into inline `onclick` handlers.
+   - Impact: malformed handlers for unusual identifiers and unnecessary injection risk.
+   - Fix: escape dynamic values as JS string literals before interpolation.
+
+### Test coverage improvements
+
+- Added `splitSessionsByDay` unit coverage for day bucketing behavior in extension-facing session lists.
+
+### Documentation updates
+
+- Updated extension README troubleshooting for offline/stale behavior and watcher/polling expectations.
+- Updated top-level README troubleshooting with Cursor extension recovery steps.
+
+### Follow-ups (not included in this PR)
+
+- Add focused unit tests for extension lifecycle (`activate`/`deactivate`) and watcher teardown behavior.
+- Consider replacing inline webview handlers with delegated event listeners + explicit CSP nonce policy.

--- a/extensions/cursor-budi/README.md
+++ b/extensions/cursor-budi/README.md
@@ -59,10 +59,29 @@ Then reload Cursor: **Cmd+Shift+P** → **Developer: Reload Window**
 ## How it works
 
 1. **Hooks** — Cursor hooks (`budi hook`) fire on chat interactions and update `cursor-sessions.json` in budi's data directory (`~/.local/share/budi` on Unix, `%LOCALAPPDATA%\budi` on Windows)
-2. **File watcher** — the extension watches the session file and detects when the active session changes
+2. **File watcher** — the extension watches both the session file and its parent directory, so it can detect active-session changes immediately (including when the file is created after extension startup)
 3. **Daemon** — `budi statusline --format json` (or direct HTTP to daemon) returns session cost, health state, and vitals
 4. **Health panel** — fetches session health details and lists recent sessions from `/analytics/sessions`
 
 ## Limitations
 
 Cursor does not expose the currently focused chat tab to extensions. The statusline tracks the most recently _interacted-with_ session (via hooks). For passive tab switching, use **Budi: Select Session** or click a session in the health panel.
+
+## Troubleshooting
+
+**Status bar says offline / panel shows daemon offline**
+
+1. Run `budi doctor` and confirm daemon health
+2. Run `budi init` if the daemon is not running
+3. If you changed `budi.daemonUrl`, run **Budi: Refresh Status** (or reload Cursor) to force an immediate reconnect
+
+**Session does not switch quickly after chat activity**
+
+1. Confirm Cursor hooks are installed (`budi doctor`)
+2. Send one message in Cursor to create/update `cursor-sessions.json`
+3. Use **Budi: Select Session** to pin manually when switching passively between chats
+
+**Panel data is stale**
+
+- The extension updates on both event-driven file changes and periodic polling (`budi.pollingIntervalMs`, default 15s)
+- Use **Budi: Refresh Status** for an immediate refresh

--- a/extensions/cursor-budi/src/budiClient.test.ts
+++ b/extensions/cursor-budi/src/budiClient.test.ts
@@ -4,6 +4,7 @@ import {
   aggregateHealth,
   formatAggregationStatusText,
   formatAggregationTooltip,
+  splitSessionsByDay,
   type SessionListEntry,
 } from "./budiClient";
 
@@ -56,5 +57,43 @@ describe("aggregation status formatting", () => {
     expect(tooltip).toContain("Today's sessions: 2");
     expect(tooltip).toContain("$12.34");
     expect(tooltip).toContain("needs attention");
+  });
+});
+
+describe("splitSessionsByDay", () => {
+  it("groups sessions into today and yesterday", () => {
+    const now = new Date();
+    const twoHoursAgo = new Date(now.getTime() - 2 * 60 * 60 * 1000).toISOString();
+    const yesterday = new Date(now.getTime() - 26 * 60 * 60 * 1000).toISOString();
+    const threeDaysAgo = new Date(now.getTime() - 72 * 60 * 60 * 1000).toISOString();
+
+    const sessions: SessionListEntry[] = [
+      {
+        session_id: "today",
+        started_at: twoHoursAgo,
+        message_count: 1,
+        cost_cents: 1,
+        provider: "cursor",
+      },
+      {
+        session_id: "yesterday",
+        started_at: yesterday,
+        message_count: 1,
+        cost_cents: 1,
+        provider: "cursor",
+      },
+      {
+        session_id: "old",
+        started_at: threeDaysAgo,
+        message_count: 1,
+        cost_cents: 1,
+        provider: "cursor",
+      },
+      { session_id: "missing", message_count: 1, cost_cents: 1, provider: "cursor" },
+    ];
+
+    const grouped = splitSessionsByDay(sessions);
+    expect(grouped.today.map((s) => s.session_id)).toEqual(["today"]);
+    expect(grouped.yesterday.map((s) => s.session_id)).toEqual(["yesterday"]);
   });
 });

--- a/extensions/cursor-budi/src/extension.ts
+++ b/extensions/cursor-budi/src/extension.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode";
 import * as fs from "fs";
+import * as path from "path";
 import {
   fetchStatusline,
   fetchRecentSessions,
@@ -14,10 +15,14 @@ import { HealthPanelProvider } from "./panel";
 let statusBarItem: vscode.StatusBarItem;
 let dataPollTimer: ReturnType<typeof setInterval> | undefined;
 let sessionFileWatcher: fs.FSWatcher | undefined;
+let sessionDirWatcher: fs.FSWatcher | undefined;
+let sessionWatchDebounce: ReturnType<typeof setTimeout> | undefined;
 let healthProvider: HealthPanelProvider;
 let currentSessionId: string | undefined;
 let pinnedSessionId: string | undefined;
 let log: vscode.OutputChannel;
+let refreshInFlight = false;
+let pendingRefreshDaemonUrl: string | undefined;
 
 export function activate(context: vscode.ExtensionContext): void {
   log = vscode.window.createOutputChannel("budi");
@@ -45,7 +50,7 @@ export function activate(context: vscode.ExtensionContext): void {
   healthProvider.setOnSelectSession((sessionId) => {
     pinnedSessionId = sessionId;
     log.appendLine(`[budi] session: pinned to ${sessionId} (from panel)`);
-    refreshData(daemonUrl);
+    requestRefresh(daemonUrl);
   });
 
   context.subscriptions.push(
@@ -65,7 +70,7 @@ export function activate(context: vscode.ExtensionContext): void {
   context.subscriptions.push(
     vscode.commands.registerCommand("budi.refreshStatus", () => {
       log.appendLine(`[budi] manual refresh triggered`);
-      refreshData(daemonUrl);
+      requestRefresh(daemonUrl);
     }),
   );
 
@@ -117,7 +122,7 @@ export function activate(context: vscode.ExtensionContext): void {
         }
       }
 
-      refreshData(daemonUrl);
+      requestRefresh(daemonUrl);
     }),
   );
 
@@ -134,13 +139,14 @@ export function activate(context: vscode.ExtensionContext): void {
         daemonUrl = updated.get("daemonUrl", "http://127.0.0.1:7878");
         dataPollInterval = updated.get("pollingIntervalMs", 15000);
         restartDataPoll(daemonUrl, dataPollInterval);
+        watchSessionFile(daemonUrl);
+        requestRefresh(daemonUrl);
       }
     }),
   );
 
   watchSessionFile(daemonUrl);
-
-  refreshData(daemonUrl);
+  requestRefresh(daemonUrl);
   startDataPoll(daemonUrl, dataPollInterval);
 }
 
@@ -153,13 +159,19 @@ export function deactivate(): void {
     sessionFileWatcher.close();
     sessionFileWatcher = undefined;
   }
+  if (sessionDirWatcher) {
+    sessionDirWatcher.close();
+    sessionDirWatcher = undefined;
+  }
+  if (sessionWatchDebounce) {
+    clearTimeout(sessionWatchDebounce);
+    sessionWatchDebounce = undefined;
+  }
 }
 
 function startDataPoll(daemonUrl: string, intervalMs: number): void {
   dataPollTimer = setInterval(() => {
-    refreshData(daemonUrl).catch((err) => {
-      log.appendLine(`[budi] poll error: ${err}`);
-    });
+    requestRefresh(daemonUrl);
   }, intervalMs);
 }
 
@@ -176,25 +188,77 @@ function restartDataPoll(daemonUrl: string, intervalMs: number): void {
  * statusline and panel — giving near-instant updates on interaction.
  */
 function watchSessionFile(daemonUrl: string): void {
-  try {
-    if (!fs.existsSync(SESSION_FILE)) return;
+  if (sessionFileWatcher) {
+    sessionFileWatcher.close();
+    sessionFileWatcher = undefined;
+  }
+  if (sessionDirWatcher) {
+    sessionDirWatcher.close();
+    sessionDirWatcher = undefined;
+  }
 
-    let debounce: ReturnType<typeof setTimeout> | undefined;
+  const scheduleRefresh = () => {
+    if (sessionWatchDebounce) clearTimeout(sessionWatchDebounce);
+    sessionWatchDebounce = setTimeout(() => {
+      const newId = resolveSessionId();
+      if (newId !== currentSessionId) {
+        log.appendLine(
+          `[budi] session file changed: ${currentSessionId ?? "none"} → ${newId ?? "none"}`,
+        );
+      }
+      requestRefresh(daemonUrl);
+    }, 500);
+  };
+
+  const attachFileWatcher = () => {
+    if (!fs.existsSync(SESSION_FILE)) return;
     sessionFileWatcher = fs.watch(SESSION_FILE, () => {
-      if (debounce) clearTimeout(debounce);
-      debounce = setTimeout(() => {
-        const newId = resolveSessionId();
-        if (newId !== currentSessionId) {
-          log.appendLine(
-            `[budi] session file changed: ${currentSessionId ?? "none"} → ${newId ?? "none"}`,
-          );
-        }
-        refreshData(daemonUrl).catch(() => {});
-      }, 500);
+      scheduleRefresh();
     });
+  };
+
+  try {
+    attachFileWatcher();
+
+    const sessionDir = path.dirname(SESSION_FILE);
+    if (fs.existsSync(sessionDir)) {
+      sessionDirWatcher = fs.watch(sessionDir, (_eventType, fileName) => {
+        if (fileName && fileName.toString() !== path.basename(SESSION_FILE)) {
+          return;
+        }
+        if (!sessionFileWatcher && fs.existsSync(SESSION_FILE)) {
+          log.appendLine("[budi] session file detected, attaching watcher");
+          attachFileWatcher();
+        }
+        scheduleRefresh();
+      });
+    }
   } catch {
     // File may not exist yet — will be created by first hook.
   }
+}
+
+function requestRefresh(daemonUrl: string): void {
+  pendingRefreshDaemonUrl = daemonUrl;
+  if (refreshInFlight) return;
+
+  refreshInFlight = true;
+  void (async () => {
+    try {
+      while (pendingRefreshDaemonUrl) {
+        const nextDaemonUrl = pendingRefreshDaemonUrl;
+        pendingRefreshDaemonUrl = undefined;
+        await refreshData(nextDaemonUrl);
+      }
+    } catch (err) {
+      log.appendLine(`[budi] refresh error: ${err}`);
+    } finally {
+      refreshInFlight = false;
+      if (pendingRefreshDaemonUrl) {
+        requestRefresh(pendingRefreshDaemonUrl);
+      }
+    }
+  })();
 }
 
 function resolveSessionId(): string | undefined {

--- a/extensions/cursor-budi/src/panel.ts
+++ b/extensions/cursor-budi/src/panel.ts
@@ -139,6 +139,8 @@ function buildHtml(
       .replace(/>/g, "&gt;")
       .replace(/"/g, "&quot;")
       .replace(/'/g, "&#039;");
+  const jsStringLiteral = (s: string) =>
+    JSON.stringify(s).replace(/</g, "\\u003c").replace(/>/g, "\\u003e");
 
   // Session details
   let detailSection = "";
@@ -193,7 +195,7 @@ function buildHtml(
       <div class="session-title">${title}</div>
       ${healthHtml}
       <div class="card-links">
-        <a href="#" onclick="openDashboard('${sessionUrl}')">Session Detail \u2197</a>
+        <a href="#" onclick='openDashboard(${jsStringLiteral(sessionUrl)})'>Session Detail \u2197</a>
       </div>
     </div>`;
   }
@@ -225,7 +227,7 @@ function buildHtml(
         const isActive = s.session_id === activeSessionId;
         const title = escapeHtml(sessionName(s.session_id));
         return `
-        <div class="session-row${isActive ? " session-active" : ""}" onclick="selectSession('${s.session_id}')">
+        <div class="session-row${isActive ? " session-active" : ""}" onclick='selectSession(${jsStringLiteral(s.session_id)})'>
           <span class="session-health">${icon(s.health_state || "green")}</span>
           <div class="session-info">
             <span class="session-name">${title}</span>
@@ -256,8 +258,8 @@ function buildHtml(
 
   const linksHtml = `
     <div class="links">
-      <a href="#" onclick="openDashboard('${dashboardUrl}/dashboard')">Dashboard \u2197</a>
-      <a href="#" onclick="openDashboard('${dashboardUrl}/dashboard/sessions')">All Sessions \u2197</a>
+      <a href="#" onclick='openDashboard(${jsStringLiteral(`${dashboardUrl}/dashboard`)})'>Dashboard \u2197</a>
+      <a href="#" onclick='openDashboard(${jsStringLiteral(`${dashboardUrl}/dashboard/sessions`)})'>All Sessions \u2197</a>
     </div>`;
 
   return `<!DOCTYPE html>


### PR DESCRIPTION
## What I reviewed
- Cursor extension activation/lifecycle behavior in `extension.ts` (polling, watcher setup, config changes, refresh fan-in)
- Daemon/client boundary usage and session bucketing behavior in `budiClient.ts` + extension usage paths
- Health panel UX and dynamic session/dashboard link handling in `panel.ts`
- Extension docs and top-level troubleshooting drift

## What I changed
- Serialized extension refreshes behind a queued `requestRefresh()` flow to avoid overlapping poll/manual/file-watch races.
- Reworked session-file watching to monitor both the file and parent directory, so updates still work when `cursor-sessions.json` appears after startup.
- Rebound session watchers and triggered immediate refresh when `budi.daemonUrl` / polling config changes.
- Added watcher debounce/timer cleanup on deactivate for cleaner lifecycle teardown.
- Escaped session IDs and dynamic URLs before injecting into webview inline handlers.
- Added `splitSessionsByDay` unit coverage for extension-facing day grouping.
- Added troubleshooting updates in extension README and root README.
- Added issue review artifact: `docs/reviews/issue-64-cursor-extension-reliability-health-ux-review.md`.

## Notable findings / risks
- Previously, daemon URL updates could leave file-watch refreshes targeting stale daemon endpoints.
- If the session file did not exist at activation, the extension might never attach a watcher and rely only on polling/manual refresh.
- Remaining risk: extension lifecycle behavior still lacks dedicated tests around activation/deactivation and watcher disposal.

## Validation performed
- `cd extensions/cursor-budi && npm ci`
- `cd extensions/cursor-budi && npm run lint`
- `cd extensions/cursor-budi && npm run format:check`
- `cd extensions/cursor-budi && npm run test`
- `cd extensions/cursor-budi && npm run build`

## Remaining follow-ups
- Add explicit unit/integration tests for extension lifecycle (`activate`/`deactivate`) and watcher teardown behavior.
- Consider replacing inline `onclick` handlers with delegated listeners plus stricter CSP model in the webview.

Closes #64

Made with [Cursor](https://cursor.com)