### PR TITLE
Add missing providers to --provider filter (codex, copilot_cli, openai)

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ budi stats --models                # model usage breakdown
 budi stats --projects              # repos ranked by cost
 budi stats --branches              # branches ranked by cost
 budi stats --branch <name>         # cost for a specific branch
+budi stats --provider codex        # filter stats to a single provider
 budi stats --tag ticket_id         # cost per ticket
 budi stats --tag ticket_prefix     # cost per team prefix
 budi sessions                      # list recent sessions with cost and health

--- a/crates/budi-cli/src/commands/stats.rs
+++ b/crates/budi-cli/src/commands/stats.rs
@@ -62,17 +62,10 @@ pub fn cmd_stats(
     tag: Option<String>,
     json_output: bool,
 ) -> Result<()> {
-    // Validate --provider early with a helpful error message
-    const KNOWN_PROVIDERS: &[&str] = &["claude_code", "cursor"];
-    if let Some(ref p) = provider
-        && !KNOWN_PROVIDERS.contains(&p.as_str())
-    {
-        anyhow::bail!(
-            "Unknown provider '{}'. Available providers: {}",
-            p,
-            KNOWN_PROVIDERS.join(", ")
-        );
-    }
+    // Normalize and validate --provider early with a helpful error message.
+    // Canonical names match the `provider` column in SQLite; aliases are
+    // user-friendly shortcuts that resolve to their canonical form.
+    let provider = provider.map(|p| normalize_provider(&p)).transpose()?;
 
     let client = DaemonClient::connect().context(
         "Could not reach budi daemon. Run `budi init` to set up, or `budi doctor` to diagnose.",
@@ -554,6 +547,35 @@ pub use super::format_cost;
 
 pub fn format_cost_cents(cents: f64) -> String {
     format_cost(cents / 100.0)
+}
+
+/// Resolve a user-supplied provider name to its canonical DB value.
+///
+/// Canonical names: `claude_code`, `cursor`, `codex`, `copilot_cli`, `openai`.
+/// Accepted aliases: `copilot` → `copilot_cli`, `anthropic` → `claude_code`.
+fn normalize_provider(input: &str) -> Result<String> {
+    const KNOWN_PROVIDERS: &[&str] = &["claude_code", "cursor", "codex", "copilot_cli", "openai"];
+
+    if KNOWN_PROVIDERS.contains(&input) {
+        return Ok(input.to_string());
+    }
+
+    match input {
+        "copilot" => Ok("copilot_cli".to_string()),
+        "anthropic" => Ok("claude_code".to_string()),
+        _ => {
+            let all: Vec<&str> = KNOWN_PROVIDERS
+                .iter()
+                .copied()
+                .chain(["copilot", "anthropic"])
+                .collect();
+            anyhow::bail!(
+                "Unknown provider '{}'. Available providers: {}",
+                input,
+                all.join(", ")
+            );
+        }
+    }
 }
 
 fn cmd_stats_tags(

--- a/crates/budi-cli/src/main.rs
+++ b/crates/budi-cli/src/main.rs
@@ -100,7 +100,7 @@ Examples:
         /// Show model usage breakdown
         #[arg(long, default_value_t = false)]
         models: bool,
-        /// Filter by provider (e.g. claude_code, cursor). Only works with the default summary view.
+        /// Filter by provider (e.g. claude_code, cursor, codex, copilot_cli, openai). Only works with the default summary view.
         #[arg(long, conflicts_with = "view")]
         provider: Option<String>,
         /// Show cost breakdown by tag key (e.g. --tag ticket_id, --tag activity)


### PR DESCRIPTION
## Summary

The `budi stats --provider` filter only accepted `claude_code` and `cursor`, rejecting valid providers like `codex`, `copilot_cli`, and `openai` with "Unknown provider" errors — even when data existed in the database.

This PR:
- Expands the canonical provider list to all five DB values: `claude_code`, `cursor`, `codex`, `copilot_cli`, `openai`
- Adds user-friendly aliases: `copilot` → `copilot_cli`, `anthropic` → `claude_code`
- Updates `--provider` help text and README examples

### ADR constraints

Per ADR-0082, provider names in the database match the proxy provider (`claude_code` for Anthropic, `openai` for OpenAI) or the import provider (`codex`, `copilot_cli`, `cursor`). The normalization respects these canonical names.

## Risks / compatibility notes

- **Backward compatible**: existing `--provider claude_code` and `--provider cursor` continue to work identically.
- **No daemon changes**: normalization happens entirely in the CLI before the HTTP call; the daemon API already accepts any provider string as a SQL filter.

## Validation

```
cargo fmt --all              ✅
cargo clippy --workspace --all-targets --locked -- -D warnings  ✅
cargo test --workspace --locked  ✅ (389 tests)
```

Closes #257

Made with [Cursor](https://cursor.com)