### PR TITLE
[8.0][E2E] Fix statusline hyperlink pointing to removed /dashboard

### DIFF
--- a/crates/budi-cli/src/commands/statusline.rs
+++ b/crates/budi-cli/src/commands/statusline.rs
@@ -237,19 +237,12 @@ pub fn cmd_statusline(format: StatuslineFormat) -> Result<()> {
         .map(|s| (s.as_str(), &values))
         .collect();
 
-    // Session-aware link target: session details if session exists, otherwise main dashboard
-    let budi_url = session_id
-        .as_ref()
-        .map(|sid| {
-            let encoded = sid
-                .replace('%', "%25")
-                .replace('/', "%2F")
-                .replace(' ', "%20")
-                .replace('#', "%23")
-                .replace('?', "%3F");
-            format!("{}/dashboard/sessions/{}", base, encoded)
-        })
-        .unwrap_or_else(|| format!("{}/dashboard", base));
+    let cloud_base = budi_core::config::DEFAULT_CLOUD_ENDPOINT;
+    let budi_url = if session_id.is_some() {
+        format!("{cloud_base}/dashboard/sessions")
+    } else {
+        format!("{cloud_base}/dashboard")
+    };
 
     match format {
         StatuslineFormat::Json => {


### PR DESCRIPTION
## Summary

The OSC 8 terminal hyperlink in the Claude Code statusline format pointed to `http://127.0.0.1:7878/dashboard` (and `/dashboard/sessions/{id}` when a session was active). Since the local dashboard was removed in #103, this URL returns 404.

This PR updates the hyperlink target to the cloud dashboard at `https://app.getbudi.dev/dashboard` (or `/dashboard/sessions` when a session is active), using the existing `DEFAULT_CLOUD_ENDPOINT` constant.

**Before:** `\e]8;;http://127.0.0.1:7878/dashboard\ebudi\e]8;;\e` → 404
**After:** `\e]8;;https://app.getbudi.dev/dashboard\ebudi\e]8;;\e` → cloud dashboard

The session-specific URL encoding was also removed since the cloud dashboard's sessions page (`/dashboard/sessions`) doesn't have individual session detail routes.

Closes #259

## Risks / compatibility notes

- None. The old URL was a 404. The new URL points to the cloud dashboard which is the canonical dashboard surface.
- Users without a cloud account will see the cloud dashboard landing/login page, which is still more useful than a 404.
- Only affects the Claude Code statusline format (OSC 8 hyperlinks). Other formats (JSON, Custom, Starship) don't use hyperlinks.

## Validation

```
cargo fmt --all                                          # ✓ clean
cargo clippy --workspace --all-targets --locked -- -D warnings  # ✓ no warnings
cargo test --workspace --locked                          # ✓ 389 tests pass
```

Made with [Cursor](https://cursor.com)