### PR TITLE
[8.0] Release readiness for v8.0.0

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,8 +14,6 @@
 - [ ] `cargo fmt --all`
 - [ ] `cargo clippy --workspace --all-targets --locked -- -D warnings`
 - [ ] `cargo test --workspace --locked`
-- [ ] If extension changed: `cd extensions/cursor-budi && npm run lint && npm run format:check && npm run test && npm run build`
-- [ ] If dashboard changed: `cd frontend/dashboard && npm ci && npm run build`
 
 Validation evidence:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,120 @@
+# Changelog
+
+## 8.0.0 — 2026-04-XX
+
+Budi 8.0 is a ground-up rearchitecture: proxy-first live cost tracking replaces the old hook/OTEL/file-sync ingestion model, the Cursor extension and cloud dashboard are extracted into independent repos, and a new optional cloud layer gives managers team-wide AI cost visibility — all while keeping prompts, code, and responses strictly local.
+
+### Proxy — real-time cost tracking
+
+- **Local proxy server** on port 9878 transparently sits between AI agents and upstream providers (Anthropic, OpenAI), capturing every request in real time (#89)
+- **Streaming pass-through** — SSE responses flow chunk-by-chunk with no visible lag; token metadata is extracted via tee/tap without modifying the stream (#90)
+- **Proxy attribution** — each request is attributed to repo, branch, and ticket via `X-Budi-Repo`/`X-Budi-Branch`/`X-Budi-Cwd` headers or automatic git resolution (#91)
+- **Cache token extraction** from proxy responses for accurate cost calculation (#192)
+- **Provider normalization** — proxy events stored as `claude_code`/`codex`/`copilot_cli` instead of raw `anthropic`/`openai` for consistent analytics (#191)
+- **Authorization header forwarding** for Anthropic OAuth sessions (#169)
+- **Large payload resilience** — daemon avoids full JSON parse on oversized bodies to prevent crashes (#274)
+
+### Auto-proxy-install — zero-config agent setup
+
+- **`budi init` auto-configures proxy routing** for selected agents (#170):
+  - CLI agents (Claude Code, Codex, Copilot): managed env-var block in shell profile (`~/.zshrc`, `~/.bashrc`)
+  - Cursor: patches `settings.json` with proxy base URL
+  - Codex Desktop: patches `~/.codex/config.toml`
+- **`budi enable`/`budi disable`** toggle proxy configuration per agent
+- **Shell restart warning** after enabling CLI agents (#188)
+- **`budi launch <agent>`** remains available as explicit fallback; `BUDI_BYPASS=1` skips proxy for one session (#95)
+
+### Cloud — optional team dashboard
+
+- **Cloud ingest API** at `app.getbudi.dev` accepts pre-aggregated daily rollups and session summaries from the daemon (#100)
+- **Async cloud sync worker** in the daemon with watermark tracking, exponential backoff, and idempotent UPSERT semantics (#101)
+- **Cloud dashboard** at [app.getbudi.dev](https://app.getbudi.dev) — Overview, Team, Models, Repos, Sessions, Settings pages (#102)
+- **Supabase Auth** (GitHub + Google + magic link) for web sign-in (ADR-0087 §4)
+- **Privacy contract** — only numeric aggregates cross the wire; prompts, code, responses, file paths, and email never leave the machine (ADR-0083)
+- **HTTPS-only** — daemon refuses to sync over plain HTTP
+- Cloud sync is **disabled by default**; opt-in via `~/.config/budi/cloud.toml`
+
+### Daemon autostart
+
+- **Platform-native autostart** so the daemon survives reboots (#150):
+  - macOS: launchd LaunchAgent
+  - Linux: systemd user service
+  - Windows: Task Scheduler
+- **`budi autostart`** subcommand: `status`, `install`, `uninstall` (#187)
+- `budi init` and `budi uninstall` manage the service automatically
+
+### Multi-agent support
+
+- **Codex Desktop/CLI transcript import** — historical backfill from `~/.codex/sessions/` (#178)
+- **Copilot CLI transcript import** — historical backfill from `~/.copilot/session-state/` (#179)
+- **Per-agent opt-in** — `budi init` prompts for each agent; choices stored in `agents.toml` (#85)
+- **Provider filter** extended with `codex`, `copilot_cli`, `openai` (#257)
+- **Model breakdown** shows provider alongside model name when duplicates exist across providers (#258)
+
+### CLI improvements
+
+- **Rich CLI is the primary local UX** — `budi stats`, `budi sessions`, `budi health`, `budi status` (#97)
+- **`budi import`** consolidates historical transcript import (replaces removed `budi sync`) (#175)
+- **Session ID** shown in `budi sessions` output with prefix matching for detail view (#174)
+- **Total cost line** in multi-agent `budi stats` output (#184)
+- **`budi doctor`** detects proxy env var configuration vs active shell state
+- **`budi status`** quick overview of daemon, proxy, and today's cost
+
+### Cursor extension
+
+- Minimal bootstrap and status flow (#96)
+- Extension extracted to [`siropkin/budi-cursor`](https://github.com/siropkin/budi-cursor) (#103)
+- Installed via VS Code Marketplace or `budi integrations install --with cursor-extension`
+- Checks daemon `api_version` on startup for compatibility
+
+### Repo extraction
+
+- **Cursor extension** extracted to [`siropkin/budi-cursor`](https://github.com/siropkin/budi-cursor) (#103)
+- **Cloud dashboard** extracted to [`siropkin/budi-cloud`](https://github.com/siropkin/budi-cloud) (#103)
+- No compile-time dependencies between repos; all communication over HTTP or JSON file contracts
+- Version coordination via `api_version` (extension) and `schema_version` (cloud sync)
+
+### Removed
+
+- **Hook ingestion** (`budi hook`, `POST /hooks/ingest`, `hook_events` table) — replaced by the proxy (#92)
+- **OTEL ingestion** (`POST /v1/logs`, `POST /v1/metrics`, `otel_events` table) — replaced by the proxy (#92)
+- **MCP server** (`budi mcp-serve`) — replaced by proxy + Rich CLI (#84)
+- **Starship integration** — replaced by the Rich CLI statusline (#84)
+- **Local dashboard** (`/dashboard`) — replaced by cloud dashboard at `app.getbudi.dev` and Rich CLI (#103)
+- **`budi sync`** command — consolidated into `budi import` (#175)
+- **Deprecated integration names** no longer accepted in `--with`/`--without` CLI flags (#261)
+- Database schema reset to v1 for clean 8.0 starting point (#92)
+
+### Bug fixes
+
+- Fix Cursor CLI discovery missing macOS app bundle path (#176)
+- Fix daemon ERROR log spam for missing session health when no sessions exist (#177)
+- Fix `budi launch codex` exit code when showing Codex Desktop instructions (#180)
+- Fix misleading Cursor extension message in `budi init` (#181)
+- Fix statusline hyperlink pointing to removed `/dashboard` (#259)
+- Fix `budi import` help text to mention all 4 providers (#262)
+- Fix `budi uninstall` description referencing removed hooks (#264)
+- Fix subagent transcript parsing for accurate cost reporting (#205)
+- Soften Cursor extension install warning (#185)
+- Make Cursor watermark catch-up warning verbose-only (#186)
+- Update `budi launch cursor` messaging to reflect auto-proxy-install (#183)
+
+### Architecture decisions
+
+- [ADR-0081](docs/adr/0081-product-contract-and-deprecation-policy.md) — surface disposition and deprecation policy
+- [ADR-0082](docs/adr/0082-proxy-compatibility-matrix-and-gateway-contract.md) — proxy compatibility matrix and gateway contract
+- [ADR-0083](docs/adr/0083-cloud-ingest-identity-and-privacy-contract.md) — cloud ingest, identity, and privacy contract
+- [ADR-0086](docs/adr/0086-extraction-boundaries.md) — extraction boundaries for budi-cursor and budi-cloud
+- [ADR-0087](docs/adr/0087-cloud-infrastructure-and-deployment.md) — cloud infrastructure, deployment, and domain strategy
+
+### Breaking changes
+
+All pre-8.0 releases were beta. 8.0.0 is the first stable release.
+
+- Hook and OTEL ingestion removed with no migration path — the proxy replaces them
+- `budi sync` removed — use `budi import` for historical data
+- `budi mcp-serve` removed
+- Starship integration removed — use `budi statusline` instead
+- Local dashboard removed from daemon — use the cloud dashboard or Rich CLI
+- Database schema reset to v1; existing pre-8.0 databases are dropped and recreated on upgrade
+- The Cursor extension and cloud dashboard now live in separate repos

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,7 +169,7 @@ dependencies = [
 
 [[package]]
 name = "budi-cli"
-version = "7.6.0"
+version = "8.0.0"
 dependencies = [
  "anyhow",
  "budi-core",
@@ -186,7 +186,7 @@ dependencies = [
 
 [[package]]
 name = "budi-core"
-version = "7.6.0"
+version = "8.0.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -202,7 +202,7 @@ dependencies = [
 
 [[package]]
 name = "budi-daemon"
-version = "7.6.0"
+version = "8.0.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "7.6.0"
+version = "8.0.0"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"

--- a/crates/budi-core/src/analytics/mod.rs
+++ b/crates/budi-core/src/analytics/mod.rs
@@ -117,7 +117,7 @@ pub fn newest_ingested_data_at(conn: &Connection) -> Result<Option<String>> {
 }
 
 /// Reset sync state and re-ingested data so the next sync starts from scratch.
-/// Used by `budi sync --force` after schema/parser changes.
+/// Used by `budi import --force` after schema/parser changes.
 pub fn reset_sync_state(conn: &Connection) -> Result<()> {
     conn.execute_batch(
         "DELETE FROM sync_state;

--- a/crates/budi-core/src/analytics/sync.rs
+++ b/crates/budi-core/src/analytics/sync.rs
@@ -15,13 +15,13 @@ use crate::jsonl::ParsedMessage;
 const INGEST_BATCH_SIZE: usize = 1000;
 
 /// Quick sync: only files modified in the last 30 days.
-/// Used by `budi sync` and the daemon's 30s auto-sync.
+/// Used by `budi import` and the daemon's 30s auto-sync.
 pub fn sync_all(conn: &mut Connection) -> Result<(usize, usize, Vec<String>)> {
     sync_with_max_age(conn, Some(30))
 }
 
 /// Full history sync: process ALL transcript files regardless of age.
-/// Used by `budi history` — may take minutes on large histories.
+/// Used by `budi import` — may take minutes on large histories.
 pub fn sync_history(conn: &mut Connection) -> Result<(usize, usize, Vec<String>)> {
     sync_with_max_age(conn, None)
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -238,61 +238,6 @@ parse_args() {
   done
 }
 
-build_cursor_extension_vsix() {
-  local extension_dir="$REPO_ROOT/extensions/cursor-budi"
-  local vsix_path="$extension_dir/cursor-budi.vsix"
-  local log_file
-  log_file="$(mktemp -t budi-cursor-extension.XXXXXX.log)"
-
-  (
-    set +e
-    cd "$extension_dir" || exit 10
-
-    if [[ -f package-lock.json ]]; then
-      npm ci --silent --no-audit --no-fund
-    else
-      npm install --silent --no-audit --no-fund
-    fi
-    local npm_install_rc=$?
-    [[ "$npm_install_rc" -eq 0 ]] || exit "$npm_install_rc"
-
-    npm run build --silent
-    local npm_build_rc=$?
-    [[ "$npm_build_rc" -eq 0 ]] || exit "$npm_build_rc"
-
-    npm run package --silent
-    exit $?
-  ) >"$log_file" 2>&1
-  local extension_rc=$?
-
-  if [[ "$extension_rc" -eq 0 ]]; then
-    rm -f "$log_file"
-    return 0
-  fi
-
-  local fallback_desc=""
-  if [[ -s "$vsix_path" ]]; then
-    fallback_desc="using existing cursor-budi.vsix"
-  else
-    : > "$vsix_path"
-    fallback_desc="created empty cursor-budi.vsix (auto-install disabled)"
-  fi
-
-  if [[ "$extension_rc" -eq 137 ]]; then
-    log "WARN: Cursor extension build was killed (exit 137; likely resource pressure); $fallback_desc"
-  else
-    log "WARN: Cursor extension build failed (exit $extension_rc); $fallback_desc"
-  fi
-  log "WARN: Cursor extension diagnostics (last 20 lines):"
-  while IFS= read -r line; do
-    log "WARN:   $line"
-  done < <(tail -n 20 "$log_file")
-  log "WARN: Hint: run 'cd $extension_dir && npm ci && npm run build && npm run package' to debug packaging."
-
-  rm -f "$log_file"
-  return 0
-}
-
 main() {
   parse_args "$@"
 
@@ -315,25 +260,6 @@ main() {
       BIN_DIR="${CARGO_HOME:-$HOME/.cargo}/bin"
     else
       if [[ "$SKIP_BUILD" -eq 0 ]]; then
-        # Build dashboard frontend bundle so daemon embeds current assets.
-        if command -v npm >/dev/null 2>&1; then
-          log "Building dashboard frontend..."
-          "$REPO_ROOT/scripts/build-dashboard.sh"
-        elif [[ ! -f "$REPO_ROOT/crates/budi-daemon/static/dashboard-dist/index.html" ]]; then
-          fail "npm not found and no prebuilt dashboard bundle present at crates/budi-daemon/static/dashboard-dist"
-        else
-          log "npm not found — using checked-in dashboard bundle"
-        fi
-
-        # Build Cursor extension (.vsix) before cargo build so it gets embedded.
-        # This is best-effort: install should still succeed even if packaging cannot run.
-        if command -v npm >/dev/null 2>&1; then
-          log "Building Cursor extension..."
-          build_cursor_extension_vsix
-        else
-          log "npm not found — skipping Cursor extension build (extension auto-install will be disabled)"
-        fi
-
         log "Building workspace with cargo ($PROFILE profile)"
         local lock_args=()
         if [[ -f "$REPO_ROOT/Cargo.lock" ]]; then


### PR DESCRIPTION
Closes #199

## Summary

Release readiness verification and preparation for v8.0.0. This PR:

- **Version bump**: workspace version 7.6.0 → 8.0.0 across all three crates
- **CHANGELOG.md**: comprehensive changelog covering all 8.0 changes organized by feature area (proxy, cloud, autostart, multi-agent, CLI, removals, bug fixes, ADRs, breaking changes)
- **install.sh cleanup**: removes stale dashboard frontend and Cursor extension build steps that reference `extensions/cursor-budi/` and `scripts/build-dashboard.sh` (both removed in #103 when repos were extracted)
- **PR template cleanup**: removes stale extension/dashboard validation checkboxes (extension → siropkin/budi-cursor, dashboard → siropkin/budi-cloud)
- **Doc comment fixes**: updates references to removed `budi sync` / `budi history` commands → `budi import`

### Release readiness checklist (from #199)

- [x] All 27 E2E polish issues are merged and closed
- [x] `cargo fmt --all` — clean
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` — zero warnings
- [x] `cargo test --workspace --locked` — 400 tests pass (49 CLI + 325 core + 26 daemon)
- [x] `budi --version` shows `budi 8.0.0`
- [x] `budi doctor` — all checks pass
- [x] `budi status` — daemon and proxy running, shows today's cost
- [x] `budi stats` — multi-agent breakdown with total cost line
- [x] `budi sessions` — session list with IDs, prefix matching works
- [x] `budi import --help` — mentions all 4 providers (Claude Code, Codex, Copilot CLI, Cursor)
- [x] `budi autostart status` — installed and running (launchd on macOS)
- [x] Changelog drafted

### Items that require manual verification by the owner

- [ ] Install smoke test on macOS (fresh install via Homebrew or standalone script)
- [ ] Install smoke test on Linux
- [ ] Install smoke test on Windows
- [ ] Verify upgrade from 7.x does not break existing installs
- [ ] Verify proxy flow end-to-end: `budi init` → agent sends prompt → `budi stats` shows non-zero
- [ ] Verify cloud flow: configure `cloud.toml` → daemon syncs → dashboard shows data at app.getbudi.dev
- [ ] Verify autostart: reboot → daemon auto-starts → proxy responds
- [ ] Verify extension install: `budi init` → Cursor extension → status bar shows health
- [ ] Verify `budi update` from a prior version works cleanly

## Risks / compatibility notes

- **Version bump is a one-way door**: once merged, any builds from main will report v8.0.0. The actual release tag (#158) should happen after #200 (final docs review).
- **install.sh changes**: the removed code tried to build `extensions/cursor-budi` and `frontend/dashboard` which no longer exist in this repo. The script was silently failing (warnings only) on fresh clones; now it skips these steps cleanly.
- **CHANGELOG date**: set to `2026-04-XX` — the actual date should be filled in when the release is tagged in #158.

## Validation

```
cargo fmt --all                                              # ✓ clean
cargo clippy --workspace --all-targets --locked -- -D warnings  # ✓ zero warnings
cargo test --workspace --locked                              # ✓ 400 passed, 0 failed
budi --version                                               # budi 8.0.0
budi doctor                                                  # all checks passed
budi status                                                  # daemon + proxy running
budi stats                                                   # non-zero cost data
budi sessions                                                # session list populated
budi autostart status                                        # installed and running
```

Made with [Cursor](https://cursor.com)