### PR TITLE
[8.0] Update DEFAULT_CLOUD_ENDPOINT to app.getbudi.dev

### DIFF
--- a/SOUL.md
+++ b/SOUL.md
@@ -86,7 +86,7 @@ Cloud sync (optional, disabled by default):
 Local SQLite daily rollups
   -> Daemon background sync worker reads aggregates only
   -> Builds sync envelope (ADR-0083 §2): daily_rollups + session_summaries
-  -> HTTPS-only POST to api.getbudi.dev/v1/ingest (Bearer budi_<key>)
+  -> HTTPS-only POST to app.getbudi.dev/v1/ingest (Bearer budi_<key>)
   -> Watermark tracking: only sends new/updated rollups since last confirmed sync
   -> Retry with exponential backoff (1s -> 2s -> ... -> 5min cap) on 429/5xx
   -> Auth failure (401) stops syncing; schema mismatch (422) pauses until update

--- a/crates/budi-core/src/cloud_sync.rs
+++ b/crates/budi-core/src/cloud_sync.rs
@@ -554,8 +554,8 @@ mod tests {
 
     #[test]
     fn https_enforcement() {
-        assert!(validate_https_endpoint("https://api.getbudi.dev").is_ok());
-        assert!(validate_https_endpoint("http://api.getbudi.dev").is_err());
+        assert!(validate_https_endpoint("https://app.getbudi.dev").is_ok());
+        assert!(validate_https_endpoint("http://app.getbudi.dev").is_err());
         assert!(validate_https_endpoint("ftp://example.com").is_err());
     }
 
@@ -572,7 +572,7 @@ mod tests {
     #[test]
     fn empty_payload_detected() {
         let result = send_sync_envelope(
-            "https://api.getbudi.dev",
+            "https://app.getbudi.dev",
             "budi_test",
             &SyncEnvelope {
                 schema_version: 1,

--- a/crates/budi-core/src/config.rs
+++ b/crates/budi-core/src/config.rs
@@ -473,7 +473,7 @@ pub fn budi_config_dir() -> Result<PathBuf> {
 // Cloud config — loaded from `~/.config/budi/cloud.toml` (ADR-0083 §9)
 // ---------------------------------------------------------------------------
 
-pub const DEFAULT_CLOUD_ENDPOINT: &str = "https://api.getbudi.dev";
+pub const DEFAULT_CLOUD_ENDPOINT: &str = "https://app.getbudi.dev";
 pub const DEFAULT_CLOUD_SYNC_INTERVAL_SECONDS: u64 = 300;
 pub const DEFAULT_CLOUD_SYNC_RETRY_MAX_SECONDS: u64 = 300;
 
@@ -967,7 +967,7 @@ daemon_port = 7878
         assert!(config.api_key.is_none());
         assert!(config.device_id.is_none());
         assert!(config.org_id.is_none());
-        assert_eq!(config.endpoint, "https://api.getbudi.dev");
+        assert_eq!(config.endpoint, "https://app.getbudi.dev");
         assert_eq!(config.sync.interval_seconds, 300);
         assert_eq!(config.sync.retry_max_seconds, 300);
     }
@@ -1036,7 +1036,7 @@ api_key = "budi_test"
         let config = w.cloud;
         assert!(config.enabled);
         assert_eq!(config.api_key.as_deref(), Some("budi_test"));
-        assert_eq!(config.endpoint, "https://api.getbudi.dev");
+        assert_eq!(config.endpoint, "https://app.getbudi.dev");
         assert_eq!(config.sync.interval_seconds, 300);
     }
 }

--- a/docs/adr/0083-cloud-ingest-identity-and-privacy-contract.md
+++ b/docs/adr/0083-cloud-ingest-identity-and-privacy-contract.md
@@ -363,7 +363,7 @@ enabled = false
 api_key = "budi_..."
 device_id = "dev_..."
 org_id = "org_..."
-endpoint = "https://api.getbudi.dev"
+endpoint = "https://app.getbudi.dev"
 
 [cloud.sync]
 interval_seconds = 300    # 5 minutes

--- a/docs/adr/0087-cloud-infrastructure-and-deployment.md
+++ b/docs/adr/0087-cloud-infrastructure-and-deployment.md
@@ -29,7 +29,7 @@ Two Supabase projects separate development from production:
 | Project | Purpose | Used by |
 |---------|---------|---------|
 | `budi-dev` | Development and staging | Preview deployments, local development, CI tests |
-| `budi-prod` | Production | `app.getbudi.dev` and `api.getbudi.dev` |
+| `budi-prod` | Production | `app.getbudi.dev` |
 
 Both projects share the same schema (managed via versioned migration files in the `budi-cloud` repo). Supabase free tier is sufficient for the cloud alpha (1-20 developers per ADR-0083 §6).
 
@@ -44,7 +44,7 @@ One Vercel project (`budi-cloud`) with automatic environments:
 | Environment | Trigger | Supabase target | URL |
 |-------------|---------|-----------------|-----|
 | Preview | Push to any PR branch | `budi-dev` | `*.vercel.app` (auto-generated) |
-| Production | Push to `main` | `budi-prod` | `app.getbudi.dev` / `api.getbudi.dev` |
+| Production | Push to `main` | `budi-prod` | `app.getbudi.dev` |
 
 Vercel environment variables connect each deployment to the correct Supabase project:
 - `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY` (client-side)
@@ -57,12 +57,11 @@ Vercel environment variables connect each deployment to the correct Supabase pro
 | Subdomain | Purpose | Hosting | Repo |
 |-----------|---------|---------|------|
 | `getbudi.dev` | Marketing / landing page | Vercel | `siropkin/getbudi.dev` |
-| `app.getbudi.dev` | Cloud dashboard (manager/member views) | Vercel | `siropkin/budi-cloud` |
-| `api.getbudi.dev` | Cloud ingest API (daemon sync target) | Vercel API routes | `siropkin/budi-cloud` |
+| `app.getbudi.dev` | Cloud dashboard + ingest API (via `/v1/*` rewrite) | Vercel | `siropkin/budi-cloud` |
 
 **DNS setup**: Either transfer nameservers from GoDaddy to Vercel (simplest — Vercel manages all DNS) or add CNAME records pointing subdomains to `cname.vercel-dns.com`. Vercel handles TLS certificates automatically.
 
-**ADR-0083 update**: §9 specifies `endpoint = "https://cloud.budi.dev"` as the default cloud endpoint. This ADR updates it to `https://api.getbudi.dev`.
+**ADR-0083 update**: §9 specifies `endpoint = "https://cloud.budi.dev"` as the default cloud endpoint. This ADR updates it to `https://app.getbudi.dev` (the `api.getbudi.dev` subdomain was never created; `app.getbudi.dev` serves both the dashboard and the ingest API via Next.js rewrites).
 
 ### 4. Web Authentication (Dashboard Users)
 
@@ -188,7 +187,7 @@ Before R4 implementation can begin, the repository owner must complete these man
 4. Configure environment variables: preview → dev Supabase keys, production → prod Supabase keys
 
 **Domain setup**:
-1. In Vercel: add custom domains `getbudi.dev`, `app.getbudi.dev`, `api.getbudi.dev`
+1. In Vercel: add custom domains `getbudi.dev`, `app.getbudi.dev`
 2. In GoDaddy: update nameservers to Vercel's (displayed in Vercel domain settings), OR add CNAME records as Vercel instructs
 3. Wait for DNS propagation and verify in Vercel
 
@@ -234,8 +233,8 @@ Before R4 implementation can begin, the repository owner must complete these man
 
 ### Downstream Impact
 
-- **#100 (R4.1)**: Ingest API implemented as Next.js API routes in `budi-cloud`, targeting `api.getbudi.dev`. Supabase schema applied via migration files.
-- **#101 (R4.2)**: Sync worker pushes to `https://api.getbudi.dev/v1/ingest` (updated from ADR-0083 §9 default).
+- **#100 (R4.1)**: Ingest API implemented as Next.js API routes in `budi-cloud`, served at `app.getbudi.dev`. Supabase schema applied via migration files.
+- **#101 (R4.2)**: Sync worker pushes to `https://app.getbudi.dev/v1/ingest` (updated from ADR-0083 §9 default).
 - **#102 (R4.3)**: Dashboard deployed at `app.getbudi.dev`, uses Supabase Auth with GitHub + Google providers.
 - **#103 (R4.4)**: Extraction creates `budi-cursor` and `budi-cloud` repos with independent CI and publishing.
 - **#108 (R5.3)**: Release readiness includes daemon autostart across all platforms.


### PR DESCRIPTION
## Summary

- Updates `DEFAULT_CLOUD_ENDPOINT` from `https://api.getbudi.dev` to `https://app.getbudi.dev`
- The `api.getbudi.dev` subdomain was never created; `app.getbudi.dev` serves both the dashboard and the ingest API via Next.js rewrites (`/v1/*` → `/api/v1/*`)
- Updates all tests, SOUL.md, ADR-0083 §9, and ADR-0087 domain tables to reflect reality

Closes #193

## Risks / compatibility notes

- Existing users with `cloud.toml` already written will have the old `api.getbudi.dev` endpoint persisted. Since that subdomain was never set up, those users were already broken — this change only affects the *default* for new installs.
- No backward compatibility concern: the old default never worked in production.

## Validation

```
cargo fmt --all                                              # pass
cargo clippy --workspace --all-targets --locked -- -D warnings  # pass
cargo test --workspace --locked                              # 363 tests pass
```