### PR TITLE
v8: Add budi launch CLI wrapper for zero-config agent launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Proxy support follows the ADR-0082 compatibility tiers:
 | **Tier 2 (should-have)** | **Copilot CLI** | Supported in BYOK mode | Set `COPILOT_PROVIDER_TYPE=openai` and `COPILOT_PROVIDER_BASE_URL=http://127.0.0.1:9878` |
 | **Tier 3 (deferred)** | **Gemini CLI** | Deferred / not implemented in proxy v1 | Requires a separate Gemini protocol handler |
 
-`budi init` currently automates onboarding for Claude Code and Cursor only. Other proxy-compatible agents can be routed through Budi with manual provider configuration.
+`budi launch <agent>` starts the proxy and launches the agent with the correct env vars — zero manual config for Tier 1/2 CLI agents. `budi init` still automates integration setup for Claude Code and Cursor.
 
 ## Contributing
 
@@ -164,8 +164,8 @@ Use this sequence if you want the fastest "did setup really work?" path:
    - Run `budi doctor`
    - Run `budi stats` to confirm data is flowing
 5. **Generate your first data point**
-   - Configure your agent to use the proxy (port 9878), send a prompt, then run `budi stats`
-   - Run `budi stats` and confirm non-zero usage
+   - Use `budi launch claude` (or `budi launch codex`) to start your agent through the proxy, send a prompt, then run `budi stats`
+   - Or configure your agent manually to use the proxy (port 9878) and confirm non-zero usage with `budi stats`
 6. **Restart apps once**
    - Restart Claude Code and Cursor after `budi init` so statusline/extension changes take effect
 
@@ -250,6 +250,11 @@ budi integrations install --with cursor-extension
 budi init                     # start daemon, configure integrations
 budi init --integrations none # initialize data/daemon without editor integrations
 budi init --with cursor-extension  # install an extra integration during init
+budi launch claude            # launch Claude Code through the proxy (zero config)
+budi launch codex             # launch Codex CLI through the proxy
+budi launch copilot           # launch Copilot CLI through the proxy
+budi launch cursor            # show Cursor GUI setup instructions
+budi launch claude --proxy-port 9999  # use a custom proxy port
 budi import                   # one-time import of historical transcripts
 budi integrations list        # show what is installed vs available
 budi integrations install ... # install integrations later

--- a/SOUL.md
+++ b/SOUL.md
@@ -52,7 +52,7 @@ These coupling points are documented with untangling plans in ADR-0086. New code
 ### Crates
 
 - **budi-core** - Business logic: analytics (SQLite queries), providers (Claude Code, Cursor) for historical import, pipeline (enrichment), cost calculation, proxy event storage, config, migrations
-- **budi-cli** - Thin HTTP client to the daemon. Commands: init, stats, sync, import, statusline, doctor, open, update, uninstall, migrate, repair, health
+- **budi-cli** - Thin HTTP client to the daemon. Commands: init, launch, stats, sync, import, statusline, doctor, open, update, uninstall, migrate, repair, health
 - **budi-daemon** - axum HTTP server (port 7878). Owns SQLite exclusively. Serves dashboard and analytics API. Also runs the proxy server on port 9878. The proxy is the sole live data source; transcript import is user-initiated via `budi import`
 
 ### Agent compatibility tiers (ADR-0082)
@@ -63,7 +63,7 @@ These coupling points are documented with untangling plans in ADR-0086. New code
 | **Tier 2 (should-have)** | Cursor, Copilot CLI | Supported with caveats (Cursor UI override, Copilot BYOK vars). |
 | **Tier 3 (deferred)** | Gemini CLI | Deferred in proxy v1; separate protocol handler required. |
 
-`budi init` currently automates onboarding for Claude Code and Cursor. Other proxy-compatible agents can be routed manually through proxy base URL settings.
+`budi launch <agent>` wraps agent startup: starts the daemon/proxy if needed, injects the correct env vars, and execs the agent. `budi launch claude` / `budi launch codex` (Tier 1) and `budi launch copilot` (Tier 2) are zero-config. `budi launch cursor` prints GUI setup instructions. `budi launch gemini` exits with a "not yet supported" message.
 
 ### Data flow
 
@@ -130,6 +130,7 @@ Nine tables, seven data entities + two supporting:
 - `crates/budi-core/src/migration.rs` - Schema v21, all migration paths
 - `crates/budi-core/src/proxy.rs` - ProxyEvent types with attribution (repo, branch, ticket, cost), proxy_events and messages table storage, ProxyAttribution resolution from headers/git
 - `crates/budi-core/src/config.rs` - BudiConfig, ProxyConfig, AgentsConfig, StatuslineConfig, TagsConfig
+- `crates/budi-cli/src/commands/launch.rs` - `budi launch <agent>` CLI wrapper: agent definitions, env var injection, proxy health check, exec
 - `crates/budi-cli/build.rs` - Build script: creates empty vsix placeholder if not pre-built
 - `crates/budi-daemon/src/main.rs` - HTTP server (port 7878) + proxy server (port 9878), ~40 routes
 - `crates/budi-daemon/src/routes/analytics.rs` - All analytics + admin endpoints (summary, messages, projects, cost, models, activity, branches, tags, providers, statusline, cache-efficiency, session-cost-curve, cost-confidence, subagent-cost, sessions, session-health, session-audit, admin/providers, admin/schema, admin/migrate, admin/repair)

--- a/crates/budi-cli/src/commands/launch.rs
+++ b/crates/budi-cli/src/commands/launch.rs
@@ -1,0 +1,415 @@
+use std::net::{SocketAddr, TcpStream};
+use std::process::Command;
+use std::time::Duration;
+
+use anyhow::Result;
+use budi_core::config::{self, BudiConfig};
+
+use crate::commands::ansi;
+use crate::daemon;
+
+// ─── Agent Definitions (ADR-0082 §1) ────────────────────────────────────────
+
+/// Env-var builder for Claude Code (Tier 1, Anthropic Messages protocol).
+fn claude_env(port: u16) -> Vec<(&'static str, String)> {
+    vec![
+        ("ANTHROPIC_BASE_URL", format!("http://localhost:{port}")),
+        ("CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC", "1".to_string()),
+    ]
+}
+
+/// Env-var builder for Codex CLI (Tier 1, OpenAI Chat Completions protocol).
+fn codex_env(port: u16) -> Vec<(&'static str, String)> {
+    vec![("OPENAI_BASE_URL", format!("http://localhost:{port}"))]
+}
+
+/// Env-var builder for Copilot CLI (Tier 2, proprietary BYOK env vars).
+fn copilot_env(port: u16) -> Vec<(&'static str, String)> {
+    vec![
+        (
+            "COPILOT_PROVIDER_BASE_URL",
+            format!("http://localhost:{port}"),
+        ),
+        ("COPILOT_PROVIDER_TYPE", "openai".to_string()),
+    ]
+}
+
+type EnvVarBuilder = fn(u16) -> Vec<(&'static str, String)>;
+
+struct AgentDef {
+    /// Short name used on the command line (e.g. "claude").
+    name: &'static str,
+    /// Human-readable display name (e.g. "Claude Code").
+    display_name: &'static str,
+    /// Primary binary to exec.
+    binary: &'static str,
+    /// Extra leading arguments injected before user args (e.g. ["copilot"] for `gh copilot`).
+    binary_prefix_args: &'static [&'static str],
+    /// Builds the env-var set to inject for the given proxy port.
+    env_vars: Option<EnvVarBuilder>,
+    /// If set, this agent cannot be CLI-launched; print these instructions instead.
+    instructions: Option<&'static str>,
+    /// If set, this agent is not yet supported; print this message and exit.
+    unsupported_msg: Option<&'static str>,
+}
+
+const AGENTS: &[AgentDef] = &[
+    AgentDef {
+        name: "claude",
+        display_name: "Claude Code",
+        binary: "claude",
+        binary_prefix_args: &[],
+        env_vars: Some(claude_env),
+        instructions: None,
+        unsupported_msg: None,
+    },
+    AgentDef {
+        name: "codex",
+        display_name: "Codex CLI",
+        binary: "codex",
+        binary_prefix_args: &[],
+        env_vars: Some(codex_env),
+        instructions: None,
+        unsupported_msg: None,
+    },
+    AgentDef {
+        name: "copilot",
+        display_name: "Copilot CLI",
+        binary: "gh",
+        binary_prefix_args: &["copilot"],
+        env_vars: Some(copilot_env),
+        instructions: None,
+        unsupported_msg: None,
+    },
+    AgentDef {
+        name: "cursor",
+        display_name: "Cursor",
+        binary: "cursor",
+        binary_prefix_args: &[],
+        env_vars: None,
+        instructions: Some(
+            "Cursor cannot be launched via CLI wrapper — it requires GUI configuration.\n\
+             \n\
+             To route Cursor through the budi proxy:\n\
+             \n\
+             1. Open Cursor Settings\n\
+             2. Go to Models\n\
+             3. Set \"Override OpenAI Base URL\" to: http://localhost:{port}\n\
+             4. Restart Cursor\n\
+             \n\
+             The proxy is running and ready to accept connections.",
+        ),
+        unsupported_msg: None,
+    },
+    AgentDef {
+        name: "gemini",
+        display_name: "Gemini CLI",
+        binary: "gemini",
+        binary_prefix_args: &[],
+        env_vars: None,
+        instructions: None,
+        unsupported_msg: Some(
+            "Gemini CLI is not yet supported by the budi proxy.\n\
+             Gemini uses a different API format that requires a separate protocol handler.\n\
+             This will be added in a future release.",
+        ),
+    },
+];
+
+fn find_agent(name: &str) -> Option<&'static AgentDef> {
+    let lower = name.to_lowercase();
+    AGENTS.iter().find(|a| {
+        a.name == lower
+            || (a.name == "claude" && lower == "claude-code")
+            || (a.name == "codex" && lower == "codex-cli")
+            || (a.name == "copilot" && lower == "copilot-cli")
+    })
+}
+
+// ─── Command ─────────────────────────────────────────────────────────────────
+
+pub fn cmd_launch(
+    agent_name: &str,
+    proxy_port_override: Option<u16>,
+    args: &[String],
+) -> Result<()> {
+    let green = ansi("\x1b[32m");
+    let yellow = ansi("\x1b[33m");
+    let dim = ansi("\x1b[2m");
+    let reset = ansi("\x1b[0m");
+    let bold = ansi("\x1b[1m");
+
+    // ── Resolve agent ────────────────────────────────────────────────────
+
+    let agent = find_agent(agent_name).ok_or_else(|| {
+        let known: Vec<&str> = AGENTS.iter().map(|a| a.name).collect();
+        anyhow::anyhow!(
+            "Unknown agent: {agent_name}\n\n\
+             Supported agents: {}\n\n\
+             Usage: budi launch <agent> [-- <args>...]",
+            known.join(", ")
+        )
+    })?;
+
+    // Tier 3 — not yet supported
+    if let Some(msg) = agent.unsupported_msg {
+        eprintln!("{yellow}⚠{reset} {msg}");
+        return Ok(());
+    }
+
+    // ── Load config & resolve proxy port ─────────────────────────────────
+
+    let repo_root = crate::commands::try_resolve_repo_root(None);
+    let config = match &repo_root {
+        Some(root) => config::load_or_default(root)?,
+        None => BudiConfig::default(),
+    };
+
+    // Precedence per ADR-0082 §3: env > CLI flag > config > default
+    let proxy_port = resolve_proxy_port(proxy_port_override, &config);
+
+    // ── GUI-only agents (Cursor) ─────────────────────────────────────────
+
+    if let Some(tpl) = agent.instructions {
+        eprintln!(
+            "{bold}{}{reset} requires manual configuration.",
+            agent.display_name
+        );
+        eprintln!();
+
+        // Still start the daemon so the proxy is ready
+        daemon::ensure_daemon_running(repo_root.as_deref(), &config)?;
+        eprintln!("{green}✓{reset} Proxy running on port {proxy_port}");
+        eprintln!();
+        eprintln!("{}", tpl.replace("{port}", &proxy_port.to_string()));
+        return Ok(());
+    }
+
+    // ── Pre-flight checks ────────────────────────────────────────────────
+
+    if !config.proxy.effective_enabled() {
+        anyhow::bail!(
+            "Proxy is disabled. Enable it in config.toml:\n\n\
+             [proxy]\n\
+             enabled = true\n\n\
+             Or set BUDI_PROXY_ENABLED=true"
+        );
+    }
+
+    if !binary_exists(agent.binary) {
+        anyhow::bail!(
+            "{} binary '{}' not found in PATH.\n\
+             Install {} first, then run: budi launch {}",
+            agent.display_name,
+            agent.binary,
+            agent.display_name,
+            agent.name
+        );
+    }
+
+    // ── Start daemon (includes proxy) ────────────────────────────────────
+
+    daemon::ensure_daemon_running(repo_root.as_deref(), &config)?;
+
+    if !proxy_port_is_listening(proxy_port) {
+        anyhow::bail!(
+            "Proxy port {proxy_port} is not listening.\n\
+             The daemon may have started without the proxy enabled.\n\
+             Check: budi doctor"
+        );
+    }
+
+    // ── Copilot: warn if COPILOT_MODEL is not set ────────────────────────
+
+    if agent.name == "copilot" && std::env::var("COPILOT_MODEL").is_err() {
+        eprintln!(
+            "{yellow}⚠{reset} COPILOT_MODEL is not set. \
+             Copilot CLI requires this env var to select a model.\n  \
+             Example: export COPILOT_MODEL=gpt-4o\n"
+        );
+    }
+
+    // ── Build and exec ───────────────────────────────────────────────────
+
+    let env_vars = (agent.env_vars.expect("launchable agent must have env_vars"))(proxy_port);
+
+    eprintln!(
+        "{green}✓{reset} Launching {bold}{}{reset} through budi proxy {dim}(port {proxy_port}){reset}",
+        agent.display_name
+    );
+    for (key, val) in &env_vars {
+        eprintln!("  {dim}{key}={val}{reset}");
+    }
+    eprintln!();
+
+    let mut cmd = Command::new(agent.binary);
+    cmd.args(agent.binary_prefix_args);
+    cmd.args(args);
+    for (key, val) in &env_vars {
+        cmd.env(key, val);
+    }
+
+    // On Unix, exec() replaces the budi process with the agent.
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        let err = cmd.exec();
+        // exec only returns on error
+        anyhow::bail!("Failed to exec {}: {}", agent.display_name, err);
+    }
+
+    // On non-Unix, spawn and forward the exit code.
+    #[cfg(not(unix))]
+    {
+        let status = cmd
+            .status()
+            .with_context(|| format!("Failed to launch {}", agent.display_name))?;
+        std::process::exit(status.code().unwrap_or(1));
+    }
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/// Resolve proxy port per ADR-0082 §3: env > CLI flag > config > default.
+fn resolve_proxy_port(cli_flag: Option<u16>, config: &BudiConfig) -> u16 {
+    if let Ok(val) = std::env::var("BUDI_PROXY_PORT")
+        && let Ok(port) = val.trim().parse::<u16>()
+    {
+        return port;
+    }
+    if let Some(port) = cli_flag {
+        return port;
+    }
+    config.proxy.port
+}
+
+/// Check if a binary is available in PATH.
+fn binary_exists(name: &str) -> bool {
+    if let Ok(paths) = std::env::var("PATH") {
+        for dir in std::env::split_paths(&std::ffi::OsString::from(&paths)) {
+            if dir.join(name).is_file() {
+                return true;
+            }
+            #[cfg(windows)]
+            {
+                if dir.join(format!("{name}.exe")).is_file() {
+                    return true;
+                }
+            }
+        }
+    }
+    false
+}
+
+/// Check that the proxy TCP port is accepting connections.
+fn proxy_port_is_listening(port: u16) -> bool {
+    let addr: SocketAddr = ([127, 0, 0, 1], port).into();
+    TcpStream::connect_timeout(&addr, Duration::from_millis(500)).is_ok()
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn find_agent_by_name() {
+        assert_eq!(find_agent("claude").unwrap().name, "claude");
+        assert_eq!(find_agent("codex").unwrap().name, "codex");
+        assert_eq!(find_agent("copilot").unwrap().name, "copilot");
+        assert_eq!(find_agent("cursor").unwrap().name, "cursor");
+        assert_eq!(find_agent("gemini").unwrap().name, "gemini");
+    }
+
+    #[test]
+    fn find_agent_aliases() {
+        assert_eq!(find_agent("claude-code").unwrap().name, "claude");
+        assert_eq!(find_agent("Claude-Code").unwrap().name, "claude");
+        assert_eq!(find_agent("CLAUDE").unwrap().name, "claude");
+        assert_eq!(find_agent("codex-cli").unwrap().name, "codex");
+        assert_eq!(find_agent("copilot-cli").unwrap().name, "copilot");
+    }
+
+    #[test]
+    fn find_agent_unknown() {
+        assert!(find_agent("vim").is_none());
+        assert!(find_agent("").is_none());
+    }
+
+    #[test]
+    fn claude_env_sets_anthropic_base_url() {
+        let vars = claude_env(9878);
+        assert_eq!(vars.len(), 2);
+        assert_eq!(vars[0].0, "ANTHROPIC_BASE_URL");
+        assert_eq!(vars[0].1, "http://localhost:9878");
+        assert_eq!(vars[1].0, "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC");
+        assert_eq!(vars[1].1, "1");
+    }
+
+    #[test]
+    fn codex_env_sets_openai_base_url() {
+        let vars = codex_env(9878);
+        assert_eq!(vars.len(), 1);
+        assert_eq!(vars[0].0, "OPENAI_BASE_URL");
+        assert_eq!(vars[0].1, "http://localhost:9878");
+    }
+
+    #[test]
+    fn copilot_env_sets_byok_vars() {
+        let vars = copilot_env(9999);
+        assert_eq!(vars.len(), 2);
+        assert_eq!(vars[0].0, "COPILOT_PROVIDER_BASE_URL");
+        assert_eq!(vars[0].1, "http://localhost:9999");
+        assert_eq!(vars[1].0, "COPILOT_PROVIDER_TYPE");
+        assert_eq!(vars[1].1, "openai");
+    }
+
+    #[test]
+    fn custom_port_in_env_vars() {
+        let vars = claude_env(1234);
+        assert_eq!(vars[0].1, "http://localhost:1234");
+    }
+
+    #[test]
+    fn cursor_has_instructions() {
+        let agent = find_agent("cursor").unwrap();
+        assert!(agent.instructions.is_some());
+        assert!(agent.env_vars.is_none());
+    }
+
+    #[test]
+    fn gemini_is_unsupported() {
+        let agent = find_agent("gemini").unwrap();
+        assert!(agent.unsupported_msg.is_some());
+    }
+
+    #[test]
+    fn resolve_proxy_port_defaults() {
+        let config = BudiConfig::default();
+        // When no env var or CLI flag, uses config default (9878)
+        let port = resolve_proxy_port(None, &config);
+        assert_eq!(port, 9878);
+    }
+
+    #[test]
+    fn resolve_proxy_port_cli_flag_overrides_config() {
+        let config = BudiConfig::default();
+        let port = resolve_proxy_port(Some(1234), &config);
+        assert_eq!(port, 1234);
+    }
+
+    #[test]
+    fn copilot_uses_gh_binary_with_prefix() {
+        let agent = find_agent("copilot").unwrap();
+        assert_eq!(agent.binary, "gh");
+        assert_eq!(agent.binary_prefix_args, &["copilot"]);
+    }
+
+    #[test]
+    fn cursor_instructions_contain_port_placeholder() {
+        let agent = find_agent("cursor").unwrap();
+        let instructions = agent.instructions.unwrap();
+        assert!(instructions.contains("{port}"));
+    }
+}

--- a/crates/budi-cli/src/commands/launch.rs
+++ b/crates/budi-cli/src/commands/launch.rs
@@ -263,7 +263,7 @@ pub fn cmd_launch(
     {
         let status = cmd
             .status()
-            .with_context(|| format!("Failed to launch {}", agent.display_name))?;
+            .map_err(|e| anyhow::anyhow!("Failed to launch {}: {}", agent.display_name, e))?;
         std::process::exit(status.code().unwrap_or(1));
     }
 }

--- a/crates/budi-cli/src/commands/mod.rs
+++ b/crates/budi-cli/src/commands/mod.rs
@@ -10,6 +10,7 @@ pub mod health;
 pub mod import;
 pub mod init;
 pub mod integrations;
+pub mod launch;
 pub mod open;
 pub mod repair;
 pub mod stats;

--- a/crates/budi-cli/src/main.rs
+++ b/crates/budi-cli/src/main.rs
@@ -17,7 +17,7 @@ const HEALTH_TIMEOUT_SECS: u64 = 3;
 #[command(about = "budi — AI cost analytics. Know where your tokens and money go.")]
 #[command(version)]
 #[command(
-    after_help = "Get started:\n  budi init\n\nCommon commands:\n  budi stats              Show today's cost summary\n  budi stats --models     Cost breakdown by model\n  budi stats --branches   Cost breakdown by branch\n  budi integrations list  Show integration status\n  budi doctor             Check health: daemon, database, config\n  budi import             Import historical transcripts from disk\n  budi sync               Sync recent transcripts (last 30 days)\n  budi sync --force       Re-ingest all data from scratch (use after upgrades)\n  budi repair             Repair schema drift and run migration\n  budi open               Open the local dashboard (legacy)\n\nMore info: https://github.com/siropkin/budi"
+    after_help = "Get started:\n  budi init\n\nCommon commands:\n  budi launch claude      Launch Claude Code through the budi proxy\n  budi launch codex       Launch Codex CLI through the budi proxy\n  budi stats              Show today's cost summary\n  budi stats --models     Cost breakdown by model\n  budi stats --branches   Cost breakdown by branch\n  budi integrations list  Show integration status\n  budi doctor             Check health: daemon, database, config\n  budi import             Import historical transcripts from disk\n  budi sync               Sync recent transcripts (last 30 days)\n  budi sync --force       Re-ingest all data from scratch (use after upgrades)\n  budi repair             Repair schema drift and run migration\n  budi open               Open the local dashboard (legacy)\n\nMore info: https://github.com/siropkin/budi"
 )]
 struct Cli {
     #[command(subcommand)]
@@ -165,6 +165,31 @@ Examples:
     Integrations {
         #[command(subcommand)]
         action: IntegrationAction,
+    },
+    /// Launch an AI agent through the budi proxy (e.g. budi launch claude)
+    #[command(after_help = "\
+Supported agents:
+  claude    Claude Code (Tier 1) — sets ANTHROPIC_BASE_URL
+  codex     Codex CLI   (Tier 1) — sets OPENAI_BASE_URL
+  copilot   Copilot CLI (Tier 2) — sets COPILOT_PROVIDER_BASE_URL
+  cursor    Cursor      (Tier 2) — prints setup instructions (GUI only)
+  gemini    Gemini CLI  (Tier 3) — not yet supported
+
+Examples:
+  budi launch claude
+  budi launch codex -- --model o3
+  budi launch copilot
+  budi launch cursor
+  budi launch claude --proxy-port 9999")]
+    Launch {
+        /// Agent to launch: claude, codex, copilot, cursor, gemini
+        agent: String,
+        /// Override proxy port (default: 9878). Precedence: BUDI_PROXY_PORT env > this flag > config.toml.
+        #[arg(long)]
+        proxy_port: Option<u16>,
+        /// Arguments to pass through to the agent (use -- to separate)
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
     },
 }
 
@@ -330,6 +355,11 @@ fn main() -> Result<()> {
             }
         }
         Commands::Integrations { action } => commands::integrations::cmd_integrations(action),
+        Commands::Launch {
+            agent,
+            proxy_port,
+            args,
+        } => commands::launch::cmd_launch(&agent, proxy_port, &args),
     }
 }
 


### PR DESCRIPTION
## Summary

Implements issue #95 — the `budi launch <agent>` CLI wrapper for zero-config agent startup through the budi proxy.

- **Tier 1 (must-have):** `budi launch claude` sets `ANTHROPIC_BASE_URL` + `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1`; `budi launch codex` sets `OPENAI_BASE_URL`. Both exec the agent after starting the daemon/proxy.
- **Tier 2 (should-have):** `budi launch copilot` sets `COPILOT_PROVIDER_BASE_URL` + `COPILOT_PROVIDER_TYPE=openai` and warns if `COPILOT_MODEL` is not set. `budi launch cursor` starts the proxy and prints GUI setup instructions (Cursor cannot be CLI-launched).
- **Tier 3 (deferred):** `budi launch gemini` exits with a clear "not yet supported" message.
- Proxy port resolution follows ADR-0082 §3 precedence: `BUDI_PROXY_PORT` env > `--proxy-port` CLI flag > `config.toml` > default (9878).
- Pre-flight checks: proxy enabled, agent binary in PATH, proxy port listening.
- On Unix, uses `exec()` to replace the budi process with the agent. On Windows, spawns and forwards exit code.
- Agent name aliases: `claude-code`, `codex-cli`, `copilot-cli` all resolve to the canonical short names.

Closes #95

## ADR References

- [ADR-0082](docs/adr/0082-proxy-compatibility-matrix-and-gateway-contract.md) — agent compatibility matrix (§1), env vars per agent, port strategy (§3)

## Risks / compatibility notes

- No breaking changes — this adds a new `launch` subcommand only.
- Does not modify the proxy, daemon, or any existing commands.
- Copilot support depends on the `gh` CLI being installed with the copilot extension.
- The `exec()` call on Unix means budi's process is replaced; there is no post-agent cleanup. This is intentional — the proxy continues running as part of the daemon.

## Validation

- `cargo fmt --all` — clean
- `cargo clippy --workspace --all-targets --locked -- -D warnings` — zero warnings
- `cargo test --workspace --locked` — 332 tests pass (46 CLI + 268 core + 18 daemon)
- 13 new unit tests for agent definitions, env var generation, port resolution, and aliases