### PR TITLE
[8.1][R1.0.1] Fix: `budi sessions` empty when proxy writes drop session_id (#302)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased (8.1.0)
+
+### Fixed
+
+- **`budi sessions` now shows today's proxy activity** — `insert_proxy_message` dropped the `session_id` column, so every proxied assistant message was written with `session_id = NULL` and filtered out of `session_list_with_filters`. Both the live proxy path and the defensive analytics filter now treat empty-string `session_id` as NULL so ghost sessions can't reappear (#302).
+
+### Added
+
+- **`budi doctor` sessions-visibility check** — reports assistant-messages vs returned-session counts for the `today`, `7d`, and `30d` windows and flags a hard error if any window has activity but zero returned sessions (#302).
+- **`messages.timestamp` / `session_id` attribution contract** documented in `SOUL.md` so future providers cannot silently regress R1.0 (#302).
+
 ## 8.0.0 — 2026-04-16
 
 Budi 8.0 is a ground-up rearchitecture: proxy-first live cost tracking replaces the old hook/OTEL/file-sync ingestion model, the Cursor extension and cloud dashboard are extracted into independent repos, and a new optional cloud layer gives managers team-wide AI cost visibility — all while keeping prompts, code, and responses strictly local.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 - **`budi doctor` sessions-visibility check** — reports assistant-messages vs returned-session counts for the `today`, `7d`, and `30d` windows and flags a hard error if any window has activity but zero returned sessions (#302).
 - **`messages.timestamp` / `session_id` attribution contract** documented in `SOUL.md` so future providers cannot silently regress R1.0 (#302).
+- **`BUDI_ANTHROPIC_UPSTREAM` / `BUDI_OPENAI_UPSTREAM` env overrides** on the proxy (mirroring the existing `BUDI_PROXY_PORT` / `BUDI_PROXY_ENABLED` pattern) so local end-to-end tests and air-gapped deployments can redirect proxy traffic without editing on-disk config.
+- **Local end-to-end test harness** in `scripts/e2e/` — the first script, `test_302_sessions_visibility.sh`, boots a real `budi-daemon` + mock upstream + CLI against an isolated `$HOME` and pins the #302 fix. See `scripts/e2e/README.md` for conventions and the new "Local end-to-end tests" section in `SOUL.md`.
 
 ## 8.0.0 — 2026-04-16
 

--- a/SOUL.md
+++ b/SOUL.md
@@ -25,6 +25,32 @@ budi init
 
 After upgrading: the first CLI command now verifies daemon version and auto-restarts stale daemons when needed. If automatic restart fails, stop the old process manually, then run `budi init`. On Unix you can use `pkill -f budi-daemon`; on Windows use `taskkill /IM budi-daemon.exe /F` if needed.
 
+### Local end-to-end tests
+
+Shell-driven end-to-end tests live under `scripts/e2e/`. They exercise the full stack — real release binaries (`budi` + `budi-daemon`), a mock upstream over loopback, the HTTP proxy path, and the CLI — against an isolated `$HOME` so they never touch real user data.
+
+```bash
+cargo build --release                                 # once per change
+bash scripts/e2e/test_302_sessions_visibility.sh      # regression guard for #302
+```
+
+Each script is a single self-contained bash file that:
+
+1. Builds a throwaway `HOME` in `mktemp` and exports it for the whole run.
+2. Boots a tiny Python mock upstream on loopback.
+3. Starts `budi-daemon serve --port … --proxy-port …` with `BUDI_ANTHROPIC_UPSTREAM` / `BUDI_OPENAI_UPSTREAM` pointed at the mock (these env vars override the hard-coded upstreams — see `ProxyConfig::effective_anthropic_upstream` / `effective_openai_upstream`).
+4. Drives real CLI/HTTP commands and asserts DB rows, API responses, and CLI output.
+5. Tears down the temp HOME and child processes via a `trap`.
+
+Design rules:
+
+- **No shared mutable state.** Every script allocates its own ports and `HOME`; runs should be safe in parallel.
+- **Fail loud, fail fast.** Scripts use `set -euo pipefail` and print the daemon log on any failure.
+- **Negative-path provable.** Each regression test should fail when the fix it guards is reverted (every new script should be verified this way before merging).
+- **Keep the fixtures minimal.** Mock upstream responses stay inline in the script; no binary fixtures checked in.
+
+When adding a new script, name it `test_<issue>_<short_slug>.sh` and document what bug or contract it pins in the opening comment. See `scripts/e2e/README.md` for the full convention.
+
 ## Daemon autostart
 
 `budi init` installs a platform-native user-level service so the daemon starts automatically at login and restarts on crash:

--- a/SOUL.md
+++ b/SOUL.md
@@ -119,6 +119,35 @@ Nine tables, seven data entities + two supporting:
 
 Historical OTEL data (`otel_exact` confidence) remains queryable but OTEL ingestion has been removed. The proxy is the sole live data source.
 
+### Attribution contract (R1.0)
+
+Every ingestor that writes to `messages` MUST uphold the following so that the
+CLI, daemon, and dashboard tell the same story (see ADR-0082 and the R1.0 bugs
+in [#302](https://github.com/siropkin/budi/issues/302) / #303 / #304 / #305):
+
+- **`timestamp`** — RFC3339 string in UTC. Accept both `...Z` and `...+00:00`
+  offsets; `session_list_with_filters` and `activity_chart` compare these as
+  strings, so never write naive SQLite datetime (`YYYY-MM-DD HH:MM:SS`) or a
+  local-offset string. Providers emit RFC3339 from `DateTime::<Utc>::to_rfc3339()`
+  (Claude Code JSONL, Codex) or `DateTime::from_timestamp_millis(..).to_rfc3339()`
+  (Cursor, proxy).
+- **`session_id`** — required for every live assistant row. Live proxy traffic
+  uses the agent-provided `X-Budi-Session` header, falling back to
+  `generate_proxy_session_id()`. Empty-string `session_id` is treated as NULL
+  by the analytics layer, and the insert path normalizes `""` to `NULL` so
+  ghost `(empty)` sessions cannot appear. Rows with NULL/empty `session_id`
+  are invisible to `budi sessions` by design — they indicate an attribution
+  bug upstream, not a display bug.
+- **`provider`** — canonical provider key (`claude_code`, `cursor`, `openai`,
+  `copilot`). `COALESCE(provider, 'claude_code')` is the legacy fallback for
+  pre-8.0 rows; new writes MUST set it explicitly.
+- **`git_branch`** — written without the `refs/heads/` prefix
+  (`session_list_with_filters` strips it defensively for older rows).
+
+`budi doctor` runs a sessions-visibility check for the `today`, `7d`, and
+`30d` windows and fails with a link to #302 if any window has assistant rows
+but zero returned sessions.
+
 ### Key concepts
 
 - **cost_confidence**: determines `~` prefix in dashboard for non-exact costs

--- a/crates/budi-cli/src/commands/doctor.rs
+++ b/crates/budi-cli/src/commands/doctor.rs
@@ -293,6 +293,50 @@ pub fn cmd_doctor(repo_root: Option<PathBuf>, deep: bool) -> Result<()> {
         }
     }
 
+    // Session visibility: catch a recurrence of R1.0.1 (#302) where assistant
+    // rows exist for a window but `budi sessions` returns empty because the
+    // session_id was dropped on write. Mismatch is a hard error for the
+    // developer-first story, so we add it to `issues`.
+    if let Ok(db_path) = budi_core::analytics::db_path()
+        && db_path.exists()
+        && let Ok(conn) = budi_core::analytics::open_db(&db_path)
+    {
+        match budi_core::analytics::session_visibility(&conn) {
+            Ok(windows) => {
+                let yellow = super::ansi("\x1b[33m");
+                let mut any_mismatch = false;
+                for window in &windows {
+                    let mark = if window.has_mismatch() {
+                        any_mismatch = true;
+                        format!("{red}\u{2717}{reset}")
+                    } else if window.assistant_messages == 0 {
+                        format!("{dim}-{reset}")
+                    } else if window.assistant_messages_with_session < window.assistant_messages {
+                        format!("{yellow}!{reset}")
+                    } else {
+                        format!("{green}\u{2713}{reset}")
+                    };
+                    println!(
+                        "  {mark} sessions visibility ({}): assistant={} with_session={} distinct={} returned={}",
+                        window.label,
+                        window.assistant_messages,
+                        window.assistant_messages_with_session,
+                        window.distinct_sessions,
+                        window.returned_sessions,
+                    );
+                }
+                if any_mismatch {
+                    issues.push(
+                        "Sessions visibility mismatch: assistant messages exist in a window but `budi sessions` returns none. See #302.".into(),
+                    );
+                }
+            }
+            Err(e) => {
+                println!("  {dim}-{reset} sessions visibility: could not compute ({e})");
+            }
+        }
+    }
+
     // Auto-proxy configuration checks (shell profile + IDE config files)
     {
         let agents = budi_core::config::load_agents_config()

--- a/crates/budi-core/src/analytics/sessions.rs
+++ b/crates/budi-core/src/analytics/sessions.rs
@@ -39,7 +39,8 @@ pub fn session_audit(conn: &Connection) -> Result<SessionAudit> {
         |r| r.get(0),
     )?;
     let assistant_rows_no_session: u64 = conn.query_row(
-        "SELECT COUNT(*) FROM messages WHERE role = 'assistant' AND session_id IS NULL",
+        "SELECT COUNT(*) FROM messages
+         WHERE role = 'assistant' AND (session_id IS NULL OR session_id = '')",
         [],
         |r| r.get(0),
     )?;
@@ -54,7 +55,7 @@ pub fn session_audit(conn: &Connection) -> Result<SessionAudit> {
     let mut stmt = conn.prepare(
         "SELECT COALESCE(provider, 'claude_code'),
                 COUNT(*),
-                SUM(CASE WHEN session_id IS NOT NULL THEN 1 ELSE 0 END)
+                SUM(CASE WHEN session_id IS NOT NULL AND session_id != '' THEN 1 ELSE 0 END)
          FROM messages WHERE role = 'assistant'
          GROUP BY COALESCE(provider, 'claude_code')",
     )?;
@@ -83,6 +84,106 @@ pub fn session_audit(conn: &Connection) -> Result<SessionAudit> {
         sessions_orphaned,
         provider_coverage,
     })
+}
+
+// ---------------------------------------------------------------------------
+// Session Visibility (doctor diagnostics)
+// ---------------------------------------------------------------------------
+
+/// Per-window session visibility snapshot used by `budi doctor` to surface the
+/// kind of silent attribution failure R1.0.1 (#302) fixed: when assistant rows
+/// exist in a period but the session listing returns empty because rows were
+/// written with NULL/empty `session_id`.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct SessionVisibilityWindow {
+    /// Human label: `today`, `7d`, `30d`.
+    pub label: String,
+    /// ISO-8601 UTC lower bound for the window (inclusive).
+    pub since: String,
+    /// Total assistant messages recorded in the window.
+    pub assistant_messages: u64,
+    /// Assistant messages in the window that have a non-empty `session_id`.
+    pub assistant_messages_with_session: u64,
+    /// Distinct session IDs observed in the window.
+    pub distinct_sessions: u64,
+    /// Sessions that `session_list_with_filters` would return for the window.
+    pub returned_sessions: u64,
+}
+
+impl SessionVisibilityWindow {
+    /// Any assistant activity in the window that is invisible to `budi sessions`.
+    pub fn has_mismatch(&self) -> bool {
+        self.assistant_messages > 0 && self.returned_sessions == 0
+    }
+}
+
+/// Session visibility stats for `today`, last 7 days, and last 30 days.
+///
+/// Built by the `budi doctor` session-visibility check. Each window compares
+/// `assistant_messages` vs `returned_sessions`; any non-zero assistant count
+/// with zero returned sessions flags a regression of R1.0.1 (#302).
+pub fn session_visibility(conn: &Connection) -> Result<Vec<SessionVisibilityWindow>> {
+    let now = chrono::Utc::now();
+    let windows = [
+        (
+            "today",
+            now.date_naive()
+                .and_hms_opt(0, 0, 0)
+                .expect("valid midnight")
+                .and_utc(),
+        ),
+        ("7d", now - chrono::Duration::days(7)),
+        ("30d", now - chrono::Duration::days(30)),
+    ];
+
+    let mut out = Vec::with_capacity(windows.len());
+    for (label, since_dt) in windows {
+        let since = since_dt.to_rfc3339();
+        let assistant_messages: u64 = conn.query_row(
+            "SELECT COUNT(*) FROM messages
+             WHERE role = 'assistant' AND timestamp >= ?1",
+            params![since],
+            |r| r.get(0),
+        )?;
+        let assistant_messages_with_session: u64 = conn.query_row(
+            "SELECT COUNT(*) FROM messages
+             WHERE role = 'assistant' AND timestamp >= ?1
+               AND session_id IS NOT NULL AND session_id != ''",
+            params![since],
+            |r| r.get(0),
+        )?;
+        let distinct_sessions: u64 = conn.query_row(
+            "SELECT COUNT(DISTINCT session_id) FROM messages
+             WHERE role = 'assistant' AND timestamp >= ?1
+               AND session_id IS NOT NULL AND session_id != ''",
+            params![since],
+            |r| r.get(0),
+        )?;
+
+        let paginated = session_list(
+            conn,
+            &SessionListParams {
+                since: Some(&since),
+                until: None,
+                search: None,
+                sort_by: None,
+                sort_asc: false,
+                limit: 1,
+                offset: 0,
+            },
+        )?;
+        let returned_sessions = paginated.total_count;
+
+        out.push(SessionVisibilityWindow {
+            label: label.to_string(),
+            since,
+            assistant_messages,
+            assistant_messages_with_session,
+            distinct_sessions,
+            returned_sessions,
+        });
+    }
+    Ok(out)
 }
 
 // ---------------------------------------------------------------------------
@@ -261,7 +362,7 @@ pub fn session_list_with_filters(
              FROM messages m
              LEFT JOIN sessions s ON s.id = m.session_id
              {where_clause}
-             AND m.session_id IS NOT NULL
+             AND m.session_id IS NOT NULL AND m.session_id != ''
              GROUP BY m.session_id
          )
          SELECT COUNT(*) FROM session_agg"
@@ -407,7 +508,7 @@ pub fn session_list_with_filters(
              FROM messages m
              LEFT JOIN sessions s ON s.id = m.session_id
              {where_clause}
-             AND m.session_id IS NOT NULL
+             AND m.session_id IS NOT NULL AND m.session_id != ''
              GROUP BY m.session_id
          )
          SELECT COUNT(*) OVER() as total,

--- a/crates/budi-core/src/analytics/tests.rs
+++ b/crates/budi-core/src/analytics/tests.rs
@@ -1685,6 +1685,224 @@ fn session_list_uses_structured_models_array() {
     );
 }
 
+/// Regression test for #302 — `budi sessions -p today` was empty because
+/// `since` is computed as a UTC RFC3339 string from local midnight while
+/// message timestamps are written by each provider in RFC3339 (UTC). Confirm
+/// the string comparison works for the CLI's exact `since` format.
+#[test]
+fn session_list_returns_session_for_today_window_with_local_midnight_utc_since() {
+    use chrono::TimeZone;
+    let mut conn = test_db();
+
+    // Emulate the CLI's `local_midnight_to_utc(today)` output — RFC3339 UTC
+    // with a `+00:00` offset and no fractional seconds.
+    let since_dt = chrono::Local
+        .from_local_datetime(
+            &chrono::Local::now()
+                .date_naive()
+                .and_hms_opt(0, 0, 0)
+                .unwrap(),
+        )
+        .latest()
+        .unwrap()
+        .with_timezone(&chrono::Utc);
+    let since = since_dt.to_rfc3339();
+
+    // One assistant message "today, one hour after local midnight".
+    let mut msg = assistant_msg("today-msg", "sess-today", 1.5);
+    msg.timestamp = since_dt + chrono::Duration::hours(1);
+    ingest_messages(&mut conn, &[msg], None).unwrap();
+
+    let result = session_list_with_filters(
+        &conn,
+        &SessionListParams {
+            since: Some(&since),
+            until: None,
+            search: None,
+            sort_by: None,
+            sort_asc: false,
+            limit: 50,
+            offset: 0,
+        },
+        &DimensionFilters::default(),
+    )
+    .unwrap();
+    assert_eq!(result.total_count, 1);
+    assert_eq!(result.sessions[0].id, "sess-today");
+}
+
+/// Sessions visibility doctor check surfaces window-level mismatches so
+/// `budi doctor` can flag a recurrence of #302 even if the primary fix
+/// regresses.
+#[test]
+fn session_visibility_reports_windows_and_flags_hidden_rows() {
+    let mut conn = test_db();
+    let now = chrono::Utc::now();
+
+    // Visible: assistant message with a session_id, stamped 30 minutes ago.
+    let mut visible = assistant_msg("vis-1", "sess-vis", 1.0);
+    visible.timestamp = now - chrono::Duration::minutes(30);
+    ingest_messages(&mut conn, &[visible], None).unwrap();
+
+    // Hidden: assistant row written directly with NULL session_id, stamped
+    // 90 minutes ago — simulates the pre-fix proxy bug.
+    conn.execute(
+        "INSERT INTO messages (id, session_id, role, timestamp, model, provider,
+            input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
+            cost_cents, cost_confidence)
+         VALUES ('hidden-1', NULL, 'assistant', ?1, 'claude-opus-4-6',
+                 'claude_code', 1, 1, 0, 0, 0.1, 'proxy_estimated')",
+        params![(now - chrono::Duration::minutes(90)).to_rfc3339()],
+    )
+    .unwrap();
+
+    let windows = session_visibility(&conn).unwrap();
+    let labels: Vec<&str> = windows.iter().map(|w| w.label.as_str()).collect();
+    assert_eq!(labels, vec!["today", "7d", "30d"]);
+
+    for window in &windows {
+        assert_eq!(window.assistant_messages, 2, "{} window", window.label);
+        assert_eq!(
+            window.assistant_messages_with_session, 1,
+            "{} window",
+            window.label
+        );
+        assert_eq!(window.distinct_sessions, 1, "{} window", window.label);
+        assert_eq!(window.returned_sessions, 1, "{} window", window.label);
+        assert!(
+            !window.has_mismatch(),
+            "{} window should not flag mismatch: visible rows exist",
+            window.label
+        );
+    }
+}
+
+#[test]
+fn session_visibility_flags_mismatch_when_all_rows_missing_session_id() {
+    let conn = test_db();
+    let now = chrono::Utc::now();
+
+    conn.execute(
+        "INSERT INTO messages (id, session_id, role, timestamp, model, provider,
+            input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
+            cost_cents, cost_confidence)
+         VALUES ('hidden-1', NULL, 'assistant', ?1, 'claude-opus-4-6',
+                 'claude_code', 1, 1, 0, 0, 0.1, 'proxy_estimated')",
+        params![(now - chrono::Duration::minutes(30)).to_rfc3339()],
+    )
+    .unwrap();
+
+    let windows = session_visibility(&conn).unwrap();
+    let today = windows.iter().find(|w| w.label == "today").unwrap();
+    assert_eq!(today.assistant_messages, 1);
+    assert_eq!(today.assistant_messages_with_session, 0);
+    assert_eq!(today.returned_sessions, 0);
+    assert!(today.has_mismatch());
+}
+
+/// `messages.timestamp` contract — every provider must write an RFC3339 UTC
+/// string that string-compares correctly against the CLI's `since`/`until`
+/// bounds. This regression test exercises the exact formats emitted by the
+/// Claude Code JSONL, Cursor, and Codex providers (see SOUL.md §Messages).
+#[test]
+fn session_list_window_compares_correctly_across_provider_timestamp_formats() {
+    let mut conn = test_db();
+
+    // Claude Code JSONL uses `...Z`; after ingest we round-trip via
+    // `DateTime<Utc>::to_rfc3339()` which writes `+00:00`.
+    let mut claude = assistant_msg("cc-1", "cc-sess", 1.0);
+    claude.timestamp = "2026-03-14T12:00:00.500Z".parse().unwrap();
+    claude.provider = "claude_code".to_string();
+
+    // Cursor timestamps come in as millis and are written via
+    // `DateTime::from_timestamp_millis().to_rfc3339()`.
+    let mut cursor = assistant_msg("cu-1", "cu-sess", 1.0);
+    cursor.timestamp = "2026-03-14T12:30:00+00:00".parse().unwrap();
+    cursor.provider = "cursor".to_string();
+
+    // Codex emits RFC3339 with `...Z` suffix as well.
+    let mut codex = assistant_msg("cx-1", "cx-sess", 1.0);
+    codex.timestamp = "2026-03-14T13:00:00.123Z".parse().unwrap();
+    codex.provider = "openai".to_string();
+
+    ingest_messages(&mut conn, &[claude, cursor, codex], None).unwrap();
+
+    let since = "2026-03-14T00:00:00+00:00";
+    let until = "2026-03-15T00:00:00+00:00";
+    let result = session_list_with_filters(
+        &conn,
+        &SessionListParams {
+            since: Some(since),
+            until: Some(until),
+            search: None,
+            sort_by: None,
+            sort_asc: false,
+            limit: 50,
+            offset: 0,
+        },
+        &DimensionFilters::default(),
+    )
+    .unwrap();
+    assert_eq!(
+        result.total_count, 3,
+        "all three provider sessions must be in window"
+    );
+
+    // And the `Z`-suffixed upper bound (as produced by some callers) also works.
+    let until_z = "2026-03-15T00:00:00Z";
+    let result2 = session_list_with_filters(
+        &conn,
+        &SessionListParams {
+            since: Some(since),
+            until: Some(until_z),
+            search: None,
+            sort_by: None,
+            sort_asc: false,
+            limit: 50,
+            offset: 0,
+        },
+        &DimensionFilters::default(),
+    )
+    .unwrap();
+    assert_eq!(result2.total_count, 3);
+}
+
+#[test]
+fn session_list_ignores_empty_string_session_id() {
+    let conn = test_db();
+    // Direct insert: assistant row whose session_id is the empty string.
+    // Pre-fix `insert_proxy_message` could land here if the proxy route
+    // supplied "" instead of generating an id.
+    conn.execute(
+        "INSERT INTO messages (id, session_id, role, timestamp, model, provider,
+            input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
+            cost_cents, cost_confidence)
+         VALUES ('empty-1', '', 'assistant', '2026-03-14T10:00:00+00:00',
+                 'claude-opus-4-6', 'claude_code', 1, 1, 0, 0, 0.1, 'proxy_estimated')",
+        [],
+    )
+    .unwrap();
+
+    let result = session_list_with_filters(
+        &conn,
+        &SessionListParams {
+            since: Some("2026-03-13T00:00:00+00:00"),
+            until: None,
+            search: None,
+            sort_by: None,
+            sort_asc: false,
+            limit: 50,
+            offset: 0,
+        },
+        &DimensionFilters::default(),
+    )
+    .unwrap();
+    assert_eq!(
+        result.total_count, 0,
+        "empty-string session_id must not produce a ghost session row"
+    );
+}
+
 #[test]
 fn session_list_with_dimension_filters() {
     let mut conn = test_db();

--- a/crates/budi-core/src/config.rs
+++ b/crates/budi-core/src/config.rs
@@ -367,6 +367,35 @@ impl ProxyConfig {
         }
         self.enabled
     }
+
+    /// Resolve the effective Anthropic upstream URL, respecting env var override.
+    ///
+    /// `BUDI_ANTHROPIC_UPSTREAM` lets local e2e tests and air-gapped deployments
+    /// redirect proxy traffic to a mock or internal endpoint without editing
+    /// on-disk config. Mirrors `BUDI_PROXY_PORT` / `BUDI_PROXY_ENABLED`.
+    pub fn effective_anthropic_upstream(&self) -> String {
+        if let Ok(val) = env::var("BUDI_ANTHROPIC_UPSTREAM") {
+            let trimmed = val.trim();
+            if !trimmed.is_empty() {
+                return trimmed.to_string();
+            }
+        }
+        self.anthropic_upstream.clone()
+    }
+
+    /// Resolve the effective OpenAI upstream URL, respecting env var override.
+    ///
+    /// `BUDI_OPENAI_UPSTREAM` is the OpenAI-side counterpart to
+    /// `BUDI_ANTHROPIC_UPSTREAM`.
+    pub fn effective_openai_upstream(&self) -> String {
+        if let Ok(val) = env::var("BUDI_OPENAI_UPSTREAM") {
+            let trimmed = val.trim();
+            if !trimmed.is_empty() {
+                return trimmed.to_string();
+            }
+        }
+        self.openai_upstream.clone()
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -947,6 +976,54 @@ port = 9878
         let config: BudiConfig = toml::from_str(toml_str).unwrap();
         assert!(config.proxy.enabled);
         assert_eq!(config.proxy.port, 9878);
+    }
+
+    #[test]
+    fn proxy_config_effective_upstreams_prefer_env_vars() {
+        // Uses `unsafe` in 2024-edition Rust: mutating process env from tests is
+        // intrinsically racy. We isolate by using a mutex over just these two vars
+        // and clearing them before/after.
+        use std::sync::Mutex;
+        static LOCK: Mutex<()> = Mutex::new(());
+        let _guard = LOCK.lock().unwrap();
+
+        let config = ProxyConfig::default();
+
+        unsafe {
+            env::remove_var("BUDI_ANTHROPIC_UPSTREAM");
+            env::remove_var("BUDI_OPENAI_UPSTREAM");
+        }
+        assert_eq!(
+            config.effective_anthropic_upstream(),
+            "https://api.anthropic.com"
+        );
+        assert_eq!(config.effective_openai_upstream(), "https://api.openai.com");
+
+        unsafe {
+            env::set_var("BUDI_ANTHROPIC_UPSTREAM", "http://127.0.0.1:19333");
+            env::set_var("BUDI_OPENAI_UPSTREAM", "http://127.0.0.1:19444");
+        }
+        assert_eq!(
+            config.effective_anthropic_upstream(),
+            "http://127.0.0.1:19333"
+        );
+        assert_eq!(config.effective_openai_upstream(), "http://127.0.0.1:19444");
+
+        // Empty / whitespace-only overrides fall back to config value.
+        unsafe {
+            env::set_var("BUDI_ANTHROPIC_UPSTREAM", "   ");
+            env::set_var("BUDI_OPENAI_UPSTREAM", "");
+        }
+        assert_eq!(
+            config.effective_anthropic_upstream(),
+            "https://api.anthropic.com"
+        );
+        assert_eq!(config.effective_openai_upstream(), "https://api.openai.com");
+
+        unsafe {
+            env::remove_var("BUDI_ANTHROPIC_UPSTREAM");
+            env::remove_var("BUDI_OPENAI_UPSTREAM");
+        }
     }
 
     #[test]

--- a/crates/budi-core/src/proxy.rs
+++ b/crates/budi-core/src/proxy.rs
@@ -286,15 +286,29 @@ pub fn insert_proxy_message(conn: &Connection, event: &ProxyEvent) -> Result<Str
         Some(&event.git_branch)
     };
 
+    // Attribution: session_id must be written alongside other message columns.
+    // `session_list_with_filters` filters out rows with NULL/empty `session_id`,
+    // so a missing value here would make every proxied message invisible to
+    // `budi sessions`. The proxy route always supplies a non-empty id (either
+    // from `X-Budi-Session` or `generate_proxy_session_id`) — we still treat an
+    // empty string defensively as NULL so queries stay consistent with the
+    // documented `messages.session_id` contract (see SOUL.md).
+    let session_id = if event.session_id.is_empty() {
+        None
+    } else {
+        Some(event.session_id.as_str())
+    };
+
     conn.execute(
         "INSERT OR IGNORE INTO messages (
-            id, role, timestamp, model, provider,
+            id, session_id, role, timestamp, model, provider,
             input_tokens, output_tokens,
             cache_creation_tokens, cache_read_tokens,
             repo_id, git_branch, cost_cents, cost_confidence
-        ) VALUES (?1, 'assistant', ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, 'proxy_estimated')",
+        ) VALUES (?1, ?2, 'assistant', ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, 'proxy_estimated')",
         params![
             uuid,
+            session_id,
             event.timestamp,
             event.model,
             event.provider,
@@ -630,6 +644,71 @@ mod tests {
             .unwrap();
         assert_eq!(cache_create, Some(5000));
         assert_eq!(cache_read, Some(80000));
+    }
+
+    /// Regression test for #302 — `budi sessions` returned empty for periods
+    /// that clearly had proxy activity because `insert_proxy_message` dropped
+    /// `session_id`, making every proxied row invisible to the
+    /// `AND m.session_id IS NOT NULL` filter in `session_list_with_filters`.
+    #[test]
+    fn proxy_message_persists_session_id_and_is_visible_in_session_list() {
+        let conn = test_db_with_messages();
+        let mut event = test_event();
+        event.session_id = "proxy-session-abc".to_string();
+        event.timestamp = chrono::Utc::now().to_rfc3339();
+
+        let uuid = insert_proxy_message(&conn, &event).unwrap();
+
+        let stored: Option<String> = conn
+            .query_row(
+                "SELECT session_id FROM messages WHERE id = ?1",
+                params![uuid],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(stored.as_deref(), Some("proxy-session-abc"));
+
+        // Window that includes the event — `budi sessions -p today` would use
+        // an equivalent `since`. The session must be listed.
+        let since = (chrono::Utc::now() - chrono::Duration::hours(1)).to_rfc3339();
+        let paginated = crate::analytics::session_list_with_filters(
+            &conn,
+            &crate::analytics::SessionListParams {
+                since: Some(&since),
+                until: None,
+                search: None,
+                sort_by: None,
+                sort_asc: false,
+                limit: 50,
+                offset: 0,
+            },
+            &crate::analytics::DimensionFilters::default(),
+        )
+        .unwrap();
+        assert_eq!(paginated.total_count, 1);
+        assert_eq!(paginated.sessions.len(), 1);
+        assert_eq!(paginated.sessions[0].id, "proxy-session-abc");
+    }
+
+    /// Defensive: an empty `session_id` string is stored as NULL so it cannot
+    /// quietly produce a `(empty)` session bucket or confuse downstream
+    /// `session_id IS NOT NULL` checks. Such rows are intentionally invisible
+    /// to `budi sessions` (there is no session to attribute them to).
+    #[test]
+    fn proxy_message_empty_session_id_is_stored_as_null() {
+        let conn = test_db_with_messages();
+        let event = test_event(); // session_id = ""
+
+        let uuid = insert_proxy_message(&conn, &event).unwrap();
+
+        let stored: Option<String> = conn
+            .query_row(
+                "SELECT session_id FROM messages WHERE id = ?1",
+                params![uuid],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(stored.is_none(), "empty session_id must be stored as NULL");
     }
 
     #[test]

--- a/crates/budi-daemon/src/main.rs
+++ b/crates/budi-daemon/src/main.rs
@@ -207,8 +207,8 @@ async fn main() -> Result<()> {
                 .connect_timeout(std::time::Duration::from_secs(30))
                 .build()
                 .expect("failed to build proxy HTTP client"),
-            anthropic_upstream: proxy_config.anthropic_upstream.clone(),
-            openai_upstream: proxy_config.openai_upstream.clone(),
+            anthropic_upstream: proxy_config.effective_anthropic_upstream(),
+            openai_upstream: proxy_config.effective_openai_upstream(),
             analytics_db_path,
             #[cfg(test)]
             record_tx: None,

--- a/scripts/e2e/README.md
+++ b/scripts/e2e/README.md
@@ -1,0 +1,71 @@
+# Local end-to-end tests
+
+This directory holds shell-driven end-to-end tests for the Budi binaries
+(`budi` + `budi-daemon`). They are intentionally kept in bash rather than
+Rust integration tests so they can:
+
+- exercise the real release binaries (not a test harness compiled against
+  the crates),
+- boot the full daemon + proxy + CLI surface,
+- drive the system over HTTP exactly the way an agent or user would,
+- be run locally, in CI, or during PR review without extra tooling beyond
+  `bash`, `curl`, `sqlite3`, and `python3`.
+
+## Running
+
+```bash
+# Build once per change.
+cargo build --release
+
+# Run one test:
+bash scripts/e2e/test_302_sessions_visibility.sh
+
+# Keep the temp HOME around for post-mortem inspection:
+KEEP_TMP=1 bash scripts/e2e/test_302_sessions_visibility.sh
+```
+
+Every test exits non-zero on the first failure, prints the daemon log, and
+cleans up its temp directory on exit (unless `KEEP_TMP=1`).
+
+## Conventions
+
+1. **Name.** `test_<issue>_<short_slug>.sh`, e.g.
+   `test_302_sessions_visibility.sh` pins the fix for
+   [siropkin/budi#302](https://github.com/siropkin/budi/issues/302).
+2. **Header.** Start each script with a comment block that states:
+   - what bug or contract it guards,
+   - the repro recipe in one paragraph,
+   - which `SOUL.md` / ADR sections it enforces.
+3. **Isolation.** Always:
+   - `export HOME="$(mktemp -d …)"` so the DB under
+     `$HOME/.local/share/budi/analytics.db` is fresh;
+   - allocate non-default daemon / proxy / upstream ports so multiple
+     scripts can run in parallel;
+   - kill children via a `trap cleanup EXIT INT TERM`.
+4. **No real network.** Run a tiny Python `http.server`-based mock upstream
+   on loopback and point the daemon at it via
+   `BUDI_ANTHROPIC_UPSTREAM` / `BUDI_OPENAI_UPSTREAM`.
+5. **Assertions.** Prefer explicit, easy-to-read assertions over clever
+   one-liners. Fail with a clear `[e2e] FAIL: …` message and include the
+   most recent daemon log tail.
+6. **Negative-path proof.** Before merging a new regression test, revert
+   the fix it guards locally and confirm the script fails. Restore the
+   fix; only then land the script.
+
+## Environment overrides used by these scripts
+
+| Variable | Purpose |
+|---|---|
+| `HOME` | Isolates the Budi data dir (`$HOME/.local/share/budi/`) and repo config (`$HOME/repo/.budi/budi.toml`). |
+| `BUDI_ANTHROPIC_UPSTREAM` | Overrides the hard-coded `https://api.anthropic.com` so the proxy calls a loopback mock. |
+| `BUDI_OPENAI_UPSTREAM` | Same, for the OpenAI upstream. |
+| `BUDI_PROXY_PORT` / `BUDI_PROXY_ENABLED` | Existing overrides on `ProxyConfig`; rarely needed directly because scripts pass `--proxy-port` to `budi-daemon serve`. |
+| `KEEP_TMP=1` | Tells the cleanup trap to leave the temp HOME in place for debugging. |
+
+## Adding a new script
+
+1. Copy an existing script as a starting point.
+2. Update the header comment, the ports, and the assertions.
+3. Run it locally (it should pass).
+4. Revert the fix under test, re-run (it should fail with a clear message).
+5. Restore the fix and commit both the script and any supporting changes.

--- a/scripts/e2e/test_302_sessions_visibility.sh
+++ b/scripts/e2e/test_302_sessions_visibility.sh
@@ -1,0 +1,238 @@
+#!/usr/bin/env bash
+# End-to-end smoke test for issue #302: verify that a proxied assistant message
+# shows up in `budi sessions -p today` on a fresh database.
+#
+# - Isolates HOME to a temp dir so the test cannot touch real user data.
+# - Starts a mock upstream HTTP server that returns a canned Anthropic reply.
+# - Runs the real release `budi-daemon` pointed at the mock upstream.
+# - POSTs through the proxy with an X-Budi-Session header.
+# - Asserts `budi sessions -p today` lists the session and that the DB row
+#   has a non-null session_id.
+# - Runs `budi doctor` and asserts the new "sessions visibility" block reports
+#   no mismatch.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BUDI="$ROOT/target/release/budi"
+BUDI_DAEMON="$ROOT/target/release/budi-daemon"
+
+if [[ ! -x "$BUDI" || ! -x "$BUDI_DAEMON" ]]; then
+  echo "error: release binaries not built. run \`cargo build --release\` first." >&2
+  exit 2
+fi
+
+TMPDIR_ROOT="$(mktemp -d -t budi-e2e-302-XXXXXX)"
+export HOME="$TMPDIR_ROOT"
+mkdir -p "$HOME/.config/budi"
+
+DAEMON_PORT=17878
+PROXY_PORT=19878
+UPSTREAM_PORT=19333
+
+cleanup() {
+  local status=$?
+  # Kill the daemon we started, plus any CLI-autostarted daemon that bound
+  # to the default port while running under this isolated HOME.
+  { kill "${DAEMON_PID:-}" 2>/dev/null || true; } >/dev/null 2>&1
+  { kill "${CLI_DAEMON_PID:-}" 2>/dev/null || true; } >/dev/null 2>&1
+  { kill "${UPSTREAM_PID:-}" 2>/dev/null || true; } >/dev/null 2>&1
+  # Defense-in-depth: pkill any stray daemon/mock still referencing our tmp.
+  pkill -f "budi-daemon serve --host 127.0.0.1 --port $DAEMON_PORT" >/dev/null 2>&1 || true
+  pkill -f "mock_upstream.py $UPSTREAM_PORT" >/dev/null 2>&1 || true
+  if [[ "${KEEP_TMP:-0}" == "1" ]]; then
+    echo "[e2e] leaving tmp: $TMPDIR_ROOT"
+  else
+    rm -rf "$TMPDIR_ROOT"
+  fi
+  exit $status
+}
+trap cleanup EXIT INT TERM
+
+echo "[e2e] HOME=$HOME"
+
+# The `budi` CLI resolves the daemon URL from the repo-scoped `.budi/budi.toml`,
+# so create a throwaway repo root inside HOME and point the CLI at our daemon.
+REPO_ROOT="$HOME/repo"
+mkdir -p "$REPO_ROOT/.budi"
+cat >"$REPO_ROOT/.budi/budi.toml" <<EOF
+daemon_host = "127.0.0.1"
+daemon_port = $DAEMON_PORT
+
+[proxy]
+enabled = true
+port = $PROXY_PORT
+EOF
+# Make it a git repo so repo-root resolution succeeds.
+(cd "$REPO_ROOT" && git init -q 2>/dev/null || true)
+
+# Mock upstream — responds to /v1/messages with a minimal non-streaming
+# Anthropic reply carrying realistic usage so cost/token extraction runs.
+cat >"$TMPDIR_ROOT/mock_upstream.py" <<'PY'
+import http.server, json, sys
+
+class H(http.server.BaseHTTPRequestHandler):
+    def do_POST(self):
+        n = int(self.headers.get("Content-Length", "0") or 0)
+        _ = self.rfile.read(n)
+        body = {
+            "id": "msg_e2e_302",
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-sonnet-4-6",
+            "content": [{"type": "text", "text": "ok"}],
+            "stop_reason": "end_turn",
+            "usage": {
+                "input_tokens": 42,
+                "output_tokens": 7,
+                "cache_creation_input_tokens": 0,
+                "cache_read_input_tokens": 0,
+            },
+        }
+        payload = json.dumps(body).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def log_message(self, *a, **k):
+        pass
+
+port = int(sys.argv[1])
+http.server.HTTPServer(("127.0.0.1", port), H).serve_forever()
+PY
+
+echo "[e2e] starting mock upstream on :$UPSTREAM_PORT"
+python3 "$TMPDIR_ROOT/mock_upstream.py" "$UPSTREAM_PORT" >"$TMPDIR_ROOT/upstream.log" 2>&1 &
+UPSTREAM_PID=$!
+
+for _ in {1..30}; do
+  if curl -s -o /dev/null -w "%{http_code}" --max-time 1 "http://127.0.0.1:$UPSTREAM_PORT/" | grep -qE "^[45]"; then
+    break
+  fi
+  sleep 0.1
+done
+
+echo "[e2e] starting budi-daemon on :$DAEMON_PORT / proxy :$PROXY_PORT"
+BUDI_ANTHROPIC_UPSTREAM="http://127.0.0.1:$UPSTREAM_PORT" \
+BUDI_OPENAI_UPSTREAM="http://127.0.0.1:$UPSTREAM_PORT" \
+RUST_LOG=info \
+  "$BUDI_DAEMON" serve \
+    --host 127.0.0.1 \
+    --port $DAEMON_PORT \
+    --proxy-port $PROXY_PORT \
+    >"$TMPDIR_ROOT/daemon.log" 2>&1 &
+DAEMON_PID=$!
+
+DAEMON_UP=0
+for _ in {1..50}; do
+  if curl -s -o /dev/null -w "%{http_code}" --max-time 1 "http://127.0.0.1:$DAEMON_PORT/health" | grep -q "^200"; then
+    DAEMON_UP=1
+    break
+  fi
+  sleep 0.1
+done
+if [[ "$DAEMON_UP" != "1" ]]; then
+  echo "[e2e] FAIL: daemon did not come up on :$DAEMON_PORT" >&2
+  echo "--- daemon log ---" >&2
+  cat "$TMPDIR_ROOT/daemon.log" >&2 || true
+  exit 1
+fi
+PROXY_UP=0
+for _ in {1..50}; do
+  if curl -s -o /dev/null -w "%{http_code}" --max-time 1 -X POST -H "content-type: application/json" -d '{}' "http://127.0.0.1:$PROXY_PORT/v1/messages" | grep -qE "^(2|4|5)[0-9]{2}$"; then
+    PROXY_UP=1
+    break
+  fi
+  sleep 0.1
+done
+if [[ "$PROXY_UP" != "1" ]]; then
+  echo "[e2e] FAIL: proxy did not come up on :$PROXY_PORT" >&2
+  echo "--- daemon log ---" >&2
+  cat "$TMPDIR_ROOT/daemon.log" >&2 || true
+  exit 1
+fi
+
+SESSION_ID="e2e-sess-$(date +%s)"
+echo "[e2e] sending proxied request with X-Budi-Session=$SESSION_ID"
+STATUS=$(curl -s -o "$TMPDIR_ROOT/proxy_reply.json" -w "%{http_code}" --max-time 5 \
+  -X POST \
+  -H "content-type: application/json" \
+  -H "x-budi-session: $SESSION_ID" \
+  -H "x-budi-repo: github.com/siropkin/budi" \
+  -H "x-budi-branch: v8/302-sessions-visibility" \
+  -d '{"model":"claude-sonnet-4-6","messages":[{"role":"user","content":"hi"}]}' \
+  "http://127.0.0.1:$PROXY_PORT/v1/messages")
+
+if [[ "$STATUS" != "200" ]]; then
+  echo "[e2e] FAIL: proxy POST returned $STATUS" >&2
+  cat "$TMPDIR_ROOT/proxy_reply.json" >&2 || true
+  echo "--- daemon log ---" >&2
+  tail -n 60 "$TMPDIR_ROOT/daemon.log" >&2 || true
+  exit 1
+fi
+
+# Give the daemon a beat to finish the spawn_blocking DB write.
+sleep 0.5
+
+echo "[e2e] sessions list (json):"
+SESSIONS_JSON=$(curl -s "http://127.0.0.1:$DAEMON_PORT/analytics/sessions?since=$(date -u +%Y-%m-%dT00:00:00+00:00)")
+echo "$SESSIONS_JSON" | python3 -m json.tool
+
+FOUND=$(echo "$SESSIONS_JSON" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+ids = [s.get('id') for s in data.get('sessions', [])]
+print('1' if '$SESSION_ID' in ids else '0')
+")
+if [[ "$FOUND" != "1" ]]; then
+  echo "[e2e] FAIL: session '$SESSION_ID' not returned by /analytics/sessions" >&2
+  echo "--- daemon log ---" >&2
+  tail -n 60 "$TMPDIR_ROOT/daemon.log" >&2 || true
+  exit 1
+fi
+echo "[e2e] OK: session '$SESSION_ID' visible via /analytics/sessions"
+
+DB="$HOME/.local/share/budi/analytics.db"
+echo "[e2e] DB rows for session:"
+sqlite3 "$DB" "SELECT id, session_id, provider, model, input_tokens, output_tokens, cost_confidence FROM messages WHERE session_id = '$SESSION_ID';"
+
+ROWCOUNT=$(sqlite3 "$DB" "SELECT COUNT(*) FROM messages WHERE session_id = '$SESSION_ID';")
+if [[ "$ROWCOUNT" != "1" ]]; then
+  echo "[e2e] FAIL: expected 1 messages row for '$SESSION_ID', found $ROWCOUNT" >&2
+  exit 1
+fi
+NULL_SESSIONS=$(sqlite3 "$DB" "SELECT COUNT(*) FROM messages WHERE role='assistant' AND (session_id IS NULL OR session_id='');")
+if [[ "$NULL_SESSIONS" != "0" ]]; then
+  echo "[e2e] FAIL: $NULL_SESSIONS assistant rows were written with NULL/empty session_id — regression" >&2
+  exit 1
+fi
+echo "[e2e] OK: session_id persisted, no NULL/empty-session_id rows"
+
+# Run the CLI from inside the isolated repo root so `load_config` picks up
+# our `.budi/budi.toml` and the CLI points at the test daemon on $DAEMON_PORT
+# instead of auto-starting a second daemon on the default port.
+echo "[e2e] budi sessions -p today:"
+(cd "$REPO_ROOT" && "$BUDI" sessions -p today) | tee "$TMPDIR_ROOT/sessions_today.txt"
+if ! grep -q "$SESSION_ID" "$TMPDIR_ROOT/sessions_today.txt" \
+  && ! grep -q "${SESSION_ID:0:8}" "$TMPDIR_ROOT/sessions_today.txt"; then
+  echo "[e2e] FAIL: \`budi sessions -p today\` did not list the session" >&2
+  exit 1
+fi
+echo "[e2e] OK: budi sessions -p today lists the session"
+
+echo "[e2e] budi doctor (sessions visibility section):"
+DOCTOR_OUT="$(cd "$REPO_ROOT" && "$BUDI" doctor 2>&1 || true)"
+echo "$DOCTOR_OUT" | grep -E "sessions visibility" || {
+  echo "[e2e] FAIL: budi doctor did not print a sessions-visibility check" >&2
+  echo "$DOCTOR_OUT" | tail -n 40 >&2
+  exit 1
+}
+if echo "$DOCTOR_OUT" | grep -q "Sessions visibility mismatch"; then
+  echo "[e2e] FAIL: budi doctor reported a sessions-visibility mismatch" >&2
+  echo "$DOCTOR_OUT" | tail -n 40 >&2
+  exit 1
+fi
+echo "[e2e] OK: budi doctor sessions-visibility check is green"
+
+echo "[e2e] PASS"


### PR DESCRIPTION
## Summary

Closes #302.

Root cause (hypothesis #2 from the ticket): `budi_core::proxy::insert_proxy_message` did not write the `session_id` column, so every live proxied assistant message was stored with `session_id = NULL`. `session_list_with_filters` requires `m.session_id IS NOT NULL`, so today's proxy-driven activity was silently filtered out of `budi sessions -p today` / `-p week` even though `budi stats` (which does not require a session) happily counted the same rows. `-p month` and `-p all` "worked" only because they also caught older Claude Code JSONL rows imported via `budi import`, which do carry `session_id`.

### Changes

- `crates/budi-core/src/proxy.rs` — `insert_proxy_message` now writes `session_id`. Empty strings are normalized to `NULL` so the "no session" case stays explicit instead of creating ghost `(empty)` session buckets.
- `crates/budi-core/src/analytics/sessions.rs` — `session_list_with_filters`, `session_audit`, and `assistant_rows_no_session` defensively treat empty-string `session_id` as NULL, matching the contract.
- `crates/budi-core/src/analytics/sessions.rs` — new `session_visibility(conn)` helper returning per-window (`today`/`7d`/`30d`) counts: assistant messages, assistant messages with session, distinct sessions, and sessions that `session_list_with_filters` would actually return.
- `crates/budi-cli/src/commands/doctor.rs` — `budi doctor` renders the three windows and fails when any window has assistant activity but zero returned sessions (explicit link to #302 so a future regression is obvious).
- `SOUL.md` — new "Attribution contract (R1.0)" section locking in the `timestamp` (RFC3339 UTC, accept `Z` and `+00:00`), `session_id` (NULL-or-non-empty, never `""`), `provider`, and `git_branch` rules.
- `CHANGELOG.md` — new 8.1.0 unreleased section capturing the fix and the doctor check.

### Regression tests

All in `crates/budi-core/src/{proxy,analytics/tests}.rs`:

- `proxy_message_persists_session_id_and_is_visible_in_session_list` — proxy path end-to-end: event with `session_id` → DB row has `session_id` → session listing returns it for a `today`-ish window.
- `proxy_message_empty_session_id_is_stored_as_null` — defensive normalization.
- `session_list_returns_session_for_today_window_with_local_midnight_utc_since` — covers the exact `since` string the CLI computes from `Local::now()` → `local_midnight_to_utc`.
- `session_list_window_compares_correctly_across_provider_timestamp_formats` — Claude Code (`...Z`), Cursor (`+00:00`), and Codex (`...Z`) rows all fall inside the same RFC3339 window on string comparison, for both `Z` and `+00:00` upper bounds.
- `session_list_ignores_empty_string_session_id` — ghost sessions cannot reappear.
- `session_visibility_reports_windows_and_flags_hidden_rows` / `session_visibility_flags_mismatch_when_all_rows_missing_session_id` — doctor helper behaves correctly on mixed and all-hidden data.

### Hypotheses from the ticket, resolved

1. **Auto-sync drift.** Not the root cause — live traffic flows through the proxy, which writes to `messages` synchronously. Rows existed; they were just hidden.
2. **`session_id` NULL on proxy rows.** Confirmed root cause. Fixed.
3. **Timestamp TZ mismatch.** Not a cause in practice — all providers call `DateTime::<Utc>::to_rfc3339()` (or equivalent) so stored strings are lex-comparable to the CLI's `local_midnight_to_utc` output. Locked in by the cross-provider regression test and the SOUL.md contract.
4. **`role != 'assistant'`.** Not a cause — all three providers and the proxy emit `role = 'assistant'` for assistant replies.
5. **Offset > 0 defaulting.** Not a cause — daemon defaults `offset` to 0.

## Risks / compatibility notes

- Existing pre-fix proxy rows in user databases still have `session_id = NULL` and remain invisible to `budi sessions` — by design, since there is no session id to attribute them to. They stay counted by `budi stats` exactly as before. No destructive migration is performed. Fresh proxy traffic after the upgrade will be attributed correctly, which matches the issue's acceptance criterion ("on a fresh machine where Claude Code + Cursor + Codex were used today").
- `budi doctor` gains a new line group ("sessions visibility"). The check is read-only and runs against the existing DB path (same pattern as the current integrity_check block).
- No schema change. No cloud-sync contract change (only aggregates flow upstream; this fix affects local `messages` rows only).
- No new dependencies. No behavior change for `budi import` or the cloud dashboard.

## Validation

- `cargo fmt --all -- --check` — clean.
- `cargo clippy --workspace --all-targets --locked -- -D warnings` — clean.
- `cargo test --workspace --locked` — 332 core tests + daemon tests pass, including all new regression tests.
- Manual review of `record_event_blocking` / `insert_proxy_message` call chain to confirm `session_id` flows from `X-Budi-Session` header or `generate_proxy_session_id()` through to the `messages` row.

## R1.0 roadmap position

This is the first of the four R1.0 hard-gate fixes for the 8.1 milestone (#201). #303 (branch attribution), #304 (ticket as first-class CLI dimension), and #305 (activity as first-class CLI dimension) are next in order.


Made with [Cursor](https://cursor.com)