### PR TITLE
chore(release): finalize 8.0.0 date in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 8.0.0 — 2026-04-XX
+## 8.0.0 — 2026-04-16
 
 Budi 8.0 is a ground-up rearchitecture: proxy-first live cost tracking replaces the old hook/OTEL/file-sync ingestion model, the Cursor extension and cloud dashboard are extracted into independent repos, and a new optional cloud layer gives managers team-wide AI cost visibility — all while keeping prompts, code, and responses strictly local.
 


### PR DESCRIPTION
## Summary
- Stamps `2026-04-16` as the 8.0.0 release date in `CHANGELOG.md`, finalizing the placeholder ahead of cutting the `v8.0.0` tag.

## Risks / compatibility notes
- Docs-only. No code paths touched.

## Validation
- `git diff` shows a single-line CHANGELOG change.
- CI (`ci-success`) expected to pass; required for the release workflow to accept the tag push.

Closes #158

Made with [Cursor](https://cursor.com)