### PR TITLE
Remove deprecated integration names from --with/--without CLI values

### DIFF
--- a/crates/budi-cli/src/commands/init.rs
+++ b/crates/budi-cli/src/commands/init.rs
@@ -321,9 +321,21 @@ fn resolve_init_integrations(
     }
 
     filter_integrations_by_agents(&mut selected, agents_config);
-    selected.remove(&super::integrations::IntegrationComponent::ClaudeCodeHooks);
-    selected.remove(&super::integrations::IntegrationComponent::ClaudeCodeOtel);
-    selected.remove(&super::integrations::IntegrationComponent::CursorHooks);
+
+    let removed: Vec<_> = selected
+        .iter()
+        .copied()
+        .filter(|c| c.is_removed_surface())
+        .collect();
+    for c in removed {
+        selected.remove(&c);
+        eprintln!(
+            "{}  Note:{} {} was removed in 8.0 and was skipped.",
+            super::ansi("\x1b[33m"),
+            super::ansi("\x1b[0m"),
+            c.display_name(),
+        );
+    }
 
     Ok(selected)
 }

--- a/crates/budi-cli/src/commands/integrations.rs
+++ b/crates/budi-cli/src/commands/integrations.rs
@@ -16,9 +16,12 @@ use serde_json::{Value, json};
 #[clap(rename_all = "kebab-case")]
 #[serde(rename_all = "kebab-case")]
 pub enum IntegrationComponent {
+    #[value(skip)]
     ClaudeCodeHooks,
+    #[value(skip)]
     ClaudeCodeOtel,
     ClaudeCodeStatusline,
+    #[value(skip)]
     CursorHooks,
     CursorExtension,
 }
@@ -34,7 +37,7 @@ impl IntegrationComponent {
         }
     }
 
-    fn is_removed_surface(self) -> bool {
+    pub fn is_removed_surface(self) -> bool {
         matches!(
             self,
             Self::ClaudeCodeHooks | Self::ClaudeCodeOtel | Self::CursorHooks


### PR DESCRIPTION
## Summary

- Hides three deprecated `IntegrationComponent` variants (`claude-code-hooks`, `claude-code-otel`, `cursor-hooks`) from clap's `ValueEnum` using `#[value(skip)]`. They no longer appear in `--help` and are rejected when passed via `--with`/`--without`.
- Makes `is_removed_surface()` public so `init.rs` can reuse it.
- In `budi init`, deprecated components loaded from saved preferences (old `integrations.toml`) now emit a visible warning instead of being silently stripped.
- Serde deserialization is preserved for backward-compatible config file reading.

**ADR context**: ADR-0081 states there is no "deprecate" category — hooks and OTEL were removed in 8.0. This change enforces that at the CLI layer.

## Risks / compatibility notes

- Users who have scripts with `--with claude-code-hooks` will now get a clap parse error instead of silent success. This is the desired behavior — the silent success was the bug.
- Old `integrations.toml` files with deprecated entries still deserialize correctly and are cleaned up with a warning.

## Validation

```
cargo fmt --all                                             # ✓ clean
cargo clippy --workspace --all-targets --locked -- -D warnings  # ✓ clean
cargo test --workspace --locked                              # ✓ 389 tests pass
```

Closes #261

Made with [Cursor](https://cursor.com)