### PR TITLE
Warn that shell restart is required for proxy to take effect

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ During init, budi automatically applies proxy routing for selected agents:
 
 `budi launch <agent>` still works as an explicit fallback. For a one-off bypass, run `BUDI_BYPASS=1 budi launch <agent>`.
 
-Restart your shell/IDE apps after init so updated settings take effect. Customize ports in the **repo-local** `config.toml` under `<budi-home>/repos/<repo-id>/config.toml` (run `budi doctor` inside the repo to see the exact path).
+**Important:** After `budi init` or `budi enable`, restart your terminal so the shell-profile proxy env vars take effect for CLI agents (Claude Code, Codex, Copilot). Already-running sessions are NOT going through the proxy until the shell is restarted. For immediate proxy routing without restart, use `budi launch <agent>`. `budi doctor` detects when proxy env vars are configured but not active in the current shell. Customize ports in the **repo-local** `config.toml` under `<budi-home>/repos/<repo-id>/config.toml` (run `budi doctor` inside the repo to see the exact path).
 
 To install a specific version, set the `VERSION` environment variable: `VERSION=v7.1.0 curl -fsSL ... | bash` (or `$env:VERSION="v7.1.0"` on PowerShell).
 
@@ -169,8 +169,10 @@ Use this sequence if you want the fastest "did setup really work?" path:
    - Optional explicit fallback: `budi launch <agent>`
    - One-off bypass for explicit launch: `BUDI_BYPASS=1 budi launch <agent>`
    - Run `budi stats` and confirm non-zero usage
-6. **Restart apps once**
-   - Restart your shell/IDE apps after `budi init` so proxy/integration changes take effect
+6. **Restart your terminal**
+   - CLI agents (Claude Code, Codex, Copilot) need a new shell session to pick up proxy env vars
+   - Or use `budi launch <agent>` for immediate proxy routing without restarting
+   - `budi doctor` warns if proxy env vars are configured but not active in the current shell
 
 ### PATH and duplicate binary checks
 
@@ -550,8 +552,9 @@ Most endpoints accept `?since=<ISO>&until=<ISO>` for date filtering.
 **No data after setup:**
 1. Run `budi status` to check daemon, proxy, and today's cost
 2. Verify auto-proxy config with `budi doctor` (shell profile + Cursor/Codex settings)
-3. Send a prompt and check `budi stats` for non-zero usage
-4. For historical data: `budi import` (one-time backfill from Claude Code JSONL, Codex sessions, Copilot CLI sessions, Cursor Usage API)
+3. If `budi doctor` reports proxy env vars not set in current shell, restart your terminal or use `budi launch <agent>` for immediate routing
+4. Send a prompt and check `budi stats` for non-zero usage
+5. For historical data: `budi import` (one-time backfill from Claude Code JSONL, Codex sessions, Copilot CLI sessions, Cursor Usage API)
 
 **Daemon won't start:**
 1. Check if port 7878 is in use: `lsof -i :7878`

--- a/SOUL.md
+++ b/SOUL.md
@@ -164,7 +164,7 @@ Historical OTEL data (`otel_exact` confidence) remains queryable but OTEL ingest
 
 - CLI never touches SQLite directly - all queries go through the daemon HTTP API
 - CostEnricher is the single source of truth for cost - sets cost_cents during pipeline. Skips if cost already set (API data)
-- `budi init` prompts for per-agent enablement (Claude Code, Codex CLI, Cursor, Copilot CLI), persists choices to `~/.config/budi/agents.toml`, and auto-configures proxy routing for enabled agents (shell profile + Cursor/Codex settings). `budi enable/disable <agent>` updates this config later. Legacy installs (no `agents.toml`) treat all available agents as enabled for backward compatibility.
+- `budi init` prompts for per-agent enablement (Claude Code, Codex CLI, Cursor, Copilot CLI), persists choices to `~/.config/budi/agents.toml`, and auto-configures proxy routing for enabled agents (shell profile + Cursor/Codex settings). `budi enable/disable <agent>` updates this config later. Legacy installs (no `agents.toml`) treat all available agents as enabled for backward compatibility. After configuring CLI agents (Claude, Codex, Copilot), both `budi init` and `budi enable` warn that a shell restart is required for proxy env vars to take effect and suggest `budi launch <agent>` for immediate routing. `budi doctor` detects when proxy env vars are configured in the shell profile but not set in the current process.
 - `budi init` configures integrations (statusline, extension) for enabled agents
 - Tags are auto-detected (`provider`, `model`, `tool`, `tool_use_id`, `ticket_id`, `activity`, and conditional tags like `cost_confidence` / `speed`) + custom rules via `~/.config/budi/tags.toml`
 - git_branch is a column on messages (not a tag) for fast queries

--- a/crates/budi-cli/src/commands/init.rs
+++ b/crates/budi-cli/src/commands/init.rs
@@ -198,10 +198,22 @@ pub fn cmd_init(
         println!(
             "  {dim}No integrations were installed. Use `budi integrations install ...` anytime.{reset}"
         );
-    } else {
+    }
+
+    let has_cli_agents = agents_config.claude_code.enabled
+        || agents_config.codex_cli.enabled
+        || agents_config.copilot_cli.enabled;
+    if has_cli_agents {
+        let yellow = super::ansi("\x1b[33m");
         println!(
-            "  {dim}Restart your shell/IDE apps to pick up updated proxy and integration settings.{reset}"
+            "  {yellow}\u{26a0}  Restart your terminal{reset} {dim}(or `source ~/.zshrc`){reset} {yellow}to activate proxy routing for CLI agents.{reset}"
         );
+        println!("     {dim}Already-running sessions are NOT going through the proxy yet.{reset}");
+        println!(
+            "     {dim}For immediate proxy routing without restart: budi launch <agent>{reset}"
+        );
+    } else if !selected_integrations.is_empty() {
+        println!("  {dim}Restart Cursor/IDE apps to pick up updated proxy settings.{reset}");
     }
     println!();
 

--- a/crates/budi-cli/src/commands/proxy_install.rs
+++ b/crates/budi-cli/src/commands/proxy_install.rs
@@ -44,6 +44,12 @@ impl ManagedAgent {
             Self::Copilot => "Copilot CLI",
         }
     }
+
+    /// CLI agents whose proxy routing depends on shell-profile env vars.
+    /// These require a shell restart after `budi enable` / `budi init`.
+    fn uses_shell_profile(self) -> bool {
+        matches!(self, Self::Claude | Self::Codex | Self::Copilot)
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -93,6 +99,24 @@ fn set_agent_enabled(agent_name: &str, enabled: bool) -> Result<()> {
             println!("  - {warning}");
         }
     }
+
+    if enabled && managed.uses_shell_profile() {
+        let yellow = super::ansi("\x1b[33m");
+        let dim = super::ansi("\x1b[90m");
+        let reset = super::ansi("\x1b[0m");
+        println!();
+        println!(
+            "{yellow}\u{26a0}  Restart your terminal{reset} {dim}(or `source ~/.zshrc`){reset} {yellow}to activate proxy routing.{reset}"
+        );
+        println!(
+            "   Already-running {} sessions are NOT going through the proxy.",
+            managed.display_name()
+        );
+        println!(
+            "   For immediate proxy routing without restart: {dim}budi launch {agent_name}{reset}"
+        );
+    }
+
     Ok(())
 }
 
@@ -187,28 +211,34 @@ pub fn doctor_auto_proxy_issues(agents: &config::AgentsConfig, proxy_port: u16) 
     let has_cli_agents =
         agents.claude_code.enabled || agents.codex_cli.enabled || agents.copilot_cli.enabled;
 
+    let mut profile_has_claude = false;
+    let mut profile_has_codex = false;
+    let mut profile_has_copilot = false;
+
     match detect_shell_profile_path(&home) {
         Some(path) => {
             let raw = fs::read_to_string(&path).unwrap_or_default();
             let block = extract_block(&raw, SHELL_BLOCK_START, SHELL_BLOCK_END);
             if has_cli_agents {
                 if let Some(block_text) = block {
-                    if agents.claude_code.enabled && !block_text.contains("ANTHROPIC_BASE_URL") {
+                    profile_has_claude = block_text.contains("ANTHROPIC_BASE_URL");
+                    profile_has_codex = block_text.contains("OPENAI_BASE_URL");
+                    profile_has_copilot = block_text.contains("COPILOT_PROVIDER_BASE_URL")
+                        && block_text.contains("COPILOT_PROVIDER_TYPE");
+
+                    if agents.claude_code.enabled && !profile_has_claude {
                         issues.push(format!(
                             "Claude proxy env var missing in {}. Run `budi enable claude`.",
                             path.display()
                         ));
                     }
-                    if agents.codex_cli.enabled && !block_text.contains("OPENAI_BASE_URL") {
+                    if agents.codex_cli.enabled && !profile_has_codex {
                         issues.push(format!(
                             "Codex proxy env var missing in {}. Run `budi enable codex`.",
                             path.display()
                         ));
                     }
-                    if agents.copilot_cli.enabled
-                        && (!block_text.contains("COPILOT_PROVIDER_BASE_URL")
-                            || !block_text.contains("COPILOT_PROVIDER_TYPE"))
-                    {
+                    if agents.copilot_cli.enabled && !profile_has_copilot {
                         issues.push(format!(
                             "Copilot proxy env vars missing in {}. Run `budi enable copilot`.",
                             path.display()
@@ -287,6 +317,34 @@ pub fn doctor_auto_proxy_issues(agents: &config::AgentsConfig, proxy_port: u16) 
             "Cursor settings {} still has budi proxy settings while Cursor is disabled.",
             cursor_path.display()
         ));
+    }
+
+    // Detect shell-profile env vars configured but not active in the current process.
+    // Only warn when the shell profile block IS correctly configured — otherwise the
+    // "block missing" / "var missing in block" messages above already cover it.
+    let env_checks: &[(&str, bool, &str, &str)] = &[
+        (
+            "ANTHROPIC_BASE_URL",
+            profile_has_claude,
+            "Claude Code",
+            "claude",
+        ),
+        ("OPENAI_BASE_URL", profile_has_codex, "Codex", "codex"),
+        (
+            "COPILOT_PROVIDER_BASE_URL",
+            profile_has_copilot,
+            "Copilot CLI",
+            "copilot",
+        ),
+    ];
+    for &(var, profile_configured, agent_display, agent_cmd) in env_checks {
+        if profile_configured && std::env::var(var).is_err() {
+            issues.push(format!(
+                "{var} is configured in shell profile but not set in current shell. \
+                 Restart your terminal to activate proxy routing for {agent_display}, \
+                 or use `budi launch {agent_cmd}`."
+            ));
+        }
     }
 
     issues


### PR DESCRIPTION
## Summary

- **`budi enable <agent>`**: After configuring shell-profile env vars for CLI agents (Claude Code, Codex, Copilot), prints a prominent ⚠ warning that already-running sessions are NOT going through the proxy and suggests `budi launch <agent>` for immediate routing.
- **`budi init`**: Replaces the generic dim "restart your shell" message with a specific yellow warning when CLI agents are enabled, with the same `budi launch` suggestion.
- **`budi doctor`**: Detects when proxy env vars (e.g. `ANTHROPIC_BASE_URL`) are correctly configured in the shell profile but not set in the current shell process, helping users diagnose why the proxy isn't capturing traffic after enable/init.

### Goal

Users who run `budi enable claude` (or `budi init`) and continue using an already-running Claude Code session expect the proxy to start working immediately. The proxy env vars are injected into the shell profile, but only take effect in new shell sessions. This change makes the gap visible and suggests a workaround.

### ADR constraints

- ADR-0082 §1: Shell-profile env vars are the mechanism for CLI agents (Tier 1/2)
- No changes to proxy protocol, agent configuration, or data flow

Closes #188

## Risks / compatibility notes

- No breaking changes. The new warnings are additive output only.
- The `budi doctor` env-var check only fires when the shell profile block IS correctly configured, avoiding redundant warnings when the block is missing (which is already reported separately).
- The `source ~/.zshrc` hint is zsh-specific but represents the most common case; bash users should `source ~/.bashrc`.

## Validation

```bash
cargo fmt --all
cargo clippy --workspace --all-targets --locked -- -D warnings
cargo test --workspace --locked
```

All 389 tests pass. No clippy warnings.

Made with [Cursor](https://cursor.com)