### PR TITLE
Soften Cursor extension install warning when CLI not found

### DIFF
--- a/crates/budi-cli/src/commands/integrations.rs
+++ b/crates/budi-cli/src/commands/integrations.rs
@@ -682,11 +682,7 @@ fn install_cursor_extension(warnings: &mut Vec<String>) {
     let cursor_cli = match find_cursor_cli() {
         Some(c) => c,
         None => {
-            println!(
-                "  Extension: Could not verify Cursor extension status \
-                 (Cursor CLI not found). The extension may already be \
-                 installed — check Cursor's extension list."
-            );
+            println!("  Extension: skipped (Cursor CLI not found)");
             return;
         }
     };


### PR DESCRIPTION
## Summary

During `budi init`, when the Cursor CLI is not found on PATH, the extension install step printed a verbose message that looked like an error:

```
Extension: Could not verify Cursor extension status (Cursor CLI not found). The extension may already be installed — check Cursor's extension list.
```

Most users won't have the `cursor` CLI installed, so this is a normal skip condition — not a warning. This PR replaces it with a brief, neutral message:

```
Extension: skipped (Cursor CLI not found)
```

Closes #185

## Risks / compatibility notes

- No behavioral change — just a message text update.
- No backward compatibility concerns.

## Validation

- `cargo fmt --all` — clean
- `cargo clippy --workspace --all-targets --locked -- -D warnings` — clean
- `cargo test --workspace --locked` — 388 tests pass

Made with [Cursor](https://cursor.com)