### PR TITLE
Add budi autostart subcommand for independent autostart management

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,9 @@ budi health --session <id>         # health vitals for a specific session
 ```bash
 budi doctor                        # check health: daemon, proxy, database, config
 budi doctor --deep                 # run full SQLite integrity_check (slower)
+budi autostart status              # check daemon autostart service
+budi autostart install             # install the autostart service
+budi autostart uninstall           # remove the autostart service
 budi import --force                # re-ingest all data from scratch (use after upgrades)
 budi repair                        # repair schema drift + run migration checks
 budi update                        # check for updates (auto-detects Homebrew)
@@ -561,7 +564,7 @@ Windows equivalent:
 3. Restart: `budi init`
 
 **Daemon doesn't survive reboots:**
-Run `budi doctor` — if the autostart check shows "not installed", run `budi init` to install the platform-native service (launchd on macOS, systemd on Linux, Task Scheduler on Windows).
+Run `budi autostart status` — if it shows "not installed", run `budi autostart install` to install the platform-native service (launchd on macOS, systemd on Linux, Task Scheduler on Windows). `budi init` also installs the autostart service.
 
 **Proxy not reachable (agent gets connection refused on port 9878):**
 1. Run `budi doctor` to check proxy health

--- a/SOUL.md
+++ b/SOUL.md
@@ -35,7 +35,7 @@ After upgrading: the first CLI command now verifies daemon version and auto-rest
 | Linux | systemd user service | `~/.config/systemd/user/budi-daemon.service` |
 | Windows | Task Scheduler | `BudiDaemon` task (created via `schtasks`) |
 
-`budi uninstall` removes the service. `budi doctor` reports service installation status. See ADR-0087 §8 for design rationale.
+`budi autostart status` checks service state, `budi autostart install` installs the service, `budi autostart uninstall` removes it. `budi uninstall` also removes the service. `budi doctor` reports service installation status. See ADR-0087 §8 for design rationale.
 
 ## Platforms
 
@@ -56,7 +56,7 @@ Three independent repos (extraction completed per [ADR-0086](docs/adr/0086-extra
 ### Crates
 
 - **budi-core** - Business logic: analytics (SQLite queries), providers (Claude Code, Codex, Copilot CLI, Cursor), pipeline (enrichment), cost calculation, proxy event storage, config, migrations, autostart (platform-native daemon service management). Historical hook/OTEL data is read-only (tables kept for schema compat, ingestion removed)
-- **budi-cli** - Thin HTTP client to the daemon. Commands: init, launch, stats, sessions, status, sync, import, statusline, doctor, health, update, integrations, uninstall, migrate, repair
+- **budi-cli** - Thin HTTP client to the daemon. Commands: init, launch, stats, sessions, status, sync, import, statusline, doctor, health, update, integrations, autostart, uninstall, migrate, repair
 - **budi-daemon** - axum HTTP server (port 7878). Owns SQLite exclusively. Serves analytics API. Also runs the proxy server on port 9878. The proxy is the sole live data source; transcript import is user-initiated via `budi import`
 
 ### Data flow

--- a/crates/budi-cli/src/commands/autostart.rs
+++ b/crates/budi-cli/src/commands/autostart.rs
@@ -1,0 +1,95 @@
+use anyhow::Result;
+use budi_core::autostart;
+use budi_core::config;
+
+use crate::daemon;
+
+/// `budi autostart status` — show current autostart state.
+pub fn cmd_autostart_status() -> Result<()> {
+    let mechanism = autostart::service_mechanism();
+    let status = autostart::service_status();
+    let green = super::ansi("\x1b[32m");
+    let yellow = super::ansi("\x1b[33m");
+    let red = super::ansi("\x1b[31m");
+    let reset = super::ansi("\x1b[0m");
+
+    match status {
+        autostart::ServiceStatus::Running => {
+            println!("{green}✓{reset} Autostart: {status} ({mechanism})");
+        }
+        autostart::ServiceStatus::Installed => {
+            println!("{yellow}!{reset} Autostart: {status} ({mechanism})");
+            println!("  The service file exists but the daemon is not running.");
+            println!("  Try: budi autostart install (to re-register and start)");
+        }
+        autostart::ServiceStatus::NotInstalled => {
+            println!("{red}✗{reset} Autostart: {status}");
+            println!("  Run: budi autostart install");
+        }
+    }
+
+    if let Some(path) = autostart::service_file_path() {
+        println!("  Service file: {}", path.display());
+    }
+
+    Ok(())
+}
+
+/// `budi autostart install` — install the autostart service.
+pub fn cmd_autostart_install() -> Result<()> {
+    let green = super::ansi("\x1b[32m");
+    let yellow = super::ansi("\x1b[33m");
+    let reset = super::ansi("\x1b[0m");
+
+    let daemon_bin = match daemon::resolve_daemon_binary() {
+        Ok(p) => p,
+        Err(e) => {
+            anyhow::bail!("Could not resolve daemon binary: {e}");
+        }
+    };
+
+    let repo_root = super::try_resolve_repo_root(None);
+    let cfg = match &repo_root {
+        Some(root) => config::load_or_default(root)?,
+        None => config::BudiConfig::default(),
+    };
+
+    match autostart::install_service(&daemon_bin, &cfg.daemon_host, cfg.daemon_port) {
+        Ok(()) => {
+            let mechanism = autostart::service_mechanism();
+            println!("{green}✓{reset} Autostart service installed ({mechanism}).");
+            if let Some(path) = autostart::service_file_path() {
+                println!("  Service file: {}", path.display());
+            }
+            println!("  The daemon will start automatically at login.");
+        }
+        Err(e) => {
+            eprintln!("{yellow}Warning:{reset} autostart install failed: {e}");
+            anyhow::bail!("Autostart installation failed. Check permissions and try again.");
+        }
+    }
+
+    Ok(())
+}
+
+/// `budi autostart uninstall` — remove the autostart service.
+pub fn cmd_autostart_uninstall() -> Result<()> {
+    let green = super::ansi("\x1b[32m");
+    let reset = super::ansi("\x1b[0m");
+
+    match autostart::uninstall_service() {
+        Ok(true) => {
+            println!("{green}✓{reset} Autostart service removed.");
+            println!("  The daemon will no longer start automatically at login.");
+            println!("  To re-enable: budi autostart install");
+        }
+        Ok(false) => {
+            println!("No autostart service found. Nothing to remove.");
+        }
+        Err(e) => {
+            anyhow::bail!("Failed to remove autostart service: {e}");
+        }
+    }
+
+    Ok(())
+}

--- a/crates/budi-cli/src/commands/doctor.rs
+++ b/crates/budi-cli/src/commands/doctor.rs
@@ -348,8 +348,10 @@ pub fn cmd_doctor(repo_root: Option<PathBuf>, deep: bool) -> Result<()> {
             }
             budi_core::autostart::ServiceStatus::NotInstalled => {
                 println!("  {red}\u{2717}{reset} autostart: {status} ({mechanism})");
-                issues
-                    .push("Autostart service not installed. Run `budi init` to install it.".into());
+                issues.push(
+                    "Autostart service not installed. Run `budi autostart install` to install it."
+                        .into(),
+                );
             }
         }
     }

--- a/crates/budi-cli/src/commands/mod.rs
+++ b/crates/budi-cli/src/commands/mod.rs
@@ -5,6 +5,7 @@ use anyhow::{Context, Result};
 use budi_core::config;
 use serde_json::Value;
 
+pub mod autostart;
 pub mod doctor;
 pub mod health;
 pub mod import;

--- a/crates/budi-cli/src/main.rs
+++ b/crates/budi-cli/src/main.rs
@@ -17,7 +17,7 @@ const HEALTH_TIMEOUT_SECS: u64 = 3;
 #[command(about = "budi — AI cost analytics. Know where your tokens and money go.")]
 #[command(version)]
 #[command(
-    after_help = "Get started:\n  budi init\n\nCommon commands:\n  budi enable claude      Enable proxy routing for Claude Code\n  budi disable cursor     Disable proxy routing for Cursor\n  budi launch claude      Explicitly launch Claude Code through the budi proxy\n  budi launch codex       Explicitly launch Codex CLI through the budi proxy\n  budi stats              Show today's cost summary\n  budi stats --models     Cost breakdown by model\n  budi stats --branches   Cost breakdown by branch\n  budi sessions           List recent sessions with cost and health\n  budi sessions <id>      Session detail: cost, models, health, tags\n  budi status             Quick check: daemon, proxy, today's spend\n  budi doctor             Full diagnostic: daemon, proxy, database, config\n  budi import             Import historical transcripts from disk\n  budi import --force     Re-ingest all data from scratch (use after upgrades)\n  budi repair             Repair schema drift and run migration\n\nMore info: https://github.com/siropkin/budi"
+    after_help = "Get started:\n  budi init\n\nCommon commands:\n  budi enable claude      Enable proxy routing for Claude Code\n  budi disable cursor     Disable proxy routing for Cursor\n  budi launch claude      Explicitly launch Claude Code through the budi proxy\n  budi launch codex       Explicitly launch Codex CLI through the budi proxy\n  budi stats              Show today's cost summary\n  budi stats --models     Cost breakdown by model\n  budi stats --branches   Cost breakdown by branch\n  budi sessions           List recent sessions with cost and health\n  budi sessions <id>      Session detail: cost, models, health, tags\n  budi status             Quick check: daemon, proxy, today's spend\n  budi doctor             Full diagnostic: daemon, proxy, database, config\n  budi autostart status   Check daemon autostart service\n  budi import             Import historical transcripts from disk\n  budi import --force     Re-ingest all data from scratch (use after upgrades)\n  budi repair             Repair schema drift and run migration\n\nMore info: https://github.com/siropkin/budi"
 )]
 struct Cli {
     #[command(subcommand)]
@@ -197,6 +197,16 @@ Examples:
         /// Agent name or alias (claude, codex, cursor, copilot)
         agent: String,
     },
+    /// Manage the daemon autostart service (launchd / systemd / Task Scheduler)
+    #[command(after_help = "\
+Examples:
+  budi autostart status      Check if autostart is installed and running
+  budi autostart install     Install the autostart service
+  budi autostart uninstall   Remove the autostart service")]
+    Autostart {
+        #[command(subcommand)]
+        action: AutostartAction,
+    },
     /// Launch an AI agent through the budi proxy (e.g. budi launch claude)
     #[command(after_help = "\
 Supported agents:
@@ -244,6 +254,16 @@ enum IntegrationAction {
         #[arg(long, default_value_t = false)]
         yes: bool,
     },
+}
+
+#[derive(Debug, Subcommand)]
+enum AutostartAction {
+    /// Show whether the autostart service is installed and running
+    Status,
+    /// Install the autostart service (daemon starts at login)
+    Install,
+    /// Remove the autostart service
+    Uninstall,
 }
 
 #[derive(Debug, Clone, Copy, ValueEnum, PartialEq, Eq)]
@@ -394,6 +414,11 @@ fn main() -> Result<()> {
         Commands::Integrations { action } => commands::integrations::cmd_integrations(action),
         Commands::Enable { agent } => commands::proxy_install::cmd_enable(&agent),
         Commands::Disable { agent } => commands::proxy_install::cmd_disable(&agent),
+        Commands::Autostart { action } => match action {
+            AutostartAction::Status => commands::autostart::cmd_autostart_status(),
+            AutostartAction::Install => commands::autostart::cmd_autostart_install(),
+            AutostartAction::Uninstall => commands::autostart::cmd_autostart_uninstall(),
+        },
         Commands::Launch {
             agent,
             proxy_port,
@@ -435,10 +460,19 @@ mod tests {
         assert!(lower.contains("stats"));
         assert!(lower.contains("import"));
         assert!(lower.contains("repair"));
+        assert!(lower.contains("autostart"));
         assert!(
             !lower.contains("\n  sync"),
             "sync command should be removed"
         );
+    }
+
+    #[test]
+    fn cli_parses_autostart_subcommands() {
+        for sub in &["status", "install", "uninstall"] {
+            Cli::try_parse_from(["budi", "autostart", sub])
+                .unwrap_or_else(|_| panic!("budi autostart {sub} should parse"));
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds `budi autostart` subcommand with three actions (`status`, `install`, `uninstall`) so users can manage the daemon autostart service independently without running full `budi init`.

- **`budi autostart status`** — shows whether the autostart service is installed, running, and the service file path
- **`budi autostart install`** — installs the platform-native autostart service (launchd / systemd / Task Scheduler), resolving daemon binary and config automatically
- **`budi autostart uninstall`** — removes the autostart service

Also updates `budi doctor` hint to reference `budi autostart install` instead of `budi init`, and adds the subcommand to CLI help text, SOUL.md, and README.md.

Closes #187

### ADR references
- ADR-0087 §8 — daemon lifecycle and autostart design

### Goal
Users currently can only install/uninstall the autostart service via `budi init` or `budi uninstall`. This makes troubleshooting autostart issues unnecessarily heavy — you have to re-run the full init flow just to reinstall the service. The new subcommand complements the existing `budi enable/disable` pattern for proxy config.

### Assumptions
- The `budi_core::autostart` public API is stable and sufficient (no changes to core needed)
- `budi init` continues to install autostart — the new subcommand is an independent alternative, not a replacement

## Risks / compatibility notes

- **No breaking changes** — `budi init` still installs autostart as before. The new subcommand is additive only.
- **No core changes** — all changes are in `budi-cli`. The `budi_core::autostart` API is used as-is.

## Validation

```
cargo fmt --all                                                    # ✓ clean
cargo clippy --workspace --all-targets --locked -- -D warnings     # ✓ clean
cargo test --workspace --locked                                    # ✓ 389 tests pass (49 CLI + 318 core + 22 daemon)
```

New tests:
- `cli_parses_autostart_subcommands` — verifies all three subcommands parse correctly
- `help_shows_expected_commands` — updated to assert `autostart` appears in help output

Made with [Cursor](https://cursor.com)