### PR TITLE
Build minimal Cursor bootstrap and status flow for 8.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,38 +32,6 @@ jobs:
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v5
-        with:
-          node-version: "20"
-
-      - name: Install Cursor extension dependencies
-        run: |
-          cd extensions/cursor-budi
-          npm ci
-
-      - name: Lint Cursor extension
-        run: |
-          cd extensions/cursor-budi
-          npm run lint
-
-      - name: Check Cursor extension formatting
-        run: |
-          cd extensions/cursor-budi
-          npm run format:check
-
-      - name: Test Cursor extension
-        run: |
-          cd extensions/cursor-budi
-          npm run test
-
-      - name: Build Cursor extension package
-        run: |
-          cd extensions/cursor-budi
-          npm run build
-          npx vsce package --no-dependencies -o cursor-budi.vsix
-          test -s cursor-budi.vsix
-
       - name: Check formatting
         run: cargo fmt --all -- --check
 
@@ -87,8 +55,6 @@ jobs:
           echo "Shell script syntax checks passed"
 
       - name: Build release binaries
-        env:
-          BUDI_REQUIRE_CURSOR_VSIX: "1"
         run: cargo build --workspace --release --locked
 
       - name: Smoke test binaries
@@ -113,7 +79,7 @@ jobs:
             echo "::error::Daemon did not become healthy within 5s"
             exit 1
           }
-          curl -sf "http://127.0.0.1:${SMOKE_PORT}/health" | jq -e '.ok == true'
+          curl -sf "http://127.0.0.1:${SMOKE_PORT}/health" | jq -e '.ok == true and .api_version >= 1'
           RESPONSE=$(curl -s -w '\n%{http_code}' "http://127.0.0.1:${SMOKE_PORT}/analytics/summary")
           HTTP_CODE=$(echo "$RESPONSE" | tail -1)
           BODY=$(echo "$RESPONSE" | sed '$d')
@@ -141,6 +107,37 @@ jobs:
           ! test -f "$RUNNER_TEMP/budi-bin/budi"
           ! test -f "$RUNNER_TEMP/budi-bin/budi-daemon"
           echo "Uninstall verified: binaries removed"
+
+  # Extension CI runs independently of the Rust workspace (ADR-0086 §4).
+  cursor-extension:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: "20"
+
+      - name: Install dependencies
+        run: cd extensions/cursor-budi && npm ci
+
+      - name: Lint
+        run: cd extensions/cursor-budi && npm run lint
+
+      - name: Check formatting
+        run: cd extensions/cursor-budi && npm run format:check
+
+      - name: Test
+        run: cd extensions/cursor-budi && npm run test
+
+      - name: Build and package
+        run: |
+          cd extensions/cursor-budi
+          npm run build
+          npx vsce package --no-dependencies -o cursor-budi.vsix
+          test -s cursor-budi.vsix
 
   macos-build:
     runs-on: macos-14
@@ -220,12 +217,13 @@ jobs:
 
   ci-success:
     if: always()
-    needs: [rust-checks, macos-build, windows-build]
+    needs: [rust-checks, cursor-extension, macos-build, windows-build]
     runs-on: ubuntu-latest
     steps:
       - name: Verify all jobs passed
         run: |
           if [[ "${{ needs.rust-checks.result }}" != "success" ]] || \
+             [[ "${{ needs.cursor-extension.result }}" != "success" ]] || \
              [[ "${{ needs.macos-build.result }}" != "success" ]] || \
              [[ "${{ needs.windows-build.result }}" != "success" ]]; then
             echo "::error::One or more CI jobs failed"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,21 +87,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v5
-        with:
-          node-version: "20"
-
-      - name: Build Cursor extension package
-        shell: bash
-        run: |
-          set -euo pipefail
-          cd extensions/cursor-budi
-          npm ci
-          npm run build
-          npx vsce package --no-dependencies -o cursor-budi.vsix
-          test -s cursor-budi.vsix
-
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -114,8 +99,6 @@ jobs:
 
       - name: Build release binaries
         shell: bash
-        env:
-          BUDI_REQUIRE_CURSOR_VSIX: "1"
         run: |
           cargo build \
             --manifest-path Cargo.toml \

--- a/crates/budi-cli/build.rs
+++ b/crates/budi-cli/build.rs
@@ -1,31 +1,5 @@
-use std::path::Path;
-
 fn main() {
-    let vsix = Path::new("../../extensions/cursor-budi/cursor-budi.vsix");
-    println!("cargo:rerun-if-changed={}", vsix.display());
-
-    let require_vsix = std::env::var("BUDI_REQUIRE_CURSOR_VSIX")
-        .map(|v| v == "1")
-        .unwrap_or(false);
-
-    let vsix_size = std::fs::metadata(vsix).map(|m| m.len()).unwrap_or(0);
-
-    if require_vsix && vsix_size == 0 {
-        panic!(
-            "Cursor extension package is missing or empty at {}. \
-             Build it before compiling (`npm ci && npm run build && npx vsce package ...`).",
-            vsix.display()
-        );
-    }
-
-    if vsix_size == 0 {
-        println!(
-            "cargo:warning=Cursor extension package not found at {}. \
-             Auto-install in `budi init` will be disabled for this build.",
-            vsix.display()
-        );
-        if !vsix.exists() {
-            let _ = std::fs::write(vsix, b"");
-        }
-    }
+    // VSIX embedding was removed in 8.0 (R3.2, issue #96).
+    // The Cursor extension is now installed via VS Code Marketplace
+    // or downloaded from GitHub Releases — see `budi integrations install`.
 }

--- a/crates/budi-cli/src/commands/integrations.rs
+++ b/crates/budi-cli/src/commands/integrations.rs
@@ -1,4 +1,3 @@
-use std::cmp::Ordering;
 use std::collections::BTreeSet;
 use std::fs;
 use std::io::{self, IsTerminal, Write};
@@ -674,91 +673,43 @@ fn install_cursor_hooks() -> Result<()> {
     Ok(())
 }
 
-static CURSOR_EXTENSION_VSIX: &[u8] =
-    include_bytes!("../../../../extensions/cursor-budi/cursor-budi.vsix");
-static CURSOR_EXTENSION_PACKAGE_JSON: &str =
-    include_str!("../../../../extensions/cursor-budi/package.json");
-
 fn install_cursor_extension(warnings: &mut Vec<String>) {
-    if CURSOR_EXTENSION_VSIX.is_empty() {
+    if is_cursor_extension_installed() {
+        println!("  Extension: Cursor extension already installed");
         return;
     }
 
     let cursor_cli = match find_cursor_cli() {
         Some(c) => c,
-        None => return,
-    };
-
-    let bundled_version = bundled_extension_version();
-    let installed_version = installed_extension_version(&cursor_cli);
-
-    if let (Some(installed), Some(bundled)) =
-        (installed_version.as_deref(), bundled_version.as_deref())
-        && compare_versions(installed, bundled) != Ordering::Less
-    {
-        println!("  Extension: Cursor extension already installed (v{installed})");
-        return;
-    }
-
-    let temp_dir = match create_secure_temp_dir("budi-vsix") {
-        Ok(path) => path,
-        Err(e) => {
-            warnings.push(format!("Cursor extension temp dir: {e}"));
+        None => {
+            println!(
+                "  Extension: Cursor CLI not found. \
+                 Install the budi extension from the VS Code Marketplace \
+                 or download from https://github.com/siropkin/budi/releases"
+            );
             return;
         }
     };
 
-    let vsix_path = temp_dir.join("cursor-budi.vsix");
-    if let Err(e) = fs::write(&vsix_path, CURSOR_EXTENSION_VSIX) {
-        warnings.push(format!("Cursor extension write temp file: {e}"));
-        let _ = fs::remove_dir_all(&temp_dir);
-        return;
-    }
-
+    // Try to install from VS Code Marketplace first
     let result = Command::new(&cursor_cli)
-        .args([
-            "--install-extension",
-            &vsix_path.to_string_lossy(),
-            "--force",
-        ])
+        .args(["--install-extension", "siropkin.budi", "--force"])
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .status();
 
-    let _ = fs::remove_dir_all(&temp_dir);
-
     match result {
         Ok(status) if status.success() => {
-            if let Some(installed) = installed_version {
-                println!("  Extension: updated Cursor extension (from v{installed})");
-            } else {
-                println!("  Extension: installed Cursor extension");
-            }
+            println!("  Extension: installed Cursor extension from marketplace");
         }
-        Ok(_) => {
-            warnings.push("Cursor extension install failed".to_string());
-        }
-        Err(e) => {
-            warnings.push(format!("could not run cursor CLI: {e}"));
+        _ => {
+            warnings.push(
+                "Could not install Cursor extension from marketplace. \
+                 Install manually: https://github.com/siropkin/budi/releases"
+                    .to_string(),
+            );
         }
     }
-}
-
-fn create_secure_temp_dir(prefix: &str) -> io::Result<PathBuf> {
-    let base = std::env::temp_dir();
-    for _ in 0..16 {
-        let stamp = chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default();
-        let candidate = base.join(format!("{prefix}-{stamp}-{}", std::process::id()));
-        match fs::create_dir(&candidate) {
-            Ok(()) => return Ok(candidate),
-            Err(e) if e.kind() == io::ErrorKind::AlreadyExists => continue,
-            Err(e) => return Err(e),
-        }
-    }
-    Err(io::Error::new(
-        io::ErrorKind::AlreadyExists,
-        "Failed to allocate temp directory",
-    ))
 }
 
 /// Check if the `cursor` CLI is on PATH (or at the well-known macOS location).
@@ -778,68 +729,6 @@ pub fn find_cursor_cli() -> Option<String> {
             .map(|s| s.success())
             .unwrap_or(false)
     })
-}
-
-fn installed_extension_version(cursor_cli: &str) -> Option<String> {
-    let output = Command::new(cursor_cli)
-        .args(["--list-extensions", "--show-versions"])
-        .output()
-        .ok()?;
-    if !output.status.success() {
-        return None;
-    }
-    let out = String::from_utf8_lossy(&output.stdout);
-    out.lines()
-        .find_map(parse_extension_line)
-        .map(|(_, version)| version)
-}
-
-fn parse_extension_line(line: &str) -> Option<(String, String)> {
-    let trimmed = line.trim();
-    let lower = trimmed.to_ascii_lowercase();
-    if !lower.starts_with("siropkin.budi") {
-        return None;
-    }
-    if let Some((name, version)) = trimmed.split_once('@') {
-        Some((name.to_string(), version.to_string()))
-    } else {
-        Some(("siropkin.budi".to_string(), String::new()))
-    }
-}
-
-fn bundled_extension_version() -> Option<String> {
-    let parsed = serde_json::from_str::<Value>(CURSOR_EXTENSION_PACKAGE_JSON).ok()?;
-    parsed
-        .get("version")
-        .and_then(|v| v.as_str())
-        .map(|v| v.to_string())
-}
-
-fn compare_versions(a: &str, b: &str) -> Ordering {
-    let parse = |v: &str| -> Option<Vec<u64>> {
-        let core = v
-            .split_once('-')
-            .map(|(lhs, _)| lhs)
-            .unwrap_or(v)
-            .trim_start_matches('v');
-        if core.is_empty() {
-            return None;
-        }
-        let mut out = Vec::new();
-        for part in core.split('.') {
-            out.push(part.parse::<u64>().ok()?);
-        }
-        Some(out)
-    };
-    match (parse(a), parse(b)) {
-        (Some(mut av), Some(mut bv)) => {
-            let max_len = av.len().max(bv.len());
-            av.resize(max_len, 0);
-            bv.resize(max_len, 0);
-            av.cmp(&bv)
-        }
-        _ => a.cmp(b),
-    }
 }
 
 /// Check if the budi Cursor extension is installed.
@@ -933,22 +822,6 @@ fn is_legacy_cursor_hook(entry: &Value) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn compare_versions_orders_semver_like_values() {
-        assert_eq!(compare_versions("1.2.3", "1.2.3"), Ordering::Equal);
-        assert_eq!(compare_versions("1.2.4", "1.2.3"), Ordering::Greater);
-        assert_eq!(compare_versions("1.2.3", "1.3.0"), Ordering::Less);
-        assert_eq!(compare_versions("v1.10.0", "1.9.9"), Ordering::Greater);
-    }
-
-    #[test]
-    fn parse_extension_line_extracts_name_and_version() {
-        let parsed = parse_extension_line("siropkin.budi@0.5.1").expect("parsed");
-        assert_eq!(parsed.0, "siropkin.budi");
-        assert_eq!(parsed.1, "0.5.1");
-        assert!(parse_extension_line("other.ext@1.0.0").is_none());
-    }
 
     #[test]
     fn apply_statusline_adds_new_statusline_when_missing() {

--- a/crates/budi-daemon/src/main.rs
+++ b/crates/budi-daemon/src/main.rs
@@ -394,6 +394,10 @@ mod tests {
         let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(json["ok"], true);
         assert!(json["version"].is_string(), "health should include version");
+        assert!(
+            json["api_version"].is_u64(),
+            "health should include api_version"
+        );
     }
 
     #[tokio::test]

--- a/crates/budi-daemon/src/routes/hooks.rs
+++ b/crates/budi-daemon/src/routes/hooks.rs
@@ -12,6 +12,10 @@ use crate::AppState;
 pub struct HealthResponse {
     pub ok: bool,
     pub version: &'static str,
+    /// Daemon management API version.  The Cursor extension checks this field
+    /// on startup and warns if its expected API version is unsupported.
+    /// Bump when a breaking change is made to any management API endpoint.
+    pub api_version: u32,
 }
 
 #[derive(serde::Serialize)]
@@ -217,10 +221,15 @@ fn is_cursor_extension_installed(home: &str) -> bool {
         || cursor_extension_installed_via_filesystem(home)
 }
 
+/// Current daemon management API version.  Bump when a breaking change is
+/// made to any management API endpoint consumed by budi-cursor or the CLI.
+pub const API_VERSION: u32 = 1;
+
 pub async fn health() -> Json<HealthResponse> {
     Json(HealthResponse {
         ok: true,
         version: env!("CARGO_PKG_VERSION"),
+        api_version: API_VERSION,
     })
 }
 

--- a/extensions/cursor-budi/README.md
+++ b/extensions/cursor-budi/README.md
@@ -2,52 +2,45 @@
 
 Live AI coding cost analytics in your Cursor status bar and side panel.
 
-## Features
-
-- **Status bar** — session cost + health indicator, updates automatically
-- **Health panel** — click the status bar to open; shows active session vitals (context growth, cache reuse, cost acceleration, retry loops), other recent sessions with health at a glance, and cost overview
-- **Session switching** — click any session in the health panel to pin it, or use **Budi: Select Session** command
-- **Auto-tracking** — when you interact with a chat, budi updates the active-session marker automatically
-
 ## Prerequisites
 
 - **budi** installed and initialized (`budi init`)
 - **budi-daemon** running (starts automatically after `budi init`)
-- Cursor integration configured (done by `budi init`)
+- **Proxy configured** — in Cursor Settings > Models, set **Override OpenAI Base URL** to `http://localhost:9878`
 
 ## Install
 
-The extension can be installed during `budi init` and later with:
+Install from the VS Code Marketplace (search for "budi"), or via CLI:
 
 ```bash
 budi integrations install --with cursor-extension
 ```
 
-Run `budi doctor` to verify.
-
-### First-run smoke check
-
-After install/reload, validate in under a minute:
-
-1. Run `budi doctor` and confirm Cursor integration + daemon are healthy
-2. Send one prompt in Cursor chat
-3. Click the budi status bar item (`🟢/🟡/🔴`) to open the health panel
-4. If no session appears yet, run **Budi: Refresh Status** once
-
-**Manual install** (if auto-install was skipped or you want to rebuild):
+**Manual install** (for development):
 
 ```bash
 cd extensions/cursor-budi
-npm ci
-npm run lint
-npm run format:check
-npm run test
-npm run build
+npm ci && npm run build
 npx vsce package --no-dependencies -o cursor-budi.vsix
 cursor --install-extension cursor-budi.vsix --force
 ```
 
-Then reload Cursor: **Cmd+Shift+P** → **Developer: Reload Window**
+Then reload Cursor: **Cmd+Shift+P** > **Developer: Reload Window**
+
+## Features
+
+- **Status bar** — today's session cost + health overview, updates automatically
+- **Health panel** — click the status bar to open; shows active session vitals, recent sessions with health at a glance
+- **Session switching** — click any session in the health panel to pin it, or use **Budi: Select Session** command
+- **Onboarding** — guides you through proxy setup when the daemon is not running
+
+## How It Works
+
+In budi 8.0, all AI cost tracking runs through a local proxy:
+
+1. **Proxy** — Cursor sends API requests to `http://localhost:9878` instead of directly to OpenAI. The proxy forwards requests transparently while capturing token usage and cost metadata.
+2. **Daemon API** — the extension queries the daemon's HTTP API for statusline data, session health, and recent sessions.
+3. **Workspace signal** — the extension writes `~/.local/share/budi/cursor-sessions.json` to indicate which workspace is active (see [Contract](#cursor-sessionsjson-contract) below).
 
 ## Commands
 
@@ -65,16 +58,32 @@ Then reload Cursor: **Cmd+Shift+P** → **Developer: Reload Window**
 | `budi.pollingIntervalMs` | `15000`                 | Status bar refresh interval (ms) |
 | `budi.daemonUrl`         | `http://127.0.0.1:7878` | Daemon URL                       |
 
-## How it works
+## cursor-sessions.json Contract
 
-1. **Session tracker file** — `cursor-sessions.json` in budi's data directory (`~/.local/share/budi` on Unix, `%LOCALAPPDATA%\budi` on Windows) is updated when Cursor activity is observed
-2. **File watcher** — the extension watches both the session file and its parent directory, so it can detect active-session changes immediately (including when the file is created after extension startup)
-3. **Daemon** — `budi statusline --format json` (or direct HTTP to daemon) returns session cost, health state, and vitals
-4. **Health panel** — fetches session health details and lists recent sessions from `/analytics/sessions`
+**Version: 1** (ADR-0086 Section 3.4)
+
+The extension writes `~/.local/share/budi/cursor-sessions.json` to signal which Cursor workspace is currently active. The daemon may read this file to correlate proxy events with the active workspace.
+
+```json
+{
+  "version": 1,
+  "active_workspace": "/absolute/path/to/project",
+  "updated_at": "2026-04-11T20:00:00.000Z"
+}
+```
+
+| Field              | Type     | Description                                                       |
+| ------------------ | -------- | ----------------------------------------------------------------- |
+| `version`          | `number` | Contract version. Currently `1`. Breaking changes require a bump. |
+| `active_workspace` | `string` | Absolute path to the active Cursor workspace.                     |
+| `updated_at`       | `string` | ISO-8601 timestamp of last update.                                |
+
+The file is written on extension activation and updated on each status refresh. It is deleted on extension deactivation.
 
 ## Limitations
 
-Cursor does not expose the currently focused chat tab to extensions. The statusline tracks the most recently _interacted-with_ session. For passive tab switching, use **Budi: Select Session** or click a session in the health panel.
+- Cursor does not expose the currently focused chat tab to extensions. The extension tracks the most recently active session. For passive tab switching, use **Budi: Select Session** or click a session in the health panel.
+- Some built-in Cursor features may bypass the proxy override and use Cursor-managed routes directly (ADR-0082 Section 1).
 
 ## Troubleshooting
 
@@ -82,15 +91,15 @@ Cursor does not expose the currently focused chat tab to extensions. The statusl
 
 1. Run `budi doctor` and confirm daemon health
 2. Run `budi init` if the daemon is not running
-3. If you changed `budi.daemonUrl`, run **Budi: Refresh Status** (or reload Cursor) to force an immediate reconnect
+3. Check that the proxy is running on port 9878
 
-**Session does not switch quickly after chat activity**
+**No sessions appear after sending prompts**
 
-1. Confirm Cursor integration is installed (`budi doctor`)
-2. Send one message in Cursor to create/update `cursor-sessions.json`
-3. Use **Budi: Select Session** to pin manually when switching passively between chats
+1. Verify "Override OpenAI Base URL" is set to `http://localhost:9878` in Cursor Settings > Models
+2. Restart Cursor after changing the setting
+3. Use **Budi: Refresh Status** for an immediate update
 
 **Panel data is stale**
 
-- The extension updates on both event-driven file changes and periodic polling (`budi.pollingIntervalMs`, default 15s)
+- The extension polls every 15 seconds (configurable via `budi.pollingIntervalMs`)
 - Use **Budi: Refresh Status** for an immediate refresh

--- a/extensions/cursor-budi/src/budiClient.test.ts
+++ b/extensions/cursor-budi/src/budiClient.test.ts
@@ -5,6 +5,7 @@ import {
   formatAggregationStatusText,
   formatAggregationTooltip,
   splitSessionsByDay,
+  MIN_API_VERSION,
   type SessionListEntry,
 } from "./budiClient";
 
@@ -95,5 +96,11 @@ describe("splitSessionsByDay", () => {
     const grouped = splitSessionsByDay(sessions);
     expect(grouped.today.map((s) => s.session_id)).toEqual(["today"]);
     expect(grouped.yesterday.map((s) => s.session_id)).toEqual(["yesterday"]);
+  });
+});
+
+describe("MIN_API_VERSION", () => {
+  it("is at least 1", () => {
+    expect(MIN_API_VERSION).toBeGreaterThanOrEqual(1);
   });
 });

--- a/extensions/cursor-budi/src/budiClient.ts
+++ b/extensions/cursor-budi/src/budiClient.ts
@@ -54,6 +54,15 @@ export interface HealthAggregation {
   total: number;
 }
 
+export interface DaemonHealth {
+  ok: boolean;
+  version: string;
+  api_version: number;
+}
+
+/** The minimum daemon api_version this extension requires. */
+export const MIN_API_VERSION = 1;
+
 function formatCost(dollars: number): string {
   if (dollars >= 1000) {
     return `$${(dollars / 1000).toFixed(1)}K`;
@@ -101,6 +110,34 @@ export function aggregateHealth(sessions: SessionListEntry[]): HealthAggregation
     }
   }
   return agg;
+}
+
+/**
+ * Check daemon health and return version / api_version info.
+ * Returns null if the daemon is unreachable.
+ */
+export function fetchDaemonHealth(daemonUrl: string): Promise<DaemonHealth | null> {
+  return new Promise((resolve) => {
+    const req = http.get(`${daemonUrl}/health`, { timeout: 3000 }, (res) => {
+      let body = "";
+      res.on("data", (chunk: Buffer) => {
+        body += chunk.toString();
+      });
+      res.on("end", () => {
+        try {
+          resolve(JSON.parse(body));
+        } catch {
+          resolve(null);
+        }
+      });
+    });
+
+    req.on("error", () => resolve(null));
+    req.on("timeout", () => {
+      req.destroy();
+      resolve(null);
+    });
+  });
 }
 
 /**

--- a/extensions/cursor-budi/src/extension.ts
+++ b/extensions/cursor-budi/src/extension.ts
@@ -1,28 +1,26 @@
 import * as vscode from "vscode";
-import * as fs from "fs";
-import * as path from "path";
 import {
   fetchStatusline,
   fetchRecentSessions,
+  fetchDaemonHealth,
   splitSessionsByDay,
   aggregateHealth,
   formatAggregationStatusText,
   formatAggregationTooltip,
+  MIN_API_VERSION,
 } from "./budiClient";
-import { getActiveSessionFromFile, getAllActiveSessions, SESSION_FILE } from "./sessionStore";
+import { writeActiveWorkspace, clearActiveWorkspace } from "./sessionStore";
 import { HealthPanelProvider } from "./panel";
 
 let statusBarItem: vscode.StatusBarItem;
 let dataPollTimer: ReturnType<typeof setInterval> | undefined;
-let sessionFileWatcher: fs.FSWatcher | undefined;
-let sessionDirWatcher: fs.FSWatcher | undefined;
-let sessionWatchDebounce: ReturnType<typeof setTimeout> | undefined;
 let healthProvider: HealthPanelProvider;
 let currentSessionId: string | undefined;
 let pinnedSessionId: string | undefined;
 let log: vscode.OutputChannel;
 let refreshInFlight = false;
 let pendingRefreshDaemonUrl: string | undefined;
+let onboardingShown = false;
 
 export function activate(context: vscode.ExtensionContext): void {
   log = vscode.window.createOutputChannel("budi");
@@ -37,6 +35,11 @@ export function activate(context: vscode.ExtensionContext): void {
   log.appendLine(
     `[budi] workspaceFolders = ${folders?.map((f) => f.uri.fsPath).join(", ") ?? "none"}`,
   );
+
+  // Write active workspace signal (cursor-sessions.json v1 contract).
+  if (folders && folders.length > 0) {
+    writeActiveWorkspace(folders[0].uri.fsPath);
+  }
 
   statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, -100);
   statusBarItem.name = "budi";
@@ -59,7 +62,7 @@ export function activate(context: vscode.ExtensionContext): void {
 
   context.subscriptions.push(
     vscode.commands.registerCommand("budi.openDashboard", () => {
-      const sid = resolveSessionId();
+      const sid = currentSessionId;
       const url = sid
         ? `${daemonUrl}/dashboard/sessions/${encodeURIComponent(sid)}`
         : `${daemonUrl}/dashboard`;
@@ -76,16 +79,10 @@ export function activate(context: vscode.ExtensionContext): void {
 
   context.subscriptions.push(
     vscode.commands.registerCommand("budi.selectSession", async () => {
-      const workspacePath = folders?.[0]?.uri.fsPath;
-      if (!workspacePath) {
-        vscode.window.showWarningMessage("budi: No workspace open.");
-        return;
-      }
-
-      const sessions = getAllActiveSessions(workspacePath);
-      if (sessions.length === 0) {
+      const sessions = await fetchRecentSessions(daemonUrl);
+      if (!sessions || sessions.length === 0) {
         vscode.window.showInformationMessage(
-          "budi: No active sessions found. Start a chat to create one.",
+          "budi: No recent sessions found. Start using Cursor with the proxy to create one.",
         );
         return;
       }
@@ -99,8 +96,8 @@ export function activate(context: vscode.ExtensionContext): void {
         },
         ...sessions.map((s) => ({
           label: s.session_id === pinnedSessionId ? `$(pin) ${s.session_id}` : s.session_id,
-          description: s.composer_mode ?? "",
-          detail: `Started ${s.started_at}${s.last_active_at ? ` · Active ${s.last_active_at}` : ""}`,
+          description: s.provider ?? "",
+          detail: `Started ${s.started_at ?? "unknown"}${s.cost_cents > 0 ? ` · $${(s.cost_cents / 100).toFixed(2)}` : ""}`,
         })),
       ];
 
@@ -139,13 +136,14 @@ export function activate(context: vscode.ExtensionContext): void {
         daemonUrl = updated.get("daemonUrl", "http://127.0.0.1:7878");
         dataPollInterval = updated.get("pollingIntervalMs", 15000);
         restartDataPoll(daemonUrl, dataPollInterval);
-        watchSessionFile(daemonUrl);
         requestRefresh(daemonUrl);
       }
     }),
   );
 
-  watchSessionFile(daemonUrl);
+  // Check daemon health and show onboarding if needed.
+  void checkDaemonAndOnboard(daemonUrl);
+
   requestRefresh(daemonUrl);
   startDataPoll(daemonUrl, dataPollInterval);
 }
@@ -155,18 +153,7 @@ export function deactivate(): void {
     clearInterval(dataPollTimer);
     dataPollTimer = undefined;
   }
-  if (sessionFileWatcher) {
-    sessionFileWatcher.close();
-    sessionFileWatcher = undefined;
-  }
-  if (sessionDirWatcher) {
-    sessionDirWatcher.close();
-    sessionDirWatcher = undefined;
-  }
-  if (sessionWatchDebounce) {
-    clearTimeout(sessionWatchDebounce);
-    sessionWatchDebounce = undefined;
-  }
+  clearActiveWorkspace();
 }
 
 function startDataPoll(daemonUrl: string, intervalMs: number): void {
@@ -183,59 +170,48 @@ function restartDataPoll(daemonUrl: string, intervalMs: number): void {
 }
 
 /**
- * Watch cursor-sessions.json for changes. When a hook fires (user sends a
- * message, tool completes, etc.), the file updates and we refresh both the
- * statusline and panel — giving near-instant updates on interaction.
+ * Check daemon health on startup. If the daemon is unreachable or has an
+ * incompatible API version, show an onboarding notification.
  */
-function watchSessionFile(daemonUrl: string): void {
-  if (sessionFileWatcher) {
-    sessionFileWatcher.close();
-    sessionFileWatcher = undefined;
-  }
-  if (sessionDirWatcher) {
-    sessionDirWatcher.close();
-    sessionDirWatcher = undefined;
+async function checkDaemonAndOnboard(daemonUrl: string): Promise<void> {
+  const health = await fetchDaemonHealth(daemonUrl);
+
+  if (!health) {
+    log.appendLine("[budi] daemon is not reachable — showing onboarding");
+    showOnboardingNotification();
+    return;
   }
 
-  const scheduleRefresh = () => {
-    if (sessionWatchDebounce) clearTimeout(sessionWatchDebounce);
-    sessionWatchDebounce = setTimeout(() => {
-      const newId = resolveSessionId();
-      if (newId !== currentSessionId) {
-        log.appendLine(
-          `[budi] session file changed: ${currentSessionId ?? "none"} → ${newId ?? "none"}`,
+  log.appendLine(
+    `[budi] daemon healthy: version=${health.version}, api_version=${health.api_version}`,
+  );
+
+  if (health.api_version < MIN_API_VERSION) {
+    vscode.window.showWarningMessage(
+      `budi: The daemon (api_version ${health.api_version}) is older than ` +
+        `this extension requires (api_version ${MIN_API_VERSION}). ` +
+        `Please update budi: curl -fsSL https://raw.githubusercontent.com/siropkin/budi/main/scripts/install.sh | bash`,
+    );
+  }
+}
+
+function showOnboardingNotification(): void {
+  if (onboardingShown) return;
+  onboardingShown = true;
+
+  void vscode.window
+    .showInformationMessage(
+      "budi: Daemon not running. Install budi and run `budi init` to start tracking AI costs.",
+      "Setup Guide",
+      "Dismiss",
+    )
+    .then((choice) => {
+      if (choice === "Setup Guide") {
+        void vscode.env.openExternal(
+          vscode.Uri.parse("https://github.com/siropkin/budi#quick-start"),
         );
       }
-      requestRefresh(daemonUrl);
-    }, 500);
-  };
-
-  const attachFileWatcher = () => {
-    if (!fs.existsSync(SESSION_FILE)) return;
-    sessionFileWatcher = fs.watch(SESSION_FILE, () => {
-      scheduleRefresh();
     });
-  };
-
-  try {
-    attachFileWatcher();
-
-    const sessionDir = path.dirname(SESSION_FILE);
-    if (fs.existsSync(sessionDir)) {
-      sessionDirWatcher = fs.watch(sessionDir, (_eventType, fileName) => {
-        if (fileName && fileName.toString() !== path.basename(SESSION_FILE)) {
-          return;
-        }
-        if (!sessionFileWatcher && fs.existsSync(SESSION_FILE)) {
-          log.appendLine("[budi] session file detected, attaching watcher");
-          attachFileWatcher();
-        }
-        scheduleRefresh();
-      });
-    }
-  } catch {
-    // File may not exist yet — will be created by first hook.
-  }
 }
 
 function requestRefresh(daemonUrl: string): void {
@@ -261,30 +237,36 @@ function requestRefresh(daemonUrl: string): void {
   })();
 }
 
+/**
+ * Resolve the active session ID. In 8.0, sessions come from the daemon's
+ * proxy event tracking — no hook-based cursor-sessions.json dependency.
+ * The extension derives the active session from the most recent session
+ * in the daemon's API that matches this workspace.
+ */
 function resolveSessionId(): string | undefined {
-  if (pinnedSessionId) return pinnedSessionId;
-
-  const folders = vscode.workspace.workspaceFolders;
-  if (!folders || folders.length === 0) return undefined;
-
-  const session = getActiveSessionFromFile(folders[0].uri.fsPath);
-  return session?.session_id;
+  return pinnedSessionId ?? currentSessionId;
 }
 
 async function refreshData(daemonUrl: string): Promise<void> {
   const folders = vscode.workspace.workspaceFolders;
   const cwd = folders?.[0]?.uri.fsPath;
-  const sessionId = resolveSessionId();
-  currentSessionId = sessionId;
 
-  log.appendLine(`[budi] refreshData: session=${sessionId ?? "none"}, cwd=${cwd ?? "none"}`);
+  // Update workspace signal on each refresh.
+  if (cwd) {
+    writeActiveWorkspace(cwd);
+  }
 
-  healthProvider.updateContext(daemonUrl, sessionId);
+  healthProvider.updateContext(daemonUrl, resolveSessionId());
 
   const [statusline, recentSessions] = await Promise.all([
-    fetchStatusline(daemonUrl, sessionId, cwd).catch(() => null),
+    fetchStatusline(daemonUrl, resolveSessionId(), cwd).catch(() => null),
     fetchRecentSessions(daemonUrl).catch(() => null),
   ]);
+
+  // Derive the active session from recent sessions if not pinned.
+  if (!pinnedSessionId && recentSessions && recentSessions.length > 0) {
+    currentSessionId = recentSessions[0].session_id;
+  }
 
   const { today: todaySessions } = recentSessions
     ? splitSessionsByDay(recentSessions)

--- a/extensions/cursor-budi/src/panel.ts
+++ b/extensions/cursor-budi/src/panel.ts
@@ -100,8 +100,16 @@ function buildHtml(
 <head>${styles()}</head>
 <body>
   <div class="container">
-    <p class="muted">budi daemon offline</p>
-    <p class="hint">Run <code>budi init</code> to start the daemon.</p>
+    <div class="card">
+      <div class="card-title">Getting Started</div>
+      <p class="muted">budi daemon is not running.</p>
+      <ol class="setup-steps">
+        <li>Install budi and run <code>budi init</code></li>
+        <li>In Cursor Settings &rarr; Models, set<br/><strong>Override OpenAI Base URL</strong> to:<br/><code>http://localhost:9878</code></li>
+        <li>Restart Cursor</li>
+      </ol>
+      <p class="hint">All AI requests will be tracked automatically through the local proxy.</p>
+    </div>
   </div>
 </body>
 </html>`;
@@ -427,6 +435,15 @@ function styles(): string {
     .hint {
       font-size: 12px;
       color: var(--vscode-descriptionForeground);
+    }
+    .setup-steps {
+      margin: 8px 0;
+      padding-left: 20px;
+      font-size: 12px;
+      line-height: 1.6;
+    }
+    .setup-steps li {
+      margin-bottom: 6px;
     }
     code {
       background: var(--vscode-textCodeBlock-background);

--- a/extensions/cursor-budi/src/sessionStore.test.ts
+++ b/extensions/cursor-budi/src/sessionStore.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "vitest";
+
+import { CONTRACT_VERSION } from "./sessionStore";
+
+describe("sessionStore contract", () => {
+  it("contract version is 1", () => {
+    expect(CONTRACT_VERSION).toBe(1);
+  });
+});

--- a/extensions/cursor-budi/src/sessionStore.ts
+++ b/extensions/cursor-budi/src/sessionStore.ts
@@ -2,55 +2,81 @@ import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
 
-interface SessionEntry {
-  session_id: string;
-  workspace_path: string;
-  started_at: string;
-  composer_mode?: string;
-  active: boolean;
-  last_active_at?: string;
-}
+/**
+ * cursor-sessions.json v1 contract (ADR-0086 §3.4, §6).
+ *
+ * This file is written by the Cursor extension to signal which workspace is
+ * currently active. The daemon may read it to correlate proxy events with the
+ * active Cursor workspace.
+ *
+ * Format (v1):
+ * ```json
+ * {
+ *   "version": 1,
+ *   "active_workspace": "/absolute/path/to/project",
+ *   "updated_at": "2026-04-11T20:00:00.000Z"
+ * }
+ * ```
+ *
+ * Breaking format changes require bumping `version`.
+ */
 
-interface SessionState {
-  sessions: SessionEntry[];
+export const CONTRACT_VERSION = 1;
+
+interface CursorSessionsV1 {
+  version: number;
+  active_workspace: string;
+  updated_at: string;
 }
 
 const STATE_DIR = path.join(os.homedir(), ".local", "share", "budi");
 export const SESSION_FILE = path.join(STATE_DIR, "cursor-sessions.json");
 
-export function getActiveSessionFromFile(workspacePath: string): { session_id: string } | null {
-  const matches = getActiveSessions(workspacePath);
-  return matches[0] ? { session_id: matches[0].session_id } : null;
+/**
+ * Write the cursor-sessions.json v1 contract file to signal the active
+ * workspace. Called by the extension on activate and when workspace changes.
+ */
+export function writeActiveWorkspace(workspacePath: string): void {
+  const data: CursorSessionsV1 = {
+    version: CONTRACT_VERSION,
+    active_workspace: path.resolve(workspacePath),
+    updated_at: new Date().toISOString(),
+  };
+
+  try {
+    fs.mkdirSync(STATE_DIR, { recursive: true });
+    fs.writeFileSync(SESSION_FILE, JSON.stringify(data, null, 2) + "\n");
+  } catch {
+    // Best-effort — don't crash the extension if the file can't be written.
+  }
 }
 
-export function getAllActiveSessions(workspacePath: string): SessionEntry[] {
-  return getActiveSessions(workspacePath);
-}
-
-function getActiveSessions(workspacePath: string): SessionEntry[] {
-  const state = readState();
-  if (!state) return [];
-
-  const normalized = normalizePath(workspacePath);
-
-  return state.sessions
-    .filter((s) => s.active && normalizePath(s.workspace_path) === normalized)
-    .sort((a, b) => {
-      const aTime = new Date(a.last_active_at ?? a.started_at).getTime();
-      const bTime = new Date(b.last_active_at ?? b.started_at).getTime();
-      return bTime - aTime;
-    });
-}
-
-function readState(): SessionState | null {
+/**
+ * Read the current active workspace from cursor-sessions.json.
+ * Returns null if the file doesn't exist or is invalid.
+ */
+export function readActiveWorkspace(): string | null {
   try {
     const raw = fs.readFileSync(SESSION_FILE, "utf-8");
-    return JSON.parse(raw);
+    const parsed = JSON.parse(raw);
+    if (parsed.version === CONTRACT_VERSION && typeof parsed.active_workspace === "string") {
+      return parsed.active_workspace;
+    }
+    return null;
   } catch {
     return null;
   }
 }
 
-function normalizePath(p: string): string {
-  return path.resolve(p).replace(/\/+$/, "");
+/**
+ * Clear the active workspace signal (e.g., on deactivate).
+ */
+export function clearActiveWorkspace(): void {
+  try {
+    if (fs.existsSync(SESSION_FILE)) {
+      fs.unlinkSync(SESSION_FILE);
+    }
+  } catch {
+    // Best-effort cleanup.
+  }
 }


### PR DESCRIPTION
## Summary

Implements the minimal Cursor bootstrap and status flow for budi 8.0 (R3.2).

- **Daemon API versioning**: Added `api_version` field to `/health` endpoint so the extension can detect incompatible daemon versions
- **VSIX embedding removed**: Extension is no longer bundled in the CLI binary; installs via VS Code Marketplace or download
- **8.0 proxy onboarding**: Extension guides users through Cursor proxy setup (Override OpenAI Base URL → `http://localhost:9878`)
- **Hook-free session tracking**: Replaced hook-dependent `cursor-sessions.json` with API-based session detection; extension writes a versioned (v1) workspace signal file
- **Independent CI**: Extension CI runs as a separate job, proving it can build/test/release independently of the Rust workspace

Closes #96

## ADR References

- ADR-0082 §1: Cursor Tier 2 compatibility, GUI setting requirement
- ADR-0086 §2: `api_version` on `/health`
- ADR-0086 §3.1: VSIX embedding removal
- ADR-0086 §3.4, §6: `cursor-sessions.json` v1 contract
- ADR-0086 §4: Extension CI independence
- ADR-0081: No dependency on removed hook ingestion paths

## Risks / Compatibility Notes

- The `install_cursor_extension` command now tries to install from VS Code Marketplace (`siropkin.budi`). If not yet published, falls back to a message directing users to GitHub Releases.
- The `cursor-sessions.json` format changed from a hook-driven sessions array to a simple v1 workspace signal. This is a clean break (no migration needed — hooks were removed in R2.4).
- Cursor may bypass the proxy override for some built-in features (documented in ADR-0082 §1).
- The `BUDI_REQUIRE_CURSOR_VSIX` env var is no longer needed or supported in CI/release.

## Validation

- `cargo fmt --all` — clean
- `cargo clippy --workspace --all-targets --locked -- -D warnings` — clean
- `cargo test --workspace --locked` — all 196+ tests pass
- `cd extensions/cursor-budi && npm ci && npm run lint && npm run format:check && npm run test && npm run build` — all pass (6 tests)