### PR TITLE
[8.0] Add competitive landscape research (April 2026)

### DIFF
--- a/docs/design-principles.md
+++ b/docs/design-principles.md
@@ -1,0 +1,48 @@
+# Budi Design Principles
+
+Core design philosophy that guides all feature decisions. These were established through experience — features that violated them were built, tested, and removed.
+
+## 1. Lightweight, Fast, Stable, Accurate
+
+Budi must be lightweight, simple, fast, easy to use, and focused on core features. Developers should love using it.
+
+Before adding any feature, ask: **does this help answer "where did my tokens/money go?"**
+
+- No admin tooling (users can manage files themselves)
+- No telemetry/debugging infrastructure in shipped code
+- No auto-detection magic (document manual integration instead)
+- Count things simply (no heuristic skip logic)
+- Every feature must earn its place in lines of code
+
+## 2. No Heavy Subprocess Spawning
+
+Don't build features that spawn many subprocesses per sync cycle.
+
+**Origin**: Git enrichment (git log per session, author resolution, batch processing) was built and then removed because it turned a 2-minute sync into 10+ minutes. The ROI wasn't there.
+
+**Rule**: Before adding any feature that spawns external processes (git, curl, etc.) per session or per message — can this be done with pure string parsing of data we already have? If subprocess spawning is needed, it should be opt-in or on-demand, not part of every sync cycle.
+
+## 3. Privacy First
+
+Prompts, code, and model responses never leave the local machine. This is structural, not configurable.
+
+- Cloud sync uses only pre-aggregated daily rollups (ADR-0083)
+- No "full upload" mode. No toggle. No exception.
+- Never-upload fields are enforced by the sync worker reading only from rollup tables
+
+## 4. Proxy-First Architecture (8.0+)
+
+The proxy is the sole live data source. Historical data (JSONL, Cursor API) is available via `budi import` for backfill only.
+
+- Don't reintroduce hooks, OTEL, or continuous file watching for live data
+- Proxy is transparent — no SDK, no per-agent integration code for live tracking
+- Adding a new agent = documenting its base URL configuration
+
+## 5. Local-First, Cloud-Optional
+
+Everything works without cloud. Cloud adds team visibility, not core functionality.
+
+- All analytics, budgets, and health vitals are computed locally
+- Cloud receives only what's needed for team aggregation
+- No cloud-to-daemon command channel (budgets are local)
+- `budi cloud join` is explicit opt-in, never automatic

--- a/docs/research/competitive-landscape-2026-04.md
+++ b/docs/research/competitive-landscape-2026-04.md
@@ -1,0 +1,268 @@
+# Competitive Landscape — AI Coding Cost Analytics
+
+- **Date**: 2026-04-12
+- **Purpose**: Inform roadmap planning for Budi 9.0+ by mapping the competitive landscape
+- **Last updated**: 2026-04-12
+
+## Market Summary
+
+The AI coding cost analytics space has exploded from ~5 tools in early 2025 to **50+ tools** by April 2026. Most are small open-source projects by individual developers targeting Claude Code. The team/manager tier remains underserved.
+
+The market splits into six tiers:
+1. **Direct competitors** — tools specifically tracking AI coding agent costs
+2. **Coding agent monitors** — process/usage monitors with cost as a secondary feature
+3. **LLM observability platforms** — broader platforms with cost tracking modules
+4. **AI gateways** — routing/proxy layers with built-in cost analytics
+5. **Enterprise FinOps** — cloud cost platforms adding AI cost features top-down
+6. **General observability** — Datadog/Grafana/etc. adding LLM modules
+
+---
+
+## Tier 1: Direct Competitors
+
+These are purpose-built tools for tracking AI coding agent costs. Most direct competition to Budi.
+
+### BurnRate
+- **URL**: https://getburnrate.io
+- **What**: AI agent observability and cost analytics. Parses local JSONL to build subagent tree views with tool calls, token usage, and cost. 46 optimization rules with provider-specific config snippets.
+- **Agents**: Claude Code, Cursor, Copilot, Codex, Windsurf, Cline, Aider (7 agents)
+- **Model**: Free local CLI. Paid team dashboard (aggregated metrics only).
+- **Target**: Individual developers and dev teams.
+- **Differentiator**: Subagent tree visualization, 46 optimization rules. macOS menu bar app + web dashboard.
+- **Threat level**: **High** — closest vision to Budi, similar local-first + team split.
+
+### Splitrail (Piebald AI)
+- **URL**: https://splitrail.dev / https://github.com/Piebald-AI/splitrail
+- **What**: Fast cross-platform token usage tracker for 10+ AI coding agents. Also runs as MCP server. Optional cloud sync for cross-machine aggregation.
+- **Agents**: Gemini CLI, Claude Code, Codex CLI, Qwen Code, Cline, Roo Code, Kilo Code, Copilot, OpenCode, Pi Agent, Piebald (10+ agents)
+- **Model**: Free/open-source (local). Cloud sync separate.
+- **Target**: Individual developers.
+- **Differentiator**: Broadest agent support. MCP server mode. VS Code extension. ~155 GitHub stars.
+- **Threat level**: **High** — multi-agent breadth, MCP, cloud sync.
+
+### Agentlytics
+- **URL**: https://agentlytics.io / https://github.com/f/agentlytics
+- **What**: Analytics dashboard for 16 AI coding editors. KPIs, activity heatmaps, editor breakdown, coding streaks, token economy, peak hours, model/tool stats. Has "Relay" for team sharing.
+- **Agents**: Cursor, Windsurf, Claude Code, VS Code Copilot, Zed, Antigravity, OpenCode, Command Code, and 8 more (16 total)
+- **Model**: Free/open-source. 100% local.
+- **Target**: Individual developers and teams.
+- **Differentiator**: Widest editor support. Relay team feature. Activity/lifestyle analytics.
+- **Threat level**: **Medium-High** — impressive breadth but shallow depth per agent.
+
+### VantageAI (vantageaiops.com)
+- **URL**: https://vantageaiops.com
+- **What**: AI spend intelligence for engineering teams. Live pricing across 24 LLMs, efficiency scoring, budget alerts.
+- **Agents**: Claude Code, Codex CLI, Gemini CLI (3 agents)
+- **Model**: Free (10K requests/month). Team at $99/month.
+- **Target**: Engineering teams.
+- **Differentiator**: SaaS-first. Efficiency scoring. Budget alerts. Paid team tier.
+- **Threat level**: **Medium** — SaaS model, but smaller agent support.
+
+### Toktrack
+- **URL**: https://github.com/mag123c/toktrack
+- **What**: Ultra-fast token and cost tracker for Claude Code. Rust + SIMD JSON parsing — scans 3,500+ session files in ~40ms. Caches cost history beyond Claude Code's 30-day retention.
+- **Agents**: Claude Code (1 agent)
+- **Model**: Free/open-source (MIT). ~78 GitHub stars.
+- **Target**: Individual developers.
+- **Differentiator**: Raw speed. Data persistence. Single-purpose simplicity.
+- **Threat level**: **Low** — CLI-only, single agent, no team features.
+
+### Claudetop
+- **URL**: https://github.com/liorwn/claudetop
+- **What**: htop-style terminal status line. Real-time cost, cache hit ratio, hourly burn rate, monthly projection, cache-aware model cost comparisons, smart alerts.
+- **Agents**: Claude Code (1 agent)
+- **Model**: Free/open-source. ~183 GitHub stars.
+- **Target**: Individual Claude Code users.
+- **Differentiator**: Real-time terminal UX. Cache-aware model comparison.
+- **Threat level**: **Low** — status line only, single agent.
+
+### ccusage
+- **URL**: https://github.com/ryoppippi/ccusage / https://ccusage.com
+- **What**: CLI for analyzing Claude Code/Codex CLI usage from JSONL. Daily, monthly, session, and 5-hour billing window views. Zero-install via bunx/npx.
+- **Agents**: Claude Code, Codex CLI (2 agents)
+- **Model**: Free/open-source.
+- **Target**: Individual developers.
+- **Differentiator**: Zero-install. Billing-window-aware tracking.
+- **Threat level**: **Low** — CLI-only, no dashboard, no team features.
+
+### claude-view
+- **URL**: https://github.com/tombelieber/claude-view
+- **What**: Live dashboard monitoring all Claude Code sessions. Running agents, past conversations, costs, sub-agents, hooks, tool calls. Source badges (terminal, VS Code, Cursor, Agent SDK).
+- **Agents**: Claude Code (1 agent)
+- **Model**: Free/open-source.
+- **Target**: Individual developers.
+- **Differentiator**: Live monitoring. Source attribution.
+- **Threat level**: **Low** — Claude Code only.
+
+### Lumo
+- **URL**: https://github.com/zhnd/lumo
+- **What**: Tauri native desktop dashboard for Claude Code. Daemon + SQLite. Cost trends, token breakdown, session counts, code changes, activity heatmaps.
+- **Agents**: Claude Code (1 agent)
+- **Model**: Free/open-source. ~138 GitHub stars.
+- **Target**: Individual developers.
+- **Differentiator**: Native desktop app (Tauri). Auto-configures telemetry.
+- **Threat level**: **Low** — single agent, no team features.
+
+### CCMeter
+- **URL**: https://github.com/hmenzagh/CCMeter
+- **What**: Terminal dashboard with efficiency score (tokens per line of code changed), active time estimation, quartile gauges.
+- **Agents**: Claude Code (1 agent)
+- **Model**: Free/open-source.
+- **Differentiator**: Unique tokens-per-line efficiency metric.
+- **Threat level**: **Low**.
+
+### Codextime
+- **URL**: https://codexti.me
+- **What**: OpenAI Codex token tracker with budget monitoring, ROI insights, multi-user dashboards, heatmaps.
+- **Agents**: Codex (1 agent)
+- **Model**: Free tier available.
+- **Target**: Teams using Codex.
+- **Differentiator**: ROI calculation. Multi-user. Streams to Supabase.
+- **Threat level**: **Low** — Codex-only.
+
+### Vigilo
+- **URL**: https://github.com/Idan3011/vigilo
+- **What**: Local audit trail and cost tracker. MCP server logging every tool call to AES-256-GCM encrypted JSONL.
+- **Agents**: Claude Code, Cursor (2 agents)
+- **Model**: Free/open-source.
+- **Differentiator**: Security/audit focus. Encryption.
+- **Threat level**: **Low** — niche security angle.
+
+### cursor-usage-tracker
+- **URL**: https://github.com/ofershap/cursor-usage-tracker
+- **What**: Cursor spending monitor with three-layer anomaly detection, Slack/email alerts, incident lifecycle tracking.
+- **Agents**: Cursor (1 agent)
+- **Model**: Free/open-source.
+- **Differentiator**: Enterprise anomaly detection. Alert integrations.
+- **Threat level**: **Low** — Cursor-only.
+
+### coding_agent_usage_tracker
+- **URL**: https://github.com/Dicklesworthstone/coding_agent_usage_tracker
+- **What**: Single CLI for remaining quota, rate limits, and cost across Codex, Claude, Gemini, Cursor, Copilot. Dual output (human + JSON for AI agents).
+- **Agents**: 5 agents
+- **Model**: Free/open-source (Rust).
+- **Differentiator**: Rate limit and quota tracking (not just cost).
+- **Threat level**: **Low** — CLI-only.
+
+---
+
+## Tier 2: Coding Agent Monitors (cost as secondary feature)
+
+| Tool | URL | What | Agents | Model |
+|------|-----|------|--------|-------|
+| **CodexBar** | codexbar.app | macOS menu bar with usage limits/quotas for 15+ services | 15+ | Free/OSS |
+| **AgentWatch** | agentwatch.tools | Desktop app: CPU/RAM monitoring, zombie detection, token costs, one-click kill | 14+ | Free |
+| **AgentsView** | agentsview.io | Local-first session browsing/search/analysis | 18 | Free/OSS |
+| **abtop / agtop / tokentop** | various | htop-style terminal monitors for AI sessions | varies | Free/OSS |
+| **ClaudeUsageTracker** | GitHub | macOS menu bar Claude Code API usage + costs | 1 | Free/OSS (Swift) |
+| **SessionWatcher / CUStats** | sessionwatcher.com | macOS menu bar, usage limits, pace predictions | 1-2 | ~$2.99 |
+| **AgentManager** | GitHub | Orchestration: kill switch, cost tracking, inter-agent messaging | multi | Free/OSS |
+
+---
+
+## Tier 3: LLM Observability Platforms
+
+| Tool | URL | Stars | Free Tier | Pricing | Coding-Specific |
+|------|-----|-------|-----------|---------|----------------|
+| **Langfuse** | langfuse.com | 19K+ | 50K events/mo | From ~$25/mo | No |
+| **Helicone** | helicone.ai | — | 100K requests/mo | From ~$25/mo | No |
+| **Portkey** | portkey.ai | — | Yes | Usage-based | No |
+| **Braintrust** | braintrust.dev | — | 1M spans/mo | $249/mo Pro | No |
+| **AgentOps** | agentops.ai | 5.4K | 5K events/mo | $40/mo Pro | No (general AI agents) |
+| **LangWatch** | langwatch.ai | — | Yes | Tiered | No |
+| **Arize Phoenix** | phoenix.arize.com | — | 25K spans | $50/mo | No |
+| **Lunary** | lunary.ai | — | 10K events/mo | Self-hostable | No |
+
+---
+
+## Tier 4: AI Gateways
+
+| Tool | URL | Stars | Key Feature | Pricing |
+|------|-----|-------|-------------|---------|
+| **LiteLLM** | litellm.ai | 43K | Proxy/SDK, 100+ LLMs, budget enforcement | Free/OSS |
+| **Cloudflare AI Gateway** | cloudflare.com | — | Free analytics/caching/rate-limiting | Free |
+| **Portkey Gateway** | github.com/Portkey-AI/gateway | — | Enterprise governance + guardrails | Usage-based |
+| **NadirClaw** | github.com/NadirRouter/NadirClaw | — | Smart routing saves 40-70% cost | Free/OSS (MIT) |
+| **Bifrost** | github.com/maximhq/bifrost | — | 50x faster than LiteLLM, hierarchical budgets | Free/OSS |
+| **Kong AI Gateway** | konghq.com | — | Enterprise API gateway + AI | Enterprise |
+| **OpenRouter** | openrouter.ai | — | LLM router + per-model cost dashboard | Pass-through + markup |
+| **MLflow AI Gateway** | mlflow.org | — | Budget policies (alert/reject), cost dashboard | Free/OSS |
+
+---
+
+## Tier 5: Enterprise FinOps (Adding AI Top-Down)
+
+| Tool | URL | AI Features | Pricing |
+|------|-----|-------------|---------|
+| **Vantage.sh** | vantage.sh | LLM Token Allocation, Cursor cost support, MCP server | Free < $2,500/mo tracked |
+| **CloudZero** | cloudzero.com | AI cost allocation by model/feature/user | Enterprise |
+| **Finout** | finout.io | AI provider invoice ingestion | Enterprise |
+| **AI Vyuh FinOps** | finops.aivyuh.com | Per-feature, per-user, per-model attribution | $50-$2K/mo |
+
+---
+
+## Tier 6: General Observability (Adding LLM Modules)
+
+| Tool | URL | LLM Features | Cost Impact |
+|------|-----|-------------|-------------|
+| **Datadog LLM** | datadoghq.com | Auto-traces OpenAI/Anthropic, cost by model/prompt | +40-200% Datadog bill |
+| **Grafana Cloud AI** | grafana.com | Anthropic integration, MCP monitoring | Usage-based |
+| **SigNoz** | signoz.io | LLM observability, cost by model/operation | $0.1/M metric samples |
+| **PostHog** | posthog.com | LLM analytics module, cost per chat/user | 100K free events/mo |
+| **Coralogix** | coralogix.com | Per-agent cost, anomaly flagging, budget limits | Enterprise |
+| **W&B Weave** | github.com/wandb/weave | Traces with auto cost/latency aggregation | Free tier |
+
+---
+
+## Budi's Competitive Position (as of 8.0)
+
+### What makes Budi unique
+
+1. **Proxy-first architecture** — Transparent interception via local proxy. No SDK integration, no JSONL parsing for live data. Works with any agent that supports base URL override. Most competitors parse log files after the fact.
+
+2. **Session health analytics** — Context drag, cache efficiency, cost acceleration, agent thrashing detection with provider-aware tips. Only BurnRate has comparable optimization features (their 46 rules), but Budi's real-time vitals approach is different.
+
+3. **Privacy-first cloud contract** — ADR-0083 structurally prevents prompts, code, and responses from leaving the machine. Only pre-aggregated daily rollups sync. BurnRate and Splitrail also have cloud features, but without a formal, auditable privacy contract.
+
+4. **Cursor Usage API integration** — Exact per-request token/cost data from Cursor's undocumented API for historical import. Rare among competitors.
+
+5. **Rich CLI as primary UX** — `budi stats`, `budi sessions` provide fast terminal analytics. Most competitors are either CLI-only (no dashboard) or dashboard-only (no CLI).
+
+6. **Cost confidence tracking** — In 8.0: `proxy_estimated` (real-time from proxy) and `exact`/`estimated` (from historical import of JSONL and Cursor API). Dashboard shows `~` prefix for non-exact costs. Unique transparency about data quality.
+
+### Gaps vs competitors
+
+| Gap | Competitor with it | Priority |
+|-----|--------------------|----------|
+| Agent breadth (4 vs 10-16) | Splitrail (10+), Agentlytics (16) | Medium — proxy architecture makes adding agents easier |
+| Subagent tree visualization | BurnRate | Low — niche feature |
+| macOS menu bar app | CodexBar, ClaudeUsageTracker | Low — statusline serves similar purpose |
+| Active cost reduction (smart routing) | NadirClaw (40-70% savings) | High — potential 9.0 differentiator |
+| Budget alerts (in progress) | LiteLLM, AgentCost, MLflow | In R5 (#106, #107) |
+| Efficiency scoring / ROI | VantageAI, Codextime | Medium |
+
+### The underserved sweet spot
+
+**Team-level cost attribution for 5-50 developer organizations.**
+
+- Enterprise platforms (Vantage.sh, Datadog) are too heavy, too expensive, and approach AI cost from the cloud bill, not from the developer's machine.
+- Individual tools (ccusage, claudetop, toktrack) have no team features.
+- BurnRate and Splitrail have team features but less rigorous privacy contracts.
+
+Budi's R4 cloud round targets exactly this gap: manager dashboard with privacy-first aggregated sync.
+
+---
+
+## Strategic Takeaways for Roadmap Planning
+
+1. **The JSONL-parsing tier is saturated.** 20+ tools parse Claude Code JSONL files. Budi's proxy-first approach is a genuine moat — don't go back to competing on JSONL parsing.
+
+2. **Multi-agent breadth matters.** Splitrail (10+) and Agentlytics (16) show demand. Budi's proxy architecture should make adding new agents cheaper than competitors who write per-agent parsers.
+
+3. **Smart routing is the next frontier.** NadirClaw claims 40-70% cost reduction by routing simple prompts to cheaper/local models. This is "Vantage that saves money" vs "Vantage that tracks money." Consider for 9.0+.
+
+4. **MCP integration is becoming table stakes.** Splitrail, Vigilo, and even Vantage.sh have MCP servers. Budi already has one (14 tools) — keep it updated.
+
+5. **Nobody has solved team onboarding well.** Every tool with team features requires manual setup. `budi cloud join <invite-token>` is simpler than most — lean into this.
+
+6. **The enterprise FinOps platforms are coming down.** Vantage.sh added Cursor support and an MCP server. They'll keep expanding. Speed matters — ship the cloud alpha before they dominate the mid-market.

--- a/docs/research/competitive-landscape-2026-04.md
+++ b/docs/research/competitive-landscape-2026-04.md
@@ -253,6 +253,146 @@ Budi's R4 cloud round targets exactly this gap: manager dashboard with privacy-f
 
 ---
 
+## Capability Matrix
+
+Comparison of top competitors across system modules. Budi 8.0 capabilities reflect the proxy-first architecture (hooks and OTEL removed).
+
+### Data Ingestion
+
+| Tool | Live Ingestion | Method | Historical Import | Agents Supported |
+|------|---------------|--------|-------------------|-----------------|
+| **Budi** | **Yes** | **Proxy (transparent)** | **Yes (JSONL, Cursor API)** | **4 (CC, Codex, Cursor, Copilot)** |
+| BurnRate | Partial (local binary scan) | File parsing | Yes (JSONL) | 7 |
+| Splitrail | Yes | File watcher | Yes (JSONL) | 10+ |
+| Agentlytics | On-demand scan | File parsing + ConnectRPC | Yes | 16 |
+| Claudetop | Yes | CC hooks + file scan | Yes (JSONL) | 1 (CC) |
+| ccusage | No (on-demand) | JSONL parsing | Yes (JSONL) | 5 |
+| claude-view | Yes | File watcher + SSE | Yes (JSONL) | 1 (CC) |
+| VantageAI | Yes | CLI wrapper/proxy | No | 3 |
+| NadirClaw | Yes | Proxy (routing) | No | Any OpenAI-compat |
+| LiteLLM | Yes | Proxy/gateway | No | 100+ providers |
+| Helicone | Yes | Proxy + async SDK | No | 20+ providers |
+| Langfuse | Yes | SDK instrumentation | Via API backfill | Any (via SDK) |
+
+### Data Classification & Attribution
+
+| Tool | Repo | Branch | Ticket | Project | Custom Tags | Cost Confidence | Activity Type |
+|------|------|--------|--------|---------|-------------|-----------------|---------------|
+| **Budi** | **Yes (native)** | **Yes (native)** | **Yes (auto-detect)** | **Yes** | **Yes (auto + rules)** | **Yes (proxy/exact/estimated)** | **Yes** |
+| BurnRate | No | No | No | Yes (by session) | No | No | No |
+| Splitrail | No | No | No | No | No | No | No |
+| Agentlytics | No | No | No | Yes (by editor) | No | No | No |
+| Claudetop | No | Via plugin | Via plugin | Yes | Manual env var | No | No |
+| ccusage | No | No | No | Via `--instances` | No | No | No |
+| claude-view | Yes (filter) | Yes (filter) | No | Yes | No | No | Yes (AI phase) |
+| VantageAI | No | No | No | Per-feature | No | No | No |
+| NadirClaw | No | No | No | No | No | No | Tier (simple/mid/complex) |
+| LiteLLM | No | No | No | Per-key/team | Yes (tag budgets) | No | No |
+| Helicone | No | No | No | Custom properties | Yes | No | No |
+| Langfuse | No | No | No | Tags/metadata | Yes | No | No |
+
+### Budget Management
+
+| Tool | Daily Budget | Per-User | Per-Team | Hard Blocks | Slack Alerts | Email Alerts | Webhooks |
+|------|-------------|----------|----------|-------------|-------------|-------------|----------|
+| **Budi** | **Planned (R5)** | **Planned** | **No** | **Planned** | **No** | **No** | **No** |
+| BurnRate | Not documented | Enterprise | Enterprise | Not documented | No | No | No |
+| Claudetop | Yes (env var) | No | No | No (visual only) | No | No | No |
+| VantageAI | Yes ($99/mo) | No | Yes | No | No | No | No |
+| NadirClaw | Yes | No | No | Yes | Webhook | No | Yes |
+| LiteLLM | **Yes** | **Yes** | **Yes** | **Yes** | **Yes** | **Yes** | Yes |
+| Helicone | Yes (graduated) | Via properties | No | No | **Yes** | **Yes** | No |
+| Langfuse | Cloud spend only | No | No | No | Yes (prompts) | No | No |
+
+### Analytics & Dashboard
+
+| Tool | Web Dashboard | CLI Analytics | Session Drill-down | Subagent Tree | Session Health | Team View |
+|------|-------------|--------------|-------------------|---------------|---------------|-----------|
+| **Budi** | **Yes (4 pages)** | **Yes (rich)** | **Yes** | **Yes** | **Yes (4 vitals)** | **Planned (R4)** |
+| BurnRate | Yes (SaaS) | No | Yes | **Yes** | No | Yes (paid) |
+| Splitrail | Yes (cloud) | Yes | No | No | No | Cloud leaderboard |
+| Agentlytics | Yes | No | Yes | No | No | Relay |
+| Claudetop | Yes (basic) | Yes | Yes (per-turn) | Yes (cost) | Partial (alerts) | No |
+| ccusage | No | Yes | Session report | No | No | No |
+| claude-view | **Yes (rich)** | No | **Yes (full)** | **Yes** | No | Teams dashboard |
+| VantageAI | Yes (SaaS) | No | No | No | Quality scores | Yes |
+| NadirClaw | Yes (basic) | Yes | No | No | No | No |
+| LiteLLM | Yes (admin) | No | No | No | No | Yes |
+| Helicone | **Yes** | No | Yes (traces) | Agent traces | No | Yes |
+| Langfuse | **Yes** | No | **Yes (traces)** | Agent traces | Evaluations | Yes |
+
+### Ecosystem Integrations
+
+| Tool | MCP Server | VS Code Ext | Slack | Jira/Linear | GitHub/CI | Prometheus | Self-hosted |
+|------|-----------|-------------|-------|-------------|-----------|-----------|-------------|
+| **Budi** | **Yes (14 tools)** | **Yes (Cursor)** | **No** | **No** | **No** | **No** | **Yes (local-first)** |
+| BurnRate | No | No | No | No | No | No | Local + cloud |
+| Splitrail | Yes (6 tools) | **Yes** | No | No | No | No | Local + cloud |
+| Agentlytics | Yes (4 tools) | No | No | No | No | No | Local |
+| Claudetop | No | No | No | No | Plugin | No | Local |
+| ccusage | Yes | No | No | No | No | No | Local |
+| claude-view | Yes (85 tools) | No | No | No | No | No | Local |
+| VantageAI | Yes | No | No | No | No | No | Cloud |
+| NadirClaw | No | No | Webhook | No | **GitHub Action** | **Yes** | Local |
+| LiteLLM | Yes (gateway) | No | **Yes** | No | No | **Yes** | **Self-host** |
+| Helicone | Yes | No | **Yes** | No | No | No | **Self-host** |
+| Langfuse | Yes | No | **Yes** | No | GitHub Actions | No | **Self-host** |
+
+### Advanced Features
+
+| Tool | Smart Routing | Caching | Rate Limiting | Efficiency Score | Context Optimization |
+|------|-------------|---------|--------------|-----------------|---------------------|
+| **Budi** | **No** | **No** | **No** | **No** | **No** |
+| NadirClaw | **Yes (core)** | LRU | Provider fallback | No | **Yes (30-70% savings)** |
+| LiteLLM | **Yes (4 modes)** | Redis | **Yes (GCRA)** | No | No |
+| Helicone | **Yes (3 modes)** | Exact + bucketed | **Yes (GCRA)** | No | No |
+| VantageAI | Prompt optimization | No | No | **Yes** | Yes (20-40% savings) |
+| Claudetop | No | No | No | No | Cache monitoring |
+
+---
+
+## Integration Whitespace Analysis
+
+### Ticket Management (Jira, Linear, GitHub Issues)
+
+**Nobody has this.** Not a single competitor integrates natively with ticket management systems.
+
+Closest approaches:
+- **Budi**: Auto-detects ticket IDs from branch names (e.g., `feature/PROJ-1234-add-auth` → `PROJ-1234`), stores as tag
+- **Claudetop**: Plugin extracts ticket from branch name (passive display only)
+- **LiteLLM/Helicone/Langfuse**: Custom properties could encode ticket IDs, but require manual instrumentation
+
+**Opportunity for Budi**: Enrich ticket IDs with metadata from Linear/Jira APIs:
+- Show ticket title alongside cost data (instead of just `PROJ-1234`)
+- "Cost per sprint" or "cost per epic" aggregation
+- "This epic has cost $450 across 12 sessions" in the cloud dashboard
+- Bi-directional: post cost summary as a comment on the ticket when a branch merges
+
+### Slack
+
+**Only gateway/platform tools have Slack integration** (LiteLLM, Helicone, Langfuse). None of the local-first coding agent tools do.
+
+**Opportunity for Budi**:
+- Budget alert notifications to team Slack channel
+- Daily/weekly cost digest: "Your team spent $X on AI this week. Top repos: ..."
+- Cloud dashboard links in Slack messages
+- Personal DM: "Your session just hit $15 — consider /compact"
+
+### Git / CI/CD Pipelines
+
+**Nearly nonexistent across all competitors.**
+- NadirClaw has a GitHub Action
+- Langfuse can trigger GitHub Actions on prompt changes
+- Claudetop has a CI status display plugin
+
+**Opportunity for Budi**:
+- **PR cost annotation**: GitHub Action that comments AI cost on PRs ("This PR used $23.50 of AI across 4 sessions")
+- **CI budget gate**: Fail CI if AI spend on a branch exceeds threshold (opt-in)
+- **Cost label**: Auto-label PRs with cost tier (e.g., `ai-cost:high` > $50)
+- **Sprint summary**: GitHub Action that posts weekly AI cost summary to a PR or issue
+
+---
+
 ## Strategic Takeaways for Roadmap Planning
 
 1. **The JSONL-parsing tier is saturated.** 20+ tools parse Claude Code JSONL files. Budi's proxy-first approach is a genuine moat — don't go back to competing on JSONL parsing.
@@ -266,3 +406,9 @@ Budi's R4 cloud round targets exactly this gap: manager dashboard with privacy-f
 5. **Nobody has solved team onboarding well.** Every tool with team features requires manual setup. `budi cloud join <invite-token>` is simpler than most — lean into this.
 
 6. **The enterprise FinOps platforms are coming down.** Vantage.sh added Cursor support and an MCP server. They'll keep expanding. Speed matters — ship the cloud alpha before they dominate the mid-market.
+
+7. **Ticket management integration is wide open.** Nobody connects AI cost to Jira/Linear tickets natively. Budi already auto-detects ticket IDs from branches — enriching with ticket metadata (title, sprint, epic) would be a unique differentiator.
+
+8. **Slack integration is expected for team tools.** Every gateway tool (LiteLLM, Helicone) has Slack alerts. Budi's cloud tier should have it for budget alerts and cost digests.
+
+9. **CI/CD integration is untapped.** PR cost annotations, budget gates, and sprint cost summaries through GitHub Actions would be novel — nobody does this today.

--- a/docs/research/competitive-landscape-2026-04.md
+++ b/docs/research/competitive-landscape-2026-04.md
@@ -325,7 +325,7 @@ Comparison of top competitors across system modules. Budi 8.0 capabilities refle
 
 | Tool | MCP Server | VS Code Ext | Slack | Jira/Linear | GitHub/CI | Prometheus | Self-hosted |
 |------|-----------|-------------|-------|-------------|-----------|-----------|-------------|
-| **Budi** | **Yes (14 tools)** | **Yes (Cursor)** | **No** | **No** | **No** | **No** | **Yes (local-first)** |
+| **Budi** | **No (removed in 8.0)** | **Yes (Cursor)** | **No** | **No** | **No** | **No** | **Yes (local-first)** |
 | BurnRate | No | No | No | No | No | No | Local + cloud |
 | Splitrail | Yes (6 tools) | **Yes** | No | No | No | No | Local + cloud |
 | Agentlytics | Yes (4 tools) | No | No | No | No | No | Local |
@@ -401,7 +401,7 @@ Closest approaches:
 
 3. **Smart routing is the next frontier.** NadirClaw claims 40-70% cost reduction by routing simple prompts to cheaper/local models. This is "Vantage that saves money" vs "Vantage that tracks money." Consider for 9.0+.
 
-4. **MCP integration is becoming table stakes.** Splitrail, Vigilo, and even Vantage.sh have MCP servers. Budi already has one (14 tools) — keep it updated.
+4. **MCP integration is becoming table stakes.** Splitrail, Vigilo, and even Vantage.sh have MCP servers. Budi removed its MCP server in 8.0 (proxy-first simplification) — consider reintroducing if demand warrants it.
 
 5. **Nobody has solved team onboarding well.** Every tool with team features requires manual setup. `budi cloud join <invite-token>` is simpler than most — lean into this.
 

--- a/docs/research/cursor-usage-api.md
+++ b/docs/research/cursor-usage-api.md
@@ -1,0 +1,80 @@
+# Cursor Usage API Research
+
+- **Date**: 2026-03-25
+- **Status**: Verified (undocumented API, may change)
+- **Used by**: `crates/budi-core/src/providers/cursor.rs` (historical import via `budi import`)
+
+## Endpoints
+
+### Filtered Usage Events (per-request, JSON)
+
+```
+POST https://cursor.com/api/dashboard/get-filtered-usage-events
+```
+
+Response:
+```json
+{
+  "totalUsageEventsCount": 4980,
+  "usageEventsDisplay": [
+    {
+      "timestamp": "1774455909363",
+      "model": "composer-2-fast",
+      "kind": "USAGE_EVENT_KIND_INCLUDED_IN_BUSINESS",
+      "tokenUsage": {
+        "inputTokens": 2958,
+        "outputTokens": 1663,
+        "cacheReadTokens": 48214,
+        "totalCents": 1.68
+      },
+      "chargedCents": 0,
+      "isChargeable": false,
+      "isTokenBasedCall": false,
+      "owningUser": "273223875",
+      "owningTeam": "9890257"
+    }
+  ]
+}
+```
+
+### CSV Export (all events in billing period)
+
+```
+GET https://cursor.com/api/dashboard/export-usage-events-csv?strategy=tokens
+```
+
+Columns: Date, Kind, Model, Max Mode, Input (w/ Cache Write), Input (w/o Cache Write), Cache Read, Output Tokens, Total Tokens, Cost
+
+### Basic Usage (aggregate)
+
+```
+POST https://cursor.com/api/dashboard/get-current-period-usage
+```
+
+Returns: `{ billingCycleStart, billingCycleEnd, displayThreshold }`
+
+## Authentication
+
+Token in the same `state.vscdb` that budi reads for Cursor provider:
+
+- **Table**: `ItemTable` (not cursorDiskKV)
+- **Key**: `cursorAuth/accessToken`
+- **Value**: JWT
+- **User ID**: decode JWT payload -> `sub` field -> split on `|` -> second part
+
+Cookie format: `WorkosCursorSessionToken={userId}%3A%3A{JWT}`
+
+Required headers (CSRF protection):
+- `Origin: https://cursor.com`
+- `Referer: https://cursor.com/dashboard`
+- Base URL: `https://cursor.com` (no www — www returns 308 redirect)
+
+## Caveats
+
+- Undocumented API — may change without notice
+- Cloudflare challenge may block curl/ureq (needs browser JS engine)
+- JWT expires but Cursor auto-refreshes in state.vscdb
+- No conversation_id in API events — correlate by timestamp to sessions
+- Returns current billing period only (not historical)
+- 4,980 events verified in single billing period (Mar 2026)
+- `kind` values: `USAGE_EVENT_KIND_INCLUDED_IN_BUSINESS`, `FREE_CREDIT`, `USAGE_BASED`

--- a/docs/research/ideas-alerts.md
+++ b/docs/research/ideas-alerts.md
@@ -1,0 +1,53 @@
+# Alerts / Signals System Design
+
+- **Date**: 2026-03-24
+- **Status**: Proposed (partially planned in R5 #106, #107)
+- **Related issues**: #106 (budget engine warn-only), #107 (hard budget blocking)
+
+## Concept
+
+Alerts are a separate entity from tags. Tags are for attribution/grouping. Alerts are for thresholds and notifications.
+
+BurnRate has per-project budget caps. Budi should have a more flexible system since it has tags — alerts can scope by any tag dimension.
+
+## Config
+
+`~/.config/budi/alerts.toml`:
+
+```toml
+[[alerts]]
+name = "daily-spend"
+description = "Daily spend limit"
+metric = "cost_cents"          # cost_cents | tokens | sessions
+period = "today"               # today | week | month | 7d | 30d
+threshold = 5000               # in cents = $50
+scope = {}                     # optional: { provider = "claude_code", repo = "budi" }
+
+[[alerts]]
+name = "opus-heavy"
+description = "Too much Opus usage"
+metric = "cost_cents"
+period = "today"
+threshold = 2000
+scope = { tag = "model:*opus*" }
+```
+
+## Entities
+
+- **AlertConfig**: name, description, metric, period, threshold, scope (optional filters)
+- **AlertState**: current_value, triggered (bool), triggered_at, acknowledged (bool)
+- No DB table needed initially — evaluate config against live queries each sync cycle
+
+## Surfaces
+
+- **Statusline**: Warning icon when any alert is triggered (e.g., `! $52.10/day`)
+- **Dashboard**: Alert banner at top when triggered, with dismiss/acknowledge
+- **CLI**: `budi alerts` — show current alert status
+
+## Future Extensions
+
+- Webhook/shell command on trigger
+- Slack notifications (cloud tier)
+- Per-team alerts (cloud tier)
+- Rate-of-change alerts ("spending 3x faster than yesterday")
+- Cloud-pushed budget policies (post-8.0, see ADR-0083 trade-offs)

--- a/docs/research/ideas-alerts.md
+++ b/docs/research/ideas-alerts.md
@@ -36,7 +36,8 @@ scope = { tag = "model:*opus*" }
 
 - **AlertConfig**: name, description, metric, period, threshold, scope (optional filters)
 - **AlertState**: current_value, triggered (bool), triggered_at, acknowledged (bool)
-- No DB table needed initially — evaluate config against live queries each sync cycle
+- No DB table needed initially — evaluate config against rollup tables periodically
+- In 8.0, data arrives via proxy (real-time) and rollup triggers update aggregates — alerts evaluate against these
 
 ## Surfaces
 
@@ -51,3 +52,10 @@ scope = { tag = "model:*opus*" }
 - Per-team alerts (cloud tier)
 - Rate-of-change alerts ("spending 3x faster than yesterday")
 - Cloud-pushed budget policies (post-8.0, see ADR-0083 trade-offs)
+
+## 8.0 Alignment Notes
+
+- R5 issues #106 (warn-only) and #107 (hard blocking) implement the budget engine at the proxy layer
+- Per ADR-0083, budget evaluation and enforcement are **local-first** — the cloud provides visibility but not enforcement
+- Proxy-based alerts can react in real-time (per-request cost threshold), not just periodic rollup evaluation
+- Hard blocking (#107) means the proxy can reject requests when budget is exceeded — more powerful than alert-only

--- a/docs/research/ideas-multi-machine-sync.md
+++ b/docs/research/ideas-multi-machine-sync.md
@@ -1,0 +1,43 @@
+# Multi-Machine Sync Design
+
+- **Date**: 2026-03-22
+- **Status**: Deferred (post-8.0, superseded by cloud sync for team use case)
+- **Origin**: Reddit request (berlinguyinca) — uses Claude Code on 5 machines, wants combined analytics
+
+## Problem
+
+Same developer using budi on multiple machines (laptop, desktop, work, home) sees separate analytics per machine. They want a combined view.
+
+## Options Considered
+
+### Serverless
+
+1. **cr-sqlite (CRDTs)** — SQLite extension with automatic conflict-free merging. No server needed, works over any transport. Most promising.
+2. **Git-based sync** — Append-only event log pushed to private git repo. Each machine commits + pulls + replays.
+3. **Syncthing/Resilio** — P2P file sync. Problem: SQLite concurrent writes = corruption unless using event log.
+4. **Cloud storage** (iCloud/Dropbox) — Same SQLite concurrency issue.
+5. **Export/Import** — Manual `budi export` / `budi import` JSON flow.
+
+### Server-based
+
+- `budi sync --remote` pushes E2E encrypted data to hosted server
+- Server merges, provides web dashboard for combined view
+- Freemium: free = local single machine, paid = multi-machine sync + team dashboards
+
+## Original Decision (pre-8.0)
+
+cr-sqlite for serverless sync. Transports: GitHub private repo or shared folder.
+
+## 8.0 Update
+
+The cloud sync worker (R4, #101) partially addresses this:
+- Cloud dashboard shows aggregated data across devices within an org
+- Identity model: Org -> User -> Device (a user can have multiple devices)
+- But cloud only shows daily rollups, not per-message detail
+
+For per-machine local analytics with full detail, cr-sqlite or export/import is still relevant as a post-8.0 feature.
+
+## Related
+
+- `github.com/berlinguyinca/ai-sync` — syncs Claude Code config files via git (complementary, not competing)
+- ADR-0083 §3 — Device identity model (one user, multiple devices)

--- a/docs/research/ideas-repo-identity.md
+++ b/docs/research/ideas-repo-identity.md
@@ -1,0 +1,35 @@
+# Repo Identity Resolution Design
+
+- **Date**: 2026-03-22
+- **Status**: Implemented (repo_id column exists, hash-based)
+- **See**: `crates/budi-core/src/repo_id.rs`
+
+## Problem
+
+Same git repo in different worktrees or clones counts as separate projects in stats/dashboard. User expects them merged.
+
+## Design (Implemented)
+
+Resolution logic at ingestion time:
+
+1. **Git + remote origin** -> normalize URL to `github.com/user/repo` (strip `.git` suffix, protocol, auth tokens)
+2. **Git + no remote** -> git root folder name
+3. **No git** -> current folder name
+
+Storage:
+- `repo_id` column on `messages` table (hash of normalized path)
+- `project_dir` / `cwd` kept for display (actual filesystem path)
+- All queries group/aggregate by `repo_id`
+
+## Current State (8.0)
+
+- `repo_id` is a SHA256 hash of the repo root path (see `crates/budi-core/src/repo_id.rs`)
+- Proxy attribution resolves repo_id from `X-Budi-Repo` header or git resolution from cwd
+- Cloud sync uses `repo_id` hash in daily rollups (ADR-0083) — actual path never leaves machine
+- Sessions have `repo_id` for session-level attribution
+
+## Future Enhancement
+
+- Display a human-readable project name derived from remote URL (e.g., `siropkin/budi`) instead of the hash
+- Allow user-defined project names via config
+- Cross-worktree dedup is handled by the hash approach


### PR DESCRIPTION
## Summary

Comprehensive research and design docs moved from local memory into the repo so they're versioned, searchable, and reusable across future epics.

### New files:

**`docs/design-principles.md`** — Core design philosophy:
- Lightweight/fast/stable/accurate
- No heavy subprocess spawning (learned from git enrichment rollback)
- Privacy-first, proxy-first, local-first cloud-optional

**`docs/research/competitive-landscape-2026-04.md`** — Full competitive analysis:
- 50+ tools across 6 tiers (direct competitors, monitors, observability, gateways, enterprise FinOps, general)
- **Capability matrix** comparing 12 tools across 6 system modules (ingestion, classification, budgets, analytics, integrations, advanced features)
- **Integration whitespace analysis** — ticket management, Slack, CI/CD (nobody has these)
- 9 strategic takeaways for roadmap planning

**`docs/research/cursor-usage-api.md`** — Undocumented Cursor Usage API (endpoints, auth from state.vscdb, caveats)

**`docs/research/ideas-alerts.md`** — Alerts/signals system design (config, entities, surfaces). Related to R5 #106/#107.

**`docs/research/ideas-multi-machine-sync.md`** — Multi-machine sync options (cr-sqlite, git transport, cloud overlap)

**`docs/research/ideas-repo-identity.md`** — Repo identity resolution design (implemented, documented for reference)

## Risks / compatibility notes

- Documentation-only, no code changes

## Validation

- No code changes — `cargo test` unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)