### PR TITLE
[8.0] Show session ID in budi sessions text output

### DIFF
--- a/crates/budi-cli/src/commands/sessions.rs
+++ b/crates/budi-cli/src/commands/sessions.rs
@@ -47,6 +47,8 @@ pub fn cmd_sessions(
     }
 
     for s in &sessions.sessions {
+        let short_id = if s.id.len() >= 8 { &s.id[..8] } else { &s.id };
+
         let time = s
             .started_at
             .as_deref()
@@ -85,7 +87,7 @@ pub fn cmd_sessions(
         };
 
         println!(
-            "  {health} {dim}{time}{reset}  {bold}{:>6}{reset}  {:<20}  {:<12}  {:>6} msgs  {yellow}{:>8}{reset}",
+            "  {health} {dim}{time}{reset}  {bold}{:>6}{reset}  {dim}{short_id}{reset}  {:<20}  {:<12}  {:>6} msgs  {yellow}{:>8}{reset}",
             duration,
             format!("{model_short}{model_extra}"),
             repo,

--- a/crates/budi-cli/src/commands/sessions.rs
+++ b/crates/budi-cli/src/commands/sessions.rs
@@ -47,8 +47,6 @@ pub fn cmd_sessions(
     }
 
     for s in &sessions.sessions {
-        let short_id = if s.id.len() >= 8 { &s.id[..8] } else { &s.id };
-
         let time = s
             .started_at
             .as_deref()
@@ -58,11 +56,6 @@ pub fn cmd_sessions(
                     .format("%m/%d %H:%M")
                     .to_string()
             })
-            .unwrap_or_else(|| "--".to_string());
-
-        let duration = s
-            .duration_ms
-            .map(format_duration_ms)
             .unwrap_or_else(|| "--".to_string());
 
         let model = s.models.first().map(|m| m.as_str()).unwrap_or("--");
@@ -87,11 +80,10 @@ pub fn cmd_sessions(
         };
 
         println!(
-            "  {health} {dim}{time}{reset}  {bold}{:>6}{reset}  {dim}{short_id}{reset}  {:<20}  {:<12}  {:>6} msgs  {yellow}{:>8}{reset}",
-            duration,
+            "  {health} {dim}{time}{reset}  {dim}{}{reset}  {:<20}  {:<12}  {yellow}{:>8}{reset}",
+            &s.id,
             format!("{model_short}{model_extra}"),
             repo,
-            s.message_count,
             format_cost_cents(s.cost_cents),
         );
     }

--- a/crates/budi-core/src/analytics/sessions.rs
+++ b/crates/budi-core/src/analytics/sessions.rs
@@ -443,6 +443,31 @@ pub fn session_list_with_filters(
     })
 }
 
+/// Resolve a (possibly short) session ID prefix to the full session ID.
+///
+/// Returns `Ok(Some(full_id))` when exactly one session matches the prefix,
+/// `Ok(None)` when no session matches, or an error when the prefix is ambiguous
+/// (matches more than one session).
+pub fn resolve_session_id(conn: &Connection, prefix: &str) -> Result<Option<String>> {
+    let mut stmt = conn.prepare(
+        "SELECT DISTINCT session_id FROM (
+             SELECT id AS session_id FROM sessions WHERE id LIKE ?1 || '%'
+             UNION
+             SELECT session_id FROM messages WHERE session_id LIKE ?1 || '%'
+         ) LIMIT 2",
+    )?;
+    let ids: Vec<String> = stmt
+        .query_map(params![prefix], |row| row.get(0))?
+        .collect::<Result<_, _>>()?;
+    match ids.len() {
+        0 => Ok(None),
+        1 => Ok(Some(ids.into_iter().next().unwrap())),
+        _ => anyhow::bail!(
+            "ambiguous session prefix '{prefix}' — matches multiple sessions; use more characters"
+        ),
+    }
+}
+
 /// Get a single session summary row for session detail metadata.
 pub fn session_detail(conn: &Connection, session_id: &str) -> Result<Option<SessionListEntry>> {
     let row = conn.query_row(

--- a/crates/budi-daemon/src/routes/analytics.rs
+++ b/crates/budi-daemon/src/routes/analytics.rs
@@ -697,10 +697,27 @@ pub async fn analytics_sessions(
     Ok(Json(result))
 }
 
+/// Resolve a session ID prefix to its full ID, returning appropriate HTTP errors.
+async fn resolve_sid(prefix: String) -> Result<String, (StatusCode, Json<serde_json::Value>)> {
+    let pfx = prefix.clone();
+    let resolved = tokio::task::spawn_blocking(move || {
+        let db_path = analytics::db_path()?;
+        let conn = analytics::open_db(&db_path)?;
+        analytics::resolve_session_id(&conn, &pfx)
+    })
+    .await
+    .map_err(|e| internal_error(anyhow::anyhow!("{e}")))?
+    .map_err(internal_error)?;
+    match resolved {
+        Some(full_id) => Ok(full_id),
+        None => Err(not_found(format!("session '{prefix}' not found"))),
+    }
+}
+
 pub async fn analytics_session_detail(
     Path(session_id): Path<String>,
 ) -> Result<Json<analytics::SessionListEntry>, (StatusCode, Json<serde_json::Value>)> {
-    let sid = session_id.clone();
+    let sid = resolve_sid(session_id.clone()).await?;
     let result = tokio::task::spawn_blocking(move || {
         let db_path = analytics::db_path()?;
         let conn = analytics::open_db(&db_path)?;
@@ -719,10 +736,11 @@ pub async fn analytics_session_detail(
 pub async fn analytics_session_tags(
     Path(session_id): Path<String>,
 ) -> Result<Json<Vec<analytics::SessionTag>>, (StatusCode, Json<serde_json::Value>)> {
+    let sid = resolve_sid(session_id).await?;
     let result = tokio::task::spawn_blocking(move || {
         let db_path = analytics::db_path()?;
         let conn = analytics::open_db(&db_path)?;
-        let tags = analytics::session_tags(&conn, &session_id)?;
+        let tags = analytics::session_tags(&conn, &sid)?;
         Ok::<_, anyhow::Error>(
             tags.into_iter()
                 .map(|(k, v)| analytics::SessionTag { key: k, value: v })
@@ -739,6 +757,7 @@ pub async fn analytics_session_messages(
     Path(session_id): Path<String>,
     Query(params): Query<SessionMessagesQueryParams>,
 ) -> Result<Json<analytics::PaginatedMessages>, (StatusCode, Json<serde_json::Value>)> {
+    let sid = resolve_sid(session_id).await?;
     let roles = match params.roles.as_deref() {
         None => analytics::SessionMessageRoles::Assistant,
         Some(raw) => raw
@@ -759,7 +778,7 @@ pub async fn analytics_session_messages(
         let conn = analytics::open_db(&db_path)?;
         analytics::session_message_list(
             &conn,
-            &session_id,
+            &sid,
             &analytics::SessionMessageListParams {
                 roles,
                 sort_by: params.sort_by.as_deref(),
@@ -778,10 +797,11 @@ pub async fn analytics_session_messages(
 pub async fn analytics_session_message_curve(
     Path(session_id): Path<String>,
 ) -> Result<Json<Vec<analytics::SessionMessageCurvePoint>>, (StatusCode, Json<serde_json::Value>)> {
+    let sid = resolve_sid(session_id).await?;
     let result = tokio::task::spawn_blocking(move || {
         let db_path = analytics::db_path()?;
         let conn = analytics::open_db(&db_path)?;
-        analytics::session_message_curve(&conn, &session_id)
+        analytics::session_message_curve(&conn, &sid)
     })
     .await
     .map_err(|e| internal_error(anyhow::anyhow!("{e}")))?


### PR DESCRIPTION
## Summary

- Show full session ID in `budi sessions` text output, replacing duration and message count columns
- Add `resolve_session_id()` prefix matching in core — users can use any unique prefix with `budi sessions <id>`
- All daemon session endpoints (detail, tags, messages, message curve) now resolve prefixes

**Before:**
```
  ● 04/13 08:38   2m39s  claude-opus-4-6       budi              96 msgs     $7.25
```

**After:**
```
  ● 04/13 08:38  c71afb27-3e4a-4b8f-9d2e-1a5f6c7d8e9f  claude-opus-4-6       budi       $7.25
```

Duration and message count remain available in `budi sessions <id>` detail view.

## Risks / compatibility notes

- Text output layout change (columns reordered/removed) — JSON output unchanged
- Prefix matching is additive; full IDs still work exactly as before
- Ambiguous prefix returns HTTP 500 with a descriptive error message

## Validation

- `cargo fmt --all` — clean
- `cargo clippy --workspace --all-targets --locked -- -D warnings` — no warnings
- `cargo test --workspace --locked` — all 363 tests pass

Closes #174