### PR TITLE
[8.0] Fix session health endpoint ERROR spam when no sessions exist

### DIFF
--- a/crates/budi-core/src/analytics/health.rs
+++ b/crates/budi-core/src/analytics/health.rs
@@ -142,8 +142,8 @@ const COST_ACCEL_MIN_REQUESTS: usize = 6;
 pub fn session_health(conn: &Connection, session_id: Option<&str>) -> Result<SessionHealth> {
     let sid = match session_id {
         Some(s) => s.to_string(),
-        None => conn
-            .query_row(
+        None => {
+            match conn.query_row(
                 "WITH latest_assistant AS (
                      SELECT session_id, MAX(timestamp) AS last_assistant_at
                      FROM messages
@@ -160,9 +160,27 @@ pub fn session_health(conn: &Connection, session_id: Option<&str>) -> Result<Ses
                      s.id DESC
                  LIMIT 1",
                 [],
-                |row| row.get(0),
-            )
-            .context("No sessions found")?,
+                |row| row.get::<_, String>(0),
+            ) {
+                Ok(id) => id,
+                Err(rusqlite::Error::QueryReturnedNoRows) => {
+                    return Ok(SessionHealth {
+                        state: "green".to_string(),
+                        message_count: 0,
+                        total_cost_cents: 0.0,
+                        vitals: SessionVitals {
+                            context_drag: None,
+                            cache_efficiency: None,
+                            thrashing: None,
+                            cost_acceleration: None,
+                        },
+                        tip: "No sessions yet".to_string(),
+                        details: vec![],
+                    });
+                }
+                Err(e) => return Err(e).context("Failed to query latest session"),
+            }
+        }
     };
 
     let provider_str: String = conn

--- a/crates/budi-core/src/analytics/tests.rs
+++ b/crates/budi-core/src/analytics/tests.rs
@@ -3375,3 +3375,14 @@ fn health_cursor_multi_reply_session_not_false_red() {
         "multi-reply Cursor session should not be false red"
     );
 }
+
+#[test]
+fn health_no_sessions_returns_green() {
+    let conn = test_db();
+    let h = session_health(&conn, None).unwrap();
+    assert_eq!(h.state, "green");
+    assert_eq!(h.message_count, 0);
+    assert_eq!(h.total_cost_cents, 0.0);
+    assert_eq!(h.tip, "No sessions yet");
+    assert!(h.details.is_empty());
+}


### PR DESCRIPTION
## Summary

- When `session_id` is `None` and no sessions exist in the database, `session_health()` now returns a graceful green/empty `SessionHealth` instead of propagating a `QueryReturnedNoRows` error.
- This eliminates the `ERROR No sessions found: Query returned no rows` log spam that repeats every ~15 seconds on fresh installs.
- Added test `health_no_sessions_returns_green` to cover the empty-database case.

## Risks / compatibility notes

- **API response change**: The `/analytics/session-health` endpoint now returns `200 OK` with `{"state":"green","message_count":0,...,"tip":"No sessions yet"}` instead of `500 Internal Server Error` when no sessions exist. This is a strictly better response for callers — no breaking change.
- No schema or configuration changes.

## Validation

- `cargo fmt --all` — clean
- `cargo clippy --workspace --all-targets --locked -- -D warnings` — clean
- `cargo test --workspace --locked` — 364 tests pass (including new `health_no_sessions_returns_green`)

Closes #177