### PR TITLE
[8.0][R4.5] Ship the minimal manager dashboard alpha

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 brew install siropkin/budi/budi && budi init
 ```
 
-Everything stays on your machine by default. Optional cloud sync for team dashboards — only aggregated metrics, never prompts or code.
+Everything stays on your machine by default. Optional cloud sync pushes aggregated daily cost metrics to a team dashboard at `app.getbudi.dev` — prompts, code, and responses never leave your machine.
 
 <p align="center">
   <img src="assets/dashboard-overview.png" alt="budi dashboard — cost overview" width="800">
@@ -46,7 +46,8 @@ Everything stays on your machine by default. Optional cloud sync for team dashbo
 - **Local proxy** (port 9878) sits between your agent and the LLM provider, capturing every request in real time — streaming responses pass through with no visible lag
 - Attributes cost to repos, branches, tickets, and custom tags
 - **Session health** — detects context bloat, cache degradation, cost acceleration, and retry loops with actionable, provider-aware tips
-- Web dashboard at `http://localhost:7878/dashboard` (legacy — will be replaced by the Rich CLI and cloud dashboard)
+- Web dashboard at `http://localhost:7878/dashboard` (local, per-developer view)
+- **Cloud dashboard** at `app.getbudi.dev` — team-wide cost visibility across users, repos, models, branches, and tickets (daily granularity, requires `budi cloud join`)
 - Live cost + health status line in Claude Code and Cursor
 - **One-time import** of historical transcripts via `budi import` (Claude Code JSONL, Cursor Usage API)
 - ~6 MB Rust binary, minimal footprint

--- a/SOUL.md
+++ b/SOUL.md
@@ -52,7 +52,7 @@ The monorepo contains three logical products planned for eventual extraction (se
 |---------|----------|------|
 | **budi-core** | `crates/`, `scripts/`, `homebrew/` | Rust workspace: daemon, CLI, core business logic. Stays in this repo. |
 | **budi-cursor** | `extensions/cursor-budi/` | VS Code/Cursor extension. Communicates with daemon over HTTP and `budi` CLI. Will be extracted to its own repo. |
-| **budi-cloud** | `frontend/dashboard/` + `cloud/` | Local dashboard + cloud ingest API (Next.js + Supabase). Will be extracted to its own repo. |
+| **budi-cloud** | `frontend/dashboard/` + `cloud/` | Local dashboard + cloud dashboard + ingest API (Next.js + Supabase). Will be extracted to its own repo. |
 
 Key coupling points today:
 - The daemon embeds the built dashboard from `crates/budi-daemon/static/dashboard-dist/`.
@@ -99,7 +99,7 @@ Local SQLite daily rollups
   -> Retry with exponential backoff (1s -> 2s -> ... -> 5min cap) on 429/5xx
   -> Auth failure (401) stops syncing; schema mismatch (422) pauses until update
   -> Supabase Postgres (UPSERT, idempotent)
-  -> Manager dashboard at app.getbudi.dev (R4.3)
+  -> Manager dashboard at app.getbudi.dev
 Config: ~/.config/budi/cloud.toml ([cloud] section), env overrides BUDI_CLOUD_*
 Never uploaded: prompts, responses, code, file paths, email, raw payloads
 ```
@@ -168,6 +168,17 @@ Historical OTEL data (`otel_exact` confidence) remains queryable but OTEL ingest
 - `cloud/src/app/api/v1/ingest/status/route.ts` - Cloud ingest API: GET /v1/ingest/status (watermark + sync health for a device)
 - `cloud/src/lib/supabase/admin.ts` - Server-side Supabase client (service_role key, bypasses RLS)
 - `cloud/supabase/migrations/001_ingest_schema.sql` - Supabase schema: orgs, users, devices, daily_rollups, session_summaries + RLS policies (ADR-0083 §8)
+- `cloud/supabase/migrations/002_dashboard_schema.sql` - Dashboard schema extension: user display_name/email, invite_tokens table
+- `cloud/src/proxy.ts` - Next.js proxy: Supabase auth session refresh + route protection for /dashboard/*
+- `cloud/src/lib/supabase/server.ts` - Server-side Supabase client (cookie-based auth, RLS-aware)
+- `cloud/src/lib/supabase/client.ts` - Browser-side Supabase client for Client Components
+- `cloud/src/lib/dal.ts` - Dashboard data access layer: overview stats, daily activity, cost-by-user/model/repo/branch/ticket, sessions
+- `cloud/src/app/login/page.tsx` - Supabase Auth sign-in (GitHub, Google, magic link)
+- `cloud/src/app/auth/callback/route.ts` - OAuth callback: exchanges code for session, auto-creates budi user row
+- `cloud/src/app/dashboard/layout.tsx` - Dashboard layout with sidebar navigation + user menu
+- `cloud/src/app/dashboard/page.tsx` - Overview: summary cards + daily activity chart
+- `cloud/src/app/dashboard/settings/page.tsx` - Org settings, API key, team members, invite link generation
+- `cloud/src/app/invite/[token]/page.tsx` - Invite join flow: validates token, links user to org
 - `extensions/cursor-budi/src/extension.ts` - Cursor extension entry point (status bar, commands, polling)
 - `extensions/cursor-budi/src/panel.ts` - Side panel webview (session details, vitals, session list)
 - `extensions/cursor-budi/src/budiClient.ts` - Daemon HTTP client + health aggregation logic
@@ -182,7 +193,8 @@ Historical OTEL data (`otel_exact` confidence) remains queryable but OTEL ingest
 - git_branch is a column on messages (not a tag) for fast queries
 - **Session health**: Four vitals computed per session - context growth (context-size growth), cache reuse (cache hit rate), cost acceleration (per-reply cost growth), retry loops (currently disabled — hook_events table dropped in v22). Each vital has green/yellow/red state. New sessions start green - the default is always positive; vitals only degrade to yellow/red when there is clear evidence of a problem. Tips are provider-aware via `ProviderKind` enum (Claude Code -> `/compact`/`/clear`, Cursor -> "new composer session", Other -> neutral). When no session ID is provided, health auto-select prefers the latest session with assistant activity, then falls back to session timestamps. Statusline "coach" mode shows health icon + session cost + tip. Dashboard session detail page has a health panel with vitals grid and tips section.
 - **Cursor extension** (`extensions/cursor-budi/`): VS Code extension that shows session health in the status bar (aggregated health circles) and a side panel (session details, vitals, tips, session list). Installed via VS Code Marketplace or `budi integrations install --with cursor-extension`. Communicates with daemon via HTTP and spawns `budi statusline --format json`. Writes `~/.local/share/budi/cursor-sessions.json` (v1 contract, ADR-0086 §3.4) to signal the active workspace. Checks daemon `api_version` on startup and warns if incompatible.
-- **Dashboard** is a React SPA at `/dashboard` with client-side routing:
+- **Cloud dashboard** (`cloud/`) is a Next.js 16 app deployed to app.getbudi.dev. Uses Supabase Auth (GitHub/Google/magic link) for web sign-in. The proxy (formerly middleware — renamed in Next.js 16) refreshes auth tokens and protects `/dashboard/*` routes. Auth users map to budi `users` rows via `id = auth.uid()`. Data access uses Supabase client with RLS (users see only their org's data). Dashboard pages: Overview (summary cards + daily activity chart), Team (cost by user), Models (cost by model/provider), Repos (cost by repo/branch/ticket), Sessions (session table), Settings (org + API key + invite link). Manager role sees all org data; member sees own data. The DAL (`cloud/src/lib/dal.ts`) aggregates `daily_rollups` and `session_summaries` tables — daily granularity only per ADR-0083.
+- **Local dashboard** is a React SPA at `/dashboard` with client-side routing:
   - `/dashboard` (Overview) - Summary cards (cost/tokens/messages), activity timeline, agents/models, projects/branches, tickets/activity types
   - `/dashboard/insights` - Cost confidence, cache efficiency, session cost curve (split: cost + count), speed mode, subagent vs main, tools
   - `/dashboard/sessions` - Session list with sort/search/pagination, drill-down to `/dashboard/sessions/:id` with session meta, tags, health panel (vitals + tips), input token growth chart, message table

--- a/cloud/package-lock.json
+++ b/cloud/package-lock.json
@@ -10,9 +10,14 @@
       "dependencies": {
         "@supabase/ssr": "^0.10.2",
         "@supabase/supabase-js": "^2.103.0",
+        "clsx": "^2.1.1",
+        "date-fns": "^4.1.0",
+        "lucide-react": "^1.8.0",
         "next": "16.2.3",
         "react": "19.2.4",
-        "react-dom": "19.2.4"
+        "react-dom": "19.2.4",
+        "recharts": "^3.8.1",
+        "tailwind-merge": "^3.5.0"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -1228,11 +1233,59 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
+      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
     "node_modules/@supabase/auth-js": {
@@ -1624,6 +1677,69 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1658,7 +1774,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -1673,6 +1789,12 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
@@ -2713,6 +2835,15 @@
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2779,8 +2910,129 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -2843,6 +3095,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -2860,6 +3122,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -3146,6 +3414,16 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.45.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.45.1.tgz",
+      "integrity": "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -3575,6 +3853,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -4041,6 +4325,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -4081,6 +4375,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-array-buffer": {
@@ -4974,6 +5277,15 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lucide-react": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.8.0.tgz",
+      "integrity": "sha512-WuvlsjngSk7TnTBJ1hsCy3ql9V9VOdcPkd3PKcSmM34vJD8KG6molxz7m7zbYFgICwsanQWmJ13JlYs4Zp7Arw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -5563,8 +5875,75 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/recharts": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -5609,6 +5988,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "2.0.0-next.6",
@@ -6181,6 +6566,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/tailwind-merge": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.5.0.tgz",
+      "integrity": "sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
@@ -6201,6 +6596,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
@@ -6536,6 +6937,37 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/which": {

--- a/cloud/package.json
+++ b/cloud/package.json
@@ -11,9 +11,14 @@
   "dependencies": {
     "@supabase/ssr": "^0.10.2",
     "@supabase/supabase-js": "^2.103.0",
+    "clsx": "^2.1.1",
+    "date-fns": "^4.1.0",
+    "lucide-react": "^1.8.0",
     "next": "16.2.3",
     "react": "19.2.4",
-    "react-dom": "19.2.4"
+    "react-dom": "19.2.4",
+    "recharts": "^3.8.1",
+    "tailwind-merge": "^3.5.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/cloud/src/app/actions/auth.ts
+++ b/cloud/src/app/actions/auth.ts
@@ -1,0 +1,10 @@
+"use server";
+
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+
+export async function signOut() {
+  const supabase = await createClient();
+  await supabase.auth.signOut();
+  redirect("/login");
+}

--- a/cloud/src/app/actions/org.ts
+++ b/cloud/src/app/actions/org.ts
@@ -1,0 +1,73 @@
+"use server";
+
+import { redirect } from "next/navigation";
+import { randomBytes } from "crypto";
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+export async function createOrg(
+  _prevState: { error: string } | undefined,
+  formData: FormData
+) {
+  const name = formData.get("name") as string;
+  if (!name?.trim()) return { error: "Org name is required" };
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return { error: "Not authenticated" };
+
+  const admin = createAdminClient();
+  const orgId = `org_${randomBytes(12).toString("base64url")}`;
+
+  // Create the org
+  const { error: orgError } = await admin.from("orgs").insert({
+    id: orgId,
+    name: name.trim(),
+  });
+  if (orgError) return { error: "Failed to create org" };
+
+  // Link user to org as manager
+  const { error: userError } = await admin
+    .from("users")
+    .update({ org_id: orgId, role: "manager" })
+    .eq("id", user.id);
+  if (userError) return { error: "Failed to link user to org" };
+
+  redirect("/dashboard");
+}
+
+export async function generateInviteToken() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return { error: "Not authenticated" };
+
+  const admin = createAdminClient();
+  const { data: budiUser } = await admin
+    .from("users")
+    .select("id, org_id, role")
+    .eq("id", user.id)
+    .single();
+
+  if (!budiUser?.org_id || budiUser.role !== "manager") {
+    return { error: "Only managers can create invite tokens" };
+  }
+
+  const token = randomBytes(24).toString("base64url");
+  const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000); // 7 days
+
+  const { error } = await admin.from("invite_tokens").insert({
+    id: token,
+    org_id: budiUser.org_id,
+    role: "member",
+    created_by: budiUser.id,
+    expires_at: expiresAt.toISOString(),
+  });
+
+  if (error) return { error: "Failed to create invite token" };
+
+  return { token };
+}

--- a/cloud/src/app/auth/callback/route.ts
+++ b/cloud/src/app/auth/callback/route.ts
@@ -1,0 +1,86 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { randomBytes } from "crypto";
+
+/**
+ * OAuth callback handler for Supabase Auth.
+ * Exchanges the code for a session, then ensures a budi `users` row exists.
+ */
+export async function GET(request: Request) {
+  const { searchParams, origin } = new URL(request.url);
+  const code = searchParams.get("code");
+  const next = searchParams.get("next") ?? "/dashboard";
+
+  if (!code) {
+    return NextResponse.redirect(`${origin}/login?error=missing_code`);
+  }
+
+  const supabase = await createClient();
+  const { error } = await supabase.auth.exchangeCodeForSession(code);
+
+  if (error) {
+    return NextResponse.redirect(`${origin}/login?error=auth_failed`);
+  }
+
+  // Get the authenticated user
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.redirect(`${origin}/login?error=no_user`);
+  }
+
+  // Ensure a budi users row exists (uses admin client to bypass RLS for upsert)
+  const admin = createAdminClient();
+  const { data: existingUser } = await admin
+    .from("users")
+    .select("id, org_id, display_name")
+    .eq("id", user.id)
+    .single();
+
+  if (!existingUser) {
+    // First sign-in: create the users row
+    const apiKey = `budi_${randomBytes(24).toString("base64url")}`;
+    const displayName =
+      user.user_metadata?.full_name ||
+      user.user_metadata?.name ||
+      user.email?.split("@")[0] ||
+      "User";
+
+    await admin.from("users").insert({
+      id: user.id,
+      org_id: null, // Will be set when creating/joining an org
+      role: "manager", // First user defaults to manager
+      api_key: apiKey,
+      display_name: displayName,
+      email: user.email,
+    });
+
+    // New user with no org — redirect to setup
+    return NextResponse.redirect(`${origin}/dashboard/setup`);
+  }
+
+  // Existing user — update email/display_name if changed
+  const displayName =
+    user.user_metadata?.full_name ||
+    user.user_metadata?.name ||
+    existingUser.display_name;
+  if (displayName || user.email) {
+    await admin
+      .from("users")
+      .update({
+        ...(displayName && { display_name: displayName }),
+        ...(user.email && { email: user.email }),
+      })
+      .eq("id", user.id);
+  }
+
+  // If user has no org, redirect to setup
+  if (!existingUser.org_id) {
+    return NextResponse.redirect(`${origin}/dashboard/setup`);
+  }
+
+  return NextResponse.redirect(`${origin}${next}`);
+}

--- a/cloud/src/app/dashboard/layout.tsx
+++ b/cloud/src/app/dashboard/layout.tsx
@@ -1,0 +1,32 @@
+import { redirect } from "next/navigation";
+import { Sidebar } from "@/components/sidebar";
+import { UserMenu } from "@/components/user-menu";
+import { getCurrentUser } from "@/lib/dal";
+
+export const dynamic = "force-dynamic";
+
+export default async function DashboardLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const user = await getCurrentUser();
+
+  if (!user) redirect("/login");
+  if (!user.org_id) redirect("/dashboard/setup");
+
+  return (
+    <div className="flex h-screen bg-[#0a0a0a] text-white">
+      <Sidebar />
+      <div className="flex flex-1 flex-col overflow-hidden">
+        <header className="flex h-14 items-center justify-end border-b border-white/10 px-6">
+          <UserMenu
+            displayName={user.display_name}
+            email={user.email}
+          />
+        </header>
+        <main className="flex-1 overflow-y-auto p-6">{children}</main>
+      </div>
+    </div>
+  );
+}

--- a/cloud/src/app/dashboard/models/page.tsx
+++ b/cloud/src/app/dashboard/models/page.tsx
@@ -1,0 +1,46 @@
+import { Suspense } from "react";
+import { getCurrentUser, getCostByModel } from "@/lib/dal";
+import { dateRangeFromDays } from "@/lib/date-range";
+import { formatModelName } from "@/lib/format";
+import { PeriodSelector } from "@/components/period-selector";
+import { CostBarChart } from "@/components/charts/cost-bar-chart";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+
+export default async function ModelsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ days?: string }>;
+}) {
+  const params = await searchParams;
+  const user = await getCurrentUser();
+  if (!user?.org_id) return null;
+
+  const range = dateRangeFromDays(params.days);
+  const models = await getCostByModel(user.org_id, range);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-xl font-bold">Models</h1>
+        <Suspense>
+          <PeriodSelector />
+        </Suspense>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Cost by Model</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <CostBarChart
+            data={models.map((m) => ({
+              label: `${m.provider} / ${formatModelName(m.model)}`,
+              cost_cents: m.cost_cents,
+            }))}
+            emptyLabel="No model data for this period"
+          />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/cloud/src/app/dashboard/page.tsx
+++ b/cloud/src/app/dashboard/page.tsx
@@ -1,0 +1,64 @@
+import { Suspense } from "react";
+import { getCurrentUser, getOverviewStats, getDailyActivity } from "@/lib/dal";
+import { dateRangeFromDays } from "@/lib/date-range";
+import { fmtCost, fmtNum } from "@/lib/format";
+import { StatCard } from "@/components/stat-card";
+import { PeriodSelector } from "@/components/period-selector";
+import { ActivityChart } from "@/components/charts/activity-chart";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+
+export default async function OverviewPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ days?: string }>;
+}) {
+  const params = await searchParams;
+  const user = await getCurrentUser();
+  if (!user?.org_id) return null;
+
+  const range = dateRangeFromDays(params.days);
+  const [stats, activity] = await Promise.all([
+    getOverviewStats(user.org_id, range),
+    getDailyActivity(user.org_id, range),
+  ]);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-xl font-bold">Overview</h1>
+        <Suspense>
+          <PeriodSelector />
+        </Suspense>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <StatCard
+          title="Total Cost"
+          value={fmtCost(stats.totalCostCents)}
+        />
+        <StatCard
+          title="Total Tokens"
+          value={fmtNum(stats.totalInputTokens + stats.totalOutputTokens)}
+          subtitle={`${fmtNum(stats.totalInputTokens)} in / ${fmtNum(stats.totalOutputTokens)} out`}
+        />
+        <StatCard
+          title="Messages"
+          value={fmtNum(stats.totalMessages)}
+        />
+        <StatCard
+          title="Sessions"
+          value={fmtNum(stats.totalSessions)}
+        />
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Daily Activity (Tokens)</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <ActivityChart data={activity} />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/cloud/src/app/dashboard/repos/page.tsx
+++ b/cloud/src/app/dashboard/repos/page.tsx
@@ -1,0 +1,87 @@
+import { Suspense } from "react";
+import {
+  getCurrentUser,
+  getCostByRepo,
+  getCostByBranch,
+  getCostByTicket,
+} from "@/lib/dal";
+import { dateRangeFromDays } from "@/lib/date-range";
+import { repoName } from "@/lib/format";
+import { PeriodSelector } from "@/components/period-selector";
+import { CostBarChart } from "@/components/charts/cost-bar-chart";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+
+export default async function ReposPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ days?: string }>;
+}) {
+  const params = await searchParams;
+  const user = await getCurrentUser();
+  if (!user?.org_id) return null;
+
+  const range = dateRangeFromDays(params.days);
+  const [repos, branches, tickets] = await Promise.all([
+    getCostByRepo(user.org_id, range),
+    getCostByBranch(user.org_id, range),
+    getCostByTicket(user.org_id, range),
+  ]);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-xl font-bold">Repos</h1>
+        <Suspense>
+          <PeriodSelector />
+        </Suspense>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <Card>
+          <CardHeader>
+            <CardTitle>Cost by Project</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <CostBarChart
+              data={repos.map((r) => ({
+                label: repoName(r.repo_id),
+                cost_cents: r.cost_cents,
+              }))}
+              emptyLabel="No project data for this period"
+            />
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Cost by Branch</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <CostBarChart
+              data={branches.map((b) => ({
+                label: `${repoName(b.repo_id)} / ${b.git_branch.replace(/^refs\/heads\//, "")}`,
+                cost_cents: b.cost_cents,
+              }))}
+              emptyLabel="No branch data for this period"
+            />
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Cost by Ticket</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <CostBarChart
+            data={tickets.map((t) => ({
+              label: t.ticket,
+              cost_cents: t.cost_cents,
+            }))}
+            emptyLabel="No ticket data for this period"
+          />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/cloud/src/app/dashboard/sessions/page.tsx
+++ b/cloud/src/app/dashboard/sessions/page.tsx
@@ -1,0 +1,116 @@
+import { Suspense } from "react";
+import { getCurrentUser, getSessions } from "@/lib/dal";
+import { dateRangeFromDays } from "@/lib/date-range";
+import { fmtCost, fmtNum, repoName } from "@/lib/format";
+import { PeriodSelector } from "@/components/period-selector";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+
+function formatDuration(ms: number | null): string {
+  if (!ms) return "-";
+  const minutes = Math.floor(ms / 60_000);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  const remaining = minutes % 60;
+  return `${hours}h ${remaining}m`;
+}
+
+function formatTimestamp(ts: string | null): string {
+  if (!ts) return "-";
+  return new Date(ts).toLocaleString("en-US", {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+export default async function SessionsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ days?: string }>;
+}) {
+  const params = await searchParams;
+  const user = await getCurrentUser();
+  if (!user?.org_id) return null;
+
+  const range = dateRangeFromDays(params.days);
+  const sessions = await getSessions(user.org_id, range);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-xl font-bold">Sessions</h1>
+        <Suspense>
+          <PeriodSelector />
+        </Suspense>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            Recent Sessions ({sessions.length}
+            {sessions.length === 100 ? "+" : ""})
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {sessions.length === 0 ? (
+            <p className="py-8 text-center text-sm text-zinc-500">
+              No sessions found for this period
+            </p>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-white/10 text-left text-zinc-400">
+                    <th className="pb-2 font-medium">Provider</th>
+                    <th className="pb-2 font-medium">Started</th>
+                    <th className="pb-2 font-medium">Duration</th>
+                    <th className="pb-2 font-medium">Repo</th>
+                    <th className="pb-2 font-medium">Branch</th>
+                    <th className="pb-2 text-right font-medium">Messages</th>
+                    <th className="pb-2 text-right font-medium">Tokens</th>
+                    <th className="pb-2 text-right font-medium">Cost</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {sessions.map((s) => (
+                    <tr
+                      key={`${s.device_id}-${s.session_id}`}
+                      className="border-b border-white/5"
+                    >
+                      <td className="py-2 text-zinc-300">{s.provider}</td>
+                      <td className="py-2 text-zinc-400">
+                        {formatTimestamp(s.started_at)}
+                      </td>
+                      <td className="py-2 text-zinc-400">
+                        {formatDuration(s.duration_ms)}
+                      </td>
+                      <td className="py-2 text-zinc-400">
+                        {repoName(s.repo_id)}
+                      </td>
+                      <td className="py-2 text-zinc-400">
+                        {s.git_branch?.replace(/^refs\/heads\//, "") || "-"}
+                      </td>
+                      <td className="py-2 text-right tabular-nums text-zinc-300">
+                        {fmtNum(s.message_count)}
+                      </td>
+                      <td className="py-2 text-right tabular-nums text-zinc-300">
+                        {fmtNum(
+                          Number(s.total_input_tokens) +
+                            Number(s.total_output_tokens)
+                        )}
+                      </td>
+                      <td className="py-2 text-right tabular-nums text-zinc-200">
+                        {fmtCost(Number(s.total_cost_cents))}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/cloud/src/app/dashboard/settings/invite-section.tsx
+++ b/cloud/src/app/dashboard/settings/invite-section.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useState } from "react";
+import { generateInviteToken } from "@/app/actions/org";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+
+export function InviteSection() {
+  const [inviteUrl, setInviteUrl] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleGenerate() {
+    setLoading(true);
+    setError(null);
+
+    const result = await generateInviteToken();
+    setLoading(false);
+
+    if (result.error) {
+      setError(result.error);
+    } else if (result.token) {
+      setInviteUrl(`${window.location.origin}/invite/${result.token}`);
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Invite Team Members</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <p className="mb-3 text-sm text-zinc-400">
+          Generate an invite link to share with your team. Links expire in 7
+          days.
+        </p>
+
+        {error && <p className="mb-3 text-sm text-red-400">{error}</p>}
+
+        {inviteUrl ? (
+          <div className="space-y-3">
+            <code className="block rounded-lg bg-black/50 px-4 py-3 font-mono text-xs text-emerald-400 break-all">
+              {inviteUrl}
+            </code>
+            <button
+              onClick={() => {
+                navigator.clipboard.writeText(inviteUrl);
+              }}
+              className="rounded-lg bg-white/10 px-4 py-2 text-sm font-medium text-zinc-200 transition-colors hover:bg-white/15"
+            >
+              Copy link
+            </button>
+          </div>
+        ) : (
+          <button
+            onClick={handleGenerate}
+            disabled={loading}
+            className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 disabled:opacity-50"
+          >
+            {loading ? "Generating..." : "Generate invite link"}
+          </button>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/cloud/src/app/dashboard/settings/page.tsx
+++ b/cloud/src/app/dashboard/settings/page.tsx
@@ -1,0 +1,103 @@
+import { getCurrentUser, getOrgMembers } from "@/lib/dal";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { InviteSection } from "./invite-section";
+
+export default async function SettingsPage() {
+  const user = await getCurrentUser();
+  if (!user?.org_id) return null;
+
+  const admin = createAdminClient();
+  const { data: org } = await admin
+    .from("orgs")
+    .select("id, name")
+    .eq("id", user.org_id)
+    .single();
+
+  const members = await getOrgMembers(user.org_id);
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-xl font-bold">Settings</h1>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Organization</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <dl className="space-y-3 text-sm">
+            <div className="flex justify-between">
+              <dt className="text-zinc-400">Name</dt>
+              <dd className="text-zinc-200">{org?.name ?? "-"}</dd>
+            </div>
+            <div className="flex justify-between">
+              <dt className="text-zinc-400">Org ID</dt>
+              <dd className="font-mono text-xs text-zinc-400">
+                {user.org_id}
+              </dd>
+            </div>
+          </dl>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Your API Key</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="mb-2 text-sm text-zinc-400">
+            Use this key with <code className="text-zinc-300">budi cloud join</code> on
+            your local machine to start syncing data.
+          </p>
+          <code className="block rounded-lg bg-black/50 px-4 py-3 font-mono text-sm text-emerald-400">
+            {user.api_key}
+          </code>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Team Members ({members.length})</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {members.length === 0 ? (
+            <p className="text-sm text-zinc-500">No members yet</p>
+          ) : (
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-white/10 text-left text-zinc-400">
+                  <th className="pb-2 font-medium">Name</th>
+                  <th className="pb-2 font-medium">Email</th>
+                  <th className="pb-2 font-medium">Role</th>
+                </tr>
+              </thead>
+              <tbody>
+                {members.map((m) => (
+                  <tr key={m.id} className="border-b border-white/5">
+                    <td className="py-2 text-zinc-200">
+                      {m.display_name || "-"}
+                    </td>
+                    <td className="py-2 text-zinc-400">{m.email || "-"}</td>
+                    <td className="py-2">
+                      <span
+                        className={
+                          m.role === "manager"
+                            ? "text-blue-400"
+                            : "text-zinc-400"
+                        }
+                      >
+                        {m.role}
+                      </span>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </CardContent>
+      </Card>
+
+      {user.role === "manager" && <InviteSection />}
+    </div>
+  );
+}

--- a/cloud/src/app/dashboard/setup/form.tsx
+++ b/cloud/src/app/dashboard/setup/form.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useActionState } from "react";
+import { createOrg } from "@/app/actions/org";
+
+export function OrgSetupForm() {
+  const [state, action, pending] = useActionState(createOrg, undefined);
+
+  return (
+    <form action={action} className="space-y-4">
+      <div>
+        <label
+          htmlFor="name"
+          className="block text-sm font-medium text-zinc-300"
+        >
+          Organization name
+        </label>
+        <input
+          id="name"
+          name="name"
+          type="text"
+          required
+          placeholder="e.g. Acme Engineering"
+          className="mt-1 w-full rounded-lg border border-white/10 bg-white/5 px-4 py-2.5 text-sm text-white placeholder:text-zinc-500 focus:border-blue-500 focus:outline-none"
+        />
+      </div>
+      {state?.error && (
+        <p className="text-sm text-red-400">{state.error}</p>
+      )}
+      <button
+        type="submit"
+        disabled={pending}
+        className="w-full rounded-lg bg-blue-600 px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-blue-700 disabled:opacity-50"
+      >
+        {pending ? "Creating..." : "Create organization"}
+      </button>
+    </form>
+  );
+}

--- a/cloud/src/app/dashboard/setup/page.tsx
+++ b/cloud/src/app/dashboard/setup/page.tsx
@@ -1,0 +1,39 @@
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { OrgSetupForm } from "./form";
+
+export const dynamic = "force-dynamic";
+
+export default async function SetupPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) redirect("/login");
+
+  // Check if user already has an org
+  const admin = createAdminClient();
+  const { data: budiUser } = await admin
+    .from("users")
+    .select("org_id")
+    .eq("id", user.id)
+    .single();
+
+  if (budiUser?.org_id) redirect("/dashboard");
+
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-[#0a0a0a]">
+      <div className="w-full max-w-sm space-y-6 rounded-xl border border-white/10 bg-white/[0.02] p-8">
+        <div className="text-center">
+          <h1 className="text-xl font-bold text-white">Create Your Team</h1>
+          <p className="mt-1 text-sm text-zinc-400">
+            Set up an organization to start tracking team AI costs.
+          </p>
+        </div>
+        <OrgSetupForm />
+      </div>
+    </main>
+  );
+}

--- a/cloud/src/app/dashboard/team/page.tsx
+++ b/cloud/src/app/dashboard/team/page.tsx
@@ -1,0 +1,74 @@
+import { Suspense } from "react";
+import { getCurrentUser, getCostByUser } from "@/lib/dal";
+import { dateRangeFromDays } from "@/lib/date-range";
+import { fmtCost } from "@/lib/format";
+import { PeriodSelector } from "@/components/period-selector";
+import { CostBarChart } from "@/components/charts/cost-bar-chart";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+
+export default async function TeamPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ days?: string }>;
+}) {
+  const params = await searchParams;
+  const user = await getCurrentUser();
+  if (!user?.org_id) return null;
+
+  const range = dateRangeFromDays(params.days);
+  const userCosts = await getCostByUser(user.org_id, range);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-xl font-bold">Team</h1>
+        <Suspense>
+          <PeriodSelector />
+        </Suspense>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Cost by Team Member</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <CostBarChart
+            data={userCosts.map((u) => ({
+              label: u.name,
+              cost_cents: u.cost_cents,
+            }))}
+            emptyLabel="No team cost data for this period"
+          />
+        </CardContent>
+      </Card>
+
+      {userCosts.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Team Members</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-white/10 text-left text-zinc-400">
+                  <th className="pb-2 font-medium">Name</th>
+                  <th className="pb-2 text-right font-medium">Cost</th>
+                </tr>
+              </thead>
+              <tbody>
+                {userCosts.map((u, i) => (
+                  <tr key={i} className="border-b border-white/5">
+                    <td className="py-2 text-zinc-200">{u.name}</td>
+                    <td className="py-2 text-right tabular-nums text-zinc-300">
+                      {fmtCost(u.cost_cents)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/cloud/src/app/globals.css
+++ b/cloud/src/app/globals.css
@@ -1,8 +1,8 @@
 @import "tailwindcss";
 
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
+  --background: #0a0a0a;
+  --foreground: #ededed;
 }
 
 @theme inline {
@@ -12,15 +12,13 @@
   --font-mono: var(--font-geist-mono);
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
-}
-
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-sans), Arial, Helvetica, sans-serif;
+}
+
+/* Recharts tooltip overrides for dark theme */
+.recharts-tooltip-wrapper {
+  outline: none;
 }

--- a/cloud/src/app/invite/[token]/page.tsx
+++ b/cloud/src/app/invite/[token]/page.tsx
@@ -1,0 +1,133 @@
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { randomBytes } from "crypto";
+
+export const dynamic = "force-dynamic";
+
+export default async function InvitePage({
+  params,
+}: {
+  params: Promise<{ token: string }>;
+}) {
+  const { token } = await params;
+  const admin = createAdminClient();
+
+  // Validate the invite token
+  const { data: invite } = await admin
+    .from("invite_tokens")
+    .select("id, org_id, role, expires_at, used_by")
+    .eq("id", token)
+    .single();
+
+  if (!invite) {
+    return (
+      <main className="flex min-h-screen items-center justify-center bg-[#0a0a0a]">
+        <div className="text-center">
+          <h1 className="text-xl font-bold text-white">Invalid Invite</h1>
+          <p className="mt-2 text-zinc-400">
+            This invite link is invalid or has already been used.
+          </p>
+        </div>
+      </main>
+    );
+  }
+
+  if (invite.used_by) {
+    return (
+      <main className="flex min-h-screen items-center justify-center bg-[#0a0a0a]">
+        <div className="text-center">
+          <h1 className="text-xl font-bold text-white">Already Used</h1>
+          <p className="mt-2 text-zinc-400">
+            This invite link has already been used.
+          </p>
+        </div>
+      </main>
+    );
+  }
+
+  if (new Date(invite.expires_at) < new Date()) {
+    return (
+      <main className="flex min-h-screen items-center justify-center bg-[#0a0a0a]">
+        <div className="text-center">
+          <h1 className="text-xl font-bold text-white">Expired</h1>
+          <p className="mt-2 text-zinc-400">
+            This invite link has expired. Ask your manager for a new one.
+          </p>
+        </div>
+      </main>
+    );
+  }
+
+  // Check if user is authenticated
+  const supabase = await createClient();
+  const {
+    data: { user: authUser },
+  } = await supabase.auth.getUser();
+
+  if (!authUser) {
+    // Redirect to login with return URL
+    redirect(`/login?next=/invite/${token}`);
+  }
+
+  // Check if user already exists
+  const { data: existingUser } = await admin
+    .from("users")
+    .select("id, org_id")
+    .eq("id", authUser.id)
+    .single();
+
+  if (existingUser?.org_id) {
+    // User already in an org
+    if (existingUser.org_id === invite.org_id) {
+      redirect("/dashboard");
+    }
+    return (
+      <main className="flex min-h-screen items-center justify-center bg-[#0a0a0a]">
+        <div className="text-center">
+          <h1 className="text-xl font-bold text-white">
+            Already in an Organization
+          </h1>
+          <p className="mt-2 text-zinc-400">
+            You are already a member of another organization. Multi-org is not
+            supported yet.
+          </p>
+        </div>
+      </main>
+    );
+  }
+
+  // Join the org
+  if (existingUser) {
+    // User exists but has no org
+    await admin
+      .from("users")
+      .update({ org_id: invite.org_id, role: invite.role })
+      .eq("id", authUser.id);
+  } else {
+    // New user
+    const apiKey = `budi_${randomBytes(24).toString("base64url")}`;
+    const displayName =
+      authUser.user_metadata?.full_name ||
+      authUser.user_metadata?.name ||
+      authUser.email?.split("@")[0] ||
+      "User";
+
+    await admin.from("users").insert({
+      id: authUser.id,
+      org_id: invite.org_id,
+      role: invite.role,
+      api_key: apiKey,
+      display_name: displayName,
+      email: authUser.email,
+    });
+  }
+
+  // Mark token as used
+  await admin
+    .from("invite_tokens")
+    .update({ used_by: authUser.id, used_at: new Date().toISOString() })
+    .eq("id", token);
+
+  redirect("/dashboard");
+}

--- a/cloud/src/app/layout.tsx
+++ b/cloud/src/app/layout.tsx
@@ -25,9 +25,11 @@ export default function RootLayout({
   return (
     <html
       lang="en"
-      className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
+      className={`${geistSans.variable} ${geistMono.variable} h-full antialiased dark`}
     >
-      <body className="min-h-full flex flex-col">{children}</body>
+      <body className="min-h-full flex flex-col bg-[#0a0a0a] text-[#ededed]">
+        {children}
+      </body>
     </html>
   );
 }

--- a/cloud/src/app/login/page.tsx
+++ b/cloud/src/app/login/page.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { useState } from "react";
+import { createClient } from "@/lib/supabase/client";
+
+export default function LoginPage() {
+  const [email, setEmail] = useState("");
+  const [magicLinkSent, setMagicLinkSent] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  async function signInWithProvider(provider: "github" | "google") {
+    const supabase = createClient();
+    const { error } = await supabase.auth.signInWithOAuth({
+      provider,
+      options: {
+        redirectTo: `${window.location.origin}/auth/callback`,
+      },
+    });
+    if (error) setError(error.message);
+  }
+
+  async function signInWithMagicLink() {
+    if (!email) return;
+    setLoading(true);
+    setError(null);
+
+    const supabase = createClient();
+    const { error } = await supabase.auth.signInWithOtp({
+      email,
+      options: {
+        emailRedirectTo: `${window.location.origin}/auth/callback`,
+      },
+    });
+
+    setLoading(false);
+    if (error) {
+      setError(error.message);
+    } else {
+      setMagicLinkSent(true);
+    }
+  }
+
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-[#0a0a0a]">
+      <div className="w-full max-w-sm space-y-6 rounded-xl border border-white/10 bg-white/[0.02] p-8">
+        <div className="text-center">
+          <h1 className="text-2xl font-bold text-white">Budi Cloud</h1>
+          <p className="mt-1 text-sm text-zinc-400">
+            Team-wide AI cost visibility
+          </p>
+        </div>
+
+        {error && (
+          <div className="rounded-lg border border-red-500/20 bg-red-500/10 px-4 py-3 text-sm text-red-400">
+            {error}
+          </div>
+        )}
+
+        {magicLinkSent ? (
+          <div className="rounded-lg border border-emerald-500/20 bg-emerald-500/10 px-4 py-3 text-center text-sm text-emerald-400">
+            Check your email for a sign-in link.
+          </div>
+        ) : (
+          <>
+            <div className="space-y-3">
+              <button
+                onClick={() => signInWithProvider("github")}
+                className="flex w-full items-center justify-center gap-2 rounded-lg bg-white px-4 py-2.5 text-sm font-medium text-black transition-colors hover:bg-zinc-200"
+              >
+                <GitHubIcon />
+                Continue with GitHub
+              </button>
+              <button
+                onClick={() => signInWithProvider("google")}
+                className="flex w-full items-center justify-center gap-2 rounded-lg border border-white/10 bg-white/5 px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-white/10"
+              >
+                <GoogleIcon />
+                Continue with Google
+              </button>
+            </div>
+
+            <div className="flex items-center gap-3">
+              <div className="h-px flex-1 bg-white/10" />
+              <span className="text-xs text-zinc-500">or</span>
+              <div className="h-px flex-1 bg-white/10" />
+            </div>
+
+            <div className="space-y-3">
+              <input
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder="Email address"
+                className="w-full rounded-lg border border-white/10 bg-white/5 px-4 py-2.5 text-sm text-white placeholder:text-zinc-500 focus:border-blue-500 focus:outline-none"
+                onKeyDown={(e) => e.key === "Enter" && signInWithMagicLink()}
+              />
+              <button
+                onClick={signInWithMagicLink}
+                disabled={loading || !email}
+                className="w-full rounded-lg bg-blue-600 px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {loading ? "Sending..." : "Send magic link"}
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </main>
+  );
+}
+
+function GitHubIcon() {
+  return (
+    <svg className="h-5 w-5" viewBox="0 0 24 24" fill="currentColor">
+      <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+    </svg>
+  );
+}
+
+function GoogleIcon() {
+  return (
+    <svg className="h-5 w-5" viewBox="0 0 24 24">
+      <path
+        d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
+        fill="#4285F4"
+      />
+      <path
+        d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+        fill="#34A853"
+      />
+      <path
+        d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+        fill="#FBBC05"
+      />
+      <path
+        d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+        fill="#EA4335"
+      />
+    </svg>
+  );
+}

--- a/cloud/src/app/page.tsx
+++ b/cloud/src/app/page.tsx
@@ -1,11 +1,30 @@
-export default function Home() {
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import Link from "next/link";
+
+export const dynamic = "force-dynamic";
+
+export default async function Home() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (user) redirect("/dashboard");
+
   return (
-    <main className="flex flex-1 items-center justify-center">
+    <main className="flex flex-1 items-center justify-center bg-[#0a0a0a]">
       <div className="text-center">
-        <h1 className="text-2xl font-bold">Budi Cloud</h1>
-        <p className="mt-2 text-gray-500">
+        <h1 className="text-3xl font-bold text-white">Budi Cloud</h1>
+        <p className="mt-2 text-zinc-400">
           Team-wide AI cost visibility for engineering managers.
         </p>
+        <Link
+          href="/login"
+          className="mt-6 inline-block rounded-lg bg-blue-600 px-6 py-2.5 text-sm font-medium text-white transition-colors hover:bg-blue-700"
+        >
+          Sign in
+        </Link>
       </div>
     </main>
   );

--- a/cloud/src/components/charts/activity-chart.tsx
+++ b/cloud/src/components/charts/activity-chart.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { fmtDate, fmtNum } from "@/lib/format";
+
+interface ActivityData {
+  bucket_day: string;
+  input_tokens: number;
+  output_tokens: number;
+  cost_cents: number;
+  message_count: number;
+}
+
+export function ActivityChart({ data }: { data: ActivityData[] }) {
+  if (data.length === 0) {
+    return (
+      <div className="flex h-64 items-center justify-center text-sm text-zinc-500">
+        No activity data for this period
+      </div>
+    );
+  }
+
+  return (
+    <ResponsiveContainer width="100%" height={300}>
+      <BarChart data={data} margin={{ left: 12, right: 8, top: 8, bottom: 8 }}>
+        <CartesianGrid
+          strokeDasharray="3 3"
+          stroke="rgba(255,255,255,0.06)"
+          vertical={false}
+        />
+        <XAxis
+          dataKey="bucket_day"
+          tickFormatter={fmtDate}
+          tick={{ fill: "#71717a", fontSize: 12 }}
+          tickLine={false}
+          axisLine={false}
+        />
+        <YAxis
+          tickFormatter={fmtNum}
+          tick={{ fill: "#71717a", fontSize: 12 }}
+          tickLine={false}
+          axisLine={false}
+        />
+        <Tooltip
+          contentStyle={{
+            background: "#18181b",
+            border: "1px solid rgba(255,255,255,0.1)",
+            borderRadius: "8px",
+            fontSize: "13px",
+          }}
+          labelFormatter={(label) => fmtDate(String(label))}
+          formatter={(value, name) => [
+            fmtNum(Number(value)),
+            String(name) === "input_tokens" ? "Input" : "Output",
+          ]}
+        />
+        <Bar
+          dataKey="input_tokens"
+          stackId="tokens"
+          fill="#3b82f6"
+          maxBarSize={28}
+          radius={[0, 0, 0, 0]}
+        />
+        <Bar
+          dataKey="output_tokens"
+          stackId="tokens"
+          fill="#8b5cf6"
+          maxBarSize={28}
+          radius={[4, 4, 0, 0]}
+        />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}

--- a/cloud/src/components/charts/cost-bar-chart.tsx
+++ b/cloud/src/components/charts/cost-bar-chart.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import {
+  Bar,
+  BarChart,
+  LabelList,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { fmtCost } from "@/lib/format";
+
+interface CostBarDatum {
+  label: string;
+  cost_cents: number;
+}
+
+const MAX_ITEMS = 10;
+const BAR_SIZE = 28;
+const BAR_GAP = 8;
+
+function barChartHeight(rows: number): number {
+  return Math.max(92, rows * (BAR_SIZE + BAR_GAP) + 32);
+}
+
+function truncateLabel(value: string, maxLen = 28): string {
+  if (value.length <= maxLen) return value;
+  return value.slice(0, maxLen - 1) + "\u2026";
+}
+
+export function CostBarChart({
+  data,
+  emptyLabel,
+}: {
+  data: CostBarDatum[];
+  emptyLabel: string;
+}) {
+  const sorted = [...data]
+    .sort((a, b) => b.cost_cents - a.cost_cents)
+    .slice(0, MAX_ITEMS);
+
+  if (sorted.length === 0) {
+    return (
+      <div className="flex h-24 items-center justify-center text-sm text-zinc-500">
+        {emptyLabel}
+      </div>
+    );
+  }
+
+  const height = barChartHeight(sorted.length);
+
+  return (
+    <ResponsiveContainer width="100%" height={height}>
+      <BarChart
+        data={sorted}
+        layout="vertical"
+        barCategoryGap={BAR_GAP}
+        margin={{ left: 20, right: 56, top: 6, bottom: 6 }}
+      >
+        <YAxis
+          dataKey="label"
+          type="category"
+          tickLine={false}
+          axisLine={false}
+          width={180}
+          interval={0}
+          tick={({ x, y, payload }) => (
+            <g transform={`translate(${x},${y})`}>
+              <text
+                x={0}
+                y={0}
+                dy={4}
+                textAnchor="end"
+                fill="#71717a"
+                fontSize={12}
+              >
+                <title>{payload.value}</title>
+                {truncateLabel(payload.value)}
+              </text>
+            </g>
+          )}
+        />
+        <XAxis
+          dataKey="cost_cents"
+          type="number"
+          tickFormatter={(v) => fmtCost(v)}
+          axisLine={false}
+          tickLine={false}
+          tick={{ fill: "#71717a", fontSize: 12 }}
+        />
+        <Tooltip
+          contentStyle={{
+            background: "#18181b",
+            border: "1px solid rgba(255,255,255,0.1)",
+            borderRadius: "8px",
+            fontSize: "13px",
+          }}
+          formatter={(value) => [fmtCost(Number(value)), "Cost"]}
+        />
+        <Bar
+          dataKey="cost_cents"
+          fill="#3b82f6"
+          barSize={BAR_SIZE}
+          radius={[5, 5, 5, 5]}
+        >
+          <LabelList
+            dataKey="cost_cents"
+            position="right"
+            fill="#71717a"
+            fontSize={12}
+            formatter={(v) => fmtCost(Number(v))}
+          />
+        </Bar>
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}

--- a/cloud/src/components/period-selector.tsx
+++ b/cloud/src/components/period-selector.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { clsx } from "clsx";
+
+const PERIODS = [
+  { label: "7d", value: "7" },
+  { label: "30d", value: "30" },
+  { label: "90d", value: "90" },
+] as const;
+
+export function PeriodSelector() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const current = searchParams.get("days") ?? "30";
+
+  function selectPeriod(days: string) {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set("days", days);
+    router.push(`?${params.toString()}`);
+  }
+
+  return (
+    <div className="flex gap-1 rounded-lg border border-white/10 bg-white/[0.02] p-1">
+      {PERIODS.map((p) => (
+        <button
+          key={p.value}
+          onClick={() => selectPeriod(p.value)}
+          className={clsx(
+            "rounded-md px-3 py-1.5 text-sm font-medium transition-colors",
+            current === p.value
+              ? "bg-white/10 text-white"
+              : "text-zinc-400 hover:text-zinc-200"
+          )}
+        >
+          {p.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/cloud/src/components/sidebar.tsx
+++ b/cloud/src/components/sidebar.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { clsx } from "clsx";
+import {
+  BarChart3,
+  GitBranch,
+  LayoutDashboard,
+  Cpu,
+  Settings,
+  Timer,
+  Users,
+} from "lucide-react";
+
+const NAV_ITEMS = [
+  { href: "/dashboard", label: "Overview", icon: LayoutDashboard },
+  { href: "/dashboard/team", label: "Team", icon: Users },
+  { href: "/dashboard/models", label: "Models", icon: Cpu },
+  { href: "/dashboard/repos", label: "Repos", icon: GitBranch },
+  { href: "/dashboard/sessions", label: "Sessions", icon: Timer },
+  { href: "/dashboard/settings", label: "Settings", icon: Settings },
+] as const;
+
+export function Sidebar() {
+  const pathname = usePathname();
+
+  return (
+    <nav className="flex w-56 flex-col border-r border-white/10 bg-[#0a0a0a] px-3 py-4">
+      <Link
+        href="/dashboard"
+        className="mb-6 flex items-center gap-2 px-3 text-lg font-bold text-white"
+      >
+        <BarChart3 className="h-5 w-5 text-blue-500" />
+        Budi Cloud
+      </Link>
+      <ul className="space-y-1">
+        {NAV_ITEMS.map((item) => {
+          const isActive =
+            item.href === "/dashboard"
+              ? pathname === "/dashboard"
+              : pathname.startsWith(item.href);
+          const Icon = item.icon;
+          return (
+            <li key={item.href}>
+              <Link
+                href={item.href}
+                className={clsx(
+                  "flex items-center gap-2.5 rounded-lg px-3 py-2 text-sm font-medium transition-colors",
+                  isActive
+                    ? "bg-white/10 text-white"
+                    : "text-zinc-400 hover:bg-white/5 hover:text-zinc-200"
+                )}
+              >
+                <Icon className="h-4 w-4" />
+                {item.label}
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}

--- a/cloud/src/components/stat-card.tsx
+++ b/cloud/src/components/stat-card.tsx
@@ -1,0 +1,21 @@
+import { Card } from "@/components/ui/card";
+
+export function StatCard({
+  title,
+  value,
+  subtitle,
+}: {
+  title: string;
+  value: string;
+  subtitle?: string;
+}) {
+  return (
+    <Card>
+      <p className="text-sm font-medium text-zinc-400">{title}</p>
+      <p className="mt-2 text-3xl font-semibold text-white">{value}</p>
+      {subtitle && (
+        <p className="mt-1 text-sm text-zinc-500">{subtitle}</p>
+      )}
+    </Card>
+  );
+}

--- a/cloud/src/components/ui/card.tsx
+++ b/cloud/src/components/ui/card.tsx
@@ -1,0 +1,32 @@
+import { clsx } from "clsx";
+
+export function Card({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <div
+      className={clsx(
+        "rounded-xl border border-white/10 bg-white/[0.02] p-6",
+        className
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+export function CardHeader({ children }: { children: React.ReactNode }) {
+  return <div className="mb-4">{children}</div>;
+}
+
+export function CardTitle({ children }: { children: React.ReactNode }) {
+  return <h3 className="text-sm font-medium text-zinc-400">{children}</h3>;
+}
+
+export function CardContent({ children }: { children: React.ReactNode }) {
+  return <div>{children}</div>;
+}

--- a/cloud/src/components/user-menu.tsx
+++ b/cloud/src/components/user-menu.tsx
@@ -1,0 +1,30 @@
+import { signOut } from "@/app/actions/auth";
+import { LogOut } from "lucide-react";
+
+export function UserMenu({
+  displayName,
+  email,
+}: {
+  displayName: string | null;
+  email: string | null;
+}) {
+  return (
+    <div className="flex items-center gap-3">
+      <div className="text-right">
+        <p className="text-sm font-medium text-zinc-200">
+          {displayName || "User"}
+        </p>
+        {email && <p className="text-xs text-zinc-500">{email}</p>}
+      </div>
+      <form action={signOut}>
+        <button
+          type="submit"
+          className="rounded-lg p-2 text-zinc-400 transition-colors hover:bg-white/5 hover:text-zinc-200"
+          title="Sign out"
+        >
+          <LogOut className="h-4 w-4" />
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/cloud/src/lib/dal.ts
+++ b/cloud/src/lib/dal.ts
@@ -1,0 +1,366 @@
+import "server-only";
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+export interface DateRange {
+  from: string; // YYYY-MM-DD
+  to: string; // YYYY-MM-DD
+}
+
+export interface BudiUser {
+  id: string;
+  org_id: string | null;
+  role: string;
+  api_key: string;
+  display_name: string | null;
+  email: string | null;
+}
+
+/**
+ * Get the current budi user and verify they have an org.
+ * Uses admin client because the auth→users mapping needs to bypass RLS
+ * during the initial lookup.
+ */
+export async function getCurrentUser(): Promise<BudiUser | null> {
+  const supabase = await createClient();
+  const {
+    data: { user: authUser },
+  } = await supabase.auth.getUser();
+  if (!authUser) return null;
+
+  const admin = createAdminClient();
+  const { data } = await admin
+    .from("users")
+    .select("id, org_id, role, api_key, display_name, email")
+    .eq("id", authUser.id)
+    .single();
+
+  return data;
+}
+
+/**
+ * Get overview stats for the org.
+ */
+export async function getOverviewStats(orgId: string, range: DateRange) {
+  const admin = createAdminClient();
+
+  // Get all device IDs in this org
+  const deviceIds = await getOrgDeviceIds(admin, orgId);
+  if (deviceIds.length === 0) {
+    return {
+      totalCostCents: 0,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      totalMessages: 0,
+      totalSessions: 0,
+    };
+  }
+
+  const { data: rollups } = await admin
+    .from("daily_rollups")
+    .select(
+      "cost_cents, input_tokens, output_tokens, message_count, cache_creation_tokens, cache_read_tokens"
+    )
+    .in("device_id", deviceIds)
+    .gte("bucket_day", range.from)
+    .lte("bucket_day", range.to);
+
+  const { count: sessionCount } = await admin
+    .from("session_summaries")
+    .select("*", { count: "exact", head: true })
+    .in("device_id", deviceIds)
+    .gte("started_at", range.from)
+    .lte("started_at", range.to + "T23:59:59Z");
+
+  const totals = (rollups ?? []).reduce(
+    (acc, r) => ({
+      totalCostCents: acc.totalCostCents + Number(r.cost_cents),
+      totalInputTokens: acc.totalInputTokens + Number(r.input_tokens),
+      totalOutputTokens: acc.totalOutputTokens + Number(r.output_tokens),
+      totalMessages: acc.totalMessages + r.message_count,
+    }),
+    { totalCostCents: 0, totalInputTokens: 0, totalOutputTokens: 0, totalMessages: 0 }
+  );
+
+  return { ...totals, totalSessions: sessionCount ?? 0 };
+}
+
+/**
+ * Get daily cost activity for charts.
+ */
+export async function getDailyActivity(orgId: string, range: DateRange) {
+  const admin = createAdminClient();
+  const deviceIds = await getOrgDeviceIds(admin, orgId);
+  if (deviceIds.length === 0) return [];
+
+  const { data: rollups } = await admin
+    .from("daily_rollups")
+    .select("bucket_day, input_tokens, output_tokens, cost_cents, message_count")
+    .in("device_id", deviceIds)
+    .gte("bucket_day", range.from)
+    .lte("bucket_day", range.to)
+    .order("bucket_day");
+
+  // Aggregate by day
+  const byDay = new Map<
+    string,
+    { input_tokens: number; output_tokens: number; cost_cents: number; message_count: number }
+  >();
+  for (const r of rollups ?? []) {
+    const existing = byDay.get(r.bucket_day) ?? {
+      input_tokens: 0,
+      output_tokens: 0,
+      cost_cents: 0,
+      message_count: 0,
+    };
+    existing.input_tokens += Number(r.input_tokens);
+    existing.output_tokens += Number(r.output_tokens);
+    existing.cost_cents += Number(r.cost_cents);
+    existing.message_count += r.message_count;
+    byDay.set(r.bucket_day, existing);
+  }
+
+  return Array.from(byDay.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([day, data]) => ({ bucket_day: day, ...data }));
+}
+
+/**
+ * Get cost breakdown by user/device.
+ */
+export async function getCostByUser(orgId: string, range: DateRange) {
+  const admin = createAdminClient();
+
+  // Get users and their devices
+  const { data: orgUsers } = await admin
+    .from("users")
+    .select("id, display_name, email")
+    .eq("org_id", orgId);
+
+  if (!orgUsers?.length) return [];
+
+  const { data: devices } = await admin
+    .from("devices")
+    .select("id, user_id, label")
+    .in(
+      "user_id",
+      orgUsers.map((u) => u.id)
+    );
+
+  const deviceIds = (devices ?? []).map((d) => d.id);
+  if (deviceIds.length === 0) return [];
+
+  const { data: rollups } = await admin
+    .from("daily_rollups")
+    .select("device_id, cost_cents, input_tokens, output_tokens, message_count")
+    .in("device_id", deviceIds)
+    .gte("bucket_day", range.from)
+    .lte("bucket_day", range.to);
+
+  // Aggregate by device → user
+  const byDevice = new Map<string, number>();
+  for (const r of rollups ?? []) {
+    byDevice.set(r.device_id, (byDevice.get(r.device_id) ?? 0) + Number(r.cost_cents));
+  }
+
+  // Map device costs to users
+  const byUser = new Map<string, { name: string; cost_cents: number }>();
+  for (const device of devices ?? []) {
+    const user = orgUsers.find((u) => u.id === device.user_id);
+    const name = user?.display_name || user?.email || device.user_id.slice(0, 8);
+    const deviceCost = byDevice.get(device.id) ?? 0;
+    const existing = byUser.get(device.user_id);
+    if (existing) {
+      existing.cost_cents += deviceCost;
+    } else {
+      byUser.set(device.user_id, { name, cost_cents: deviceCost });
+    }
+  }
+
+  return Array.from(byUser.values())
+    .filter((u) => u.cost_cents > 0)
+    .sort((a, b) => b.cost_cents - a.cost_cents);
+}
+
+/**
+ * Get cost breakdown by model.
+ */
+export async function getCostByModel(orgId: string, range: DateRange) {
+  const admin = createAdminClient();
+  const deviceIds = await getOrgDeviceIds(admin, orgId);
+  if (deviceIds.length === 0) return [];
+
+  const { data: rollups } = await admin
+    .from("daily_rollups")
+    .select("provider, model, cost_cents")
+    .in("device_id", deviceIds)
+    .gte("bucket_day", range.from)
+    .lte("bucket_day", range.to);
+
+  const byModel = new Map<string, { provider: string; model: string; cost_cents: number }>();
+  for (const r of rollups ?? []) {
+    const key = `${r.provider}:${r.model}`;
+    const existing = byModel.get(key);
+    if (existing) {
+      existing.cost_cents += Number(r.cost_cents);
+    } else {
+      byModel.set(key, {
+        provider: r.provider,
+        model: r.model,
+        cost_cents: Number(r.cost_cents),
+      });
+    }
+  }
+
+  return Array.from(byModel.values())
+    .filter((m) => m.cost_cents > 0)
+    .sort((a, b) => b.cost_cents - a.cost_cents);
+}
+
+/**
+ * Get cost breakdown by repo.
+ */
+export async function getCostByRepo(orgId: string, range: DateRange) {
+  const admin = createAdminClient();
+  const deviceIds = await getOrgDeviceIds(admin, orgId);
+  if (deviceIds.length === 0) return [];
+
+  const { data: rollups } = await admin
+    .from("daily_rollups")
+    .select("repo_id, cost_cents")
+    .in("device_id", deviceIds)
+    .gte("bucket_day", range.from)
+    .lte("bucket_day", range.to);
+
+  const byRepo = new Map<string, number>();
+  for (const r of rollups ?? []) {
+    byRepo.set(r.repo_id, (byRepo.get(r.repo_id) ?? 0) + Number(r.cost_cents));
+  }
+
+  return Array.from(byRepo.entries())
+    .map(([repo_id, cost_cents]) => ({ repo_id, cost_cents }))
+    .filter((r) => r.cost_cents > 0)
+    .sort((a, b) => b.cost_cents - a.cost_cents);
+}
+
+/**
+ * Get cost breakdown by branch.
+ */
+export async function getCostByBranch(orgId: string, range: DateRange) {
+  const admin = createAdminClient();
+  const deviceIds = await getOrgDeviceIds(admin, orgId);
+  if (deviceIds.length === 0) return [];
+
+  const { data: rollups } = await admin
+    .from("daily_rollups")
+    .select("repo_id, git_branch, cost_cents")
+    .in("device_id", deviceIds)
+    .gte("bucket_day", range.from)
+    .lte("bucket_day", range.to);
+
+  const byBranch = new Map<string, { repo_id: string; git_branch: string; cost_cents: number }>();
+  for (const r of rollups ?? []) {
+    const key = `${r.repo_id}:${r.git_branch}`;
+    const existing = byBranch.get(key);
+    if (existing) {
+      existing.cost_cents += Number(r.cost_cents);
+    } else {
+      byBranch.set(key, {
+        repo_id: r.repo_id,
+        git_branch: r.git_branch,
+        cost_cents: Number(r.cost_cents),
+      });
+    }
+  }
+
+  return Array.from(byBranch.values())
+    .filter((b) => b.cost_cents > 0)
+    .sort((a, b) => b.cost_cents - a.cost_cents);
+}
+
+/**
+ * Get cost breakdown by ticket.
+ */
+export async function getCostByTicket(orgId: string, range: DateRange) {
+  const admin = createAdminClient();
+  const deviceIds = await getOrgDeviceIds(admin, orgId);
+  if (deviceIds.length === 0) return [];
+
+  const { data: rollups } = await admin
+    .from("daily_rollups")
+    .select("ticket, cost_cents")
+    .in("device_id", deviceIds)
+    .gte("bucket_day", range.from)
+    .lte("bucket_day", range.to)
+    .not("ticket", "is", null);
+
+  const byTicket = new Map<string, number>();
+  for (const r of rollups ?? []) {
+    if (r.ticket) {
+      byTicket.set(r.ticket, (byTicket.get(r.ticket) ?? 0) + Number(r.cost_cents));
+    }
+  }
+
+  return Array.from(byTicket.entries())
+    .map(([ticket, cost_cents]) => ({ ticket, cost_cents }))
+    .filter((t) => t.cost_cents > 0)
+    .sort((a, b) => b.cost_cents - a.cost_cents);
+}
+
+/**
+ * Get sessions list.
+ */
+export async function getSessions(orgId: string, range: DateRange) {
+  const admin = createAdminClient();
+  const deviceIds = await getOrgDeviceIds(admin, orgId);
+  if (deviceIds.length === 0) return [];
+
+  const { data: sessions } = await admin
+    .from("session_summaries")
+    .select("*")
+    .in("device_id", deviceIds)
+    .gte("started_at", range.from)
+    .lte("started_at", range.to + "T23:59:59Z")
+    .order("started_at", { ascending: false })
+    .limit(100);
+
+  return sessions ?? [];
+}
+
+/**
+ * Get org members list.
+ */
+export async function getOrgMembers(orgId: string) {
+  const admin = createAdminClient();
+  const { data } = await admin
+    .from("users")
+    .select("id, display_name, email, role, created_at")
+    .eq("org_id", orgId)
+    .order("created_at");
+
+  return data ?? [];
+}
+
+// --- Helpers ---
+
+async function getOrgDeviceIds(
+  admin: ReturnType<typeof createAdminClient>,
+  orgId: string
+): Promise<string[]> {
+  const { data: users } = await admin
+    .from("users")
+    .select("id")
+    .eq("org_id", orgId);
+
+  if (!users?.length) return [];
+
+  const { data: devices } = await admin
+    .from("devices")
+    .select("id")
+    .in(
+      "user_id",
+      users.map((u) => u.id)
+    );
+
+  return (devices ?? []).map((d) => d.id);
+}

--- a/cloud/src/lib/date-range.ts
+++ b/cloud/src/lib/date-range.ts
@@ -1,0 +1,13 @@
+import { type DateRange } from "@/lib/dal";
+import { format, subDays } from "date-fns";
+
+/** Build a DateRange from the `days` search param (default 30). */
+export function dateRangeFromDays(days: string | undefined): DateRange {
+  const n = Number(days) || 30;
+  const to = new Date();
+  const from = subDays(to, n);
+  return {
+    from: format(from, "yyyy-MM-dd"),
+    to: format(to, "yyyy-MM-dd"),
+  };
+}

--- a/cloud/src/lib/format.ts
+++ b/cloud/src/lib/format.ts
@@ -1,0 +1,40 @@
+/**
+ * Formatting utilities — reuses patterns from frontend/dashboard/src/lib/format.ts.
+ */
+
+/** Format a dollar cost from cents. */
+export function fmtCost(cents: number): string {
+  const dollars = cents / 100;
+  if (dollars === 0) return "$0.00";
+  if (Math.abs(dollars) < 0.01) return `$${dollars.toFixed(4)}`;
+  if (Math.abs(dollars) < 1) return `$${dollars.toFixed(2)}`;
+  return `$${dollars.toFixed(2)}`;
+}
+
+/** Format a number with locale-aware grouping. */
+export function fmtNum(n: number): string {
+  if (n === 0) return "0";
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return n.toLocaleString("en-US");
+}
+
+/** Extract a short repo name from a hashed repo_id. */
+export function repoName(repoId: string | null): string {
+  if (!repoId) return "(unknown)";
+  if (repoId.startsWith("sha256:")) return repoId.slice(7, 15) + "...";
+  if (repoId.length > 16) return repoId.slice(0, 12) + "...";
+  return repoId;
+}
+
+/** Format a model name for display. */
+export function formatModelName(model: string): string {
+  // Strip date suffixes like -20250514
+  return model.replace(/-\d{8}$/, "");
+}
+
+/** Format a date string for chart labels. */
+export function fmtDate(dateStr: string): string {
+  const d = new Date(dateStr + "T00:00:00");
+  return d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}

--- a/cloud/src/lib/supabase/client.ts
+++ b/cloud/src/lib/supabase/client.ts
@@ -1,0 +1,20 @@
+import { createBrowserClient } from "@supabase/ssr";
+
+/**
+ * Browser-side Supabase client for Client Components.
+ * Uses cookie-based session managed by the proxy.
+ * Only call this from event handlers or effects — never at module level
+ * or during SSR prerender.
+ */
+export function createClient() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  if (!url || !key) {
+    throw new Error(
+      "Missing NEXT_PUBLIC_SUPABASE_URL or NEXT_PUBLIC_SUPABASE_ANON_KEY"
+    );
+  }
+
+  return createBrowserClient(url, key);
+}

--- a/cloud/src/lib/supabase/server.ts
+++ b/cloud/src/lib/supabase/server.ts
@@ -1,0 +1,40 @@
+import { createServerClient as _createServerClient } from "@supabase/ssr";
+import { cookies } from "next/headers";
+
+/**
+ * Server-side Supabase client that uses the user's session cookies.
+ * Respects RLS — use in Server Components, route handlers, and server actions.
+ * Create a fresh client for each request.
+ */
+export async function createClient() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  if (!url || !key) {
+    throw new Error(
+      "Missing NEXT_PUBLIC_SUPABASE_URL or NEXT_PUBLIC_SUPABASE_ANON_KEY"
+    );
+  }
+
+  const cookieStore = await cookies();
+
+  return _createServerClient(url, key,
+    {
+      cookies: {
+        getAll() {
+          return cookieStore.getAll();
+        },
+        setAll(cookiesToSet) {
+          try {
+            for (const { name, value, options } of cookiesToSet) {
+              cookieStore.set(name, value, options);
+            }
+          } catch {
+            // setAll may be called from a Server Component where cookies
+            // cannot be set. The proxy handles session refresh in that case.
+          }
+        },
+      },
+    }
+  );
+}

--- a/cloud/src/proxy.ts
+++ b/cloud/src/proxy.ts
@@ -1,0 +1,66 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { createServerClient } from "@supabase/ssr";
+
+/**
+ * Next.js 16 Proxy (formerly Middleware).
+ *
+ * Refreshes the Supabase auth session on every navigation and
+ * protects /dashboard/* routes from unauthenticated users.
+ */
+export async function proxy(request: NextRequest) {
+  let supabaseResponse = NextResponse.next({ request });
+
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return request.cookies.getAll();
+        },
+        setAll(cookiesToSet) {
+          for (const { name, value } of cookiesToSet) {
+            request.cookies.set(name, value);
+          }
+          supabaseResponse = NextResponse.next({ request });
+          for (const { name, value, options } of cookiesToSet) {
+            supabaseResponse.cookies.set(name, value, options);
+          }
+        },
+      },
+    }
+  );
+
+  // Refresh session — important for keeping auth tokens valid.
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  const path = request.nextUrl.pathname;
+
+  // Protect dashboard routes
+  if (path.startsWith("/dashboard") && !user) {
+    const url = request.nextUrl.clone();
+    url.pathname = "/login";
+    url.searchParams.set("next", path);
+    return NextResponse.redirect(url);
+  }
+
+  // Redirect authenticated users away from login
+  if (path === "/login" && user) {
+    const next = request.nextUrl.searchParams.get("next") || "/dashboard";
+    const url = request.nextUrl.clone();
+    url.pathname = next;
+    url.searchParams.delete("next");
+    return NextResponse.redirect(url);
+  }
+
+  return supabaseResponse;
+}
+
+export const config = {
+  matcher: [
+    // Run on all routes except static files and API routes
+    "/((?!_next/static|_next/image|favicon.ico|api/).*)",
+  ],
+};

--- a/cloud/supabase/migrations/002_dashboard_schema.sql
+++ b/cloud/supabase/migrations/002_dashboard_schema.sql
@@ -1,0 +1,53 @@
+-- Budi Cloud Dashboard Schema Extension
+-- Adds columns and tables needed for the web dashboard (issue #102).
+-- Applied after 001_ingest_schema.sql.
+
+-- ============================================================
+-- 1. Extend users table for web-authenticated users
+-- ============================================================
+
+ALTER TABLE users ADD COLUMN IF NOT EXISTS display_name TEXT;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS email TEXT;
+
+-- Make org_id nullable so a user can exist before creating/joining an org.
+ALTER TABLE users ALTER COLUMN org_id DROP NOT NULL;
+
+-- ============================================================
+-- 2. Invite tokens for org onboarding
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS invite_tokens (
+    id          TEXT PRIMARY KEY,                -- random token string
+    org_id      TEXT NOT NULL REFERENCES orgs(id),
+    role        TEXT NOT NULL DEFAULT 'member'
+                CHECK (role IN ('member', 'manager')),
+    created_by  TEXT NOT NULL REFERENCES users(id),
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    expires_at  TIMESTAMPTZ NOT NULL,
+    used_by     TEXT REFERENCES users(id),
+    used_at     TIMESTAMPTZ
+);
+
+ALTER TABLE invite_tokens ENABLE ROW LEVEL SECURITY;
+
+-- Managers can see invite tokens for their org
+CREATE POLICY "Managers can read org invite tokens"
+    ON invite_tokens FOR SELECT
+    USING (
+        org_id IN (
+            SELECT org_id FROM users
+            WHERE id = auth.uid()::text
+              AND role = 'manager'
+        )
+    );
+
+-- Managers can create invite tokens for their org
+CREATE POLICY "Managers can create invite tokens"
+    ON invite_tokens FOR INSERT
+    WITH CHECK (
+        org_id IN (
+            SELECT org_id FROM users
+            WHERE id = auth.uid()::text
+              AND role = 'manager'
+        )
+    );


### PR DESCRIPTION
## Summary

Closes #102

- Build the cloud dashboard at `app.getbudi.dev` for team-wide AI cost visibility
- Supabase Auth integration (GitHub, Google, magic link) with Next.js 16 proxy for session management
- 6 dashboard pages: Overview, Team, Models, Repos, Sessions, Settings
- Org creation + invite link flow for team onboarding
- Data access layer querying `daily_rollups` and `session_summaries` with daily granularity per ADR-0083
- Schema migration 002: `display_name`/`email` on users, `invite_tokens` table

### Key design decisions

- **Auth ↔ users mapping**: Uses Supabase Auth UUID as `users.id` (not `usr_` prefix) so existing RLS policies work without changes. The `api_key` field (for daemon auth) is unchanged.
- **Next.js 16 proxy.ts**: Replaces the deprecated `middleware.ts` convention. Refreshes auth tokens on every navigation and protects `/dashboard/*` routes.
- **DAL uses admin client**: Data access layer uses the service_role key for queries to avoid complex RLS join performance issues. Auth is verified separately via `getUser()`.
- **Dynamic rendering**: All pages touching Supabase use `force-dynamic` to avoid prerender failures when env vars are absent.

### ADR references

- [ADR-0083](docs/adr/0083-cloud-ingest-identity-and-privacy-contract.md) — privacy contract (aggregates only), sync payload, identity model, team model
- [ADR-0087](docs/adr/0087-cloud-infrastructure-and-deployment.md) — cloud infra, web auth (§4), tech stack (§5)

## Risks / compatibility notes

- **Supabase Auth UUID as users.id**: Departs from `usr_` prefix in ADR-0083 §3. Acceptable for alpha — column is TEXT, existing ingest API and daemon sync are unaffected.
- **Schema migration 002**: Makes `users.org_id` nullable (users can exist before joining an org). No data loss — new column default is NULL.
- **No end-to-end test**: Dashboard depends on Supabase Auth + RLS. Validated via `npm run build` (type-check + compilation). Manual testing requires `.env.local` with real Supabase credentials.
- **Existing ingest API routes unchanged**: No modifications to `POST /v1/ingest` or `GET /v1/ingest/status`.

## Validation

- [x] `cd cloud && npm ci && npm run build` — passes (type-check + Next.js build)
- [x] `cd cloud && npm run lint` — clean (0 errors, 0 warnings)
- [x] `cargo fmt --all -- --check` — Rust formatting unchanged
- [x] `cd frontend/dashboard && npm run build` — local dashboard still builds
- [x] Ingest API routes unmodified

🤖 Generated with [Claude Code](https://claude.com/claude-code)