### PR TITLE
Simplify GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,73 +1,27 @@
 name: Bug report
-description: Report a reproducible problem in budi
+description: Report a problem in budi
 title: "bug: "
 labels:
   - bug
 body:
   - type: textarea
-    id: summary
+    id: description
     attributes:
-      label: Summary
-      description: What went wrong?
-      placeholder: A clear and short description of the bug.
+      label: What happened?
+      placeholder: Describe the bug — what you did, what you expected, and what happened instead.
     validations:
       required: true
-  - type: textarea
-    id: expected
-    attributes:
-      label: Expected behavior
-      placeholder: What did you expect to happen?
-    validations:
-      required: true
-  - type: textarea
-    id: actual
-    attributes:
-      label: Actual behavior
-      placeholder: What happened instead?
-    validations:
-      required: true
-  - type: textarea
-    id: reproduce
-    attributes:
-      label: Reproduction steps
-      description: Provide exact steps, commands, and inputs.
-      placeholder: |
-        1. Run ...
-        2. Open ...
-        3. Observe ...
-    validations:
-      required: true
-  - type: textarea
-    id: logs
-    attributes:
-      label: Logs or output
-      description: Paste relevant command output, stack traces, or screenshots.
-      render: shell
-  - type: textarea
-    id: diagnostics
-    attributes:
-      label: Diagnostic checks run
-      description: Share `budi doctor` output and any relevant validation commands already tried.
-      placeholder: |
-        - budi doctor:
-        - budi sync:
-        - additional checks:
   - type: textarea
     id: environment
     attributes:
       label: Environment
-      description: Include OS, budi version, install method, and Rust/Node versions if relevant.
+      description: "Output of: uname -s && budi --version"
       placeholder: |
-        - OS:
-        - budi version:
-        - Install method:
-        - Rust:
-        - Node:
-    validations:
-      required: true
+        macOS / Linux
+        budi 0.x.x
   - type: textarea
-    id: impact
+    id: logs
     attributes:
-      label: Impact and urgency
-      description: Who is blocked and how severe is the issue?
-      placeholder: Affects all new installs / blocks release / minor annoyance, etc.
+      label: Logs or output
+      description: Paste any relevant output, errors, or screenshots.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: Q&A and usage questions
     url: https://github.com/siropkin/budi/discussions
-    about: Please use Discussions for questions and troubleshooting that are not confirmed bugs.
+    about: Use Discussions for questions and troubleshooting that are not confirmed bugs.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,51 +1,13 @@
 name: Feature request
-description: Suggest a new capability or workflow improvement
+description: Suggest an improvement or new feature
 title: "feat: "
 labels:
   - enhancement
 body:
   - type: textarea
-    id: problem
+    id: description
     attributes:
-      label: Problem statement
-      description: What user problem are you trying to solve?
-      placeholder: The current behavior makes it hard to...
+      label: What would you like?
+      placeholder: Describe the problem you're trying to solve and/or the feature you'd like to see.
     validations:
       required: true
-  - type: textarea
-    id: proposal
-    attributes:
-      label: Proposed solution
-      description: Describe the change you want.
-      placeholder: Add a command/API/UI change that...
-    validations:
-      required: true
-  - type: textarea
-    id: alternatives
-    attributes:
-      label: Alternatives considered
-      description: What other approaches did you evaluate?
-  - type: textarea
-    id: scope
-    attributes:
-      label: Scope and non-goals
-      description: Clarify what should be in/out of scope for the first implementation.
-      placeholder: |
-        In scope:
-        Out of scope:
-  - type: textarea
-    id: success
-    attributes:
-      label: Success criteria
-      description: How will we know this is complete and working?
-      placeholder: |
-        - [ ] ...
-        - [ ] ...
-    validations:
-      required: true
-  - type: textarea
-    id: validation
-    attributes:
-      label: Suggested validation
-      description: Which checks should pass (tests, lint, manual flow) before this is considered done?
-      placeholder: cargo test target, dashboard build path, extension checks, etc.


### PR DESCRIPTION
## Summary
- Reduce bug report from 7 fields (4 required) to 3 fields (1 required)
- Reduce feature request from 5 fields (3 required) to 1 field (1 required)
- Enable blank issues so people can file free-form issues when templates don't fit

Lower the barrier to reporting — follow-up questions can happen in comments.

Made with [Cursor](https://cursor.com)