### PR TITLE
[8.0][R2.2] Implement streaming pass-through without user-visible lag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,6 +213,7 @@ dependencies = [
  "include_dir",
  "mime_guess",
  "reqwest",
+ "rusqlite",
  "serde",
  "serde_json",
  "tokio",

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ No cloud. No uploads. Everything stays on your machine.
 ## What it does
 
 - Tracks tokens, costs, and usage per message across AI coding agents
-- **Local proxy** (port 9878) sits between your agent and the LLM provider, capturing every request in real time
+- **Local proxy** (port 9878) sits between your agent and the LLM provider, capturing every request in real time — streaming responses pass through with no visible lag
 - **Exact cost** via OpenTelemetry for Claude Code (includes thinking tokens)
 - Attributes cost to repos, branches, tickets, and custom tags
 - **Session health** — detects context bloat, cache degradation, cost acceleration, and retry loops with actionable, provider-aware tips
@@ -342,7 +342,7 @@ Budi is 100% local — no cloud, no uploads, no telemetry. All data stays on you
 
 ## How it works
 
-A lightweight Rust daemon (port 7878) receives real-time OpenTelemetry events, syncs JSONL transcripts, and processes hook events — merging all sources into a single SQLite database. The daemon also runs a **proxy server** on port 9878 that transparently forwards agent traffic to upstream providers (Anthropic, OpenAI) while capturing metadata. The CLI is a thin HTTP client — all queries go through the daemon.
+A lightweight Rust daemon (port 7878) receives real-time OpenTelemetry events, syncs JSONL transcripts, and processes hook events — merging all sources into a single SQLite database. The daemon also runs a **proxy server** on port 9878 that transparently forwards agent traffic to upstream providers (Anthropic, OpenAI) while capturing metadata. Streaming (SSE) responses pass through chunk-by-chunk with no buffering; token metadata is extracted from the byte stream without modifying it. The CLI is a thin HTTP client — all queries go through the daemon.
 
 ## Details
 

--- a/SOUL.md
+++ b/SOUL.md
@@ -66,7 +66,8 @@ Sources (JSONL files, OTEL spans, Cursor API, Hooks)
 
 Proxy (agent -> localhost:9878 -> upstream provider)
   -> Path-based routing (Anthropic /v1/messages, OpenAI /v1/chat/completions)
-  -> Transparent pass-through with metadata capture
+  -> SSE: chunk-by-chunk pass-through with tee/tap token extraction
+  -> Non-SSE: buffered with JSON usage parsing
   -> SQLite (proxy_events table)
 ```
 
@@ -89,7 +90,7 @@ Nine tables, seven data entities + two supporting:
 
 | Source | Confidence | What it provides |
 |--------|-----------|-----------------|
-| **Proxy** (all agents) | `proxy` | Real-time per-request tokens from response body (non-streaming) or best-effort (streaming) |
+| **Proxy** (all agents) | `proxy` | Real-time per-request tokens from response body (non-streaming) or SSE tee/tap extraction (streaming) |
 | **OTEL** (Claude Code) | `otel_exact` | Per-request tokens including thinking, exact cost |
 | **JSONL** (Claude Code) | `estimated` | Per-message tokens (no thinking), cost calculated from pricing |
 | **Cursor Usage API** | `exact` | Per-request tokens + totalCents from Cursor's API |
@@ -104,7 +105,7 @@ OTEL and JSONL deduplicate: same API call matched by session_id + model + timest
 - **Progressive sync**: files processed newest-first so dashboard shows recent data quickly
 - **Sync split**: `budi sync` = 30-day window (fast), `budi sync --all` = full history
 - **Hook system**: `budi hook` reads stdin JSON, POSTs to daemon. Fire-and-forget, <50ms
-- **Proxy mode**: Daemon runs a second HTTP server on port 9878 that acts as a transparent proxy between AI agents and upstream providers (Anthropic, OpenAI). Agents set `ANTHROPIC_BASE_URL=http://localhost:9878` or `OPENAI_BASE_URL=http://localhost:9878` to route through the proxy. Path-based routing: `/v1/messages` → Anthropic, `/v1/chat/completions` → OpenAI. Captures metadata (model, tokens, duration, status) in `proxy_events` table without modifying the response. Config: `[proxy]` section in `config.toml`, `BUDI_PROXY_PORT` / `BUDI_PROXY_ENABLED` env vars, `--proxy-port` / `--no-proxy` CLI flags. See [ADR-0082](docs/adr/0082-proxy-compatibility-matrix-and-gateway-contract.md) for the full contract.
+- **Proxy mode**: Daemon runs a second HTTP server on port 9878 that acts as a transparent proxy between AI agents and upstream providers (Anthropic, OpenAI). Agents set `ANTHROPIC_BASE_URL=http://localhost:9878` or `OPENAI_BASE_URL=http://localhost:9878` to route through the proxy. Path-based routing: `/v1/messages` → Anthropic, `/v1/chat/completions` → OpenAI. SSE streaming responses are passed through chunk-by-chunk with no buffering; a tee/tap on the byte stream extracts token metadata (input/output tokens) from SSE events without modifying the data. Non-streaming responses are buffered and parsed for usage data. Duration is measured from request start to stream end (not to first headers). Mid-stream failures and client disconnects are handled gracefully — partial metadata is recorded via Drop. No read timeout on streaming; non-streaming uses 300s. Config: `[proxy]` section in `config.toml`, `BUDI_PROXY_PORT` / `BUDI_PROXY_ENABLED` env vars, `--proxy-port` / `--no-proxy` CLI flags. See [ADR-0082](docs/adr/0082-proxy-compatibility-matrix-and-gateway-contract.md) for the full contract.
 
 ## Key files
 

--- a/crates/budi-daemon/Cargo.toml
+++ b/crates/budi-daemon/Cargo.toml
@@ -24,4 +24,5 @@ tracing-subscriber.workspace = true
 
 [dev-dependencies]
 http-body-util = "0.1"
+rusqlite.workspace = true
 tower = { version = "0.5", features = ["util"] }

--- a/crates/budi-daemon/src/main.rs
+++ b/crates/budi-daemon/src/main.rs
@@ -718,10 +718,11 @@ mod tests {
     }
 
     fn proxy_with_upstream(upstream: &str) -> ProxyTestHarness {
-        let tmp = std::env::temp_dir().join(format!(
-            "budi-sse-test-{}",
-            std::thread::current().name().unwrap_or("t")
-        ));
+        let safe_name = std::thread::current()
+            .name()
+            .unwrap_or("t")
+            .replace("::", "_");
+        let tmp = std::env::temp_dir().join(format!("budi-sse-test-{safe_name}"));
         std::fs::create_dir_all(&tmp).ok();
         let db_path = tmp.join("analytics.db");
         let _ = std::fs::remove_file(&db_path);

--- a/crates/budi-daemon/src/main.rs
+++ b/crates/budi-daemon/src/main.rs
@@ -685,4 +685,239 @@ mod tests {
             .unwrap();
         assert_eq!(resp.status(), StatusCode::PAYLOAD_TOO_LARGE);
     }
+
+    // --- SSE streaming tests ---
+
+    /// Start a mock HTTP server that returns an SSE response, then closes.
+    async fn start_mock_sse_server(sse_body: String) -> std::net::SocketAddr {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut buf = vec![0u8; 16384];
+            let _ = socket.read(&mut buf).await;
+            let resp = format!(
+                "HTTP/1.1 200 OK\r\n\
+                 Content-Type: text/event-stream\r\n\
+                 Connection: close\r\n\
+                 \r\n\
+                 {sse_body}"
+            );
+            let _ = socket.write_all(resp.as_bytes()).await;
+        });
+
+        addr
+    }
+
+    struct ProxyTestHarness {
+        app: Router,
+        db_path: PathBuf,
+    }
+
+    fn proxy_with_upstream(upstream: &str) -> ProxyTestHarness {
+        let tmp = std::env::temp_dir().join(format!(
+            "budi-sse-test-{}",
+            std::thread::current().name().unwrap_or("t")
+        ));
+        std::fs::create_dir_all(&tmp).ok();
+        let db_path = tmp.join("analytics.db");
+        let _ = std::fs::remove_file(&db_path);
+
+        let proxy_state = ProxyState {
+            http_client: reqwest::Client::new(),
+            anthropic_upstream: upstream.to_string(),
+            openai_upstream: upstream.to_string(),
+            analytics_db_path: db_path.clone(),
+        };
+        ProxyTestHarness {
+            app: build_proxy_router(proxy_state),
+            db_path,
+        }
+    }
+
+    #[tokio::test]
+    async fn proxy_streams_anthropic_sse_and_extracts_tokens() {
+        let sse_body = [
+            "event: message_start\n",
+            "data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_t\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"claude-sonnet-4-6\",\"usage\":{\"input_tokens\":25,\"output_tokens\":1}}}\n\n",
+            "event: content_block_delta\n",
+            "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"Hello\"}}\n\n",
+            "event: message_delta\n",
+            "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":15}}\n\n",
+            "event: message_stop\n",
+            "data: {\"type\":\"message_stop\"}\n\n",
+        ].concat();
+
+        let addr = start_mock_sse_server(sse_body).await;
+        let h = proxy_with_upstream(&format!("http://{addr}"));
+
+        let body = serde_json::json!({
+            "model": "claude-sonnet-4-6",
+            "stream": true,
+            "max_tokens": 100,
+            "messages": [{"role": "user", "content": "hello"}]
+        });
+        let resp = h
+            .app
+            .oneshot(
+                Request::post("/v1/messages")
+                    .header("content-type", "application/json")
+                    .header("x-api-key", "test-key")
+                    .header("anthropic-version", "2023-06-01")
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let ct = resp
+            .headers()
+            .get("content-type")
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert!(
+            ct.contains("text/event-stream"),
+            "expected SSE content-type"
+        );
+
+        let resp_bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        let text = String::from_utf8_lossy(&resp_bytes);
+        assert!(
+            text.contains("message_start"),
+            "SSE data should pass through"
+        );
+        assert!(text.contains("Hello"), "content delta should pass through");
+
+        // Wait for spawn_blocking event recording
+        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+        let conn = rusqlite::Connection::open(&h.db_path).unwrap();
+        budi_core::proxy::ensure_proxy_schema(&conn).unwrap();
+        let (input, output, streaming): (Option<i64>, Option<i64>, i64) = conn
+            .query_row(
+                "SELECT input_tokens, output_tokens, is_streaming FROM proxy_events ORDER BY id DESC LIMIT 1",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(input, Some(25), "input_tokens from message_start");
+        assert_eq!(output, Some(15), "output_tokens from message_delta");
+        assert_eq!(streaming, 1);
+    }
+
+    #[tokio::test]
+    async fn proxy_streams_openai_sse_and_extracts_tokens() {
+        let sse_body = [
+            "data: {\"id\":\"chatcmpl-t\",\"object\":\"chat.completion.chunk\",\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hi\"},\"finish_reason\":null}]}\n\n",
+            "data: {\"id\":\"chatcmpl-t\",\"object\":\"chat.completion.chunk\",\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":20,\"total_tokens\":30}}\n\n",
+            "data: [DONE]\n\n",
+        ].concat();
+
+        let addr = start_mock_sse_server(sse_body).await;
+        let h = proxy_with_upstream(&format!("http://{addr}"));
+
+        let body = serde_json::json!({
+            "model": "gpt-4o",
+            "stream": true,
+            "messages": [{"role": "user", "content": "hello"}]
+        });
+        let resp = h
+            .app
+            .oneshot(
+                Request::post("/v1/chat/completions")
+                    .header("content-type", "application/json")
+                    .header("authorization", "Bearer test-key")
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let resp_bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        let text = String::from_utf8_lossy(&resp_bytes);
+        assert!(text.contains("Hi"), "content should pass through");
+        assert!(
+            text.contains("[DONE]"),
+            "terminal event should pass through"
+        );
+
+        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+        let conn = rusqlite::Connection::open(&h.db_path).unwrap();
+        budi_core::proxy::ensure_proxy_schema(&conn).unwrap();
+        let (input, output): (Option<i64>, Option<i64>) = conn
+            .query_row(
+                "SELECT input_tokens, output_tokens FROM proxy_events ORDER BY id DESC LIMIT 1",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(input, Some(10), "prompt_tokens from usage");
+        assert_eq!(output, Some(20), "completion_tokens from usage");
+    }
+
+    #[tokio::test]
+    async fn proxy_sse_duration_reflects_stream_end() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut buf = vec![0u8; 16384];
+            let _ = socket.read(&mut buf).await;
+            let headers =
+                "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nConnection: close\r\n\r\n";
+            let _ = socket.write_all(headers.as_bytes()).await;
+            let _ = socket
+                .write_all(b"data: {\"type\":\"message_start\"}\n\n")
+                .await;
+            tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+            let _ = socket
+                .write_all(b"data: {\"type\":\"message_stop\"}\n\n")
+                .await;
+        });
+
+        let h = proxy_with_upstream(&format!("http://{addr}"));
+        let body = serde_json::json!({
+            "model": "claude-sonnet-4-6",
+            "stream": true,
+            "messages": [{"role": "user", "content": "hi"}]
+        });
+        let resp = h
+            .app
+            .oneshot(
+                Request::post("/v1/messages")
+                    .header("content-type", "application/json")
+                    .header("x-api-key", "k")
+                    .header("anthropic-version", "2023-06-01")
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let _ = resp.into_body().collect().await.unwrap();
+
+        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+        let conn = rusqlite::Connection::open(&h.db_path).unwrap();
+        budi_core::proxy::ensure_proxy_schema(&conn).unwrap();
+        let duration_ms: i64 = conn
+            .query_row(
+                "SELECT duration_ms FROM proxy_events ORDER BY id DESC LIMIT 1",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(
+            duration_ms >= 200,
+            "duration_ms ({duration_ms}) should reflect stream end, not header time"
+        );
+    }
 }

--- a/crates/budi-daemon/src/routes/proxy.rs
+++ b/crates/budi-daemon/src/routes/proxy.rs
@@ -3,14 +3,19 @@
 //! Supports two protocol families (ADR-0082):
 //! - OpenAI Chat Completions: `POST /v1/chat/completions`, `GET /v1/models`
 //! - Anthropic Messages: `POST /v1/messages`
+//!
+//! Streaming responses use [`SseTapStream`] to extract token metadata from SSE
+//! chunks without buffering or modifying the pass-through data (ADR-0082 §5).
 
+use std::pin::Pin;
+use std::task::{Context, Poll};
 use std::time::Instant;
 
 use axum::body::Body;
 use axum::extract::State;
 use axum::http::{HeaderMap, HeaderValue, Method, Request, Response, StatusCode, header};
 use axum::response::IntoResponse;
-use futures_util::StreamExt;
+use futures_util::Stream;
 use serde_json::Value;
 
 use budi_core::proxy::{ProxyEvent, ProxyProvider};
@@ -84,10 +89,13 @@ async fn proxy_request(
     };
 
     let upstream_url = format!("{}{}", upstream_base_url(&state, provider), path);
-    let mut upstream_req = state
-        .http_client
-        .request(method, &upstream_url)
-        .timeout(std::time::Duration::from_secs(300));
+    let mut upstream_req = state.http_client.request(method, &upstream_url);
+    // ADR-0082 §5: no read timeout on streaming responses. The stream ends
+    // when upstream closes or sends a terminal event. Non-streaming requests
+    // keep a generous whole-request timeout.
+    if !is_streaming {
+        upstream_req = upstream_req.timeout(std::time::Duration::from_secs(300));
+    }
 
     upstream_req = forward_headers(upstream_req, &incoming_headers, provider);
 
@@ -130,22 +138,19 @@ async fn proxy_request(
         .is_some_and(|ct| ct.contains("text/event-stream"));
 
     if is_sse {
-        let duration_ms = start.elapsed().as_millis() as i64;
-        record_event(
-            &state,
+        let tap = SseTapStream {
+            inner: Box::pin(upstream_resp.bytes_stream()),
             provider,
-            &model,
-            None,
-            None,
-            duration_ms,
-            status.as_u16(),
-            true,
-        );
-
-        let stream = upstream_resp
-            .bytes_stream()
-            .map(|chunk| chunk.map_err(std::io::Error::other));
-        let body = Body::from_stream(stream);
+            model,
+            status_code: status.as_u16(),
+            start,
+            state,
+            line_buf: Vec::new(),
+            input_tokens: None,
+            output_tokens: None,
+            recorded: false,
+        };
+        let body = Body::from_stream(tap);
 
         let mut response = Response::builder().status(status);
         copy_response_headers(&resp_headers, response.headers_mut().unwrap());
@@ -206,6 +211,132 @@ async fn proxy_request(
             &proxy_error_json("failed to build response"),
         )
     })
+}
+
+/// Wraps an upstream SSE byte stream to extract token metadata without
+/// modifying the pass-through data. Records a [`ProxyEvent`] when the stream
+/// completes, errors, or is dropped (client disconnect).
+///
+/// ADR-0082 §5: "capture happens via a tee/tap on the byte stream, not by
+/// deserializing and re-serializing every chunk."
+struct SseTapStream {
+    inner: Pin<Box<dyn Stream<Item = Result<axum::body::Bytes, reqwest::Error>> + Send>>,
+    provider: ProxyProvider,
+    model: String,
+    status_code: u16,
+    start: Instant,
+    state: ProxyState,
+    line_buf: Vec<u8>,
+    input_tokens: Option<i64>,
+    output_tokens: Option<i64>,
+    recorded: bool,
+}
+
+impl Stream for SseTapStream {
+    type Item = Result<axum::body::Bytes, std::io::Error>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+        match this.inner.as_mut().poll_next(cx) {
+            Poll::Ready(Some(Ok(bytes))) => {
+                this.scan_sse_bytes(&bytes);
+                Poll::Ready(Some(Ok(bytes)))
+            }
+            Poll::Ready(Some(Err(e))) => {
+                this.finish_recording();
+                Poll::Ready(Some(Err(std::io::Error::other(e))))
+            }
+            Poll::Ready(None) => {
+                this.finish_recording();
+                Poll::Ready(None)
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+impl Drop for SseTapStream {
+    fn drop(&mut self) {
+        self.finish_recording();
+    }
+}
+
+impl SseTapStream {
+    /// Scan incoming bytes for complete SSE `data:` lines and extract tokens.
+    fn scan_sse_bytes(&mut self, bytes: &[u8]) {
+        self.line_buf.extend_from_slice(bytes);
+        while let Some(pos) = self.line_buf.iter().position(|&b| b == b'\n') {
+            let line: Vec<u8> = self.line_buf.drain(..=pos).collect();
+            let trimmed = line.strip_suffix(b"\n").unwrap_or(&line);
+            let trimmed = trimmed.strip_suffix(b"\r").unwrap_or(trimmed);
+            if let Some(data) = trimmed.strip_prefix(b"data: ") {
+                if data == b"[DONE]" {
+                    continue;
+                }
+                if let Ok(json) = serde_json::from_slice::<Value>(data) {
+                    self.extract_tokens(&json);
+                }
+            }
+        }
+    }
+
+    /// Best-effort token extraction from a single SSE data event.
+    fn extract_tokens(&mut self, json: &Value) {
+        match self.provider {
+            ProxyProvider::Anthropic => {
+                // message_start → .message.usage.input_tokens
+                if let Some(n) = json
+                    .pointer("/message/usage/input_tokens")
+                    .and_then(|v| v.as_i64())
+                {
+                    self.input_tokens = Some(n);
+                }
+                // message_delta → .usage.output_tokens
+                if let Some(n) = json
+                    .pointer("/usage/output_tokens")
+                    .and_then(|v| v.as_i64())
+                {
+                    self.output_tokens = Some(n);
+                }
+                // Fallback: .usage.input_tokens (some event shapes)
+                if self.input_tokens.is_none()
+                    && let Some(n) = json.pointer("/usage/input_tokens").and_then(|v| v.as_i64())
+                {
+                    self.input_tokens = Some(n);
+                }
+            }
+            ProxyProvider::OpenAi => {
+                // Final chunk (or stream_options include_usage) → .usage.*
+                if let Some(usage) = json.get("usage").filter(|u| !u.is_null()) {
+                    if let Some(n) = usage.get("prompt_tokens").and_then(|v| v.as_i64()) {
+                        self.input_tokens = Some(n);
+                    }
+                    if let Some(n) = usage.get("completion_tokens").and_then(|v| v.as_i64()) {
+                        self.output_tokens = Some(n);
+                    }
+                }
+            }
+        }
+    }
+
+    /// Record the proxy event exactly once (normal end, error, or Drop).
+    fn finish_recording(&mut self) {
+        if self.recorded {
+            return;
+        }
+        self.recorded = true;
+        let duration_ms = self.start.elapsed().as_millis() as i64;
+        record_event(
+            &self.state,
+            self.provider,
+            &self.model,
+            self.input_tokens,
+            self.output_tokens,
+            duration_ms,
+            self.status_code,
+            true,
+        );
+    }
 }
 
 async fn read_body(req: Request<Body>) -> Result<axum::body::Bytes, Response<Body>> {


### PR DESCRIPTION
## Summary

Implements streaming SSE pass-through for the proxy so that proxy mode feels invisible to agents using streaming responses.

**Changes:**
- **`SseTapStream`** — custom `Stream` wrapper that taps the upstream SSE byte stream for token metadata without modifying or buffering the pass-through data (ADR-0082 §5).
- **Token extraction** — best-effort parsing of SSE `data:` lines to capture `input_tokens` and `output_tokens` from both Anthropic (message_start/message_delta) and OpenAI (usage field in final chunk) protocols.
- **Duration at stream end** — `duration_ms` now reflects the full stream lifetime (request start → stream end), not time-to-first-headers.
- **No read timeout on streaming** — removed the 300s whole-request timeout for `stream: true` requests per ADR-0082 §5. Non-streaming requests keep the 300s timeout.
- **Mid-stream failure handling** — `SseTapStream` records partial analytics via `Drop`, covering normal completion, errors, and client disconnects.

Closes #90

## Risks / compatibility notes

- **No behavioral change for non-streaming requests** — the buffered path is untouched.
- **Token extraction is best-effort** — if an SSE event format changes or doesn't contain usage fields, tokens are `None`. This matches the ADR's "token capture is best-effort" contract.
- **No new dependencies** — `rusqlite` added only as a dev-dependency for test DB assertions.
- **Timeout change** — streaming requests no longer have a 300s cap. This matches the ADR but means a stuck upstream that sends headers + SSE Content-Type but no data will hang until the agent disconnects. Connect timeout (30s) still applies.

## Validation

```
cargo fmt --all -- --check   ✅
cargo clippy --workspace --all-targets --locked -- -D warnings   ✅
cargo test --workspace --locked   ✅ (338 tests, 3 new)
```

New tests:
- `proxy_streams_anthropic_sse_and_extracts_tokens` — mock SSE upstream, verifies pass-through and token extraction (input=25, output=15)
- `proxy_streams_openai_sse_and_extracts_tokens` — mock SSE upstream, verifies pass-through and token extraction (prompt=10, completion=20)
- `proxy_sse_duration_reflects_stream_end` — mock server with 250ms delay, asserts duration_ms ≥ 200


Made with [Cursor](https://cursor.com)