### PR TITLE
[8.0] Add Codex Desktop/CLI transcript import provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Everything stays on your machine by default. Optional cloud sync pushes aggregat
 - **Session health** — detects context bloat, cache degradation, cost acceleration, and retry loops with actionable, provider-aware tips
 - **Cloud dashboard** at [`app.getbudi.dev`](https://app.getbudi.dev) — team-wide cost visibility across users, repos, models, branches, and tickets (daily granularity, requires `budi cloud join`)
 - Live cost + health status line in Claude Code and Cursor
-- **One-time import** of historical transcripts via `budi import` (Claude Code JSONL, Cursor Usage API)
+- **One-time import** of historical transcripts via `budi import` (Claude Code JSONL, Codex Desktop/CLI sessions, Cursor Usage API)
 - ~6 MB Rust binary, minimal footprint
 
 ## Platforms
@@ -61,7 +61,7 @@ budi targets **macOS**, **Linux** (glibc), and **Windows 10+**. Prebuilt release
 
 Tier 1 agents use simple env vars with high confidence. Tier 2 agents work but have onboarding caveats (GUI settings, proprietary env vars). See [ADR-0082](docs/adr/0082-proxy-compatibility-matrix-and-gateway-contract.md) for the full compatibility matrix.
 
-All agents also support one-time historical import via `budi import` (Claude Code JSONL transcripts, Cursor Usage API).
+All agents also support one-time historical import via `budi import` (Claude Code JSONL transcripts, Codex Desktop/CLI sessions, Cursor Usage API).
 
 ## Contributing
 
@@ -160,7 +160,7 @@ Use this sequence if you want the fastest "did setup really work?" path:
 2. **Choose agents and integrations** during `budi init` (recommended defaults are safe)
    - `budi init` also installs a platform-native autostart service (launchd on macOS, systemd on Linux, Task Scheduler on Windows) so the daemon restarts automatically after reboots
 3. **Import historical data** (optional)
-   - Run `budi import` to backfill from Claude Code JSONL transcripts and Cursor Usage API
+   - Run `budi import` to backfill from Claude Code JSONL transcripts, Codex Desktop/CLI sessions, and Cursor Usage API
 4. **Confirm health**
    - Run `budi doctor` to check daemon, proxy, autostart service, and agent configuration
    - Run `budi status` for a quick overview of daemon, proxy, and today's cost
@@ -405,10 +405,11 @@ A lightweight Rust daemon (port 7878) manages a single SQLite database. The daem
 
 Historical import (budi import):
   JSONL transcripts (Claude Code) ──┐
-  Usage API (Cursor) ───────────────┴──▶ Pipeline → SQLite
+  JSONL sessions (Codex) ───────────┼──▶ Pipeline → SQLite
+  Usage API (Cursor) ───────────────┘
 ```
 
-The daemon is the single source of truth — the CLI never opens the database directly. The **proxy** is the sole live data source: every LLM request flows through it, capturing tokens, cost, and attribution in real time. Historical data from Claude Code JSONL transcripts and Cursor Usage API can be imported via `budi import` for one-time backfill.
+The daemon is the single source of truth — the CLI never opens the database directly. The **proxy** is the sole live data source: every LLM request flows through it, capturing tokens, cost, and attribution in real time. Historical data from Claude Code JSONL transcripts, Codex Desktop/CLI sessions, and Cursor Usage API can be imported via `budi import` for one-time backfill.
 
 **Data model** — nine tables, seven data entities + two supporting:
 
@@ -546,7 +547,7 @@ Most endpoints accept `?since=<ISO>&until=<ISO>` for date filtering.
 1. Run `budi status` to check daemon, proxy, and today's cost
 2. Verify auto-proxy config with `budi doctor` (shell profile + Cursor/Codex settings)
 3. Send a prompt and check `budi stats` for non-zero usage
-4. For historical data: `budi import` (one-time backfill from Claude Code JSONL / Cursor Usage API)
+4. For historical data: `budi import` (one-time backfill from Claude Code JSONL, Codex sessions, Cursor Usage API)
 
 **Daemon won't start:**
 1. Check if port 7878 is in use: `lsof -i :7878`

--- a/SOUL.md
+++ b/SOUL.md
@@ -55,7 +55,7 @@ Three independent repos (extraction completed per [ADR-0086](docs/adr/0086-extra
 
 ### Crates
 
-- **budi-core** - Business logic: analytics (SQLite queries), providers (Claude Code, Cursor), pipeline (enrichment), cost calculation, proxy event storage, config, migrations, autostart (platform-native daemon service management). Historical hook/OTEL data is read-only (tables kept for schema compat, ingestion removed)
+- **budi-core** - Business logic: analytics (SQLite queries), providers (Claude Code, Codex, Cursor), pipeline (enrichment), cost calculation, proxy event storage, config, migrations, autostart (platform-native daemon service management). Historical hook/OTEL data is read-only (tables kept for schema compat, ingestion removed)
 - **budi-cli** - Thin HTTP client to the daemon. Commands: init, launch, stats, sessions, status, sync, import, statusline, doctor, health, update, integrations, uninstall, migrate, repair
 - **budi-daemon** - axum HTTP server (port 7878). Owns SQLite exclusively. Serves analytics API. Also runs the proxy server on port 9878. The proxy is the sole live data source; transcript import is user-initiated via `budi import`
 
@@ -72,7 +72,7 @@ Proxy (agent -> localhost:9878 -> upstream provider)
   -> SQLite (proxy_events table + messages table for unified analytics)
 
 Historical import (budi import):
-Sources (JSONL files, Cursor API)
+Sources (Claude Code JSONL, Codex sessions, Cursor API)
   -> Providers discover + parse -> ParsedMessage structs
   -> Pipeline: IdentityEnricher -> GitEnricher -> ToolEnricher -> CostEnricher -> TagEnricher
   -> SQLite (messages + tags + derived rollup tables)
@@ -113,6 +113,7 @@ Nine tables, seven data entities + two supporting:
 |--------|-----------|-----------------|
 | **Proxy** (all agents) | `proxy_estimated` | Real-time per-request tokens from response body (non-streaming) or SSE tee/tap extraction (streaming). Attribution via `X-Budi-Repo`, `X-Budi-Branch`, `X-Budi-Cwd` headers or git-resolved from cwd. Falls back to `Unassigned` repo |
 | **JSONL** (Claude Code) | `estimated` | Per-message tokens (no thinking), cost calculated from pricing. Used by `budi import` for historical backfill |
+| **JSONL** (Codex) | `estimated` | Per-API-call tokens from `token_count` events in `~/.codex/sessions/`. Used by `budi import` for historical backfill |
 | **Cursor Usage API** | `exact` | Per-request tokens + totalCents from Cursor's API. Used by `budi import` for historical backfill |
 
 Historical OTEL data (`otel_exact` confidence) remains queryable but OTEL ingestion has been removed. The proxy is the sole live data source.
@@ -137,6 +138,7 @@ Historical OTEL data (`otel_exact` confidence) remains queryable but OTEL ingest
 - `crates/budi-core/src/hooks.rs` - Prompt classification and migration helpers (hook_events table dropped in v22)
 - `crates/budi-core/src/jsonl.rs` - JSONL transcript parser, ParsedMessage struct
 - `crates/budi-core/src/providers/claude_code.rs` - Claude Code provider (JSONL discovery, pricing)
+- `crates/budi-core/src/providers/codex.rs` - Codex provider (Codex Desktop/CLI transcript import from `~/.codex/sessions/`, OpenAI model pricing)
 - `crates/budi-core/src/providers/cursor.rs` - Cursor provider (Usage API primary, transcript fallback; auth/session context from state.vscdb across macOS/Linux/Windows layouts)
 - `crates/budi-core/src/migration.rs` - Schema v21, all migration paths
 - `crates/budi-core/src/proxy.rs` - ProxyEvent types with attribution (repo, branch, ticket, cost), proxy_events and messages table storage, ProxyAttribution resolution from headers/git

--- a/crates/budi-core/src/config.rs
+++ b/crates/budi-core/src/config.rs
@@ -79,7 +79,7 @@ impl AgentsConfig {
     pub fn is_agent_enabled(&self, provider_name: &str) -> bool {
         match provider_name {
             "claude_code" => self.claude_code.enabled,
-            "codex_cli" => self.codex_cli.enabled,
+            "codex" | "codex_cli" => self.codex_cli.enabled,
             "cursor" => self.cursor.enabled,
             "copilot_cli" => self.copilot_cli.enabled,
             _ => false,
@@ -855,6 +855,7 @@ format = "{today} | {week} | {branch}"
         assert!(!config.cursor.enabled);
         assert!(!config.copilot_cli.enabled);
         assert!(!config.is_agent_enabled("claude_code"));
+        assert!(!config.is_agent_enabled("codex"));
         assert!(!config.is_agent_enabled("codex_cli"));
         assert!(!config.is_agent_enabled("cursor"));
         assert!(!config.is_agent_enabled("copilot_cli"));
@@ -864,6 +865,7 @@ format = "{today} | {week} | {branch}"
     fn agents_config_all_enabled() {
         let config = AgentsConfig::all_enabled();
         assert!(config.is_agent_enabled("claude_code"));
+        assert!(config.is_agent_enabled("codex"));
         assert!(config.is_agent_enabled("codex_cli"));
         assert!(config.is_agent_enabled("cursor"));
         assert!(config.is_agent_enabled("copilot_cli"));

--- a/crates/budi-core/src/provider.rs
+++ b/crates/budi-core/src/provider.rs
@@ -56,6 +56,7 @@ impl ModelPricing {
 /// Look up pricing for a model using the correct provider's pricing table.
 pub fn pricing_for_model(model: &str, provider: &str) -> ModelPricing {
     match provider {
+        "codex" => crate::providers::codex::codex_pricing_for_model(model),
         "cursor" => crate::providers::cursor::cursor_pricing_for_model(model),
         _ => crate::providers::claude_code::claude_pricing_for_model(model),
     }
@@ -101,6 +102,7 @@ pub trait Provider: Send + Sync {
 pub fn all_providers() -> Vec<Box<dyn Provider>> {
     vec![
         Box::new(crate::providers::claude_code::ClaudeCodeProvider),
+        Box::new(crate::providers::codex::CodexProvider),
         Box::new(crate::providers::cursor::CursorProvider),
     ]
 }

--- a/crates/budi-core/src/providers/codex.rs
+++ b/crates/budi-core/src/providers/codex.rs
@@ -1,0 +1,613 @@
+//! Codex provider — imports historical sessions from OpenAI Codex Desktop and
+//! Codex CLI transcripts stored at `~/.codex/sessions/` and
+//! `~/.codex/archived_sessions/`.
+//!
+//! Session files are JSONL with event types: `session_meta`, `turn_context`,
+//! `event_msg`, `response_item`, etc. We extract token usage from `token_count`
+//! events and model info from `turn_context` events.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+use chrono::{DateTime, Utc};
+use sha2::{Digest, Sha256};
+
+use crate::jsonl::ParsedMessage;
+use crate::provider::{DiscoveredFile, ModelPricing, Provider};
+
+/// The Codex provider (covers both Codex Desktop and Codex CLI).
+pub struct CodexProvider;
+
+impl Provider for CodexProvider {
+    fn name(&self) -> &'static str {
+        "codex"
+    }
+
+    fn display_name(&self) -> &'static str {
+        "Codex"
+    }
+
+    fn is_available(&self) -> bool {
+        codex_home().map(|p| p.exists()).unwrap_or(false)
+    }
+
+    fn discover_files(&self) -> Result<Vec<DiscoveredFile>> {
+        let home = codex_home()?;
+        let mut files = Vec::new();
+
+        // Active sessions: ~/.codex/sessions/YYYY/MM/DD/*.jsonl
+        let sessions_dir = home.join("sessions");
+        collect_jsonl_recursive(&sessions_dir, &mut files, 0);
+
+        // Archived sessions: ~/.codex/archived_sessions/*.jsonl
+        let archived_dir = home.join("archived_sessions");
+        collect_jsonl_recursive(&archived_dir, &mut files, 0);
+
+        // Sort by modification time descending (newest first) for progressive sync.
+        files.sort_by(|a, b| {
+            let mtime = |p: &PathBuf| {
+                p.metadata()
+                    .and_then(|m| m.modified())
+                    .unwrap_or(std::time::SystemTime::UNIX_EPOCH)
+            };
+            mtime(b).cmp(&mtime(a))
+        });
+
+        Ok(files
+            .into_iter()
+            .map(|path| DiscoveredFile { path })
+            .collect())
+    }
+
+    fn parse_file(
+        &self,
+        _path: &Path,
+        content: &str,
+        offset: usize,
+    ) -> Result<(Vec<ParsedMessage>, usize)> {
+        Ok(parse_codex_transcript(content, offset))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn codex_home() -> Result<PathBuf> {
+    Ok(crate::config::home_dir()?.join(".codex"))
+}
+
+fn collect_jsonl_recursive(dir: &Path, files: &mut Vec<PathBuf>, depth: u32) {
+    if depth > 5 {
+        return;
+    }
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_jsonl_recursive(&path, files, depth + 1);
+        } else if path.extension().is_some_and(|e| e == "jsonl") {
+            files.push(path);
+        }
+    }
+}
+
+/// Generate a deterministic UUID from a session ID and line index.
+fn deterministic_uuid(session_id: &str, line_index: usize) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(session_id.as_bytes());
+    hasher.update(line_index.to_le_bytes());
+    let hash = hasher.finalize();
+    // Format as UUID v5-style: 8-4-4-4-12
+    format!(
+        "{:08x}-{:04x}-{:04x}-{:04x}-{:012x}",
+        u32::from_be_bytes([hash[0], hash[1], hash[2], hash[3]]),
+        u16::from_be_bytes([hash[4], hash[5]]),
+        u16::from_be_bytes([hash[6], hash[7]]),
+        u16::from_be_bytes([hash[8], hash[9]]),
+        // 6 bytes for the last segment
+        u64::from_be_bytes([
+            0, 0, hash[10], hash[11], hash[12], hash[13], hash[14], hash[15]
+        ])
+    )
+}
+
+// ---------------------------------------------------------------------------
+// JSONL parsing
+// ---------------------------------------------------------------------------
+
+/// Session-level metadata extracted from `session_meta` events.
+#[derive(Debug, Default)]
+struct SessionContext {
+    session_id: Option<String>,
+    cwd: Option<String>,
+    git_branch: Option<String>,
+}
+
+/// Parse a Codex session JSONL file into `ParsedMessage` records.
+///
+/// Each `token_count` event with `last_token_usage` data produces one message.
+/// The model is tracked from the most recent `turn_context` event.
+fn parse_codex_transcript(content: &str, start_offset: usize) -> (Vec<ParsedMessage>, usize) {
+    let mut messages = Vec::new();
+    let mut offset = start_offset;
+
+    let mut ctx = SessionContext::default();
+    let mut current_model: Option<String> = None;
+    let mut line_index: usize = 0;
+
+    let remaining = &content[start_offset..];
+    let mut pos = 0;
+
+    for line in remaining.lines() {
+        let line_end = pos + line.len();
+        let has_newline = line_end < remaining.len() && remaining.as_bytes()[line_end] == b'\n';
+        if !has_newline && line_end == remaining.len() {
+            break;
+        }
+        pos = line_end + if has_newline { 1 } else { 0 };
+        offset = start_offset + pos;
+        line_index += 1;
+
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(line) else {
+            continue;
+        };
+
+        let event_type = value.get("type").and_then(|v| v.as_str()).unwrap_or("");
+
+        match event_type {
+            "session_meta" => {
+                parse_session_meta(&value, &mut ctx);
+            }
+            "turn_context" => {
+                if let Some(model) = value
+                    .pointer("/payload/model")
+                    .and_then(|v| v.as_str())
+                    .filter(|s| !s.is_empty())
+                {
+                    current_model = Some(model.to_string());
+                }
+            }
+            "event_msg" => {
+                let payload_type = value
+                    .pointer("/payload/type")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("");
+
+                if payload_type == "token_count"
+                    && let Some(msg) =
+                        parse_token_count(&value, &ctx, current_model.as_deref(), line_index)
+                {
+                    messages.push(msg);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    (messages, offset)
+}
+
+fn parse_session_meta(value: &serde_json::Value, ctx: &mut SessionContext) {
+    let payload = match value.get("payload") {
+        Some(p) => p,
+        None => return,
+    };
+
+    ctx.session_id = payload
+        .get("id")
+        .and_then(|v| v.as_str())
+        .map(|s| format!("codex-{s}"));
+
+    ctx.cwd = payload
+        .get("cwd")
+        .and_then(|v| v.as_str())
+        .map(String::from);
+
+    ctx.git_branch = payload
+        .pointer("/git/branch")
+        .and_then(|v| v.as_str())
+        .map(String::from);
+}
+
+fn parse_token_count(
+    value: &serde_json::Value,
+    ctx: &SessionContext,
+    model: Option<&str>,
+    line_index: usize,
+) -> Option<ParsedMessage> {
+    let last_usage = value.pointer("/payload/info/last_token_usage")?;
+
+    let input_tokens = last_usage
+        .get("input_tokens")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+    let output_tokens = last_usage
+        .get("output_tokens")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+    let cached_input_tokens = last_usage
+        .get("cached_input_tokens")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+
+    // Skip events with zero tokens (no-op API calls)
+    if input_tokens == 0 && output_tokens == 0 {
+        return None;
+    }
+
+    let timestamp = value
+        .get("timestamp")
+        .and_then(|v| v.as_str())
+        .and_then(|s| s.parse::<DateTime<Utc>>().ok())
+        .unwrap_or_else(|| DateTime::from_timestamp(0, 0).expect("epoch is valid"));
+
+    let session_id_str = ctx.session_id.as_deref().unwrap_or("unknown");
+    let uuid = deterministic_uuid(session_id_str, line_index);
+
+    Some(ParsedMessage {
+        uuid,
+        session_id: ctx.session_id.clone(),
+        timestamp,
+        cwd: ctx.cwd.clone(),
+        role: "assistant".to_string(),
+        model: model.map(String::from),
+        input_tokens,
+        output_tokens,
+        cache_creation_tokens: 0,
+        cache_read_tokens: cached_input_tokens,
+        git_branch: ctx.git_branch.clone(),
+        repo_id: None,
+        provider: "codex".to_string(),
+        cost_cents: None,
+        session_title: None,
+        parent_uuid: None,
+        user_name: None,
+        machine_name: None,
+        cost_confidence: "estimated".to_string(),
+        request_id: None,
+        speed: None,
+        cache_creation_1h_tokens: 0,
+        web_search_requests: 0,
+        prompt_category: None,
+        tool_names: Vec::new(),
+        tool_use_ids: Vec::new(),
+    })
+}
+
+/// OpenAI model pricing lookup (per million tokens, USD).
+/// Source: https://platform.openai.com/docs/pricing
+///
+/// Codex uses OpenAI models (GPT-5.x, o3, etc.) — share pricing with Cursor's
+/// OpenAI entries but in a dedicated function for maintainability.
+pub fn codex_pricing_for_model(model: &str) -> ModelPricing {
+    let m = model.to_lowercase();
+
+    // --- GPT-5.x models ---
+    if m.contains("gpt-5.4") && m.contains("nano") {
+        ModelPricing {
+            input: 0.20,
+            output: 1.25,
+            cache_write: 0.20,
+            cache_read: 0.02,
+        }
+    } else if m.contains("gpt-5.4") && m.contains("mini") {
+        ModelPricing {
+            input: 0.75,
+            output: 4.50,
+            cache_write: 0.75,
+            cache_read: 0.075,
+        }
+    } else if m.contains("gpt-5.4") {
+        ModelPricing {
+            input: 2.50,
+            output: 15.0,
+            cache_write: 2.50,
+            cache_read: 0.25,
+        }
+    } else if m.contains("gpt-5.2") || m.contains("gpt-5.3") {
+        ModelPricing {
+            input: 1.75,
+            output: 14.0,
+            cache_write: 1.75,
+            cache_read: 0.175,
+        }
+    } else if m.contains("gpt-5") && m.contains("mini") {
+        ModelPricing {
+            input: 0.25,
+            output: 2.0,
+            cache_write: 0.25,
+            cache_read: 0.025,
+        }
+    } else if m.contains("gpt-5") && m.contains("fast") {
+        ModelPricing {
+            input: 2.50,
+            output: 20.0,
+            cache_write: 2.50,
+            cache_read: 0.25,
+        }
+    } else if m.contains("gpt-5") {
+        ModelPricing {
+            input: 1.25,
+            output: 10.0,
+            cache_write: 1.25,
+            cache_read: 0.125,
+        }
+
+    // --- GPT-4.x models ---
+    } else if m.contains("gpt-4o-mini") {
+        ModelPricing {
+            input: 0.15,
+            output: 0.60,
+            cache_write: 0.15,
+            cache_read: 0.075,
+        }
+    } else if m.contains("gpt-4o") || m.contains("gpt-4-turbo") {
+        ModelPricing {
+            input: 2.50,
+            output: 10.0,
+            cache_write: 2.50,
+            cache_read: 1.25,
+        }
+    } else if m.contains("gpt-4") {
+        ModelPricing {
+            input: 30.0,
+            output: 60.0,
+            cache_write: 30.0,
+            cache_read: 15.0,
+        }
+
+    // --- OpenAI reasoning models ---
+    } else if m.contains("o3-mini") || m.contains("o1-mini") {
+        ModelPricing {
+            input: 1.10,
+            output: 4.40,
+            cache_write: 1.10,
+            cache_read: 0.55,
+        }
+    } else if m.contains("o3") {
+        ModelPricing {
+            input: 2.0,
+            output: 8.0,
+            cache_write: 2.0,
+            cache_read: 0.20,
+        }
+    } else if m.contains("o1") {
+        ModelPricing {
+            input: 15.0,
+            output: 60.0,
+            cache_write: 15.0,
+            cache_read: 7.50,
+        }
+    } else {
+        // Unknown model — use GPT-5.2/5.3 as default (most common Codex model)
+        tracing::warn!(
+            "Unknown Codex model '{}', using GPT-5.2/5.3 default pricing",
+            model
+        );
+        ModelPricing {
+            input: 1.75,
+            output: 14.0,
+            cache_write: 1.75,
+            cache_read: 0.175,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deterministic_uuid_is_stable() {
+        let a = deterministic_uuid("sess-1", 42);
+        let b = deterministic_uuid("sess-1", 42);
+        assert_eq!(a, b);
+        let c = deterministic_uuid("sess-1", 43);
+        assert_ne!(a, c);
+    }
+
+    #[test]
+    fn parse_session_meta_extracts_fields() {
+        let json: serde_json::Value = serde_json::from_str(
+            r#"{
+            "timestamp": "2026-04-11T19:28:32.582Z",
+            "type": "session_meta",
+            "payload": {
+                "id": "019d7e04-6762-7f50-baee-ea6ac87cd3e9",
+                "cwd": "/tmp/project",
+                "git": {"branch": "main", "commit_hash": "abc123"}
+            }
+        }"#,
+        )
+        .unwrap();
+
+        let mut ctx = SessionContext::default();
+        parse_session_meta(&json, &mut ctx);
+        assert_eq!(
+            ctx.session_id.as_deref(),
+            Some("codex-019d7e04-6762-7f50-baee-ea6ac87cd3e9")
+        );
+        assert_eq!(ctx.cwd.as_deref(), Some("/tmp/project"));
+        assert_eq!(ctx.git_branch.as_deref(), Some("main"));
+    }
+
+    #[test]
+    fn parse_token_count_with_last_usage() {
+        let json: serde_json::Value = serde_json::from_str(
+            r#"{
+            "timestamp": "2026-04-11T19:29:00.415Z",
+            "type": "event_msg",
+            "payload": {
+                "type": "token_count",
+                "info": {
+                    "last_token_usage": {
+                        "input_tokens": 18063,
+                        "cached_input_tokens": 5504,
+                        "output_tokens": 561,
+                        "reasoning_output_tokens": 401,
+                        "total_tokens": 18624
+                    }
+                }
+            }
+        }"#,
+        )
+        .unwrap();
+
+        let ctx = SessionContext {
+            session_id: Some("codex-test".to_string()),
+            cwd: Some("/tmp".to_string()),
+            git_branch: Some("main".to_string()),
+        };
+
+        let msg = parse_token_count(&json, &ctx, Some("gpt-5.3-codex"), 1).unwrap();
+        assert_eq!(msg.input_tokens, 18063);
+        assert_eq!(msg.output_tokens, 561);
+        assert_eq!(msg.cache_read_tokens, 5504);
+        assert_eq!(msg.cache_creation_tokens, 0);
+        assert_eq!(msg.model.as_deref(), Some("gpt-5.3-codex"));
+        assert_eq!(msg.session_id.as_deref(), Some("codex-test"));
+        assert_eq!(msg.provider, "codex");
+        assert_eq!(msg.role, "assistant");
+    }
+
+    #[test]
+    fn parse_token_count_skips_null_info() {
+        let json: serde_json::Value = serde_json::from_str(
+            r#"{
+            "timestamp": "2026-04-11T19:28:32.704Z",
+            "type": "event_msg",
+            "payload": {
+                "type": "token_count",
+                "info": null
+            }
+        }"#,
+        )
+        .unwrap();
+
+        let ctx = SessionContext::default();
+        assert!(parse_token_count(&json, &ctx, None, 1).is_none());
+    }
+
+    #[test]
+    fn parse_token_count_skips_zero_tokens() {
+        let json: serde_json::Value = serde_json::from_str(
+            r#"{
+            "timestamp": "2026-04-11T19:28:32.704Z",
+            "type": "event_msg",
+            "payload": {
+                "type": "token_count",
+                "info": {
+                    "last_token_usage": {
+                        "input_tokens": 0,
+                        "cached_input_tokens": 0,
+                        "output_tokens": 0,
+                        "total_tokens": 0
+                    }
+                }
+            }
+        }"#,
+        )
+        .unwrap();
+
+        let ctx = SessionContext::default();
+        assert!(parse_token_count(&json, &ctx, None, 1).is_none());
+    }
+
+    #[test]
+    fn parse_transcript_full_session() {
+        let content = concat!(
+            r#"{"timestamp":"2026-04-11T19:28:32.582Z","type":"session_meta","payload":{"id":"sess-1","cwd":"/tmp","git":{"branch":"feat/test","commit_hash":"abc"}}}"#,
+            "\n",
+            r#"{"timestamp":"2026-04-11T19:28:32.587Z","type":"turn_context","payload":{"model":"gpt-5.3-codex","turn_id":"t1"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-04-11T19:28:32.704Z","type":"event_msg","payload":{"type":"token_count","info":null}}"#,
+            "\n",
+            r#"{"timestamp":"2026-04-11T19:29:00.415Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":18063,"cached_input_tokens":5504,"output_tokens":561,"total_tokens":18624}}}}"#,
+            "\n",
+            r#"{"timestamp":"2026-04-11T19:29:08.850Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":19531,"cached_input_tokens":0,"output_tokens":132,"total_tokens":19663}}}}"#,
+            "\n",
+        );
+
+        let (msgs, _offset) = parse_codex_transcript(content, 0);
+        assert_eq!(msgs.len(), 2);
+
+        assert_eq!(msgs[0].input_tokens, 18063);
+        assert_eq!(msgs[0].output_tokens, 561);
+        assert_eq!(msgs[0].cache_read_tokens, 5504);
+        assert_eq!(msgs[0].model.as_deref(), Some("gpt-5.3-codex"));
+        assert_eq!(msgs[0].session_id.as_deref(), Some("codex-sess-1"));
+        assert_eq!(msgs[0].cwd.as_deref(), Some("/tmp"));
+        assert_eq!(msgs[0].git_branch.as_deref(), Some("feat/test"));
+
+        assert_eq!(msgs[1].input_tokens, 19531);
+        assert_eq!(msgs[1].output_tokens, 132);
+        assert_eq!(msgs[1].cache_read_tokens, 0);
+    }
+
+    #[test]
+    fn parse_transcript_incremental() {
+        let content = concat!(
+            r#"{"timestamp":"2026-04-11T19:28:32.582Z","type":"session_meta","payload":{"id":"s","cwd":"/tmp"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-04-11T19:29:00.000Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":100,"output_tokens":50,"total_tokens":150}}}}"#,
+            "\n",
+        );
+
+        let (msgs, offset) = parse_codex_transcript(content, 0);
+        assert_eq!(msgs.len(), 1);
+
+        // No new data from offset
+        let (msgs2, _) = parse_codex_transcript(content, offset);
+        assert!(msgs2.is_empty());
+    }
+
+    #[test]
+    fn pricing_gpt_5_3_codex() {
+        let p = codex_pricing_for_model("gpt-5.3-codex");
+        assert_eq!(p.input, 1.75);
+        assert_eq!(p.output, 14.0);
+    }
+
+    #[test]
+    fn pricing_gpt_5_2_codex() {
+        let p = codex_pricing_for_model("gpt-5.2-codex");
+        assert_eq!(p.input, 1.75);
+        assert_eq!(p.output, 14.0);
+    }
+
+    #[test]
+    fn pricing_gpt_5_4() {
+        let p = codex_pricing_for_model("gpt-5.4");
+        assert_eq!(p.input, 2.50);
+        assert_eq!(p.output, 15.0);
+    }
+
+    #[test]
+    fn pricing_gpt_4o() {
+        let p = codex_pricing_for_model("gpt-4o-2024-08-06");
+        assert_eq!(p.input, 2.50);
+        assert_eq!(p.output, 10.0);
+    }
+
+    #[test]
+    fn pricing_o3() {
+        let p = codex_pricing_for_model("o3-2025-04-16");
+        assert_eq!(p.input, 2.0);
+        assert_eq!(p.output, 8.0);
+    }
+
+    #[test]
+    fn pricing_unknown_defaults_to_gpt_5_2() {
+        let p = codex_pricing_for_model("some-future-model");
+        assert_eq!(p.input, 1.75);
+        assert_eq!(p.output, 14.0);
+    }
+}

--- a/crates/budi-core/src/providers/mod.rs
+++ b/crates/budi-core/src/providers/mod.rs
@@ -1,2 +1,3 @@
 pub mod claude_code;
+pub mod codex;
 pub mod cursor;


### PR DESCRIPTION
## Summary

- Implements `CodexProvider` in `crates/budi-core/src/providers/codex.rs` that imports historical session data from `~/.codex/sessions/` (active) and `~/.codex/archived_sessions/` (archived)
- Parses Codex Desktop/CLI JSONL format: extracts `session_meta` for session context, `turn_context` for model tracking, and `token_count` events with `last_token_usage` for per-API-call token counts
- Adds OpenAI model pricing function covering GPT-5.x, GPT-4.x, and o3/o1 reasoning models
- Registers provider in `all_providers()` and routes `"codex"` to its pricing in `pricing_for_model()`
- Maps provider name `"codex"` to `codex_cli` agent config entry in `is_agent_enabled()`

## Risks / compatibility notes

- **No breaking changes** — additive only (new provider, new pricing route, expanded `is_agent_enabled` match)
- Codex Desktop JSONL format is undocumented and evolving rapidly. Parsing is defensive (skips unrecognized events, tolerates missing fields, uses `serde_json::Value` instead of strict structs)
- Pricing values match Cursor provider's OpenAI entries; if OpenAI changes pricing, both need updating

## Validation

```
cargo fmt --all                                               # pass
cargo clippy --workspace --all-targets --locked -- -D warnings # pass
cargo test --workspace --locked                                # 377 tests pass (13 new)
```

Closes #178