### PR TITLE
Update import help text to mention all 4 supported providers

### DIFF
--- a/crates/budi-cli/src/commands/init.rs
+++ b/crates/budi-cli/src/commands/init.rs
@@ -189,7 +189,7 @@ pub fn cmd_init(
     );
     println!("       {dim}Need one-off bypass? Use `BUDI_BYPASS=1 budi launch <agent>`{reset}");
     println!(
-        "    2. Import history: `budi import` {dim}(load past transcripts from Claude Code / Cursor){reset}"
+        "    2. Import history: `budi import` {dim}(load past transcripts from Claude Code / Codex / Copilot / Cursor){reset}"
     );
     println!("    3. Health check:   `budi status`");
     println!("    4. Cloud dashboard:  https://app.getbudi.dev");

--- a/crates/budi-cli/src/main.rs
+++ b/crates/budi-cli/src/main.rs
@@ -132,7 +132,7 @@ Examples:
     Migrate,
     /// Repair schema drift and run migration checks
     Repair,
-    /// Import historical transcripts from Claude Code and Cursor into the analytics database.
+    /// Import historical transcripts from Claude Code, Codex, Copilot CLI, and Cursor into the analytics database.
     /// Use --force to clear all data and re-ingest from scratch (e.g. after upgrades).
     Import {
         /// Clear all data and re-ingest from scratch.


### PR DESCRIPTION
## Summary

- Updates the `Import` command doc comment to list all 4 providers: Claude Code, Codex, Copilot CLI, and Cursor.
- Updates `budi init` next-steps text to mention all 4 providers in the import suggestion.

The README already correctly lists all 4 providers; only the CLI help text was stale.

## Risks / compatibility notes

Help-text-only change. No behavioral impact.

## Validation

```
cargo fmt --all                                             # ✓ clean
cargo clippy --workspace --all-targets --locked -- -D warnings  # ✓ clean
cargo test --workspace --locked                              # ✓ 389 tests pass
```

Closes #262

Made with [Cursor](https://cursor.com)