### PR TITLE
[8.0] Normalize proxy provider from 'anthropic' to 'claude_code'

### DIFF
--- a/crates/budi-core/src/cloud_sync.rs
+++ b/crates/budi-core/src/cloud_sync.rs
@@ -737,7 +737,7 @@ mod tests {
                 daily_rollups: vec![DailyRollupRecord {
                     bucket_day: "2026-04-10".into(),
                     role: "assistant".into(),
-                    provider: "anthropic".into(),
+                    provider: "claude_code".into(),
                     model: "claude-sonnet-4-6".into(),
                     repo_id: "sha256:abc".into(),
                     git_branch: "main".into(),

--- a/crates/budi-core/src/proxy.rs
+++ b/crates/budi-core/src/proxy.rs
@@ -25,7 +25,7 @@ pub enum ProxyProvider {
 impl ProxyProvider {
     pub fn as_str(self) -> &'static str {
         match self {
-            Self::Anthropic => "anthropic",
+            Self::Anthropic => "claude_code",
             Self::OpenAi => "openai",
         }
     }
@@ -150,11 +150,7 @@ pub fn compute_proxy_cost_cents(
     input_tokens: Option<i64>,
     output_tokens: Option<i64>,
 ) -> f64 {
-    let provider_name = match provider {
-        ProxyProvider::Anthropic => "claude_code",
-        ProxyProvider::OpenAi => "openai",
-    };
-    let pricing = crate::provider::pricing_for_model(model, provider_name);
+    let pricing = crate::provider::pricing_for_model(model, provider.as_str());
     pricing.calculate_cost_cents(
         input_tokens.unwrap_or(0).max(0) as u64,
         output_tokens.unwrap_or(0).max(0) as u64,
@@ -400,7 +396,7 @@ mod tests {
     fn proxy_event_with_null_tokens() {
         let conn = test_db();
         let mut event = test_event();
-        event.provider = "anthropic".to_string();
+        event.provider = "claude_code".to_string();
         event.model = "claude-sonnet-4-6".to_string();
         event.input_tokens = None;
         event.output_tokens = None;
@@ -418,7 +414,7 @@ mod tests {
 
     #[test]
     fn proxy_provider_display() {
-        assert_eq!(ProxyProvider::Anthropic.as_str(), "anthropic");
+        assert_eq!(ProxyProvider::Anthropic.as_str(), "claude_code");
         assert_eq!(ProxyProvider::OpenAi.as_str(), "openai");
     }
 


### PR DESCRIPTION
## Summary

Proxy events were stored with `provider = "anthropic"` while transcript imports used `"claude_code"`, splitting stats into two phantom providers for the same Claude Code traffic.

- Change `ProxyProvider::Anthropic.as_str()` to return `"claude_code"` so all Claude traffic is unified under one provider key in both `proxy_events` and `messages` tables.
- Simplify `compute_proxy_cost_cents` to use `provider.as_str()` directly, removing the redundant match arm that was already mapping Anthropic → `"claude_code"` for pricing lookup.
- Update test fixtures to match.

Before:
```
claude_code / claude-opus-4-6 = $378.75  (from transcripts)
anthropic   / claude-opus-4-6 = $8.50    (from proxy)
```

After: all rows appear under `claude_code`.

## Risks / compatibility notes

- **Existing proxy_events rows**: Historical rows already stored with `provider = "anthropic"` will remain as-is. New proxy events will use `"claude_code"`. Stats queries already use `COALESCE(provider, 'claude_code')` for NULL handling, but the existing `"anthropic"` rows will still show separately until re-ingested or until a follow-up migration normalizes them.
- **Cloud sync**: Future rollup rows will use `"claude_code"`. No schema change needed.
- **No breaking API change**: `ProxyProvider` enum variants are unchanged; only the string serialization changes.

## Validation

- `cargo fmt --all` — clean
- `cargo clippy --workspace --all-targets --locked -- -D warnings` — clean
- `cargo test --workspace --locked` — 360 tests pass

Closes #191