### PR TITLE
Clarify ADR-0083 §6: daily granularity applies to cost aggregations, not session summaries

### DIFF
--- a/docs/adr/0083-cloud-ingest-identity-and-privacy-contract.md
+++ b/docs/adr/0083-cloud-ingest-identity-and-privacy-contract.md
@@ -249,7 +249,7 @@ The cloud alpha (R4) supports one org size: **small team** (1–20 developers).
 | Member onboarding | Developer runs `budi cloud join <invite-token>`, which registers the device and stores the API key locally. |
 | Roles | `manager` (view dashboard, manage members, create/revoke invite links) and `member` (sync data, view own data). |
 | Dashboard access | Manager sees aggregated cost data across the org: by day, by user/device, by repo, by model, by ticket. Member sees only their own data. |
-| Data granularity | Dashboard shows daily granularity. No per-message, per-hour, or real-time streaming views in v1. |
+| Data granularity | Dashboard shows daily granularity for cost aggregations. Session summaries provide per-session metadata (start/end time, duration, totals) but no per-message detail. No per-hour or real-time streaming views in v1. |
 | Retention | Cloud retains synced data for 90 days in v1. Configurable in later versions. |
 | Multi-org | Not supported in v1. A user belongs to exactly one org. |
 | SSO / SAML | Not supported in v1. API key auth only. |
@@ -400,7 +400,7 @@ New env vars:
 
 ### Trade-offs
 
-- **Daily granularity only.** Managers cannot see real-time or hourly breakdowns in the cloud dashboard. This is intentional — hourly data can reveal individual work patterns too precisely, and the privacy benefit outweighs the analytics cost. Hourly data remains available locally via the Rich CLI.
+- **Daily granularity for cost aggregations.** Managers cannot see real-time or hourly cost breakdowns in the cloud dashboard. Session summaries (§2) provide per-session metadata (timestamps, duration, totals) but no per-message detail — this is sub-daily but not content-revealing. Hourly cost data remains available locally via the Rich CLI.
 - **No per-message visibility in the cloud.** The cloud sees totals per day per model per branch, not individual requests. This limits debugging capability but preserves the privacy contract.
 - **No tag sync.** Tag values are user-defined and could contain sensitive information. Tags remain local-only. Managers can see cost by model/repo/branch/ticket but not by custom tag.
 - **Single org per user.** Consultants working for multiple clients cannot aggregate across orgs. Multi-org support is a post-8.0 concern.


### PR DESCRIPTION
Closes #196

## Summary

- Amends ADR-0083 §6 (Minimum Viable Team Model) to clarify that "daily granularity" applies to **cost aggregations**, not to session summaries. Session summaries (defined in §2) provide per-session metadata (start/end time, duration, totals) but no per-message detail.
- Updates the matching Trade-offs bullet to use consistent language and cross-reference §2.

## Goal

Resolve the internal inconsistency found during the R4 code review pass (#104):
- **§2** explicitly defines session summaries as part of the sync payload with per-session timestamps and durations.
- **§6** stated "Dashboard shows daily granularity" without qualifying that this refers to cost aggregations.

This follows the issue's recommended Option 1: the implementation correctly follows §2, and §6's intent was "no per-message detail", not "no per-session detail."

## ADR constraints

- ADR-0083 §2 session summary shape is unchanged.
- Privacy contract (§1) is unchanged — session summaries already contain only computed totals, never per-message content.
- No code changes required; this is a spec-only clarification.

## Risks / compatibility notes

- **None.** This is a documentation-only change that aligns the ADR text with the already-implemented and already-shipped behavior. No code, schema, or API changes.

## Validation

- `cargo fmt --all` — clean
- `cargo clippy --workspace --all-targets --locked -- -D warnings` — clean
- `cargo test --workspace --locked` — all 22 tests pass

Made with [Cursor](https://cursor.com)