### PR TITLE
[8.0][E2E] Document proxy 401 behavior for invalid API keys

### DIFF
--- a/docs/adr/0082-proxy-compatibility-matrix-and-gateway-contract.md
+++ b/docs/adr/0082-proxy-compatibility-matrix-and-gateway-contract.md
@@ -120,7 +120,7 @@ The agent's API key in the request header determines authentication with the ups
 
 | Failure mode | Proxy behavior |
 |--------------|---------------|
-| Upstream returns HTTP error (4xx/5xx) | Pass the error response through to the client unmodified. Log the status code and model for analytics. |
+| Upstream returns HTTP error (4xx/5xx) | Pass the error response through to the client unmodified. Log the status code and model for analytics. (e.g. invalid API key returns `401 Unauthorized` from upstream). |
 | Upstream is unreachable (DNS, connect timeout) | Return `502 Bad Gateway` with a JSON body: `{"error": {"type": "proxy_error", "message": "..."}}`. Log the failure. |
 | Proxy itself crashes or is not running | The agent gets `ECONNREFUSED` on the proxy port. The agent's own error handling applies. The proxy does not implement automatic fallback to direct connections — that would silently bypass observability. |
 | Malformed request from agent | Return `400 Bad Request`. Do not forward to upstream. |


### PR DESCRIPTION
Closes #281

## Summary
The proxy correctly passes through upstream HTTP errors (4xx/5xx) per ADR-0082. This PR adds explicit documentation to ADR-0082 that an invalid API key will result in a `401 Unauthorized` from the upstream provider, not a `502 Bad Gateway` from the proxy.

## Risks / compatibility notes
None. This is a documentation-only change that clarifies existing behavior.

## Validation
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`

Made with [Cursor](https://cursor.com)