### PR TITLE
Replace non-existent `budi cloud join` references with actual cloud.toml setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Everything stays on your machine by default. Optional cloud sync pushes aggregat
 - **Local proxy** (port 9878) sits between your agent and the LLM provider, capturing every request in real time — streaming responses pass through with no visible lag
 - Attributes cost to repos, branches, tickets, and custom tags
 - **Session health** — detects context bloat, cache degradation, cost acceleration, and retry loops with actionable, provider-aware tips
-- **Cloud dashboard** at [`app.getbudi.dev`](https://app.getbudi.dev) — team-wide cost visibility across users, repos, models, branches, and tickets (daily granularity, requires `budi cloud join`)
+- **Cloud dashboard** at [`app.getbudi.dev`](https://app.getbudi.dev) — team-wide cost visibility across users, repos, models, branches, and tickets (daily granularity, opt-in via `~/.config/budi/cloud.toml`)
 - Live cost + health status line in Claude Code and Cursor
 - **One-time import** of historical transcripts via `budi import` (Claude Code JSONL, Codex Desktop/CLI sessions, Copilot CLI sessions, Cursor Usage API)
 - ~6 MB Rust binary, minimal footprint
@@ -244,6 +244,20 @@ budi integrations install --with cursor-extension
 ```
 
 **Restart Claude Code and Cursor** after updating to pick up any changes.
+
+## Cloud sync (optional)
+
+Cloud sync is disabled by default. To enable it, sign up at [app.getbudi.dev](https://app.getbudi.dev), copy your API key from Settings, and create `~/.config/budi/cloud.toml`:
+
+```toml
+[cloud]
+enabled = true
+api_key = "budi_your_key_here"
+```
+
+The daemon picks up the config on next restart (`budi init`). Only pre-aggregated daily rollups are synced — prompts, code, and responses never leave your machine. See the [Privacy](#privacy) section for full details.
+
+Environment variable overrides: `BUDI_CLOUD_ENABLED=true`, `BUDI_CLOUD_API_KEY=budi_...`, `BUDI_CLOUD_ENDPOINT=https://...`.
 
 ## CLI
 

--- a/crates/budi-core/src/cloud_sync.rs
+++ b/crates/budi-core/src/cloud_sync.rs
@@ -6,7 +6,7 @@
 //!
 //! The sync worker runs as a background task in the daemon on a configurable
 //! interval (default 300s). It is disabled by default and requires explicit
-//! opt-in via `budi cloud join` or `cloud.toml` configuration.
+//! opt-in via `~/.config/budi/cloud.toml` configuration.
 
 use std::path::Path;
 use std::time::Duration;

--- a/crates/budi-core/src/config.rs
+++ b/crates/budi-core/src/config.rs
@@ -478,7 +478,7 @@ pub const DEFAULT_CLOUD_SYNC_INTERVAL_SECONDS: u64 = 300;
 pub const DEFAULT_CLOUD_SYNC_RETRY_MAX_SECONDS: u64 = 300;
 
 /// Cloud sync configuration loaded from `~/.config/budi/cloud.toml`.
-/// Created by `budi cloud join` or `budi cloud init`.
+/// Created by editing `~/.config/budi/cloud.toml` (see README § Cloud sync).
 /// Cloud sync is **disabled by default** — requires explicit opt-in.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]

--- a/crates/budi-daemon/src/workers/cloud_sync.rs
+++ b/crates/budi-daemon/src/workers/cloud_sync.rs
@@ -23,7 +23,7 @@ pub async fn run(db_path: PathBuf, config: CloudConfig) {
         if auth_failed {
             tracing::warn!(
                 "Cloud sync stopped: authentication failed. \
-                 Run `budi cloud login` to re-authenticate."
+                 Check api_key in ~/.config/budi/cloud.toml."
             );
             // Sleep long and re-check config in case user re-authenticates
             tokio::time::sleep(Duration::from_secs(retry_max)).await;

--- a/docs/design-principles.md
+++ b/docs/design-principles.md
@@ -55,4 +55,4 @@ Everything works without cloud. Cloud adds team visibility, not core functionali
 - All analytics, budgets, and health vitals are computed locally
 - Cloud receives only what's needed for team aggregation
 - No cloud-to-daemon command channel (budgets are local)
-- `budi cloud join` is explicit opt-in, never automatic
+- Cloud sync is explicit opt-in via `cloud.toml`, never automatic


### PR DESCRIPTION
## Summary

- Replaces `requires budi cloud join` in README with `opt-in via ~/.config/budi/cloud.toml`
- Adds a **Cloud sync (optional)** section to README with concrete setup instructions (create cloud.toml, set API key, env var overrides)
- Fixes 3 stale code comments that referenced `budi cloud join`/`budi cloud login`/`budi cloud init` in `config.rs`, `cloud_sync.rs`, and `workers/cloud_sync.rs`
- Updates `design-principles.md` to match

## Risks / compatibility notes

- Documentation-only change to README and design-principles.md
- Code changes are comment-only (no logic changes) — the auth-failure log message now points users to cloud.toml instead of a non-existent `budi cloud login` command
- No behavioral changes

## Validation

```
cargo fmt --all                                              # ✅ clean
cargo clippy --workspace --all-targets --locked -- -D warnings  # ✅ clean
cargo test --workspace --locked                              # ✅ 389 tests pass
```

Closes #260

Made with [Cursor](https://cursor.com)