### PR TITLE
Update budi uninstall description to remove hooks reference

### DIFF
--- a/crates/budi-cli/src/main.rs
+++ b/crates/budi-cli/src/main.rs
@@ -119,7 +119,7 @@ Examples:
         #[arg(long)]
         version: Option<String>,
     },
-    /// Remove budi hooks, status line, and data (keeps binaries)
+    /// Remove budi configuration, integrations, and data (keeps binaries)
     Uninstall {
         /// Keep the analytics database and data
         #[arg(long)]


### PR DESCRIPTION
## Summary

- Changes the `Uninstall` command doc comment from "Remove budi hooks, status line, and data (keeps binaries)" to "Remove budi configuration, integrations, and data (keeps binaries)".
- The implementation still correctly cleans up leftover hook entries from legacy pre-8.0 installs during uninstall — only the user-facing description was stale.

## Risks / compatibility notes

Help-text-only change. No behavioral impact.

## Validation

```
cargo fmt --all                                             # ✓ clean
cargo clippy --workspace --all-targets --locked -- -D warnings  # ✓ clean
cargo test --workspace --locked                              # ✓ 389 tests pass
```

Closes #264

Made with [Cursor](https://cursor.com)