### PR TITLE
[8.0] budi stats: show total cost line in multi-agent output

### DIFF
--- a/crates/budi-cli/src/commands/stats.rs
+++ b/crates/budi-cli/src/commands/stats.rs
@@ -236,6 +236,7 @@ fn cmd_stats_multi_agent(
     let dim = ansi("\x1b[90m");
     let cyan = ansi("\x1b[36m");
     let yellow = ansi("\x1b[33m");
+    let green = ansi("\x1b[32m");
     let reset = ansi("\x1b[0m");
 
     println!();
@@ -250,7 +251,6 @@ fn cmd_stats_multi_agent(
     for ps in providers {
         let total_tokens =
             ps.input_tokens + ps.output_tokens + ps.cache_creation_tokens + ps.cache_read_tokens;
-        // Use ground-truth cost_cents when available, fall back to estimated
         let cost = if ps.total_cost_cents > 0.0 {
             ps.total_cost_cents / 100.0
         } else {
@@ -266,7 +266,6 @@ fn cmd_stats_multi_agent(
     }
     println!();
 
-    // Show combined summary
     let (since, until) = period_date_range(period);
     let summary = client.summary(since.as_deref(), until.as_deref(), None)?;
 
@@ -280,6 +279,26 @@ fn cmd_stats_multi_agent(
         format_tokens(summary.total_input_tokens),
         format_tokens(summary.total_output_tokens),
     );
+
+    let est = client.cost(since.as_deref(), until.as_deref(), None)?;
+    println!();
+    println!(
+        "  {bold}Est. cost{reset}    {yellow}{}{reset}",
+        format_cost(est.total_cost)
+    );
+    println!(
+        "  {dim}  input {}  output {}  cache write {}  cache read {}{reset}",
+        format_cost(est.input_cost),
+        format_cost(est.output_cost),
+        format_cost(est.cache_write_cost),
+        format_cost(est.cache_read_cost)
+    );
+    if est.cache_savings > 0.0 {
+        println!(
+            "  {green}  cache savings {}{reset}",
+            format_cost(est.cache_savings)
+        );
+    }
 
     println!();
     Ok(())


### PR DESCRIPTION
## Summary

When multiple agents are detected (e.g. Claude Code + Cursor), `budi stats` enters the multi-agent display path (`cmd_stats_multi_agent`). This path showed per-agent cost breakdown and aggregate messages/tokens, but **omitted the overall total cost line** with input/output/cache breakdown and cache savings.

This adds the same cost section that the single-agent path (`cmd_stats_summary_filtered`) already displays: total estimated cost, per-component breakdown (input, output, cache write, cache read), and cache savings when applicable.

**Before** (multi-agent):
```
Agents
  Claude Code      521 msgs  42.2M  $35.40
  Cursor             1 msgs  159.1K  $0.32

Total        1339 messages
Tokens       25.0K in, 187.7K out
```

**After** (multi-agent):
```
Agents
  Claude Code      521 msgs  42.2M  $35.40
  Cursor             1 msgs  159.1K  $0.32

Total        1339 messages
Tokens       25.0K in, 187.7K out

Est. cost    $35.72
  input $0.08  output $2.67  cache write $6.34  cache read $9.36
  cache savings $84.20
```

Closes #184

## Risks / compatibility notes

- **No breaking changes.** This only adds output lines to the multi-agent display path.
- The cost is fetched via the same `client.cost()` call used by the single-agent path, so the numbers are consistent.

## Validation

- `cargo fmt --all` — clean
- `cargo clippy --workspace --all-targets --locked -- -D warnings` — clean
- `cargo test --workspace --locked` — 388 tests pass

Made with [Cursor](https://cursor.com)