### PR TITLE
[8.0] Fix budi launch codex exit code when showing Codex Desktop instructions

### DIFF
--- a/crates/budi-cli/src/commands/launch.rs
+++ b/crates/budi-cli/src/commands/launch.rs
@@ -197,21 +197,21 @@ pub fn cmd_launch(
     // ── Binary checks ─────────────────────────────────────────────────────
     if !binary_exists(agent.binary) {
         // Special case: codex CLI not found, check for Codex Desktop app
-        if agent.name == "codex" {
-            #[cfg(target_os = "macos")]
-            if std::path::Path::new("/Applications/Codex.app").exists() {
-                eprintln!(
-                    "{yellow}Codex Desktop detected but Codex CLI is not installed.{reset}\n\
-                     \n\
-                     To route Codex Desktop through the budi proxy, add to ~/.codex/config.toml:\n\
-                     \n\
-                     openai_base_url = \"http://localhost:{proxy_port}\"\n\
-                     \n\
-                     Then restart Codex Desktop.",
-                    proxy_port = resolve_proxy_port(proxy_port_override, &config),
-                );
-                return Ok(());
-            }
+        if agent.name == "codex" && codex_desktop_detected() {
+            // Start the daemon so the proxy is ready (like the Cursor path)
+            daemon::ensure_daemon_running(repo_root.as_deref(), &config)?;
+            eprintln!("{green}✓{reset} Proxy running on port {proxy_port}");
+            eprintln!();
+            eprintln!(
+                "{yellow}Codex Desktop detected but Codex CLI is not installed.{reset}\n\
+                 \n\
+                 To route Codex Desktop through the budi proxy, add to ~/.codex/config.toml:\n\
+                 \n\
+                 openai_base_url = \"http://localhost:{proxy_port}\"\n\
+                 \n\
+                 Then restart Codex Desktop.",
+            );
+            return Ok(());
         }
 
         anyhow::bail!(
@@ -340,6 +340,21 @@ fn bypass_requested() -> bool {
     std::env::var("BUDI_BYPASS")
         .ok()
         .is_some_and(|value| value.trim() == "1")
+}
+
+/// Check if Codex Desktop is installed (cross-platform).
+///
+/// macOS: `/Applications/Codex.app`
+/// All platforms: `~/.codex` directory (created by Codex Desktop on first run)
+fn codex_desktop_detected() -> bool {
+    #[cfg(target_os = "macos")]
+    if std::path::Path::new("/Applications/Codex.app").exists() {
+        return true;
+    }
+    // Codex Desktop creates ~/.codex on all platforms
+    budi_core::config::home_dir()
+        .map(|home| home.join(".codex").is_dir())
+        .unwrap_or(false)
 }
 
 /// Check if a binary is available in PATH.


### PR DESCRIPTION
## Summary

- Extracts `codex_desktop_detected()` helper that works cross-platform: checks macOS `/Applications/Codex.app` and `~/.codex` directory on all platforms
- Starts the daemon before showing Codex Desktop instructions (consistent with the Cursor GUI-only path)
- Ensures exit code 0 when instructions are shown successfully

Previously, the detection was gated behind `#[cfg(target_os = "macos")]`, so on Linux/Windows the block didn't compile and fell through to `anyhow::bail!` (exit 1). Even on macOS, the daemon wasn't started before showing proxy configuration instructions.

Closes #180

## Risks / compatibility notes

- No breaking changes — the Codex Desktop fallback path now behaves like the Cursor instructions path
- `~/.codex` directory check may detect Codex CLI history (not just Desktop), but in the "binary not found" context this is the right detection: the user has Codex config but no CLI binary

## Validation

- `cargo fmt --all` — pass
- `cargo clippy --workspace --all-targets --locked -- -D warnings` — pass
- `cargo test --workspace --locked` — pass