### PR TITLE
Make Cursor watermark catch-up message verbose-only

### DIFF
--- a/crates/budi-core/src/providers/cursor.rs
+++ b/crates/budi-core/src/providers/cursor.rs
@@ -874,14 +874,12 @@ fn sync_from_usage_api(
     };
 
     let api_calls = fetched.pages_fetched.max(1) as usize;
-    let mut warnings = Vec::new();
+    let warnings = Vec::new();
     if fetched.pages_fetched > 1 {
-        let diagnostic = format!(
+        tracing::info!(
             "Cursor Usage API returned {} pages in one sync tick (watermark catch-up active)",
             fetched.pages_fetched
         );
-        tracing::info!("{diagnostic}");
-        warnings.push(diagnostic);
     }
 
     if fetched.events.is_empty() {


### PR DESCRIPTION
## Summary

The "Cursor Usage API returned N pages in one sync tick (watermark catch-up active)" diagnostic was displayed to users as `Warning:` during `budi import`, causing confusion — it's purely informational, not user-actionable.

Removed the message from the user-visible warnings vector. It remains logged via `tracing::info!` in daemon logs for debugging.

Closes #186

## Risks / compatibility notes

- **None.** This only removes a non-actionable diagnostic from CLI output. The message is still available in daemon logs via `tracing::info!` for anyone debugging Cursor Usage API pagination.
- No behavioral change to sync logic, pagination, or data ingestion.

## Validation

- `cargo fmt --all` — clean
- `cargo clippy --workspace --all-targets --locked -- -D warnings` — clean
- `cargo test --workspace --locked` — 388 tests pass

Made with [Cursor](https://cursor.com)