### PR TITLE
Persist proxy metadata with repo, branch, and ticket attribution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,6 +197,7 @@ dependencies = [
  "toml",
  "tracing",
  "ureq",
+ "uuid",
 ]
 
 [[package]]
@@ -236,9 +237,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.58"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -570,9 +571,22 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -586,9 +600,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "hashlink"
@@ -652,9 +666,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -666,7 +680,6 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -738,12 +751,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -751,9 +765,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -764,9 +778,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -778,15 +792,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -798,15 +812,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -816,6 +830,12 @@ dependencies = [
  "zerotrie",
  "zerovec",
 ]
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "idna"
@@ -859,12 +879,14 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -875,9 +897,9 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8e7418f59cc01c88316161279a7f665217ae316b388e58a0d10e29f54f1e5eb"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
 dependencies = [
  "memchr",
  "serde",
@@ -897,10 +919,12 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -912,10 +936,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "libc"
-version = "0.2.183"
+name = "leb128fmt"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.184"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "libsqlite3-sys"
@@ -930,9 +960,9 @@ dependencies = [
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "litrs"
@@ -1059,12 +1089,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1072,9 +1096,9 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -1092,6 +1116,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]
@@ -1172,6 +1206,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -1291,9 +1331,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustls"
@@ -1322,9 +1362,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -1342,6 +1382,12 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -1593,9 +1639,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -1618,9 +1664,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
 dependencies = [
  "bytes",
  "libc",
@@ -1634,9 +1680,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1840,6 +1886,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1908,6 +1960,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+dependencies = [
+ "getrandom 0.4.2",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1950,10 +2013,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.114"
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1964,23 +2036,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.64"
+version = "0.4.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1988,9 +2056,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2001,11 +2069,33 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
 ]
 
 [[package]]
@@ -2022,10 +2112,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "web-sys"
-version = "0.3.91"
+name = "wasmparser"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2279,18 +2381,100 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -2299,9 +2483,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2311,18 +2495,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.47"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.47"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2331,18 +2515,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2358,9 +2542,9 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -2369,9 +2553,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -2380,9 +2564,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,4 @@ toml = "0.8"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 ureq = { version = "3", features = ["json"] }
+uuid = { version = "1", features = ["v4"] }

--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ Budi is 100% local — no cloud, no uploads, no telemetry. All data stays on you
 
 ## How it works
 
-A lightweight Rust daemon (port 7878) receives real-time OpenTelemetry events, syncs JSONL transcripts, and processes hook events — merging all sources into a single SQLite database. The daemon also runs a **proxy server** on port 9878 that transparently forwards agent traffic to upstream providers (Anthropic, OpenAI) while capturing metadata. Streaming (SSE) responses pass through chunk-by-chunk with no buffering; token metadata is extracted from the byte stream without modifying it. The CLI is a thin HTTP client — all queries go through the daemon.
+A lightweight Rust daemon (port 7878) receives real-time OpenTelemetry events, syncs JSONL transcripts, and processes hook events — merging all sources into a single SQLite database. The daemon also runs a **proxy server** on port 9878 that transparently forwards agent traffic to upstream providers (Anthropic, OpenAI) while capturing metadata. Streaming (SSE) responses pass through chunk-by-chunk with no buffering; token metadata is extracted from the byte stream without modifying it. Proxy traffic is attributed to repos, branches, and tickets via `X-Budi-Repo`/`X-Budi-Branch`/`X-Budi-Cwd` headers or automatic git resolution, with cost computed from provider pricing tables. The CLI is a thin HTTP client — all queries go through the daemon.
 
 ## Details
 
@@ -411,7 +411,7 @@ The daemon is the single source of truth — the CLI never opens the database di
 | **sessions** | Lifecycle context (start/end, duration, mode) without mixing cost concerns |
 | **hook_events** | Raw event log for tool stats and session metadata |
 | **otel_events** | Raw OpenTelemetry event storage for debugging/audit |
-| **proxy_events** | Append-only log of proxied LLM API requests (provider, model, tokens, duration, status) |
+| **proxy_events** | Append-only log of proxied LLM API requests (provider, model, tokens, duration, status, repo, branch, ticket, cost) |
 | **tags** | Flexible key-value pairs per message (repo, ticket, activity, user, etc.) |
 | **sync_state** | Tracks incremental ingestion progress per file for progressive sync |
 | **message_rollups_hourly** | Derived hourly aggregates (provider/model/repo/branch/role) for low-latency analytics reads |

--- a/SOUL.md
+++ b/SOUL.md
@@ -66,9 +66,11 @@ Sources (JSONL files, OTEL spans, Cursor API, Hooks)
 
 Proxy (agent -> localhost:9878 -> upstream provider)
   -> Path-based routing (Anthropic /v1/messages, OpenAI /v1/chat/completions)
+  -> Attribution: X-Budi-Repo/Branch/Cwd headers -> git resolution -> Unassigned fallback
   -> SSE: chunk-by-chunk pass-through with tee/tap token extraction
   -> Non-SSE: buffered with JSON usage parsing
-  -> SQLite (proxy_events table)
+  -> Cost: computed from provider pricing tables
+  -> SQLite (proxy_events table + messages table for unified analytics)
 ```
 
 Enricher order is critical - each depends on prior enrichers. Do not reorder.
@@ -80,7 +82,7 @@ Nine tables, seven data entities + two supporting:
 - **sessions** - Lifecycle context (start/end, duration, mode, title) without mixing cost concerns. One row per conversation from hooks. Primary key field: id
 - **hook_events** - Raw event log for tool stats. One row per hook event
 - **otel_events** - Raw OpenTelemetry event storage for debugging/audit
-- **proxy_events** - Append-only log of proxied LLM API requests. Fields: timestamp, provider, model, input/output_tokens, duration_ms, status_code, is_streaming
+- **proxy_events** - Append-only log of proxied LLM API requests. Fields: timestamp, provider, model, input/output_tokens, duration_ms, status_code, is_streaming, repo_id, git_branch, ticket_id, cost_cents. Successful proxy events are also inserted into `messages` (cost_confidence='proxy_estimated') so existing analytics surfaces work without modification
 - **tags** - Flexible key-value pairs per message (repo, ticket_id, activity, user, etc.) using message_id FK to messages(id)
 - **sync_state** - Tracks incremental ingestion progress per file for progressive sync
 - **message_rollups_hourly** - Derived hourly aggregates (provider/model/repo/branch/role dimensions) for low-latency analytics reads
@@ -90,7 +92,7 @@ Nine tables, seven data entities + two supporting:
 
 | Source | Confidence | What it provides |
 |--------|-----------|-----------------|
-| **Proxy** (all agents) | `proxy` | Real-time per-request tokens from response body (non-streaming) or SSE tee/tap extraction (streaming) |
+| **Proxy** (all agents) | `proxy_estimated` | Real-time per-request tokens from response body (non-streaming) or SSE tee/tap extraction (streaming). Attribution via `X-Budi-Repo`, `X-Budi-Branch`, `X-Budi-Cwd` headers or git-resolved from cwd. Falls back to `Unassigned` repo |
 | **OTEL** (Claude Code) | `otel_exact` | Per-request tokens including thinking, exact cost |
 | **JSONL** (Claude Code) | `estimated` | Per-message tokens (no thinking), cost calculated from pricing |
 | **Cursor Usage API** | `exact` | Per-request tokens + totalCents from Cursor's API |
@@ -121,7 +123,7 @@ OTEL and JSONL deduplicate: same API call matched by session_id + model + timest
 - `crates/budi-core/src/providers/claude_code.rs` - Claude Code provider (JSONL discovery, pricing)
 - `crates/budi-core/src/providers/cursor.rs` - Cursor provider (Usage API primary, transcript fallback; auth/session context from state.vscdb across macOS/Linux/Windows layouts)
 - `crates/budi-core/src/migration.rs` - Schema v21, all migration paths
-- `crates/budi-core/src/proxy.rs` - ProxyEvent types, proxy_events table schema and storage
+- `crates/budi-core/src/proxy.rs` - ProxyEvent types with attribution (repo, branch, ticket, cost), proxy_events and messages table storage, ProxyAttribution resolution from headers/git
 - `crates/budi-core/src/config.rs` - BudiConfig, ProxyConfig, AgentsConfig, StatuslineConfig, TagsConfig
 - `crates/budi-cli/build.rs` - Build script: creates empty vsix placeholder if not pre-built
 - `crates/budi-daemon/src/main.rs` - HTTP server (port 7878) + proxy server (port 9878), ~40 routes

--- a/crates/budi-core/Cargo.toml
+++ b/crates/budi-core/Cargo.toml
@@ -16,3 +16,4 @@ sha2.workspace = true
 toml.workspace = true
 tracing.workspace = true
 ureq.workspace = true
+uuid.workspace = true

--- a/crates/budi-core/src/proxy.rs
+++ b/crates/budi-core/src/proxy.rs
@@ -1,12 +1,18 @@
 //! Proxy event types and analytics storage.
 //!
 //! Each proxied request produces a `ProxyEvent` record that is appended to the
-//! `proxy_events` table in the analytics database. This is append-only and
-//! compatible with the existing analytics pipeline.
+//! `proxy_events` table in the analytics database. Attribution fields (repo,
+//! branch, ticket, cost) make proxy traffic visible in existing analytics
+//! surfaces via a unified insert into the `messages` table.
 
 use anyhow::Result;
 use rusqlite::{Connection, params};
 use serde::{Deserialize, Serialize};
+
+use crate::pipeline::extract_ticket_id;
+
+/// The fallback repo_id when attribution cannot be determined.
+pub const UNASSIGNED_REPO: &str = "Unassigned";
 
 /// Provider determined by path-based routing.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -31,6 +37,94 @@ impl std::fmt::Display for ProxyProvider {
     }
 }
 
+/// Attribution context resolved from request headers or git state.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ProxyAttribution {
+    pub repo_id: String,
+    pub git_branch: String,
+    pub ticket_id: String,
+}
+
+impl ProxyAttribution {
+    /// Build attribution from explicit values and/or cwd-based git resolution.
+    ///
+    /// Priority: explicit header values > git-resolved values > Unassigned fallback.
+    pub fn resolve(repo: Option<&str>, branch: Option<&str>, cwd: Option<&str>) -> Self {
+        let (resolved_repo, resolved_branch) = match cwd {
+            Some(dir) => {
+                let path = std::path::Path::new(dir);
+                let r = repo
+                    .filter(|s| !s.is_empty())
+                    .map(String::from)
+                    .unwrap_or_else(|| crate::repo_id::resolve_repo_id(path));
+                let b = branch
+                    .filter(|s| !s.is_empty())
+                    .map(String::from)
+                    .unwrap_or_else(|| resolve_git_branch(path));
+                (r, b)
+            }
+            None => (
+                repo.filter(|s| !s.is_empty())
+                    .unwrap_or(UNASSIGNED_REPO)
+                    .to_string(),
+                branch
+                    .filter(|s| !s.is_empty())
+                    .unwrap_or_default()
+                    .to_string(),
+            ),
+        };
+
+        let repo_id = if resolved_repo.is_empty() {
+            UNASSIGNED_REPO.to_string()
+        } else {
+            resolved_repo
+        };
+
+        let ticket_id = extract_ticket_id(&resolved_branch).unwrap_or_default();
+
+        Self {
+            repo_id,
+            git_branch: resolved_branch,
+            ticket_id,
+        }
+    }
+}
+
+/// Resolve the current git branch for a directory.
+fn resolve_git_branch(cwd: &std::path::Path) -> String {
+    std::process::Command::new("git")
+        .args(["rev-parse", "--abbrev-ref", "HEAD"])
+        .current_dir(cwd)
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .unwrap_or_default()
+}
+
+/// Compute cost in cents for a proxy event using the provider pricing tables.
+pub fn compute_proxy_cost_cents(
+    provider: ProxyProvider,
+    model: &str,
+    input_tokens: Option<i64>,
+    output_tokens: Option<i64>,
+) -> f64 {
+    let provider_name = match provider {
+        ProxyProvider::Anthropic => "claude_code",
+        ProxyProvider::OpenAi => "openai",
+    };
+    let pricing = crate::provider::pricing_for_model(model, provider_name);
+    pricing.calculate_cost_cents(
+        input_tokens.unwrap_or(0).max(0) as u64,
+        output_tokens.unwrap_or(0).max(0) as u64,
+        0,
+        0,
+        0,
+        None,
+        0,
+    )
+}
+
 /// A single proxy event record captured from a proxied request/response cycle.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProxyEvent {
@@ -42,6 +136,14 @@ pub struct ProxyEvent {
     pub duration_ms: i64,
     pub status_code: u16,
     pub is_streaming: bool,
+    #[serde(default)]
+    pub repo_id: String,
+    #[serde(default)]
+    pub git_branch: String,
+    #[serde(default)]
+    pub ticket_id: String,
+    #[serde(default)]
+    pub cost_cents: f64,
 }
 
 /// Ensure the `proxy_events` table exists in the analytics database.
@@ -57,14 +159,32 @@ pub fn ensure_proxy_schema(conn: &Connection) -> Result<()> {
             duration_ms   INTEGER NOT NULL DEFAULT 0,
             status_code   INTEGER NOT NULL DEFAULT 0,
             is_streaming  INTEGER NOT NULL DEFAULT 0,
+            repo_id       TEXT NOT NULL DEFAULT '',
+            git_branch    TEXT NOT NULL DEFAULT '',
+            ticket_id     TEXT NOT NULL DEFAULT '',
+            cost_cents    REAL NOT NULL DEFAULT 0.0,
             created_at    TEXT NOT NULL DEFAULT (datetime('now'))
         );
 
         CREATE INDEX IF NOT EXISTS idx_proxy_events_timestamp
             ON proxy_events(timestamp);
         CREATE INDEX IF NOT EXISTS idx_proxy_events_provider
-            ON proxy_events(provider);",
+            ON proxy_events(provider);
+        CREATE INDEX IF NOT EXISTS idx_proxy_events_repo
+            ON proxy_events(repo_id);",
     )?;
+    // Additive migration for existing databases missing the new columns.
+    for (col, def) in [
+        ("repo_id", "TEXT NOT NULL DEFAULT ''"),
+        ("git_branch", "TEXT NOT NULL DEFAULT ''"),
+        ("ticket_id", "TEXT NOT NULL DEFAULT ''"),
+        ("cost_cents", "REAL NOT NULL DEFAULT 0.0"),
+    ] {
+        let _ = conn.execute_batch(&format!("ALTER TABLE proxy_events ADD COLUMN {col} {def};"));
+    }
+    let _ = conn.execute_batch(
+        "CREATE INDEX IF NOT EXISTS idx_proxy_events_repo ON proxy_events(repo_id);",
+    );
     Ok(())
 }
 
@@ -73,8 +193,9 @@ pub fn insert_proxy_event(conn: &Connection, event: &ProxyEvent) -> Result<i64> 
     conn.execute(
         "INSERT INTO proxy_events (
             timestamp, provider, model, input_tokens, output_tokens,
-            duration_ms, status_code, is_streaming
-        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            duration_ms, status_code, is_streaming,
+            repo_id, git_branch, ticket_id, cost_cents
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
         params![
             event.timestamp,
             event.provider,
@@ -84,9 +205,66 @@ pub fn insert_proxy_event(conn: &Connection, event: &ProxyEvent) -> Result<i64> 
             event.duration_ms,
             event.status_code as i64,
             event.is_streaming as i64,
+            event.repo_id,
+            event.git_branch,
+            event.ticket_id,
+            event.cost_cents,
         ],
     )?;
     Ok(conn.last_insert_rowid())
+}
+
+/// Insert a proxy event into the unified `messages` table so existing analytics
+/// surfaces (dashboard, CLI, statusline) can query it without modification.
+///
+/// Returns the generated message UUID on success.
+pub fn insert_proxy_message(conn: &Connection, event: &ProxyEvent) -> Result<String> {
+    let uuid = format!("proxy-{}", uuid::Uuid::new_v4());
+    let repo_id = if event.repo_id.is_empty() {
+        None
+    } else {
+        Some(&event.repo_id)
+    };
+    let git_branch = if event.git_branch.is_empty() {
+        None
+    } else {
+        Some(&event.git_branch)
+    };
+
+    conn.execute(
+        "INSERT OR IGNORE INTO messages (
+            id, role, timestamp, model, provider,
+            input_tokens, output_tokens,
+            cache_creation_tokens, cache_read_tokens,
+            repo_id, git_branch, cost_cents, cost_confidence
+        ) VALUES (?1, 'assistant', ?2, ?3, ?4, ?5, ?6, 0, 0, ?7, ?8, ?9, 'proxy_estimated')",
+        params![
+            uuid,
+            event.timestamp,
+            event.model,
+            event.provider,
+            event.input_tokens.unwrap_or(0),
+            event.output_tokens.unwrap_or(0),
+            repo_id,
+            git_branch,
+            event.cost_cents,
+        ],
+    )?;
+
+    if !event.ticket_id.is_empty() {
+        conn.execute(
+            "INSERT OR IGNORE INTO tags (message_id, key, value) VALUES (?1, 'ticket_id', ?2)",
+            params![uuid, event.ticket_id],
+        )?;
+        if let Some(dash) = event.ticket_id.find('-') {
+            conn.execute(
+                "INSERT OR IGNORE INTO tags (message_id, key, value) VALUES (?1, 'ticket_prefix', ?2)",
+                params![uuid, &event.ticket_id[..dash]],
+            )?;
+        }
+    }
+
+    Ok(uuid)
 }
 
 #[cfg(test)]
@@ -101,10 +279,17 @@ mod tests {
         conn
     }
 
-    #[test]
-    fn proxy_event_round_trip() {
-        let conn = test_db();
-        let event = ProxyEvent {
+    fn test_db_with_messages() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")
+            .unwrap();
+        crate::migration::migrate(&conn).unwrap();
+        ensure_proxy_schema(&conn).unwrap();
+        conn
+    }
+
+    fn test_event() -> ProxyEvent {
+        ProxyEvent {
             timestamp: "2026-04-10T12:00:00Z".to_string(),
             provider: "openai".to_string(),
             model: "gpt-4o".to_string(),
@@ -113,7 +298,17 @@ mod tests {
             duration_ms: 1200,
             status_code: 200,
             is_streaming: false,
-        };
+            repo_id: String::new(),
+            git_branch: String::new(),
+            ticket_id: String::new(),
+            cost_cents: 0.0,
+        }
+    }
+
+    #[test]
+    fn proxy_event_round_trip() {
+        let conn = test_db();
+        let event = test_event();
         let id = insert_proxy_event(&conn, &event).unwrap();
         assert!(id > 0);
 
@@ -130,18 +325,37 @@ mod tests {
     }
 
     #[test]
+    fn proxy_event_with_attribution() {
+        let conn = test_db();
+        let mut event = test_event();
+        event.repo_id = "github.com/siropkin/budi".to_string();
+        event.git_branch = "PAVA-2057-fix-auth".to_string();
+        event.ticket_id = "PAVA-2057".to_string();
+        event.cost_cents = 1.5;
+
+        let id = insert_proxy_event(&conn, &event).unwrap();
+        let (repo, branch, ticket, cost): (String, String, String, f64) = conn
+            .query_row(
+                "SELECT repo_id, git_branch, ticket_id, cost_cents FROM proxy_events WHERE id = ?1",
+                params![id],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .unwrap();
+        assert_eq!(repo, "github.com/siropkin/budi");
+        assert_eq!(branch, "PAVA-2057-fix-auth");
+        assert_eq!(ticket, "PAVA-2057");
+        assert!((cost - 1.5).abs() < f64::EPSILON);
+    }
+
+    #[test]
     fn proxy_event_with_null_tokens() {
         let conn = test_db();
-        let event = ProxyEvent {
-            timestamp: "2026-04-10T12:00:00Z".to_string(),
-            provider: "anthropic".to_string(),
-            model: "claude-sonnet-4-6".to_string(),
-            input_tokens: None,
-            output_tokens: None,
-            duration_ms: 500,
-            status_code: 200,
-            is_streaming: true,
-        };
+        let mut event = test_event();
+        event.provider = "anthropic".to_string();
+        event.model = "claude-sonnet-4-6".to_string();
+        event.input_tokens = None;
+        event.output_tokens = None;
+        event.is_streaming = true;
         let id = insert_proxy_event(&conn, &event).unwrap();
         assert!(id > 0);
     }
@@ -157,5 +371,137 @@ mod tests {
     fn proxy_provider_display() {
         assert_eq!(ProxyProvider::Anthropic.as_str(), "anthropic");
         assert_eq!(ProxyProvider::OpenAi.as_str(), "openai");
+    }
+
+    #[test]
+    fn attribution_resolve_with_explicit_values() {
+        let attr =
+            ProxyAttribution::resolve(Some("github.com/test/repo"), Some("feat/PROJ-42-fix"), None);
+        assert_eq!(attr.repo_id, "github.com/test/repo");
+        assert_eq!(attr.git_branch, "feat/PROJ-42-fix");
+        assert_eq!(attr.ticket_id, "PROJ-42");
+    }
+
+    #[test]
+    fn attribution_resolve_empty_falls_back_to_unassigned() {
+        let attr = ProxyAttribution::resolve(None, None, None);
+        assert_eq!(attr.repo_id, UNASSIGNED_REPO);
+        assert!(attr.git_branch.is_empty());
+        assert!(attr.ticket_id.is_empty());
+    }
+
+    #[test]
+    fn attribution_resolve_empty_repo_with_branch() {
+        let attr = ProxyAttribution::resolve(Some(""), Some("ABC-123-feat"), None);
+        assert_eq!(attr.repo_id, UNASSIGNED_REPO);
+        assert_eq!(attr.git_branch, "ABC-123-feat");
+        assert_eq!(attr.ticket_id, "ABC-123");
+    }
+
+    #[test]
+    fn attribution_resolve_poor_branch_no_ticket() {
+        let attr = ProxyAttribution::resolve(Some("my-repo"), Some("main"), None);
+        assert_eq!(attr.repo_id, "my-repo");
+        assert_eq!(attr.git_branch, "main");
+        assert!(attr.ticket_id.is_empty());
+    }
+
+    #[test]
+    fn compute_proxy_cost_anthropic() {
+        let cost = compute_proxy_cost_cents(
+            ProxyProvider::Anthropic,
+            "claude-sonnet-4-6",
+            Some(100_000),
+            Some(50_000),
+        );
+        assert!(cost > 0.0, "cost should be positive for non-zero tokens");
+    }
+
+    #[test]
+    fn compute_proxy_cost_zero_tokens() {
+        let cost = compute_proxy_cost_cents(ProxyProvider::OpenAi, "gpt-4o", None, None);
+        assert!((cost - 0.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn insert_proxy_message_creates_messages_row() {
+        let conn = test_db_with_messages();
+        let mut event = test_event();
+        event.repo_id = "github.com/test/repo".to_string();
+        event.git_branch = "PROJ-42-fix".to_string();
+        event.ticket_id = "PROJ-42".to_string();
+        event.cost_cents = 2.5;
+
+        let uuid = insert_proxy_message(&conn, &event).unwrap();
+        assert!(uuid.starts_with("proxy-"));
+
+        let (role, provider, model, repo, branch, cost, confidence): (
+            String,
+            String,
+            String,
+            Option<String>,
+            Option<String>,
+            f64,
+            String,
+        ) = conn
+            .query_row(
+                "SELECT role, provider, model, repo_id, git_branch, cost_cents, cost_confidence
+                 FROM messages WHERE id = ?1",
+                params![uuid],
+                |row| {
+                    Ok((
+                        row.get(0)?,
+                        row.get(1)?,
+                        row.get(2)?,
+                        row.get(3)?,
+                        row.get(4)?,
+                        row.get(5)?,
+                        row.get(6)?,
+                    ))
+                },
+            )
+            .unwrap();
+        assert_eq!(role, "assistant");
+        assert_eq!(provider, "openai");
+        assert_eq!(model, "gpt-4o");
+        assert_eq!(repo.as_deref(), Some("github.com/test/repo"));
+        assert_eq!(branch.as_deref(), Some("PROJ-42-fix"));
+        assert!((cost - 2.5).abs() < f64::EPSILON);
+        assert_eq!(confidence, "proxy_estimated");
+
+        // Ticket tags should be present
+        let ticket: String = conn
+            .query_row(
+                "SELECT value FROM tags WHERE message_id = ?1 AND key = 'ticket_id'",
+                params![uuid],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(ticket, "PROJ-42");
+
+        let prefix: String = conn
+            .query_row(
+                "SELECT value FROM tags WHERE message_id = ?1 AND key = 'ticket_prefix'",
+                params![uuid],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(prefix, "PROJ");
+    }
+
+    #[test]
+    fn insert_proxy_message_no_ticket_skips_tags() {
+        let conn = test_db_with_messages();
+        let event = test_event();
+        let uuid = insert_proxy_message(&conn, &event).unwrap();
+
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM tags WHERE message_id = ?1",
+                params![uuid],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 0);
     }
 }

--- a/crates/budi-daemon/src/routes/proxy.rs
+++ b/crates/budi-daemon/src/routes/proxy.rs
@@ -227,9 +227,12 @@ async fn proxy_request(
 
     let mut response = Response::builder().status(status);
     copy_response_headers(&resp_headers, response.headers_mut().unwrap());
-    response
-        .body(Body::from(resp_bytes))
-        .unwrap_or_else(|_| build_error_response(StatusCode::INTERNAL_SERVER_ERROR, &proxy_error_json("failed to build response")))
+    response.body(Body::from(resp_bytes)).unwrap_or_else(|_| {
+        build_error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            &proxy_error_json("failed to build response"),
+        )
+    })
 }
 
 /// Wraps an upstream SSE byte stream to extract token metadata without
@@ -320,8 +323,7 @@ impl SseTapStream {
                 }
                 // Fallback: .usage.input_tokens (some event shapes)
                 if self.input_tokens.is_none()
-                    && let Some(n) =
-                        json.pointer("/usage/input_tokens").and_then(|v| v.as_i64())
+                    && let Some(n) = json.pointer("/usage/input_tokens").and_then(|v| v.as_i64())
                 {
                     self.input_tokens = Some(n);
                 }
@@ -397,8 +399,12 @@ fn extract_response_tokens(body: &[u8], provider: ProxyProvider) -> (Option<i64>
     let usage = parsed.get("usage");
     match provider {
         ProxyProvider::Anthropic => {
-            let input = usage.and_then(|u| u.get("input_tokens")).and_then(|v| v.as_i64());
-            let output = usage.and_then(|u| u.get("output_tokens")).and_then(|v| v.as_i64());
+            let input = usage
+                .and_then(|u| u.get("input_tokens"))
+                .and_then(|v| v.as_i64());
+            let output = usage
+                .and_then(|u| u.get("output_tokens"))
+                .and_then(|v| v.as_i64());
             (input, output)
         }
         ProxyProvider::OpenAi => {
@@ -535,10 +541,7 @@ fn record_event(
     });
 }
 
-fn record_event_blocking(
-    db_path: &std::path::Path,
-    event: &ProxyEvent,
-) -> anyhow::Result<()> {
+fn record_event_blocking(db_path: &std::path::Path, event: &ProxyEvent) -> anyhow::Result<()> {
     let conn = budi_core::analytics::open_db(db_path)?;
     budi_core::proxy::ensure_proxy_schema(&conn)?;
     budi_core::proxy::insert_proxy_event(&conn, event)?;

--- a/crates/budi-daemon/src/routes/proxy.rs
+++ b/crates/budi-daemon/src/routes/proxy.rs
@@ -18,9 +18,13 @@ use axum::response::IntoResponse;
 use futures_util::Stream;
 use serde_json::Value;
 
-use budi_core::proxy::{ProxyEvent, ProxyProvider};
+use budi_core::proxy::{ProxyAttribution, ProxyEvent, ProxyProvider};
 
 use crate::ProxyState;
+
+const HEADER_BUDI_REPO: &str = "x-budi-repo";
+const HEADER_BUDI_BRANCH: &str = "x-budi-branch";
+const HEADER_BUDI_CWD: &str = "x-budi-cwd";
 
 const MAX_BODY_SIZE: usize = 16 * 1024 * 1024; // 16 MiB per ADR-0082
 
@@ -67,6 +71,14 @@ fn proxy_error_json(message: &str) -> Value {
     })
 }
 
+fn extract_header(headers: &HeaderMap, name: &str) -> Option<String> {
+    headers
+        .get(name)
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
 async fn proxy_request(
     state: ProxyState,
     req: Request<Body>,
@@ -76,6 +88,12 @@ async fn proxy_request(
     let start = Instant::now();
     let method = req.method().clone();
     let incoming_headers = req.headers().clone();
+
+    let attribution = ProxyAttribution::resolve(
+        extract_header(&incoming_headers, HEADER_BUDI_REPO).as_deref(),
+        extract_header(&incoming_headers, HEADER_BUDI_BRANCH).as_deref(),
+        extract_header(&incoming_headers, HEADER_BUDI_CWD).as_deref(),
+    );
 
     let body_bytes: axum::body::Bytes = match read_body(req).await {
         Ok(bytes) => bytes,
@@ -122,6 +140,7 @@ async fn proxy_request(
                 duration_ms,
                 502,
                 is_streaming,
+                &attribution,
             );
             return build_error_response(
                 StatusCode::BAD_GATEWAY,
@@ -145,6 +164,7 @@ async fn proxy_request(
             status_code: status.as_u16(),
             start,
             state,
+            attribution,
             line_buf: Vec::new(),
             input_tokens: None,
             output_tokens: None,
@@ -176,6 +196,7 @@ async fn proxy_request(
                 duration_ms,
                 502,
                 is_streaming,
+                &attribution,
             );
             return build_error_response(
                 StatusCode::BAD_GATEWAY,
@@ -201,16 +222,14 @@ async fn proxy_request(
         duration_ms,
         status.as_u16(),
         is_streaming,
+        &attribution,
     );
 
     let mut response = Response::builder().status(status);
     copy_response_headers(&resp_headers, response.headers_mut().unwrap());
-    response.body(Body::from(resp_bytes)).unwrap_or_else(|_| {
-        build_error_response(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            &proxy_error_json("failed to build response"),
-        )
-    })
+    response
+        .body(Body::from(resp_bytes))
+        .unwrap_or_else(|_| build_error_response(StatusCode::INTERNAL_SERVER_ERROR, &proxy_error_json("failed to build response")))
 }
 
 /// Wraps an upstream SSE byte stream to extract token metadata without
@@ -226,6 +245,7 @@ struct SseTapStream {
     status_code: u16,
     start: Instant,
     state: ProxyState,
+    attribution: ProxyAttribution,
     line_buf: Vec<u8>,
     input_tokens: Option<i64>,
     output_tokens: Option<i64>,
@@ -300,7 +320,8 @@ impl SseTapStream {
                 }
                 // Fallback: .usage.input_tokens (some event shapes)
                 if self.input_tokens.is_none()
-                    && let Some(n) = json.pointer("/usage/input_tokens").and_then(|v| v.as_i64())
+                    && let Some(n) =
+                        json.pointer("/usage/input_tokens").and_then(|v| v.as_i64())
                 {
                     self.input_tokens = Some(n);
                 }
@@ -335,6 +356,7 @@ impl SseTapStream {
             duration_ms,
             self.status_code,
             true,
+            &self.attribution,
         );
     }
 }
@@ -375,12 +397,8 @@ fn extract_response_tokens(body: &[u8], provider: ProxyProvider) -> (Option<i64>
     let usage = parsed.get("usage");
     match provider {
         ProxyProvider::Anthropic => {
-            let input = usage
-                .and_then(|u| u.get("input_tokens"))
-                .and_then(|v| v.as_i64());
-            let output = usage
-                .and_then(|u| u.get("output_tokens"))
-                .and_then(|v| v.as_i64());
+            let input = usage.and_then(|u| u.get("input_tokens")).and_then(|v| v.as_i64());
+            let output = usage.and_then(|u| u.get("output_tokens")).and_then(|v| v.as_i64());
             (input, output)
         }
         ProxyProvider::OpenAi => {
@@ -471,7 +489,14 @@ fn record_event(
     duration_ms: i64,
     status_code: u16,
     is_streaming: bool,
+    attribution: &ProxyAttribution,
 ) {
+    let cost_cents = if status_code < 400 {
+        budi_core::proxy::compute_proxy_cost_cents(provider, model, input_tokens, output_tokens)
+    } else {
+        0.0
+    };
+
     let event = ProxyEvent {
         timestamp: chrono::Utc::now().to_rfc3339(),
         provider: provider.to_string(),
@@ -481,6 +506,10 @@ fn record_event(
         duration_ms,
         status_code,
         is_streaming,
+        repo_id: attribution.repo_id.clone(),
+        git_branch: attribution.git_branch.clone(),
+        ticket_id: attribution.ticket_id.clone(),
+        cost_cents,
     };
 
     tracing::info!(
@@ -491,6 +520,10 @@ fn record_event(
         input_tokens = ?event.input_tokens,
         output_tokens = ?event.output_tokens,
         streaming = event.is_streaming,
+        repo_id = %event.repo_id,
+        git_branch = %event.git_branch,
+        ticket_id = %event.ticket_id,
+        cost_cents = event.cost_cents,
         "Proxy request completed"
     );
 
@@ -502,9 +535,19 @@ fn record_event(
     });
 }
 
-fn record_event_blocking(db_path: &std::path::Path, event: &ProxyEvent) -> anyhow::Result<()> {
+fn record_event_blocking(
+    db_path: &std::path::Path,
+    event: &ProxyEvent,
+) -> anyhow::Result<()> {
     let conn = budi_core::analytics::open_db(db_path)?;
     budi_core::proxy::ensure_proxy_schema(&conn)?;
     budi_core::proxy::insert_proxy_event(&conn, event)?;
+    // Only insert into the messages table for successful requests with a model.
+    if event.status_code < 400
+        && !event.model.is_empty()
+        && let Err(e) = budi_core::proxy::insert_proxy_message(&conn, event)
+    {
+        tracing::debug!("Failed to insert proxy message: {e}");
+    }
     Ok(())
 }


### PR DESCRIPTION
## Summary

Extends the proxy to capture business context (repo, branch, ticket) for every proxied LLM request and integrates proxy events into the unified analytics pipeline.

- **Attribution resolution**: Agents send `X-Budi-Repo`, `X-Budi-Branch`, `X-Budi-Cwd` headers. The daemon resolves these via git (branch from cwd, ticket extracted from branch name) with fallback to `Unassigned` repo.
- **Cost computation**: Each proxy event gets a `cost_cents` field computed from the existing `ModelPricing` tables at recording time.
- **Unified analytics**: Successful proxy events (status < 400, model identified) are inserted into the `messages` table with `cost_confidence = 'proxy_estimated'`, plus `ticket_id`/`ticket_prefix` tags — so existing dashboard, CLI, and analytics queries surface proxy data without any changes.
- **Schema migration**: Additive `ALTER TABLE` for `proxy_events` (repo_id, git_branch, ticket_id, cost_cents columns + repo index). Backward-compatible with existing databases.

## Risks / compatibility notes

- **Additive only**: New columns have defaults; existing proxy_events rows get empty strings and 0.0 cost. No breaking schema changes.
- **No header requirement**: If agents don't send `X-Budi-*` headers, attribution falls back gracefully to `Unassigned` repo with empty branch/ticket.
- **Messages table integration**: Uses `cost_confidence = 'proxy_estimated'` to clearly distinguish proxy-originated entries from JSONL/OTEL-ingested ones.
- **uuid dependency added**: `uuid v1` with `v4` feature for generating message IDs. Added to workspace deps.

## Validation

- `cargo fmt --all` — clean
- `cargo clippy --workspace --all-targets --locked -- -D warnings` — clean
- `cargo test --workspace --locked` — all 380 tests pass

Closes #91

Made with [Cursor](https://cursor.com)