### PR TITLE
[8.0][R2.6] Docs review pass for proxy round

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -159,7 +159,7 @@ If a review issue leads to "no code changes needed", still include a small artif
 3. Optionally implement `sync_direct()` for API-based data sources (like Cursor Usage API)
 4. Add a pricing function `<name>_pricing_for_model(model: &str) -> ModelPricing`
 5. Register in `crate::provider::all_providers()`
-6. Add hook installation in `crates/budi-cli/src/commands/init.rs` if the agent supports hooks
+6. Add proxy/onboarding integration steps in `crates/budi-cli/src/commands/init.rs` if the agent needs setup automation
 7. Add tests
 
 ## Adding a new enricher
@@ -167,7 +167,7 @@ If a review issue leads to "no code changes needed", still include a small artif
 1. Create a struct implementing `pipeline::Enricher` in `crates/budi-core/src/pipeline/enrichers.rs`
 2. `enrich(&mut self, msg: &mut ParsedMessage) -> Vec<Tag>` - mutate the message and/or return tags
 3. Register in `Pipeline::default_pipeline()` in `crates/budi-core/src/pipeline/mod.rs`
-4. Enricher order matters: Hook -> Identity -> Git -> Tool -> Cost -> Tag
+4. Enricher order matters: Identity -> Git -> Tool -> Cost -> Tag
 
 ## Releasing
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License](https://img.shields.io/github/license/siropkin/budi)](https://github.com/siropkin/budi/blob/main/LICENSE)
 [![GitHub stars](https://img.shields.io/github/stars/siropkin/budi?style=social)](https://github.com/siropkin/budi)
 
-**Local-first cost analytics for AI coding agents.** See where your tokens and money go across Claude Code, Cursor, and more.
+**Local-first cost analytics for AI coding agents.** See where your tokens and money go across Claude Code, Cursor, and other proxy-compatible agents.
 
 ```bash
 brew install siropkin/budi/budi && budi init
@@ -57,11 +57,17 @@ budi targets **macOS**, **Linux** (glibc), and **Windows 10+**. Prebuilt release
 
 ## Supported agents
 
-| Agent | Status | How |
-|-------|--------|-----|
-| **Claude Code** | Supported | Proxy (real-time) + JSONL transcripts (historical import) |
-| **Cursor** | Supported | Proxy (real-time) + Usage API (historical import) |
-| **Copilot CLI, Codex CLI, Cline, Aider, Gemini CLI** | Planned | |
+Proxy support follows the ADR-0082 compatibility tiers:
+
+| Tier | Agent | 8.0 proxy status | Setup |
+|------|-------|------------------|-------|
+| **Tier 1 (must-have)** | **Claude Code** | Supported | Set `ANTHROPIC_BASE_URL=http://127.0.0.1:9878` (+ `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1`) |
+| **Tier 1 (must-have)** | **Codex CLI** | Supported | Set `openai_base_url` (preferred) or `OPENAI_BASE_URL=http://127.0.0.1:9878` |
+| **Tier 2 (should-have)** | **Cursor** | Supported with caveats | Use Cursor's `Override OpenAI Base URL` setting (`http://127.0.0.1:9878`) |
+| **Tier 2 (should-have)** | **Copilot CLI** | Supported in BYOK mode | Set `COPILOT_PROVIDER_TYPE=openai` and `COPILOT_PROVIDER_BASE_URL=http://127.0.0.1:9878` |
+| **Tier 3 (deferred)** | **Gemini CLI** | Deferred / not implemented in proxy v1 | Requires a separate Gemini protocol handler |
+
+`budi init` currently automates onboarding for Claude Code and Cursor only. Other proxy-compatible agents can be routed through Budi with manual provider configuration.
 
 ## Contributing
 
@@ -137,7 +143,7 @@ If you install with Homebrew, run `budi init` right after `brew install`.
 
 **One install on PATH.** Do not mix Homebrew with `~/.local/bin` (macOS/Linux) or with `%LOCALAPPDATA%\budi\bin` (Windows): you can end up with different `budi` and `budi-daemon` versions and confusing restarts. Keep a single install directory ahead of others on `PATH` (or remove duplicates). `budi init` warns if it detects multiple binaries.
 
-`budi init` starts the daemon and **prompts you to choose which agents to track** (Claude Code, Cursor) and then **which integrations to install** (statusline, extension). Only enabled agents have their data collected; disabled agents produce no collection side effects. Agent choices are stored in `~/.config/budi/agents.toml`. In non-interactive mode it uses safe defaults (all agents enabled). You can also choose integrations explicitly with flags like `--with`, `--without`, and `--integrations all|none|auto`. **Restart Claude Code and Cursor** after install to activate config changes. The daemon uses port 7878 by default — customize `daemon_port` in the **repo-local** `config.toml` under `<budi-home>/repos/<repo-id>/config.toml` (run `budi doctor` inside the repo to see the exact path).
+`budi init` starts the daemon and **prompts you to choose which agents to track for built-in integrations and historical import** (currently Claude Code, Cursor) and then **which integrations to install** (statusline, extension). Only enabled agents have their data collected through those built-in import/integration paths; disabled agents produce no collection side effects there. Agent choices are stored in `~/.config/budi/agents.toml`. In non-interactive mode it uses safe defaults (all agents enabled). You can also choose integrations explicitly with flags like `--with`, `--without`, and `--integrations all|none|auto`. **Restart Claude Code and Cursor** after install to activate config changes. The daemon uses port 7878 by default — customize `daemon_port` in the **repo-local** `config.toml` under `<budi-home>/repos/<repo-id>/config.toml` (run `budi doctor` inside the repo to see the exact path).
 
 To install a specific version, set the `VERSION` environment variable: `VERSION=v7.1.0 curl -fsSL ... | bash` (or `$env:VERSION="v7.1.0"` on PowerShell).
 
@@ -196,17 +202,6 @@ slots = ["today", "week", "month", "branch"]
 ```
 
 Available slots: `today`, `week`, `month`, `session`, `branch`, `project`, `provider`.
-
-For Starship integration, add to `~/.config/starship.toml`:
-
-```toml
-[custom.budi]
-command = "budi statusline --format=starship"
-when = "curl -sf http://localhost:7878/health >/dev/null 2>&1"
-format = "[$output]($style) "
-style = "cyan"
-shell = ["sh"]
-```
 
 ## Cursor extension
 
@@ -268,9 +263,9 @@ budi stats --branches         # branches ranked by cost
 budi stats --branch <name>    # cost for a specific branch
 budi stats --tag ticket_id    # cost per ticket
 budi stats --tag ticket_prefix # cost per team prefix
-budi sync                     # sync recent data (last 30 days)
-budi sync --all               # load full history (all time)
-budi sync --force             # re-ingest all data from scratch (use after upgrades)
+budi sync                     # on-demand historical backfill (30-day window)
+budi sync --all               # on-demand historical backfill (full history)
+budi sync --force             # re-run historical backfill from scratch
 budi repair                   # repair schema drift + run migration checks
 budi update                   # check for updates (auto-detects Homebrew)
 budi update --version <name>  # update to a specific version
@@ -337,11 +332,11 @@ Health state appears in the status line, the Cursor extension panel, and the ses
 
 ## Privacy
 
-Budi is 100% local — no cloud, no uploads, no telemetry. All data stays on your machine (`~/.local/share/budi/` on Unix, `%LOCALAPPDATA%\budi` on Windows). Budi only stores metadata: timestamps, token counts, model names, and costs. It **never** reads, stores, or transmits file contents, prompt text, or AI responses.
+Budi is 100% local-first — no prompt, code, or response uploads to any Budi cloud service. All analytics data stays on your machine (`~/.local/share/budi/` on Unix, `%LOCALAPPDATA%\budi` on Windows). Budi stores metadata such as timestamps, token counts, model names, and costs. Provider auth headers are forwarded to upstream APIs for normal request execution, but Budi does not persist API keys.
 
 ## How it works
 
-A lightweight Rust daemon (port 7878) manages a single SQLite database. The daemon runs a **proxy server** on port 9878 that transparently forwards agent traffic to upstream providers (Anthropic, OpenAI) while capturing metadata. Streaming (SSE) responses pass through chunk-by-chunk with no buffering; token metadata is extracted from the byte stream without modifying it. Proxy traffic is attributed to repos, branches, and tickets via `X-Budi-Repo`/`X-Budi-Branch`/`X-Budi-Cwd` headers or automatic git resolution, with cost computed from provider pricing tables. Historical data from Claude Code JSONL transcripts and Cursor Usage API can be backfilled via `budi import`. The CLI is a thin HTTP client — all queries go through the daemon.
+A lightweight Rust daemon (port 7878) manages a single SQLite database. The daemon runs a **proxy server** on port 9878 that transparently forwards agent traffic to upstream providers (Anthropic, OpenAI) while capturing metadata. Streaming (SSE) responses pass through chunk-by-chunk with no buffering; token metadata is extracted from the byte stream without modifying it. Proxy attribution uses `X-Budi-Repo`/`X-Budi-Branch`/`X-Budi-Cwd` headers first, then best-effort git resolution from `cwd`; if repo attribution cannot be resolved it falls back to `Unassigned`. Ticket attribution is best-effort from branch naming. Historical data from Claude Code JSONL transcripts and Cursor Usage API can be backfilled via `budi import`. The proxy is the only live ingest path. The CLI is a thin HTTP client — all queries go through the daemon.
 
 ## Details
 
@@ -350,7 +345,7 @@ A lightweight Rust daemon (port 7878) manages a single SQLite database. The daem
 
 | | budi | ccusage | Claude `/cost` |
 |---|---|---|---|
-| Multi-agent support | **Yes** (Claude Code + Cursor) | Claude Code only | Claude Code only |
+| Multi-agent support | **Yes** (tiered proxy support across Claude/Codex/Cursor/Copilot) | Claude Code only | Claude Code only |
 | Real-time cost via proxy | **Yes** | No | No |
 | Cost history | **Per-message + daily** | Per-session | Current session |
 | Web dashboard | **Yes** | No | No |
@@ -379,7 +374,7 @@ A lightweight Rust daemon (port 7878) manages a single SQLite database. The daem
                          ┌──────────────┐
 ┌──────────┐    proxy    │ budi proxy   │    upstream
 │ AI Agent │ ──────────▶ │  (port 9878) │ ──────────▶ Anthropic / OpenAI
-│ (CC/CX)  │  localhost  │  transparent │  API calls
+│ (tiered) │  localhost  │  transparent │  API calls
 └──────────┘             │  pass-thru   │
                          └──────────────┘
 
@@ -436,31 +431,6 @@ Retention cleanup runs automatically after sync and queued realtime ingestion pr
   - build budi against SQLCipher-enabled SQLite (`libsqlite3-sys` SQLCipher build),
   - or place the budi data directory on an encrypted volume (FileVault, LUKS, BitLocker).
 - SQLCipher integration is feasible but has tradeoffs (key management UX, packaging complexity, migration path from existing plaintext DBs), so default remains plain SQLite for now.
-
-</details>
-
-<details>
-<summary>Hooks (removed in 8.0)</summary>
-
-Hook-based ingestion (`budi hook`) and the `hook_events` table have been removed. The proxy (port 9878) is now the sole live data source.
-
-</details>
-
-<details>
-<summary>OpenTelemetry (removed in 8.0)</summary>
-
-OTEL ingestion endpoints (`POST /v1/logs`, `POST /v1/metrics`) and the `otel_events` table have been removed. The proxy captures real-time cost data directly.
-
-**Cost confidence levels:**
-
-| Level | Source | Accuracy |
-|-------|--------|----------|
-| `proxy_estimated` | Proxy real-time capture | Estimated from response body / SSE stream |
-| `otel_exact` | Historical OTEL data (read-only) | Exact (includes thinking tokens) |
-| `exact` | Cursor Usage API / Claude Code JSONL tokens | Exact tokens, calculated cost |
-| `estimated` | JSONL tokens x model pricing | ~92-96% accurate (missing thinking tokens) |
-
-Messages with `otel_exact` or `exact` confidence show exact cost in the dashboard. Estimated costs are prefixed with `~`.
 
 </details>
 

--- a/SOUL.md
+++ b/SOUL.md
@@ -1,6 +1,6 @@
 # SOUL.md
 
-Local-first cost analytics for AI coding agents (Claude Code, Cursor). Tracks tokens, costs, and usage per message via proxy interception and transcript analysis. No cloud - everything on-machine.
+Local-first cost analytics for AI coding agents. Tracks tokens, costs, and usage per message via proxy interception and on-demand historical transcript import. No cloud prompt/code/response uploads.
 
 ## Build & Test
 
@@ -51,9 +51,19 @@ These coupling points are documented with untangling plans in ADR-0086. New code
 
 ### Crates
 
-- **budi-core** - Business logic: analytics (SQLite queries), providers (Claude Code, Cursor), pipeline (enrichment), cost calculation, proxy event storage, config, migrations. Historical hook/OTEL data is read-only (tables kept for schema compat, ingestion removed)
+- **budi-core** - Business logic: analytics (SQLite queries), providers (Claude Code, Cursor) for historical import, pipeline (enrichment), cost calculation, proxy event storage, config, migrations
 - **budi-cli** - Thin HTTP client to the daemon. Commands: init, stats, sync, import, statusline, doctor, open, update, uninstall, migrate, repair, health
 - **budi-daemon** - axum HTTP server (port 7878). Owns SQLite exclusively. Serves dashboard and analytics API. Also runs the proxy server on port 9878. The proxy is the sole live data source; transcript import is user-initiated via `budi import`
+
+### Agent compatibility tiers (ADR-0082)
+
+| Tier | Agents | Notes |
+|------|--------|-------|
+| **Tier 1 (must-have)** | Claude Code, Codex CLI | High-confidence proxy compatibility. |
+| **Tier 2 (should-have)** | Cursor, Copilot CLI | Supported with caveats (Cursor UI override, Copilot BYOK vars). |
+| **Tier 3 (deferred)** | Gemini CLI | Deferred in proxy v1; separate protocol handler required. |
+
+`budi init` currently automates onboarding for Claude Code and Cursor. Other proxy-compatible agents can be routed manually through proxy base URL settings.
 
 ### Data flow
 
@@ -61,7 +71,8 @@ These coupling points are documented with untangling plans in ADR-0086. New code
 Live data:
 Proxy (agent -> localhost:9878 -> upstream provider)
   -> Path-based routing (Anthropic /v1/messages, OpenAI /v1/chat/completions)
-  -> Attribution: X-Budi-Repo/Branch/Cwd headers -> git resolution -> Unassigned fallback
+  -> Attribution: X-Budi-Repo/X-Budi-Branch/X-Budi-Cwd headers -> git resolution fallback
+     -> repo fallback: Unassigned; ticket attribution: best-effort from branch naming
   -> SSE: chunk-by-chunk pass-through with tee/tap token extraction
   -> Non-SSE: buffered with JSON usage parsing
   -> Cost: computed from provider pricing tables
@@ -96,15 +107,13 @@ Nine tables, seven data entities + two supporting:
 | **JSONL** (Claude Code) | `estimated` | Per-message tokens (no thinking), cost calculated from pricing. Used by `budi import` for historical backfill |
 | **Cursor Usage API** | `exact` | Per-request tokens + totalCents from Cursor's API. Used by `budi import` for historical backfill |
 
-Historical OTEL data (`otel_exact` confidence) remains queryable but OTEL ingestion has been removed. The proxy is the sole live data source.
-
 ### Key concepts
 
 - **cost_confidence**: determines `~` prefix in dashboard for non-exact costs
 - **Source of truth vs derived**: `messages` remains canonical; rollup tables are derived caches maintained incrementally via SQLite triggers during ingest/update/delete
 - **Session context propagation**: git_branch/repo_id flow from user -> assistant messages within a session
 - **Progressive sync**: files processed newest-first so dashboard shows recent data quickly
-- **Sync split**: `budi sync` = 30-day window (fast), `budi sync --all` = full history. If proxy-ingested data exists, transcript sync/import only backfills messages before the first proxy event to avoid double-counting
+- **Sync split**: `budi sync` = on-demand 30-day historical backfill, `budi sync --all` = on-demand full historical backfill. If proxy-ingested data exists, sync/import only backfills messages before the first proxy event to avoid double-counting
 - **Proxy mode**: Daemon runs a second HTTP server on port 9878 that acts as a transparent proxy between AI agents and upstream providers (Anthropic, OpenAI). Agents set `ANTHROPIC_BASE_URL=http://localhost:9878` or `OPENAI_BASE_URL=http://localhost:9878` to route through the proxy. Path-based routing: `/v1/messages` → Anthropic, `/v1/chat/completions` → OpenAI. SSE streaming responses are passed through chunk-by-chunk with no buffering; a tee/tap on the byte stream extracts token metadata (input/output tokens) from SSE events without modifying the data. Non-streaming responses are buffered and parsed for usage data. Duration is measured from request start to stream end (not to first headers). Mid-stream failures and client disconnects are handled gracefully — partial metadata is recorded via Drop. No read timeout on streaming; non-streaming uses 300s. Config: `[proxy]` section in `config.toml`, `BUDI_PROXY_PORT` / `BUDI_PROXY_ENABLED` env vars, `--proxy-port` / `--no-proxy` CLI flags. See [ADR-0082](docs/adr/0082-proxy-compatibility-matrix-and-gateway-contract.md) for the full contract.
 
 ## Key files
@@ -113,9 +122,8 @@ Historical OTEL data (`otel_exact` confidence) remains queryable but OTEL ingest
 - `crates/budi-core/src/analytics/health.rs` - Session health vitals, ProviderKind-aware tips, overall-state logic
 - `crates/budi-core/src/analytics/tests.rs` - Analytics + session health unit tests
 - `crates/budi-core/src/pipeline/mod.rs` - Pipeline struct, Enricher trait, default_pipeline()
-- `crates/budi-core/src/pipeline/enrichers.rs` - All 5 enricher implementations (HookEnricher removed)
+- `crates/budi-core/src/pipeline/enrichers.rs` - All 5 enricher implementations
 - `crates/budi-core/src/cost.rs` - Cost estimation, ModelPricing, per-provider pricing tables
-- `crates/budi-core/src/hooks.rs` - Prompt classification and migration helpers (hook_events table dropped in v22)
 - `crates/budi-core/src/jsonl.rs` - JSONL transcript parser, ParsedMessage struct
 - `crates/budi-core/src/providers/claude_code.rs` - Claude Code provider (JSONL discovery, pricing)
 - `crates/budi-core/src/providers/cursor.rs` - Cursor provider (Usage API primary, transcript fallback; auth/session context from state.vscdb across macOS/Linux/Windows layouts)
@@ -124,7 +132,6 @@ Historical OTEL data (`otel_exact` confidence) remains queryable but OTEL ingest
 - `crates/budi-core/src/config.rs` - BudiConfig, ProxyConfig, AgentsConfig, StatuslineConfig, TagsConfig
 - `crates/budi-cli/build.rs` - Build script: creates empty vsix placeholder if not pre-built
 - `crates/budi-daemon/src/main.rs` - HTTP server (port 7878) + proxy server (port 9878), ~40 routes
-- `crates/budi-daemon/src/routes/hooks.rs` - /sync, /sync/all, /sync/reset, /sync/status, /health, /health/integrations, /health/check-update, /admin/integrations/install endpoints (hook ingestion removed)
 - `crates/budi-daemon/src/routes/analytics.rs` - All analytics + admin endpoints (summary, messages, projects, cost, models, activity, branches, tags, providers, statusline, cache-efficiency, session-cost-curve, cost-confidence, subagent-cost, sessions, session-health, session-audit, admin/providers, admin/schema, admin/migrate, admin/repair)
 - `crates/budi-daemon/src/routes/proxy.rs` - Proxy handlers for Anthropic Messages and OpenAI Chat Completions
 - `crates/budi-cli/src/commands/statusline.rs` - Statusline rendering (coach mode with health tips) + installation
@@ -139,10 +146,10 @@ Historical OTEL data (`otel_exact` confidence) remains queryable but OTEL ingest
 - CLI never touches SQLite directly - all queries go through the daemon HTTP API
 - CostEnricher is the single source of truth for cost - sets cost_cents during pipeline. Skips if cost already set (API data)
 - `budi init` prompts for per-agent enablement (Claude Code, Cursor) and persists choices to `~/.config/budi/agents.toml`. Only enabled agents are synced. Legacy installs (no `agents.toml`) treat all available agents as enabled for backward compatibility.
-- `budi init` configures integrations (statusline, extension) for enabled agents. Legacy hook/OTEL/hook integrations are removed surfaces and are skipped if explicitly selected
+- `budi init` configures integrations (statusline, extension) for enabled agents. Removed legacy integrations are skipped if explicitly selected
 - Tags are auto-detected (`provider`, `model`, `tool`, `tool_use_id`, `ticket_id`, `activity`, and conditional tags like `cost_confidence` / `speed`) + custom rules via `~/.config/budi/tags.toml`
 - git_branch is a column on messages (not a tag) for fast queries
-- **Session health**: Four vitals computed per session - context growth (context-size growth), cache reuse (cache hit rate), cost acceleration (per-reply cost growth), retry loops (currently disabled — hook_events table dropped in v22). Each vital has green/yellow/red state. New sessions start green - the default is always positive; vitals only degrade to yellow/red when there is clear evidence of a problem. Tips are provider-aware via `ProviderKind` enum (Claude Code -> `/compact`/`/clear`, Cursor -> "new composer session", Other -> neutral). When no session ID is provided, health auto-select prefers the latest session with assistant activity, then falls back to session timestamps. Statusline "coach" mode shows health icon + session cost + tip. Dashboard session detail page has a health panel with vitals grid and tips section.
+- **Session health**: Four vitals computed per session - context growth (context-size growth), cache reuse (cache hit rate), cost acceleration (per-reply cost growth), retry loops (currently disabled). Each vital has green/yellow/red state. New sessions start green - the default is always positive; vitals only degrade to yellow/red when there is clear evidence of a problem. Tips are provider-aware via `ProviderKind` enum (Claude Code -> `/compact`/`/clear`, Cursor -> "new composer session", Other -> neutral). When no session ID is provided, health auto-select prefers the latest session with assistant activity, then falls back to session timestamps. Statusline "coach" mode shows health icon + session cost + tip. Dashboard session detail page has a health panel with vitals grid and tips section.
 - **Cursor extension** (`extensions/cursor-budi/`): VS Code extension that shows session health in the status bar (aggregated health circles) and a side panel (session details, vitals, tips, session list). Auto-installed by `budi init` when Cursor CLI is on PATH (`.vsix` embedded in binary via `include_bytes!`). Communicates with daemon via HTTP. Tracks active session via `~/.local/share/budi/cursor-sessions.json` (watched by extension). `budi doctor` and `/health/integrations` both check extension install status.
 - **Dashboard** is a React SPA at `/dashboard` with client-side routing:
   - `/dashboard` (Overview) - Summary cards (cost/tokens/messages), activity timeline, agents/models, projects/branches, tickets/activity types

--- a/extensions/cursor-budi/README.md
+++ b/extensions/cursor-budi/README.md
@@ -7,13 +7,13 @@ Live AI coding cost analytics in your Cursor status bar and side panel.
 - **Status bar** — session cost + health indicator, updates automatically
 - **Health panel** — click the status bar to open; shows active session vitals (context growth, cache reuse, cost acceleration, retry loops), other recent sessions with health at a glance, and cost overview
 - **Session switching** — click any session in the health panel to pin it, or use **Budi: Select Session** command
-- **Auto-tracking** — when you interact with a chat, budi detects the active session via hooks and updates automatically
+- **Auto-tracking** — when you interact with a chat, budi updates the active-session marker automatically
 
 ## Prerequisites
 
 - **budi** installed and initialized (`budi init`)
 - **budi-daemon** running (starts automatically after `budi init`)
-- Cursor hooks configured (done by `budi init`)
+- Cursor integration configured (done by `budi init`)
 
 ## Install
 
@@ -29,7 +29,7 @@ Run `budi doctor` to verify.
 
 After install/reload, validate in under a minute:
 
-1. Run `budi doctor` and confirm Cursor hooks + daemon are healthy
+1. Run `budi doctor` and confirm Cursor integration + daemon are healthy
 2. Send one prompt in Cursor chat
 3. Click the budi status bar item (`🟢/🟡/🔴`) to open the health panel
 4. If no session appears yet, run **Budi: Refresh Status** once
@@ -67,14 +67,14 @@ Then reload Cursor: **Cmd+Shift+P** → **Developer: Reload Window**
 
 ## How it works
 
-1. **Hooks** — Cursor hooks (`budi hook`) fire on chat interactions and update `cursor-sessions.json` in budi's data directory (`~/.local/share/budi` on Unix, `%LOCALAPPDATA%\budi` on Windows)
+1. **Session tracker file** — `cursor-sessions.json` in budi's data directory (`~/.local/share/budi` on Unix, `%LOCALAPPDATA%\budi` on Windows) is updated when Cursor activity is observed
 2. **File watcher** — the extension watches both the session file and its parent directory, so it can detect active-session changes immediately (including when the file is created after extension startup)
 3. **Daemon** — `budi statusline --format json` (or direct HTTP to daemon) returns session cost, health state, and vitals
 4. **Health panel** — fetches session health details and lists recent sessions from `/analytics/sessions`
 
 ## Limitations
 
-Cursor does not expose the currently focused chat tab to extensions. The statusline tracks the most recently _interacted-with_ session (via hooks). For passive tab switching, use **Budi: Select Session** or click a session in the health panel.
+Cursor does not expose the currently focused chat tab to extensions. The statusline tracks the most recently _interacted-with_ session. For passive tab switching, use **Budi: Select Session** or click a session in the health panel.
 
 ## Troubleshooting
 
@@ -86,7 +86,7 @@ Cursor does not expose the currently focused chat tab to extensions. The statusl
 
 **Session does not switch quickly after chat activity**
 
-1. Confirm Cursor hooks are installed (`budi doctor`)
+1. Confirm Cursor integration is installed (`budi doctor`)
 2. Send one message in Cursor to create/update `cursor-sessions.json`
 3. Use **Budi: Select Session** to pin manually when switching passively between chats
 

--- a/frontend/dashboard/README.md
+++ b/frontend/dashboard/README.md
@@ -9,7 +9,7 @@ npm install
 npm run dev
 ```
 
-Vite runs on `http://127.0.0.1:5174` and proxies daemon API routes (`/analytics`, `/admin`, `/sync`, `/health`, `/hooks`, `/v1`) to `http://127.0.0.1:7878`.
+Vite runs on `http://127.0.0.1:5174` and proxies daemon API routes (`/analytics`, `/admin`, `/sync`, `/health`) to `http://127.0.0.1:7878`.
 
 ### App surfaces
 


### PR DESCRIPTION
Closes #94

## Summary

- Removes all stale hook, OTEL, continuous-sync, MCP-serve, and Starship references from user-facing docs (README.md, SOUL.md, CONTRIBUTING.md, extension and dashboard READMEs)
- Updates proxy support tiers and attribution header documentation per ADR-0082
- Documents `budi import` as the one-time historical backfill path replacing continuous sync
- Aligns architecture/data-flow diagrams with proxy-first design

## Risks / compatibility notes

- Docs-only change — no code or behavior changes
- ADR files are intentionally left unchanged (they are the locked spec)

## Validation

- `rg -ni "budi hook|hooks|otel|opentelemetry|continuous sync|mcp-serve|starship" --glob '*.md' --glob '!docs/adr/**'` → no matches
- No Rust/npm builds needed (markdown only)


Made with [Cursor](https://cursor.com)