### PR TITLE
docs: close #66 with contributor workflow and template updates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -44,6 +44,15 @@ body:
       description: Paste relevant command output, stack traces, or screenshots.
       render: shell
   - type: textarea
+    id: diagnostics
+    attributes:
+      label: Diagnostic checks run
+      description: Share `budi doctor` output and any relevant validation commands already tried.
+      placeholder: |
+        - budi doctor:
+        - budi sync:
+        - additional checks:
+  - type: textarea
     id: environment
     attributes:
       label: Environment
@@ -56,3 +65,9 @@ body:
         - Node:
     validations:
       required: true
+  - type: textarea
+    id: impact
+    attributes:
+      label: Impact and urgency
+      description: Who is blocked and how severe is the issue?
+      placeholder: Affects all new installs / blocks release / minor annoyance, etc.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -26,6 +26,14 @@ body:
       label: Alternatives considered
       description: What other approaches did you evaluate?
   - type: textarea
+    id: scope
+    attributes:
+      label: Scope and non-goals
+      description: Clarify what should be in/out of scope for the first implementation.
+      placeholder: |
+        In scope:
+        Out of scope:
+  - type: textarea
     id: success
     attributes:
       label: Success criteria
@@ -35,3 +43,9 @@ body:
         - [ ] ...
     validations:
       required: true
+  - type: textarea
+    id: validation
+    attributes:
+      label: Suggested validation
+      description: Which checks should pass (tests, lint, manual flow) before this is considered done?
+      placeholder: cargo test target, dashboard build path, extension checks, etc.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,13 @@
 ## Summary
 
 - Describe what changed and why.
+- Link the issue/review scope this PR addresses.
+
+## Review scope
+
+- Area reviewed:
+- Key findings:
+- Follow-up items intentionally deferred:
 
 ## Validation
 
@@ -8,6 +15,11 @@
 - [ ] `cargo clippy --workspace --all-targets --locked -- -D warnings`
 - [ ] `cargo test --workspace --locked`
 - [ ] If extension changed: `cd extensions/cursor-budi && npm run lint && npm run format:check && npm run test && npm run build`
+- [ ] If dashboard changed: `cd frontend/dashboard && npm ci && npm run build`
+
+Validation evidence:
+
+- [ ] Paste key command output or CI links
 
 ## Risk and compatibility
 
@@ -19,3 +31,4 @@
 - [ ] Docs updated for user-visible behavior
 - [ ] Backward compatibility considered
 - [ ] Tests added/updated for changed behavior
+- [ ] Issue linkage included (`Closes #<issue>`) when applicable

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,12 @@
 
 Thanks for helping improve budi.
 
+## Prerequisites
+
+- Rust stable toolchain (`rustup`, `cargo`)
+- Node.js 20+ and npm (for dashboard and Cursor extension work)
+- `gh` CLI (required when validating release-install flows with `scripts/install.sh --from-release`)
+
 ## Quick start
 
 ```bash
@@ -18,6 +24,8 @@ cargo test
 
 ## Local quality checks
 
+Run checks only for the area you changed, plus any shared Rust code impacted by your change.
+
 ### Rust workspace
 
 ```bash
@@ -26,11 +34,17 @@ cargo clippy --workspace --all-targets --locked -- -D warnings
 cargo test --workspace --locked
 ```
 
+To mirror CI exactly for formatting, use:
+
+```bash
+cargo fmt --all -- --check
+```
+
 ### Dashboard frontend (`frontend/dashboard`)
 
 ```bash
 cd frontend/dashboard
-npm install
+npm ci
 npm run build
 ```
 
@@ -54,11 +68,11 @@ For local dashboard UI development (hot reload + API proxy):
 
 ```bash
 # terminal A (repo root)
-cargo run -p budi-daemon
+cargo run -p budi-daemon -- serve
 
 # terminal B
 cd frontend/dashboard
-npm install
+npm ci
 npm run dev
 ```
 
@@ -118,6 +132,26 @@ Issue templates are available in the repository to keep reports actionable.
 - [ ] Extension lint/format/test/build checks pass if extension code changed.
 - [ ] Docs were updated for user-visible behavior changes.
 - [ ] Migration or compatibility impact is noted (if relevant).
+- [ ] Follow-up work is captured explicitly (issue or PR TODO) if not included in this PR.
+- [ ] PR links the driving issue (`Closes #...` or equivalent) when applicable.
+
+## PR review expectations
+
+Use findings-first PR descriptions so reviewers can quickly assess risk:
+
+1. What area you reviewed or changed
+2. What you changed and why
+3. Risks/compatibility notes and any deferred follow-ups
+4. Validation evidence (commands run + pass/fail)
+
+If a review issue leads to "no code changes needed", still include a small artifact (for example a docs note, checklist update, or review report in `docs/reviews/`) so the decision is auditable.
+
+## Contributor troubleshooting quick hits
+
+- **`budi` and `budi-daemon` mismatch**: keep one install source on `PATH`; run `budi doctor`.
+- **Dashboard looks stale after frontend edits**: rebuild via `./scripts/build-dashboard.sh`, then restart daemon.
+- **Cursor extension status stale/offline**: run `budi doctor`, then `Budi: Refresh Status` or reload Cursor window.
+- **MCP tests fail unexpectedly**: verify `budi-daemon` is running before `budi mcp-serve` contract checks.
 
 ## Adding a new provider
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,13 @@ budi targets **macOS**, **Linux** (glibc), and **Windows 10+**. Prebuilt release
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for local setup, quality checks, and PR workflow.
+Architecture and module boundaries are documented in [SOUL.md](SOUL.md).
+
+Quick validation matrix:
+
+- Rust changes: `cargo fmt --all && cargo clippy --workspace --all-targets --locked -- -D warnings && cargo test --workspace --locked`
+- Dashboard changes: `cd frontend/dashboard && npm ci && npm run build`
+- Cursor extension changes: `cd extensions/cursor-budi && npm ci && npm run lint && npm run format:check && npm run test && npm run build`
 
 To report a bug or request a feature, open a GitHub issue using the repository templates so maintainers get reproducible details quickly.
 

--- a/SOUL.md
+++ b/SOUL.md
@@ -52,7 +52,7 @@ Enricher order is critical - each depends on prior enrichers. Do not reorder.
 
 ### Database (SQLite, WAL mode, schema v21)
 
-Six tables, four data entities + two supporting:
+Eight tables, six data entities + two supporting:
 - **messages** - Single cost entity. One row per API call. All token/cost data lives here. Fields: id, session_id, role, model, provider, timestamp, input/output/cache tokens, cost_cents, cost_confidence, git_branch, repo_id, cwd, request_id
 - **sessions** - Lifecycle context (start/end, duration, mode, title) without mixing cost concerns. One row per conversation from hooks. Primary key field: id
 - **hook_events** - Raw event log for tool stats and MCP tracking. One row per hook event

--- a/docs/reviews/issue-66-contributing-workflow-review.md
+++ b/docs/reviews/issue-66-contributing-workflow-review.md
@@ -1,0 +1,46 @@
+# Issue #66 review: contributing workflow and development documentation
+
+## What was reviewed
+
+- Contributor setup and validation docs: `CONTRIBUTING.md`, `README.md`
+- Architecture/source-of-truth notes: `SOUL.md`
+- Review process templates: `.github/pull_request_template.md`
+- Intake quality templates: `.github/ISSUE_TEMPLATE/bug_report.yml`, `.github/ISSUE_TEMPLATE/feature_request.yml`
+- Referenced workflow scripts: `scripts/build-dashboard.sh`, `scripts/install.sh`
+
+## Findings (highest impact first)
+
+1. **Architecture doc inconsistency:** `SOUL.md` described "Six tables" while listing eight tables. This creates avoidable confusion for migration and analytics reviewers.
+2. **Validation guidance drift:** contributor docs did not clearly separate CI-equivalent checks from fast local loops, and frontend examples mixed `npm install`/`npm ci`.
+3. **Review ambiguity:** PR template did not explicitly ask for review scope/findings/follow-ups, which leads to variable PR quality for review-driven issues.
+4. **Issue intake gaps:** bug/feature templates were missing structured prompts for diagnostics, impact, scope boundaries, and suggested validation.
+
+## Changes made
+
+- Fixed the SQLite table-count mismatch in `SOUL.md`.
+- Strengthened `CONTRIBUTING.md` with:
+  - prerequisites and area-scoped validation guidance,
+  - CI-equivalent rustfmt check command,
+  - consistent `npm ci` guidance,
+  - findings-first PR review expectations,
+  - contributor troubleshooting quick hits.
+- Expanded `README.md` contributing section with:
+  - direct architecture link (`SOUL.md`),
+  - compact validation matrix for Rust/dashboard/extension changes.
+- Updated `.github/pull_request_template.md` to require:
+  - review scope and findings context,
+  - deferred follow-ups disclosure,
+  - validation evidence and issue linkage.
+- Updated issue templates:
+  - bug report: added diagnostics and impact/urgency prompts,
+  - feature request: added scope/non-goals and suggested validation prompts.
+
+## Risks / trade-offs
+
+- These are documentation/template updates only; no runtime behavior or binary artifacts changed.
+- Slightly more structured templates increase authoring overhead, but reduce review back-and-forth and missing context.
+
+## Follow-ups not included in this PR
+
+- Add a lightweight `scripts/validate-changed-area.sh` helper to automate area-specific checks (Rust vs dashboard vs extension) and keep docs + CI permanently aligned.
+- Consider adding `.github/ISSUE_TEMPLATE/config.yml` with contact links and issue-form defaults if triage volume increases.


### PR DESCRIPTION
## What I reviewed
- `CONTRIBUTING.md`, `SOUL.md`, and `README.md` against current repo workflows and validation commands.
- `.github/pull_request_template.md` and issue templates for review clarity and intake quality.
- Referenced scripts (`scripts/build-dashboard.sh`, `scripts/install.sh`) to ensure docs match operational behavior.

## What I changed
- Fixed architecture documentation drift in `SOUL.md` (table count wording now matches the listed schema tables).
- Strengthened contributor workflow guidance in `CONTRIBUTING.md` (prerequisites, area-scoped validation, CI-equivalent rustfmt check, consistent `npm ci`, PR expectations, troubleshooting quick hits).
- Added a compact validation matrix and architecture link in `README.md`.
- Improved PR template to capture review scope, findings, deferred follow-ups, validation evidence, and issue linkage.
- Expanded bug/feature issue templates to collect diagnostics, impact, scope boundaries, and suggested validation.
- Added a findings-first review artifact: `docs/reviews/issue-66-contributing-workflow-review.md`.

## Notable findings or risks
- Primary finding: `SOUL.md` had a concrete table-count inconsistency that could mislead migration/analytics reviewers.
- Risk is low: this PR is docs/template-only (no runtime or packaging behavior changed).

## Validation performed
- `git diff --check`
- `cargo fmt --all -- --check`

## Remaining follow-ups
- Optional: add a helper script (for example `scripts/validate-changed-area.sh`) to codify area-specific checks and keep docs + CI aligned.
- Optional: add `.github/ISSUE_TEMPLATE/config.yml` defaults/contact guidance if issue volume grows.

Closes #66

Made with [Cursor](https://cursor.com)