### PR TITLE
review: improve onboarding first-run docs and smoke checks (#65)

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,38 @@ To install a specific version, set the `VERSION` environment variable: `VERSION=
 
 Run `budi doctor` to verify everything is set up correctly.
 
+### First run checklist (5 minutes)
+
+Use this sequence if you want the fastest "did setup really work?" path:
+
+1. **Install and initialize**
+   - Homebrew: `brew install siropkin/budi/budi` then `budi init`
+   - Standalone installers and `./scripts/install.sh` already run `budi init` for you
+2. **Accept integration prompts** during `budi init` (recommended defaults are safe)
+3. **Wait for first sync**
+   - Fresh install: full history scan (can take a few minutes)
+   - Re-run init: quick recent sync (last 30 days)
+4. **Confirm health**
+   - Run `budi doctor`
+   - Open dashboard at `http://127.0.0.1:7878/dashboard`
+5. **Generate your first data point**
+   - Send one prompt in Claude Code or Cursor, then run `budi sync`
+   - Run `budi stats` and confirm non-zero usage
+6. **Restart apps once**
+   - Restart Claude Code and Cursor after `budi init` so hooks/statusline/extension changes take effect
+
+### PATH and duplicate binary checks
+
+If `budi` is "not found" or behavior looks inconsistent after an update, verify which binary is being executed:
+
+- macOS/Linux:
+  - `command -v budi`
+  - `which -a budi`
+- Windows (PowerShell):
+  - `Get-Command budi -All`
+
+Keep only one install source first on PATH (Homebrew **or** standalone path), not both.
+
 ## Status line
 
 Budi adds a live cost display to Claude Code (optional in `budi init`):

--- a/docs/reviews/issue-65-onboarding-first-run-review.md
+++ b/docs/reviews/issue-65-onboarding-first-run-review.md
@@ -1,0 +1,53 @@
+# Issue #65 review: onboarding flow and first-run documentation
+
+## Findings (ordered by severity)
+
+1. **No single "first 5 minutes" path in README**
+   - The README had all required commands, but install, init, first sync, app restart, and first verification were spread across sections.
+   - New users could finish install and still be unsure what to do next.
+   - Fixed in this PR by adding a single first-run checklist with ordered steps and expected outcomes.
+
+2. **PATH/duplicate binary recovery guidance was fragmented**
+   - README warned about mixed installs, but did not give a compact command set to confirm which binary was actually being executed.
+   - This increases confusion during upgrade/reinstall troubleshooting.
+   - Fixed in this PR by adding explicit macOS/Linux and Windows commands to verify active binaries.
+
+3. **Cursor extension first-run validation was implicit**
+   - Extension README described troubleshooting, but did not provide a short smoke test sequence for the happy path.
+   - Fixed in this PR by adding a first-run smoke check with expected UI behavior.
+
+## Changes made
+
+- `README.md`
+  - Added "First run checklist (5 minutes)" with install/init/integration selection/sync/verification/restart flow.
+  - Added "PATH and duplicate binary checks" section with concrete commands for Unix and Windows.
+- `extensions/cursor-budi/README.md`
+  - Added "First-run smoke check" with a quick sequence to validate hooks, session tracking, and panel updates.
+
+## Notable risks
+
+- Documentation still assumes users can run shell commands directly; users in locked-down corporate environments may need an additional "restricted shell" path.
+- The README remains long; even with a checklist, future growth can reintroduce onboarding drift if first-run content is not kept near install instructions.
+
+## Validation and review method
+
+- Reviewed issue scope and relevant files:
+  - `README.md`
+  - `SOUL.md`
+  - `scripts/install.sh`
+  - `scripts/install-standalone.sh`
+  - `scripts/install-standalone.ps1`
+  - `crates/budi-cli/src/commands/init.rs`
+  - `crates/budi-cli/src/commands/integrations.rs`
+  - `extensions/cursor-budi/README.md`
+  - `frontend/dashboard/README.md`
+- Confirmed documented first-run behavior aligns with current code:
+  - `budi init` integration prompt flow, daemon start, sync behavior, and next-step messaging
+  - installer auto-init behavior and PATH messaging
+  - Cursor extension install + refresh workflow
+
+## Follow-ups (not included in this PR)
+
+1. Add an automated docs smoke test that verifies README command snippets against current CLI flags.
+2. Add a short troubleshooting decision tree ("symptom -> next command") for top onboarding failures.
+3. Consider splitting README onboarding into a dedicated `docs/getting-started.md` and keeping README as a concise entry point.

--- a/extensions/cursor-budi/README.md
+++ b/extensions/cursor-budi/README.md
@@ -25,6 +25,15 @@ budi integrations install --with cursor-extension
 
 Run `budi doctor` to verify.
 
+### First-run smoke check
+
+After install/reload, validate in under a minute:
+
+1. Run `budi doctor` and confirm Cursor hooks + daemon are healthy
+2. Send one prompt in Cursor chat
+3. Click the budi status bar item (`🟢/🟡/🔴`) to open the health panel
+4. If no session appears yet, run **Budi: Refresh Status** once
+
 **Manual install** (if auto-install was skipped or you want to rebuild):
 
 ```bash


### PR DESCRIPTION
## What I reviewed
- Install paths and first-run flow in `README.md`
- Installer behavior in `scripts/install.sh`, `scripts/install-standalone.sh`, and `scripts/install-standalone.ps1`
- Init/integrations behavior in `crates/budi-cli/src/commands/init.rs` and `crates/budi-cli/src/commands/integrations.rs`
- Cursor and dashboard onboarding docs in `extensions/cursor-budi/README.md` and `frontend/dashboard/README.md`

## What I changed
- Added a focused first-run checklist to `README.md` to cover install -> init prompts -> first sync -> dashboard -> first data -> app restart.
- Added explicit PATH/duplicate-binary verification commands for macOS/Linux and Windows in `README.md`.
- Added a quick first-run smoke test sequence to `extensions/cursor-budi/README.md`.
- Added findings-first review artifact: `docs/reviews/issue-65-onboarding-first-run-review.md`.

## Notable findings or risks
- Main friction was discoverability/order, not missing capability: users had all commands but no single guided "first 5 minutes" path.
- Remaining risk: README length may drift again without docs-smoke automation for command snippets.

## Validation performed
- `cargo test --workspace --locked` (passed)

## Remaining follow-ups
- Add automated docs smoke tests for command snippets/flags.
- Add a troubleshooting decision tree (symptom -> command).
- Consider splitting onboarding into a dedicated `docs/getting-started.md`.

Closes #65

Made with [Cursor](https://cursor.com)