### PR TITLE
[8.0] Add macOS app bundle path to Cursor CLI discovery

### DIFF
--- a/crates/budi-cli/src/commands/integrations.rs
+++ b/crates/budi-cli/src/commands/integrations.rs
@@ -715,7 +715,11 @@ fn install_cursor_extension(warnings: &mut Vec<String>) {
 /// Check if the `cursor` CLI is on PATH (or at the well-known macOS location).
 pub fn find_cursor_cli() -> Option<String> {
     let candidates = if cfg!(target_os = "macos") {
-        vec!["cursor".to_string(), "/usr/local/bin/cursor".to_string()]
+        vec![
+            "cursor".to_string(),
+            "/usr/local/bin/cursor".to_string(),
+            "/Applications/Cursor.app/Contents/Resources/app/bin/cursor".to_string(),
+        ]
     } else {
         vec!["cursor".to_string()]
     };


### PR DESCRIPTION
## Summary

- `find_cursor_cli()` now checks `/Applications/Cursor.app/Contents/Resources/app/bin/cursor` in addition to `cursor` (PATH) and `/usr/local/bin/cursor`
- Fixes `budi integrations list` and `budi init` incorrectly reporting Cursor as not installed when the CLI is only available via the app bundle

Closes #176

## Risks / compatibility notes

- No backward-compatibility impact — this only adds a new candidate path to an existing search
- Only applies on macOS (`cfg!(target_os = "macos")`)

## Validation

- `cargo fmt --all` — clean
- `cargo clippy --workspace --all-targets --locked -- -D warnings` — clean
- `cargo test --workspace --locked` — 363 tests pass