### PR TITLE
[8.0] Extract cache tokens from proxy for accurate cost calculation

### DIFF
--- a/crates/budi-core/src/proxy.rs
+++ b/crates/budi-core/src/proxy.rs
@@ -149,13 +149,15 @@ pub fn compute_proxy_cost_cents(
     model: &str,
     input_tokens: Option<i64>,
     output_tokens: Option<i64>,
+    cache_creation_input_tokens: Option<i64>,
+    cache_read_input_tokens: Option<i64>,
 ) -> f64 {
     let pricing = crate::provider::pricing_for_model(model, provider.as_str());
     pricing.calculate_cost_cents(
         input_tokens.unwrap_or(0).max(0) as u64,
         output_tokens.unwrap_or(0).max(0) as u64,
-        0,
-        0,
+        cache_creation_input_tokens.unwrap_or(0).max(0) as u64,
+        cache_read_input_tokens.unwrap_or(0).max(0) as u64,
         0,
         None,
         0,
@@ -170,6 +172,10 @@ pub struct ProxyEvent {
     pub model: String,
     pub input_tokens: Option<i64>,
     pub output_tokens: Option<i64>,
+    /// Cache tokens written (Anthropic `cache_creation_input_tokens`).
+    pub cache_creation_input_tokens: Option<i64>,
+    /// Cache tokens read (Anthropic `cache_read_input_tokens`).
+    pub cache_read_input_tokens: Option<i64>,
     pub duration_ms: i64,
     pub status_code: u16,
     pub is_streaming: bool,
@@ -222,6 +228,8 @@ pub fn ensure_proxy_schema(conn: &Connection) -> Result<()> {
         ("ticket_id", "TEXT NOT NULL DEFAULT ''"),
         ("cost_cents", "REAL NOT NULL DEFAULT 0.0"),
         ("session_id", "TEXT NOT NULL DEFAULT ''"),
+        ("cache_creation_input_tokens", "INTEGER"),
+        ("cache_read_input_tokens", "INTEGER"),
     ] {
         let _ = conn.execute_batch(&format!("ALTER TABLE proxy_events ADD COLUMN {col} {def};"));
     }
@@ -236,15 +244,18 @@ pub fn insert_proxy_event(conn: &Connection, event: &ProxyEvent) -> Result<i64> 
     conn.execute(
         "INSERT INTO proxy_events (
             timestamp, provider, model, input_tokens, output_tokens,
+            cache_creation_input_tokens, cache_read_input_tokens,
             duration_ms, status_code, is_streaming,
             repo_id, git_branch, ticket_id, cost_cents, session_id
-        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)",
         params![
             event.timestamp,
             event.provider,
             event.model,
             event.input_tokens,
             event.output_tokens,
+            event.cache_creation_input_tokens,
+            event.cache_read_input_tokens,
             event.duration_ms,
             event.status_code as i64,
             event.is_streaming as i64,
@@ -281,7 +292,7 @@ pub fn insert_proxy_message(conn: &Connection, event: &ProxyEvent) -> Result<Str
             input_tokens, output_tokens,
             cache_creation_tokens, cache_read_tokens,
             repo_id, git_branch, cost_cents, cost_confidence
-        ) VALUES (?1, 'assistant', ?2, ?3, ?4, ?5, ?6, 0, 0, ?7, ?8, ?9, 'proxy_estimated')",
+        ) VALUES (?1, 'assistant', ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, 'proxy_estimated')",
         params![
             uuid,
             event.timestamp,
@@ -289,6 +300,8 @@ pub fn insert_proxy_message(conn: &Connection, event: &ProxyEvent) -> Result<Str
             event.provider,
             event.input_tokens.unwrap_or(0),
             event.output_tokens.unwrap_or(0),
+            event.cache_creation_input_tokens.unwrap_or(0),
+            event.cache_read_input_tokens.unwrap_or(0),
             repo_id,
             git_branch,
             event.cost_cents,
@@ -339,6 +352,8 @@ mod tests {
             model: "gpt-4o".to_string(),
             input_tokens: Some(100),
             output_tokens: Some(50),
+            cache_creation_input_tokens: None,
+            cache_read_input_tokens: None,
             duration_ms: 1200,
             status_code: 200,
             is_streaming: false,
@@ -476,13 +491,42 @@ mod tests {
             "claude-sonnet-4-6",
             Some(100_000),
             Some(50_000),
+            None,
+            None,
         );
         assert!(cost > 0.0, "cost should be positive for non-zero tokens");
     }
 
     #[test]
+    fn compute_proxy_cost_with_cache_tokens() {
+        // Without cache tokens
+        let cost_no_cache = compute_proxy_cost_cents(
+            ProxyProvider::Anthropic,
+            "claude-opus-4-6",
+            Some(1_000),
+            Some(500),
+            None,
+            None,
+        );
+        // With cache tokens
+        let cost_with_cache = compute_proxy_cost_cents(
+            ProxyProvider::Anthropic,
+            "claude-opus-4-6",
+            Some(1_000),
+            Some(500),
+            Some(50_000),
+            Some(100_000),
+        );
+        assert!(
+            cost_with_cache > cost_no_cache,
+            "cost with cache tokens ({cost_with_cache}) should exceed cost without ({cost_no_cache})"
+        );
+    }
+
+    #[test]
     fn compute_proxy_cost_zero_tokens() {
-        let cost = compute_proxy_cost_cents(ProxyProvider::OpenAi, "gpt-4o", None, None);
+        let cost =
+            compute_proxy_cost_cents(ProxyProvider::OpenAi, "gpt-4o", None, None, None, None);
         assert!((cost - 0.0).abs() < f64::EPSILON);
     }
 
@@ -566,5 +610,45 @@ mod tests {
             )
             .unwrap();
         assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn proxy_event_stores_cache_tokens() {
+        let conn = test_db();
+        let mut event = test_event();
+        event.cache_creation_input_tokens = Some(5000);
+        event.cache_read_input_tokens = Some(80000);
+        let id = insert_proxy_event(&conn, &event).unwrap();
+
+        let (cache_create, cache_read): (Option<i64>, Option<i64>) = conn
+            .query_row(
+                "SELECT cache_creation_input_tokens, cache_read_input_tokens
+                 FROM proxy_events WHERE id = ?1",
+                params![id],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(cache_create, Some(5000));
+        assert_eq!(cache_read, Some(80000));
+    }
+
+    #[test]
+    fn proxy_message_stores_cache_tokens() {
+        let conn = test_db_with_messages();
+        let mut event = test_event();
+        event.cache_creation_input_tokens = Some(3000);
+        event.cache_read_input_tokens = Some(60000);
+        let uuid = insert_proxy_message(&conn, &event).unwrap();
+
+        let (cache_create, cache_read): (i64, i64) = conn
+            .query_row(
+                "SELECT cache_creation_tokens, cache_read_tokens
+                 FROM messages WHERE id = ?1",
+                params![uuid],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(cache_create, 3000);
+        assert_eq!(cache_read, 60000);
     }
 }

--- a/crates/budi-daemon/src/routes/proxy.rs
+++ b/crates/budi-daemon/src/routes/proxy.rs
@@ -141,6 +141,8 @@ async fn proxy_request(
                 &model,
                 None,
                 None,
+                None,
+                None,
                 duration_ms,
                 502,
                 is_streaming,
@@ -174,6 +176,8 @@ async fn proxy_request(
             line_buf: Vec::new(),
             input_tokens: None,
             output_tokens: None,
+            cache_creation_input_tokens: None,
+            cache_read_input_tokens: None,
             recorded: false,
         };
         let body = Body::from_stream(tap);
@@ -199,6 +203,8 @@ async fn proxy_request(
                 &model,
                 None,
                 None,
+                None,
+                None,
                 duration_ms,
                 502,
                 is_streaming,
@@ -214,18 +220,25 @@ async fn proxy_request(
 
     let duration_ms = start.elapsed().as_millis() as i64;
 
-    let (input_tokens, output_tokens) = if status.is_success() {
+    let tokens = if status.is_success() {
         extract_response_tokens(&resp_bytes, provider)
     } else {
-        (None, None)
+        ResponseTokens {
+            input: None,
+            output: None,
+            cache_creation: None,
+            cache_read: None,
+        }
     };
 
     record_event(
         &state,
         provider,
         &model,
-        input_tokens,
-        output_tokens,
+        tokens.input,
+        tokens.output,
+        tokens.cache_creation,
+        tokens.cache_read,
         duration_ms,
         status.as_u16(),
         is_streaming,
@@ -261,6 +274,8 @@ struct SseTapStream {
     line_buf: Vec<u8>,
     input_tokens: Option<i64>,
     output_tokens: Option<i64>,
+    cache_creation_input_tokens: Option<i64>,
+    cache_read_input_tokens: Option<i64>,
     recorded: bool,
 }
 
@@ -323,6 +338,20 @@ impl SseTapStream {
                 {
                     self.input_tokens = Some(n);
                 }
+                // message_start → .message.usage.cache_creation_input_tokens
+                if let Some(n) = json
+                    .pointer("/message/usage/cache_creation_input_tokens")
+                    .and_then(|v| v.as_i64())
+                {
+                    self.cache_creation_input_tokens = Some(n);
+                }
+                // message_start → .message.usage.cache_read_input_tokens
+                if let Some(n) = json
+                    .pointer("/message/usage/cache_read_input_tokens")
+                    .and_then(|v| v.as_i64())
+                {
+                    self.cache_read_input_tokens = Some(n);
+                }
                 // message_delta → .usage.output_tokens
                 if let Some(n) = json
                     .pointer("/usage/output_tokens")
@@ -335,6 +364,22 @@ impl SseTapStream {
                     && let Some(n) = json.pointer("/usage/input_tokens").and_then(|v| v.as_i64())
                 {
                     self.input_tokens = Some(n);
+                }
+                // Fallback: .usage.cache_creation_input_tokens
+                if self.cache_creation_input_tokens.is_none()
+                    && let Some(n) = json
+                        .pointer("/usage/cache_creation_input_tokens")
+                        .and_then(|v| v.as_i64())
+                {
+                    self.cache_creation_input_tokens = Some(n);
+                }
+                // Fallback: .usage.cache_read_input_tokens
+                if self.cache_read_input_tokens.is_none()
+                    && let Some(n) = json
+                        .pointer("/usage/cache_read_input_tokens")
+                        .and_then(|v| v.as_i64())
+                {
+                    self.cache_read_input_tokens = Some(n);
                 }
             }
             ProxyProvider::OpenAi => {
@@ -364,6 +409,8 @@ impl SseTapStream {
             &self.model,
             self.input_tokens,
             self.output_tokens,
+            self.cache_creation_input_tokens,
+            self.cache_read_input_tokens,
             duration_ms,
             self.status_code,
             true,
@@ -401,31 +448,52 @@ fn extract_request_metadata(body: &[u8]) -> (String, bool) {
     (model, is_streaming)
 }
 
-fn extract_response_tokens(body: &[u8], provider: ProxyProvider) -> (Option<i64>, Option<i64>) {
+/// Extracted token counts from an API response.
+struct ResponseTokens {
+    input: Option<i64>,
+    output: Option<i64>,
+    cache_creation: Option<i64>,
+    cache_read: Option<i64>,
+}
+
+fn extract_response_tokens(body: &[u8], provider: ProxyProvider) -> ResponseTokens {
     let parsed: Value = match serde_json::from_slice(body) {
         Ok(v) => v,
-        Err(_) => return (None, None),
+        Err(_) => {
+            return ResponseTokens {
+                input: None,
+                output: None,
+                cache_creation: None,
+                cache_read: None,
+            };
+        }
     };
     let usage = parsed.get("usage");
     match provider {
-        ProxyProvider::Anthropic => {
-            let input = usage
+        ProxyProvider::Anthropic => ResponseTokens {
+            input: usage
                 .and_then(|u| u.get("input_tokens"))
-                .and_then(|v| v.as_i64());
-            let output = usage
+                .and_then(|v| v.as_i64()),
+            output: usage
                 .and_then(|u| u.get("output_tokens"))
-                .and_then(|v| v.as_i64());
-            (input, output)
-        }
-        ProxyProvider::OpenAi => {
-            let input = usage
+                .and_then(|v| v.as_i64()),
+            cache_creation: usage
+                .and_then(|u| u.get("cache_creation_input_tokens"))
+                .and_then(|v| v.as_i64()),
+            cache_read: usage
+                .and_then(|u| u.get("cache_read_input_tokens"))
+                .and_then(|v| v.as_i64()),
+        },
+        ProxyProvider::OpenAi => ResponseTokens {
+            input: usage
                 .and_then(|u| u.get("prompt_tokens"))
-                .and_then(|v| v.as_i64());
-            let output = usage
+                .and_then(|v| v.as_i64()),
+            output: usage
                 .and_then(|u| u.get("completion_tokens"))
-                .and_then(|v| v.as_i64());
-            (input, output)
-        }
+                .and_then(|v| v.as_i64()),
+            cache_creation: None,
+            cache_read: None,
+        },
     }
 }
 
@@ -505,6 +573,8 @@ fn record_event(
     model: &str,
     input_tokens: Option<i64>,
     output_tokens: Option<i64>,
+    cache_creation_input_tokens: Option<i64>,
+    cache_read_input_tokens: Option<i64>,
     duration_ms: i64,
     status_code: u16,
     is_streaming: bool,
@@ -512,7 +582,14 @@ fn record_event(
     session_id: &str,
 ) {
     let cost_cents = if status_code < 400 {
-        budi_core::proxy::compute_proxy_cost_cents(provider, model, input_tokens, output_tokens)
+        budi_core::proxy::compute_proxy_cost_cents(
+            provider,
+            model,
+            input_tokens,
+            output_tokens,
+            cache_creation_input_tokens,
+            cache_read_input_tokens,
+        )
     } else {
         0.0
     };
@@ -523,6 +600,8 @@ fn record_event(
         model: model.to_string(),
         input_tokens,
         output_tokens,
+        cache_creation_input_tokens,
+        cache_read_input_tokens,
         duration_ms,
         status_code,
         is_streaming,
@@ -540,6 +619,8 @@ fn record_event(
         duration_ms = event.duration_ms,
         input_tokens = ?event.input_tokens,
         output_tokens = ?event.output_tokens,
+        cache_creation_input_tokens = ?event.cache_creation_input_tokens,
+        cache_read_input_tokens = ?event.cache_read_input_tokens,
         streaming = event.is_streaming,
         repo_id = %event.repo_id,
         git_branch = %event.git_branch,


### PR DESCRIPTION
## Summary

- **Root cause**: The proxy only captured `input_tokens` and `output_tokens` from Anthropic API responses, missing `cache_creation_input_tokens` and `cache_read_input_tokens` entirely. Since Claude Code uses prompt caching heavily (cache reads often 1000x larger than non-cached input), proxy-based cost was 8.5x lower than ground truth (~$0.009/msg vs $0.076/msg for opus).
- **Fix**: Extract both cache token fields from streaming (SSE `message_start`) and non-streaming Anthropic responses. Thread them through `ProxyEvent` → `proxy_events` table → `messages` table → rollups → cloud sync.
- **Schema**: Additive migration adds `cache_creation_input_tokens` and `cache_read_input_tokens` columns to `proxy_events` table. Existing rows remain unchanged (NULL = unknown).

## Investigation: Cross-platform reconciliation (April 2026)

### Data sources verified

| Source | Data | Accuracy |
|--------|------|----------|
| **claude.ai/settings/usage** | $586.73 (Enterprise plan ground truth) | Billing source |
| **Budi transcripts** (Apr 1–13) | $424.87 (6,887 msgs with full cache tokens) | ~97-99% |
| **Budi proxy** (Apr 13–14) | $11.54 (1,649 msgs, **0 cache tokens** — bug) | ~12% |
| **Claude Platform workspace** | $9,676.97 (109 users, company API — NOT Ivan's) | N/A for this user |
| **Cursor CSV** (cursor.com) | 308 included requests, $0 on-demand | Token-exact match with Budi |

### Eliminated factors

- **Fast mode (6x multiplier)**: All 52,263 transcript entries have `speed: "standard"` — zero fast-mode usage in April
- **Web search ($0.01/req)**: All 52,320 transcript entries have `web_search_requests: 0`
- **Cursor token accuracy**: Budi's token counts match cursor.com CSV **exactly** for every day and every model. The only difference is request counting (Cursor counts 2 "requests" per Anthropic turn, Budi counts 1 message).

### Cost reconciliation

| Component | Amount | Source |
|-----------|--------|--------|
| Transcript (Apr 1–13 18:54) | $424.87 | JSONL import |
| Proxy corrected estimate (Apr 13–14) | ~$102.73 | Estimated using transcript cache ratios |
| **Budi subtotal** | **~$527.60** | |
| Non-Code usage (Workbench chat, etc.) | ~$59.13 | Residual (claude.ai includes all usage) |
| **claude.ai ground truth** | **$586.73** | Enterprise billing |

### Proxy under-report detail

Per-message comparison on the same day (Apr 13, opus-4-6):

| Source | Sample | Avg output | Avg cache_read | Avg cost/msg |
|--------|--------|-----------|----------------|-------------|
| Transcript | 785 msgs | 321 tok | 85,441 tok | $0.076 |
| Proxy (before fix) | 665 msgs | 337 tok | **0** tok | $0.009 |

The proxy sees similar output tokens but zero cache tokens, resulting in 8.5x cost under-report.

## Remaining gaps (follow-up considerations)

- **Non-Code usage (~$59, 10%)**: claude.ai/settings/usage includes Workbench chat. Budi only tracks CLI transcripts. This is inherent and not a bug.
- **`cache_creation_1h_tokens`**: The 1-hour cache tier breakdown is only in transcripts, not the API response. Proxy treats all cache writes as 5-minute tier (slight over-estimate vs actual, but compensating).
- **Historical proxy data**: The 1,649 proxy messages from Apr 13–14 with 0 cache tokens cannot be retroactively fixed. A `budi import` re-run could overwrite them with transcript data if desired.

## Risks / compatibility notes

- **Additive only**: No breaking schema changes. New columns are nullable. Old proxy events retain NULL cache tokens.
- **Cloud sync**: No changes needed — the `messages` table feeds rollups which already have `cache_creation_tokens` and `cache_read_tokens` columns.
- **Backward compatible**: `compute_proxy_cost_cents` gained two new parameters. Only called from the daemon proxy handler (updated).

## Validation

```
cargo fmt --all              ✓
cargo clippy --workspace ... ✓ (0 warnings)
cargo test --workspace       ✓ (363 tests, 0 failures)
```

New tests added:
- `compute_proxy_cost_with_cache_tokens` — verifies cache tokens increase cost
- `proxy_event_stores_cache_tokens` — verifies DB storage
- `proxy_message_stores_cache_tokens` — verifies messages table gets real cache values

Closes #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)