### PR TITLE
Review #67: harden CI/release packaging checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,14 @@ jobs:
           cargo install cargo-audit --quiet
           cargo audit
 
+      - name: Validate shell script syntax
+        run: |
+          set -euo pipefail
+          for script in scripts/*.sh homebrew/setup-tap.sh; do
+            bash -n "$script"
+          done
+          echo "Shell script syntax checks passed"
+
       - name: Build release binaries
         env:
           BUDI_REQUIRE_CURSOR_VSIX: "1"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,6 +151,43 @@ jobs:
             tar -C "${RUNNER_TEMP}" -czf "${archive}" "${package}"
           fi
 
+          ARCHIVE_PATH="${GITHUB_WORKSPACE}/${archive}"
+          if [[ "$target" != *windows* ]]; then
+            ARCHIVE_PATH="${archive}"
+          fi
+
+          ARCHIVE_PATH="${ARCHIVE_PATH}" PACKAGE_NAME="${package}" TARGET_TRIPLE="${target}" python - <<'PY'
+          import os
+          import sys
+          import tarfile
+          import zipfile
+
+          archive = os.environ["ARCHIVE_PATH"]
+          package = os.environ["PACKAGE_NAME"]
+          target = os.environ["TARGET_TRIPLE"]
+
+          required = ["README.md", "LICENSE", "budi", "budi-daemon"]
+          if "windows" in target:
+            required[2] = "budi.exe"
+            required[3] = "budi-daemon.exe"
+
+          expected = {f"{package}/{name}" for name in required}
+          names: set[str]
+          if archive.endswith(".zip"):
+            with zipfile.ZipFile(archive, "r") as zf:
+              names = set(zf.namelist())
+          else:
+            with tarfile.open(archive, "r:gz") as tf:
+              names = set(tf.getnames())
+
+          missing = sorted(path for path in expected if path not in names)
+          if missing:
+            print(f"::error::Archive validation failed for {archive}; missing: {', '.join(missing)}")
+            sys.exit(1)
+
+          print(f"Archive validation passed for {archive}")
+          PY
+
       - name: Upload packaged artifact
         uses: actions/upload-artifact@v4
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -184,11 +184,34 @@ The MCP server uses stdio (stdout = JSON-RPC, stderr = logging). It's a thin HTT
 
 ## Releasing
 
-```bash
-./scripts/release.sh 7.0.0        # bump version + update Cargo.lock
-./scripts/release.sh 7.0.0 --tag  # also create git tag
+Release automation is tag-driven (`.github/workflows/release.yml`) and expects a clean `main` branch.
 
-# Then:
+```bash
+./scripts/release.sh 7.0.0        # bump version + update Cargo.lock (clean tree required)
 git commit -am "chore: bump version to 7.0.0"
-git push origin main v7.0.0       # CI builds release artifacts
+./scripts/release.sh 7.0.0 --tag  # create tag v7.0.0 (main only; refuses duplicate tags)
+git push origin main v7.0.0       # CI + release workflows build and publish assets
 ```
+
+Post-push release checks:
+
+```bash
+gh release view v7.0.0 --repo siropkin/budi
+gh release download v7.0.0 --repo siropkin/budi --pattern SHA256SUMS -D /tmp/budi-release-check
+cat /tmp/budi-release-check/SHA256SUMS
+```
+
+Expected release artifacts:
+
+- `budi-v<version>-x86_64-unknown-linux-gnu.tar.gz`
+- `budi-v<version>-aarch64-unknown-linux-gnu.tar.gz`
+- `budi-v<version>-x86_64-apple-darwin.tar.gz`
+- `budi-v<version>-aarch64-apple-darwin.tar.gz`
+- `budi-v<version>-x86_64-pc-windows-msvc.zip`
+- `SHA256SUMS`
+
+Homebrew auto-update notes:
+
+- The release workflow updates `siropkin/homebrew-budi` after publishing assets.
+- `HOMEBREW_TAP_TOKEN` must be configured in `siropkin/budi` repo secrets.
+- If the workflow cannot push the formula update, run `homebrew/setup-tap.sh <tag>` manually and open a follow-up PR/issue with the failure details.

--- a/docs/reviews/issue-67-ci-release-packaging-pipeline-review.md
+++ b/docs/reviews/issue-67-ci-release-packaging-pipeline-review.md
@@ -1,0 +1,43 @@
+# Issue #67 review: CI, release, and packaging pipeline
+
+## What was reviewed
+
+- CI workflow coverage and protection gates: `.github/workflows/ci.yml`
+- Release workflow correctness and packaging: `.github/workflows/release.yml`, `.github/release.yml`
+- Release helper and installer scripts: `scripts/release.sh`, `scripts/install.sh`, `scripts/uninstall.sh`
+- Distribution handoff files: `homebrew/budi.rb`, `homebrew/setup-tap.sh`
+- Maintainer docs: `CONTRIBUTING.md`
+
+## Findings (highest impact first)
+
+1. **Release preflight gap:** `scripts/release.sh` allowed version bumping/tag attempts from dirty worktrees, non-`main` branches, or duplicate tags, increasing the risk of inconsistent release history.
+2. **Packaging correctness blind spot:** release workflow created archives but did not validate archive contents before upload/publish, so missing binaries/docs could slip through until user install time.
+3. **Script quality coverage gap in CI:** CI validated Rust and extension flows but did not enforce syntax checks for release/install shell scripts, leaving regressions possible in critical install/release paths.
+4. **Process documentation drift:** contributing docs had the minimal release sequence, but lacked explicit post-release verification and Homebrew handoff guidance for maintainers.
+
+## Changes made
+
+- Hardened `scripts/release.sh` with preflight checks:
+  - fail on dirty working tree,
+  - reject unknown flags,
+  - require `main` when creating tags,
+  - fail fast if tag already exists locally or on `origin`.
+- Added CI shell syntax validation in `.github/workflows/ci.yml`:
+  - `bash -n` across `scripts/*.sh` and `homebrew/setup-tap.sh`.
+- Added release archive content validation in `.github/workflows/release.yml`:
+  - verifies each packaged asset includes expected binaries plus `README.md` and `LICENSE` before upload.
+- Expanded `CONTRIBUTING.md` release guidance with:
+  - explicit clean-release workflow,
+  - post-release validation commands,
+  - expected artifact list,
+  - Homebrew token/fallback maintenance notes.
+
+## Risks / trade-offs
+
+- New release-script guards are intentionally strict and may block ad-hoc release attempts from feature branches; this is a deliberate safety trade-off.
+- Archive validation introduces a small amount of workflow runtime overhead in exchange for better release integrity.
+
+## Follow-ups not included in this PR
+
+- Add end-to-end install smoke tests against published release artifacts on all supported platforms after `publish-release` (currently CI install tests are source-build based).
+- Add digest/signing provenance (e.g., artifact attestations and optional signature verification) to strengthen supply-chain trust beyond SHA256 checksums.

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -33,7 +33,20 @@ if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
   fail "Version must use semantic version format X.Y.Z (got: $VERSION)"
 fi
 
+if [[ -n "$CREATE_TAG" && "$CREATE_TAG" != "--tag" ]]; then
+  fail "Unknown flag: $CREATE_TAG (expected --tag)"
+fi
+
 cd "$REPO_ROOT"
+
+if [[ -n "$(git status --porcelain)" ]]; then
+  fail "Working tree is not clean. Commit/stash changes before running release."
+fi
+
+current_branch="$(git rev-parse --abbrev-ref HEAD)"
+if [[ "$CREATE_TAG" == "--tag" && "$current_branch" != "main" ]]; then
+  fail "Refusing to create release tag from branch '$current_branch' (expected main)"
+fi
 
 # 1. Bump workspace Cargo.toml version
 log "Bumping Cargo.toml workspace version to $VERSION"
@@ -51,6 +64,12 @@ git diff --name-only
 
 # 4. Optionally tag
 if [[ "$CREATE_TAG" == "--tag" ]]; then
+  if git rev-parse -q --verify "refs/tags/v$VERSION" >/dev/null; then
+    fail "Tag v$VERSION already exists locally"
+  fi
+  if git ls-remote --exit-code --tags origin "refs/tags/v$VERSION" >/dev/null 2>&1; then
+    fail "Tag v$VERSION already exists on origin"
+  fi
   log "Creating git tag v$VERSION"
   git tag "v$VERSION"
   log "Tag v$VERSION created. Push with: git push origin v$VERSION"


### PR DESCRIPTION
## What I reviewed
- CI workflow protections and smoke coverage in `.github/workflows/ci.yml`
- Release workflow packaging/release/handoff flow in `.github/workflows/release.yml`
- Release helper and maintainer process docs in `scripts/release.sh` and `CONTRIBUTING.md`
- Review artifact in `docs/reviews/issue-67-ci-release-packaging-pipeline-review.md`

## What I changed
- Added shell script syntax validation in CI (`bash -n` for `scripts/*.sh` and `homebrew/setup-tap.sh`).
- Added archive content validation in release packaging to ensure expected binaries/docs are present before upload.
- Hardened `scripts/release.sh` preflight checks:
  - rejects dirty worktrees,
  - rejects unknown flags,
  - requires `main` for `--tag`,
  - blocks duplicate local/remote release tags.
- Expanded `CONTRIBUTING.md` release guidance with post-release verification and Homebrew handoff notes.
- Added findings-first review document for issue #67.

## Notable findings / risks
- Before this change, release/tag flow could proceed from dirty state or duplicate tags.
- Before this change, packaged artifacts were not validated for required contents.
- These guards are intentionally stricter and may block ad-hoc release attempts from non-`main` branches.

## Validation performed
- `bash -n scripts/*.sh homebrew/setup-tap.sh`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`

## Remaining follow-ups
- Add post-publish install smoke tests against GitHub release artifacts on all supported platforms.
- Add stronger supply-chain provenance/signing beyond SHA256SUMS.

Closes #67

Made with [Cursor](https://cursor.com)