### PR TITLE
[8.0] Add YC landscape research for AI cost/observability space

### DIFF
--- a/docs/research/yc-landscape-2026-04.md
+++ b/docs/research/yc-landscape-2026-04.md
@@ -1,0 +1,166 @@
+# Y Combinator Companies in AI Cost / Observability Space
+
+- **Date**: 2026-04-12
+- **Purpose**: Understand which competitors and adjacent companies are YC-backed, funding levels, and market signals
+
+## Summary
+
+YC W23 was the defining batch for LLM observability — Helicone, Langfuse, LiteLLM, Traceloop, and Athina AI all came from it. The shakeout since then is telling:
+
+- **2 acquired** (Helicone by Mintlify, Langfuse by ClickHouse)
+- **1 acqui-hired** by Anthropic (Humanloop)
+- **1 pivoted away** entirely (Athina AI)
+- **Only 2 survive independently** (LiteLLM, Traceloop)
+
+**No YC company does what Budi does** — local-first, developer-facing cost analytics for AI coding tools. The YC companies are cloud-hosted platforms for teams building LLM applications.
+
+Budi's closest YC analogy is **Infracost** (W21, $15M) — developer-empowerment, shift-left cost visibility, PR-level insights.
+
+---
+
+## Tier 1: Direct Overlap (LLM Observability / Cost Tracking)
+
+### Helicone — YC W23 | ACQUIRED
+
+- **What**: Open-source LLM observability. One-line proxy integration for cost, latency, usage tracking.
+- **Funding**: ~$5M seed at $25M valuation. Investors: YC, Village Global, FundersClub.
+- **Status**: **Acquired by Mintlify (YC W22), March 2026.** Services in maintenance mode. Team joined Mintlify in SF.
+- **Signal**: Standalone LLM observability may struggle as independent business. Acquirer wanted the team/tech.
+
+### Langfuse — YC W23 | ACQUIRED
+
+- **What**: Open-source LLM engineering platform — observability, analytics, evals, prompt management, cost tracking.
+- **Funding**: $4.5M total ($4M seed from Lightspeed + La Famiglia, $500K from YC).
+- **Status**: **Acquired by ClickHouse as part of their $400M Series D at $15B valuation, January 2026.** Remains open-source, roadmap continues.
+- **Signal**: LLM observability is validated as a category, but may consolidate into larger data infrastructure plays.
+
+### LiteLLM / BerriAI — YC W23 | Active
+
+- **What**: Open-source AI Gateway/Proxy for 100+ LLM APIs. Built-in cost tracking, per-key/team budgets, rate limiting.
+- **Funding**: ~$2.1M seed from YC, FoundersX Ventures, Gravity Fund, Pioneer Fund.
+- **Status**: Active. 43K GitHub stars. Used by Stripe, Netflix, Adobe.
+- **Signal**: The gateway/proxy approach has staying power. LiteLLM is infrastructure, not just observability.
+
+### Keywords AI / Respan — YC W24 | Active
+
+- **What**: Agent observability + evals + gateway. Traces agent behavior, surfaces issues, cost tracking.
+- **Funding**: $5M seed led by Gradient Ventures (Google's AI fund), with YC.
+- **Status**: Active. Processes 1B+ logs and 2T+ tokens monthly. Rebranded from Keywords AI.
+- **Signal**: Newer entrant combining observability + evals + gateway. Enterprise/SaaS-focused.
+
+### Traceloop — YC W23 | Active
+
+- **What**: LLM observability built on OpenTelemetry. Created OpenLLMetry (the OTel standard for LLMs). 6.6K GitHub stars.
+- **Funding**: $6.1M seed led by Sorenson Ventures. Angels: CEOs of Datadog, Elastic, and Sentry.
+- **Status**: Active. Open-source foundation + commercial platform.
+- **Signal**: OTel-native approach. Angel investors from major observability companies validates the space.
+
+### Humanloop — YC S20 | ACQUI-HIRED
+
+- **What**: "Datadog for LLMs." Evals, prompt management, observability. Used by Gusto, Vanta, Duolingo.
+- **Funding**: $7.9M seed from YC and Index Ventures.
+- **Status**: **Acqui-hired by Anthropic, August 2025.** Co-founders and ~dozen engineers joined Anthropic. No IP acquired.
+- **Signal**: Anthropic building observability capabilities in-house. Long-term, AI providers may absorb this layer.
+
+### Athina AI — YC W23 | PIVOTED
+
+- **What**: Was an LLM observability and evaluation platform. Used by Perplexity, Doximity, You.com.
+- **Funding**: ~$4M total.
+- **Status**: **Pivoted to "Gooseworks" — AI coworkers for GTM teams.** No longer in observability.
+- **Signal**: Even with strong customers (Perplexity!), the space was competitive enough to pivot away.
+
+---
+
+## Tier 2: Adjacent YC Companies
+
+### Infracost — YC W21 | Active
+
+- **What**: Open-source cloud cost estimator for Terraform pull requests. Shows cost impact before merge.
+- **Funding**: $15M Series A led by Pruven Capital, with YC, Sequoia.
+- **Status**: Active. Added AI-powered AutoFix and Guardrails.
+- **Why it matters**: Pioneer of "shift-left" developer cost visibility. **Closest philosophical match to Budi** — show developers costs proactively, in their workflow (PRs, CLI). Not LLM-specific, but the same product archetype.
+
+### Confident AI — YC W25 | Active
+
+- **What**: Open-source LLM evaluation framework (DeepEval, 12K stars, 3M monthly downloads). Claims 70%+ LLM cost reduction through eval-driven model switching.
+- **Funding**: $2.2M seed.
+- **Status**: Active. Enterprise customers: BCG, AstraZeneca, Microsoft.
+- **Why it matters**: Cost reduction through evaluation, not tracking. If Budi adds smart routing (9.0), this is the competition.
+
+### Laminar — YC S24 | Active
+
+- **What**: Open-source observability for AI agents. Trace complex workflows, replay/debug agent runs.
+- **Funding**: $3M.
+- **Status**: Active. OTel-native tracing.
+- **Why it matters**: Focused on long-running agent sessions (40+ min). Tracks costs alongside latency/quality.
+
+### VibeKit / Superagent — YC W24 | Active
+
+- **What**: Open-source safety layer for coding agents (Claude Code, Gemini CLI). Sandboxing + observability.
+- **Funding**: YC-backed.
+- **Status**: Active.
+- **Why it matters**: Same user persona as Budi (AI coding agent users), but security/safety focus.
+
+### The Context Company — YC F25 | Active (early)
+
+- **What**: AI-native observability for AI agents. Conversation analysis + behavior patterns + cost/latency.
+- **Funding**: Early stage (2-person team, just graduated YC F25).
+- **Why it matters**: Newest entrant. Too early to assess threat level.
+
+### Middleware — YC W23 | Active
+
+- **What**: AI-based full-stack cloud observability (Datadog alternative).
+- **Funding**: $6.5M seed led by 8VC. Angel: Guillermo Rauch (Vercel CEO).
+- **Why it matters**: General cloud observability, not LLM-specific. Represents the platform play.
+
+---
+
+## Not YC-Backed (Budi's Direct Competitors)
+
+None of Budi's closest direct competitors are YC-backed:
+
+| Company | Funding | Source |
+|---------|---------|--------|
+| BurnRate | Unknown | Independent |
+| Splitrail / Piebald AI | Unknown | Open-source |
+| Agentlytics | Unknown | Open-source |
+| VantageAI | Unknown | Independent |
+| NadirClaw | Unknown | Open-source |
+
+Larger players funded by other VCs:
+
+| Company | Funding | Investors |
+|---------|---------|-----------|
+| Vantage.sh | $25M+ | a16z, Scale Venture Partners |
+| Braintrust | $41M+ | Greylock, a16z |
+| Portkey AI | $18M+ | Elevation Capital, Lightspeed |
+| CloudZero | $100M+ | BlueCrest, Matrix Partners |
+| Finout | $85M+ | Pitango, Maor Investments |
+
+---
+
+## Strategic Implications for Budi
+
+### 1. Standalone LLM observability is consolidating
+
+3 of 6 YC W23 LLM observability companies are no longer independent (Helicone acquired, Langfuse acquired, Athina pivoted). This doesn't mean the space is dead — it means the **observability layer is being absorbed into larger platforms** (ClickHouse, Mintlify, Anthropic).
+
+**For Budi**: Don't position as "LLM observability." Position as **developer cost tooling** — closer to Infracost than Langfuse.
+
+### 2. The proxy/gateway approach has legs
+
+LiteLLM (43K stars, used by Stripe/Netflix) proves that sitting in the traffic path is a durable business. Budi's proxy-first architecture (8.0) aligns with the winning pattern.
+
+### 3. AI providers are absorbing observability
+
+Anthropic acqui-hired Humanloop. Claude Code already has built-in OTEL and `/cost` commands. Long-term, basic cost tracking may become a built-in feature of coding agents.
+
+**For Budi**: The moat is **cross-agent aggregation + team visibility + budget enforcement** — things individual agent providers won't build.
+
+### 4. The developer-facing niche is unoccupied at YC
+
+No YC company targets individual developers tracking their AI coding spend. All YC companies in this space target platform teams building LLM applications. Budi's "Vantage for AI coding agents" positioning is genuinely novel in the YC landscape.
+
+### 5. Infracost is the best comp for positioning
+
+Infracost (W21, $15M Series A) succeeded by showing infrastructure costs in developer workflows (PR comments, CLI). Budi can follow the same playbook for AI costs — proxy tracking, CLI analytics, PR cost annotations (#163), budget gates.


### PR DESCRIPTION
## Summary

New `docs/research/yc-landscape-2026-04.md` — maps all Y Combinator companies in the AI cost analytics and LLM observability space.

### Key findings:

- **YC W23 was the LLM observability cohort** — Helicone, Langfuse, LiteLLM, Traceloop, Athina AI
- **3 of 6 no longer independent**: Helicone acquired by Mintlify, Langfuse acquired by ClickHouse, Athina pivoted to GTM tools. Humanloop (S20) acqui-hired by Anthropic.
- **No YC company does what Budi does** — local-first, developer-facing cost analytics for AI coding tools
- **Infracost (W21, $15M Series A)** is the closest philosophical match — shift-left cost visibility for developers
- **None of Budi's direct competitors** (BurnRate, Splitrail, Agentlytics, VantageAI) are YC-backed
- **5 strategic implications** for Budi's positioning and roadmap

## Risks / compatibility notes

- Documentation-only, no code changes

## Validation

- No code changes — `cargo test` unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)