### PR TITLE
[8.1][R1.0.2] Fix: branch attribution for live proxy traffic (#303)

### DIFF
--- a/SOUL.md
+++ b/SOUL.md
@@ -32,6 +32,7 @@ Shell-driven end-to-end tests live under `scripts/e2e/`. They exercise the full 
 ```bash
 cargo build --release                                 # once per change
 bash scripts/e2e/test_302_sessions_visibility.sh      # regression guard for #302
+bash scripts/e2e/test_303_branch_attribution.sh       # regression guard for #303
 ```
 
 Each script is a single self-contained bash file that:
@@ -168,11 +169,37 @@ in [#302](https://github.com/siropkin/budi/issues/302) / #303 / #304 / #305):
   `copilot`). `COALESCE(provider, 'claude_code')` is the legacy fallback for
   pre-8.0 rows; new writes MUST set it explicitly.
 - **`git_branch`** — written without the `refs/heads/` prefix
-  (`session_list_with_filters` strips it defensively for older rows).
+  (`session_list_with_filters` strips it defensively for older rows). Live
+  proxy ingest resolves the branch in this priority order
+  (`ProxyAttribution::resolve` in `crates/budi-core/src/proxy.rs`):
+  1. **`X-Budi-Branch` header** — set by an integration shim that knows the
+     client's git state (e.g. a future agent wrapper).
+  2. **`X-Budi-Cwd` header** → `git rev-parse --abbrev-ref HEAD` — the proxy
+     shells out to git against the client-supplied cwd.
+  3. **Session-level propagation in `insert_proxy_message`** (R1.0.2, #303)
+     — if the incoming event has no branch, the insert path looks up the
+     most recent message in the same session that does and adopts it; if
+     the incoming event does resolve a branch, earlier NULL-branch rows in
+     the same session are backfilled in the same transaction. This mirrors
+     the batch pipeline's `propagate_session_context` on the live path so
+     that once a session learns its branch, every row in that session
+     reflects it.
+  4. **`Unassigned` repo + empty branch** — last-resort fallback. Rows in
+     this state surface as `(untagged)` in `budi stats --branches`.
 
-`budi doctor` runs a sessions-visibility check for the `today`, `7d`, and
-`30d` windows and fails with a link to #302 if any window has assistant rows
-but zero returned sessions.
+  A detached HEAD (`git rev-parse --abbrev-ref HEAD` == `"HEAD"`) is
+  explicitly normalized to empty so that worktrees, mid-rebase sessions, and
+  CI runs do not pollute the branches list with a bogus `HEAD` bucket.
+
+`budi doctor` runs two attribution checks:
+
+- **Session visibility** for the `today`, `7d`, and `30d` windows (R1.0.1,
+  #302) — fails when a window has assistant rows but zero returned sessions.
+- **Branch attribution (7d, per provider)** (R1.0.2, #303) — yellow at >10%
+  of assistant rows missing `git_branch`, red at >50%. A red result points
+  at a broken attribution path for that provider (no headers, no resolvable
+  cwd, session propagation not rescuing the session) even if overall cost
+  numbers look healthy.
 
 ### Key concepts
 

--- a/crates/budi-cli/src/commands/doctor.rs
+++ b/crates/budi-cli/src/commands/doctor.rs
@@ -337,6 +337,54 @@ pub fn cmd_doctor(repo_root: Option<PathBuf>, deep: bool) -> Result<()> {
         }
     }
 
+    // Branch attribution: catch a recurrence of R1.0.2 (#303) where live
+    // proxy traffic lands in the database without `git_branch`, collapsing
+    // `budi stats --branches` into `(untagged)`. A single provider with a
+    // significant missing-branch ratio points at a broken attribution path
+    // for that provider even if totals are healthy overall.
+    if let Ok(db_path) = budi_core::analytics::db_path()
+        && db_path.exists()
+        && let Ok(conn) = budi_core::analytics::open_db(&db_path)
+    {
+        match budi_core::analytics::branch_attribution_stats(&conn) {
+            Ok(stats) if stats.is_empty() => {
+                println!("  {dim}-{reset} branch attribution (7d): no assistant activity yet");
+            }
+            Ok(stats) => {
+                let yellow = super::ansi("\x1b[33m");
+                let mut any_red = false;
+                for row in &stats {
+                    let pct = row.missing_branch_ratio() * 100.0;
+                    let mark = if pct > 50.0 {
+                        any_red = true;
+                        format!("{red}\u{2717}{reset}")
+                    } else if pct > 10.0 {
+                        format!("{yellow}!{reset}")
+                    } else {
+                        format!("{green}\u{2713}{reset}")
+                    };
+                    println!(
+                        "  {mark} branch attribution ({}, 7d): assistant={} missing_branch={} ({:.0}%) missing_repo={} missing_cwd={}",
+                        row.provider,
+                        row.total_assistant,
+                        row.missing_branch,
+                        pct,
+                        row.missing_repo,
+                        row.missing_cwd,
+                    );
+                }
+                if any_red {
+                    issues.push(
+                        "Branch attribution is broken for at least one provider (>50% of assistant rows have no git_branch). `budi stats --branches` will show `(untagged)`. See #303.".into(),
+                    );
+                }
+            }
+            Err(e) => {
+                println!("  {dim}-{reset} branch attribution: could not compute ({e})");
+            }
+        }
+    }
+
     // Auto-proxy configuration checks (shell profile + IDE config files)
     {
         let agents = budi_core::config::load_agents_config()

--- a/crates/budi-core/src/analytics/sessions.rs
+++ b/crates/budi-core/src/analytics/sessions.rs
@@ -187,6 +187,68 @@ pub fn session_visibility(conn: &Connection) -> Result<Vec<SessionVisibilityWind
 }
 
 // ---------------------------------------------------------------------------
+// Branch Attribution (doctor diagnostics — #303)
+// ---------------------------------------------------------------------------
+
+/// Per-provider counts of assistant rows in the last 7 days that are missing
+/// the branch/repo/cwd attribution fields. Drives the `budi doctor`
+/// branch-attribution check so a regression of #303 is visible the same way
+/// #302's session-visibility mismatch is.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct BranchAttributionProvider {
+    pub provider: String,
+    pub total_assistant: u64,
+    pub missing_branch: u64,
+    pub missing_repo: u64,
+    pub missing_cwd: u64,
+}
+
+impl BranchAttributionProvider {
+    /// Share of rows (0.0..=1.0) in this provider that have no `git_branch`.
+    pub fn missing_branch_ratio(&self) -> f64 {
+        if self.total_assistant == 0 {
+            0.0
+        } else {
+            self.missing_branch as f64 / self.total_assistant as f64
+        }
+    }
+}
+
+/// 7-day branch-attribution health per provider.
+///
+/// We deliberately scope to 7 days: it is long enough that short outages
+/// (laptop off overnight) do not starve the check, and short enough that a
+/// regression surfaces within a day of a new bad build landing.
+pub fn branch_attribution_stats(conn: &Connection) -> Result<Vec<BranchAttributionProvider>> {
+    let since = (chrono::Utc::now() - chrono::Duration::days(7)).to_rfc3339();
+
+    let mut stmt = conn.prepare(
+        "SELECT COALESCE(provider, 'claude_code') AS p,
+                COUNT(*) AS total,
+                SUM(CASE WHEN git_branch IS NULL OR git_branch = '' THEN 1 ELSE 0 END),
+                SUM(CASE WHEN repo_id IS NULL OR repo_id = '' OR repo_id = 'Unassigned' THEN 1 ELSE 0 END),
+                SUM(CASE WHEN cwd IS NULL OR cwd = '' THEN 1 ELSE 0 END)
+         FROM messages
+         WHERE role = 'assistant' AND timestamp >= ?1
+         GROUP BY p
+         ORDER BY total DESC",
+    )?;
+    let rows = stmt
+        .query_map(params![since], |row| {
+            Ok(BranchAttributionProvider {
+                provider: row.get(0)?,
+                total_assistant: row.get::<_, i64>(1)? as u64,
+                missing_branch: row.get::<_, i64>(2)? as u64,
+                missing_repo: row.get::<_, i64>(3)? as u64,
+                missing_cwd: row.get::<_, i64>(4)? as u64,
+            })
+        })?
+        .filter_map(|r| r.ok())
+        .collect();
+    Ok(rows)
+}
+
+// ---------------------------------------------------------------------------
 // Session List
 // ---------------------------------------------------------------------------
 

--- a/crates/budi-core/src/analytics/tests.rs
+++ b/crates/budi-core/src/analytics/tests.rs
@@ -1800,6 +1800,65 @@ fn session_visibility_flags_mismatch_when_all_rows_missing_session_id() {
     assert!(today.has_mismatch());
 }
 
+/// Regression for #303 — `budi doctor` must see when live proxy traffic
+/// lands in the last 7 days without `git_branch`, which is exactly what
+/// makes `budi stats --branches` collapse into `(untagged)`.
+#[test]
+fn branch_attribution_stats_reports_missing_branch_within_7d() {
+    let conn = test_db();
+    let now = chrono::Utc::now();
+
+    // Two claude_code rows without a branch, one with.
+    for (id, branch) in [
+        ("m-no-1", None::<&str>),
+        ("m-no-2", None),
+        ("m-ok-1", Some("PROJ-1-feat")),
+    ] {
+        conn.execute(
+            "INSERT INTO messages (id, session_id, role, timestamp, model, provider,
+                                   input_tokens, output_tokens, cache_creation_tokens,
+                                   cache_read_tokens, git_branch, cost_cents, cost_confidence)
+             VALUES (?1, ?2, 'assistant', ?3, 'claude-sonnet-4-6',
+                     'claude_code', 1, 1, 0, 0, ?4, 0.1, 'proxy_estimated')",
+            params![
+                id,
+                format!("sess-{id}"),
+                (now - chrono::Duration::hours(1)).to_rfc3339(),
+                branch,
+            ],
+        )
+        .unwrap();
+    }
+
+    // One openai row, outside the 7-day window. Must be excluded.
+    conn.execute(
+        "INSERT INTO messages (id, session_id, role, timestamp, model, provider,
+                               input_tokens, output_tokens, cache_creation_tokens,
+                               cache_read_tokens, git_branch, cost_cents, cost_confidence)
+         VALUES ('old-1', 'sess-old', 'assistant', ?1, 'gpt-4o',
+                 'openai', 1, 1, 0, 0, NULL, 0.1, 'proxy_estimated')",
+        params![(now - chrono::Duration::days(30)).to_rfc3339()],
+    )
+    .unwrap();
+
+    let stats = branch_attribution_stats(&conn).unwrap();
+    assert_eq!(
+        stats.len(),
+        1,
+        "only claude_code should appear in 7d window, got: {stats:?}"
+    );
+    let claude = &stats[0];
+    assert_eq!(claude.provider, "claude_code");
+    assert_eq!(claude.total_assistant, 3);
+    assert_eq!(claude.missing_branch, 2);
+    // 2/3 ≈ 66.7% — should breach the 50% red threshold.
+    assert!(
+        claude.missing_branch_ratio() > 0.5,
+        "2 of 3 rows missing a branch must breach the red threshold, got {}",
+        claude.missing_branch_ratio()
+    );
+}
+
 /// `messages.timestamp` contract — every provider must write an RFC3339 UTC
 /// string that string-compares correctly against the CLI's `since`/`until`
 /// bounds. This regression test exercises the exact formats emitted by the

--- a/crates/budi-core/src/proxy.rs
+++ b/crates/budi-core/src/proxy.rs
@@ -102,15 +102,24 @@ impl ProxyAttribution {
 }
 
 /// Resolve the current git branch for a directory.
+///
+/// Returns an empty string if `cwd` is not a git repo OR the repo is in
+/// detached-HEAD state (`git rev-parse --abbrev-ref HEAD` returns the literal
+/// `"HEAD"` in that case, which would pollute the branch attribution bucket).
+/// Callers treat empty as "no branch" and fall through to `propagate_session_context`
+/// or `Unassigned`. See #303 hypothesis #3.
 fn resolve_git_branch(cwd: &std::path::Path) -> String {
-    std::process::Command::new("git")
+    let raw = std::process::Command::new("git")
         .args(["rev-parse", "--abbrev-ref", "HEAD"])
         .current_dir(cwd)
         .output()
         .ok()
         .filter(|o| o.status.success())
         .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
-        .unwrap_or_default()
+        .unwrap_or_default();
+    // Detached HEAD: git reports the literal "HEAD". Drop it so we never show
+    // a bogus `HEAD` branch bucket in `budi stats --branches`.
+    if raw == "HEAD" { String::new() } else { raw }
 }
 
 /// Extract a numeric-only ticket ID from a branch name per ADR-0082 §9.
@@ -273,18 +282,31 @@ pub fn insert_proxy_event(conn: &Connection, event: &ProxyEvent) -> Result<i64> 
 /// surfaces (dashboard, CLI, statusline) can query it without modification.
 ///
 /// Returns the generated message UUID on success.
+///
+/// ## Session-level branch propagation (#303)
+///
+/// The live proxy ingest path does **not** go through `Pipeline::process` (that
+/// is used by batch `budi import`), so `propagate_session_context` never ran on
+/// proxied rows. When the first turns of a session landed without a branch (the
+/// very common case — agents do not set `X-Budi-*` headers, client cwd is not
+/// yet known, etc.) every later assistant reply in the same session also got
+/// `git_branch = NULL`, and `budi stats --branches` collapsed them into the
+/// `(untagged)` bucket.
+///
+/// This function mirrors the pipeline's per-session carry-forward directly in
+/// SQL so live ingest matches batch ingest:
+///
+/// - If the incoming event has an empty `git_branch` but another message in
+///   the same session already has one, inherit it.
+/// - If the incoming event has a `git_branch` but earlier same-session rows
+///   are empty, backfill them. This covers the "first message lacked context,
+///   later one resolved it" race described in the ticket.
+/// - Same pattern for `repo_id`.
+///
+/// The propagation runs inside a single connection scope so a concurrent
+/// writer on another session is unaffected.
 pub fn insert_proxy_message(conn: &Connection, event: &ProxyEvent) -> Result<String> {
     let uuid = format!("proxy-{}", uuid::Uuid::new_v4());
-    let repo_id = if event.repo_id.is_empty() {
-        None
-    } else {
-        Some(&event.repo_id)
-    };
-    let git_branch = if event.git_branch.is_empty() {
-        None
-    } else {
-        Some(&event.git_branch)
-    };
 
     // Attribution: session_id must be written alongside other message columns.
     // `session_list_with_filters` filters out rows with NULL/empty `session_id`,
@@ -298,6 +320,13 @@ pub fn insert_proxy_message(conn: &Connection, event: &ProxyEvent) -> Result<Str
     } else {
         Some(event.session_id.as_str())
     };
+
+    // Session-level propagation: if this row lacks branch/repo but a prior row
+    // in the same session has one, adopt it before inserting. See fn doc above.
+    let (repo_id, git_branch) = resolve_session_attribution(conn, session_id, event);
+
+    let repo_id_param = repo_id.as_deref();
+    let git_branch_param = git_branch.as_deref();
 
     conn.execute(
         "INSERT OR IGNORE INTO messages (
@@ -316,11 +345,37 @@ pub fn insert_proxy_message(conn: &Connection, event: &ProxyEvent) -> Result<Str
             event.output_tokens.unwrap_or(0),
             event.cache_creation_input_tokens.unwrap_or(0),
             event.cache_read_input_tokens.unwrap_or(0),
-            repo_id,
-            git_branch,
+            repo_id_param,
+            git_branch_param,
             event.cost_cents,
         ],
     )?;
+
+    // Backfill earlier same-session rows whose branch/repo was NULL at write
+    // time. This catches the exact race in #303: the first few proxy turns of
+    // a session land before any attribution is resolved, then a later turn
+    // arrives with a cwd-derived branch. Without backfill, the early turns
+    // stay in `(untagged)` forever.
+    if let Some(sid) = session_id {
+        if let Some(ref branch) = git_branch {
+            conn.execute(
+                "UPDATE messages SET git_branch = ?1
+                 WHERE session_id = ?2
+                   AND (git_branch IS NULL OR git_branch = '')
+                   AND id != ?3",
+                params![branch, sid, uuid],
+            )?;
+        }
+        if let Some(ref repo) = repo_id {
+            conn.execute(
+                "UPDATE messages SET repo_id = ?1
+                 WHERE session_id = ?2
+                   AND (repo_id IS NULL OR repo_id = '' OR repo_id = 'Unassigned')
+                   AND id != ?3",
+                params![repo, sid, uuid],
+            )?;
+        }
+    }
 
     if !event.ticket_id.is_empty() {
         conn.execute(
@@ -336,6 +391,70 @@ pub fn insert_proxy_message(conn: &Connection, event: &ProxyEvent) -> Result<Str
     }
 
     Ok(uuid)
+}
+
+/// Merge the incoming event's attribution with whatever the rest of the
+/// session already knows. Used by `insert_proxy_message` to propagate
+/// `git_branch` / `repo_id` forward in a session (#303).
+///
+/// Returns `(repo_id, git_branch)` where each field is either:
+/// - the event's value if non-empty, or
+/// - the latest non-empty value observed on any prior message in the same
+///   session, or
+/// - `None` / `Unassigned` fallback if neither is known yet.
+fn resolve_session_attribution(
+    conn: &Connection,
+    session_id: Option<&str>,
+    event: &ProxyEvent,
+) -> (Option<String>, Option<String>) {
+    let event_repo = if event.repo_id.is_empty() || event.repo_id == UNASSIGNED_REPO {
+        None
+    } else {
+        Some(event.repo_id.clone())
+    };
+    let event_branch = if event.git_branch.is_empty() {
+        None
+    } else {
+        Some(event.git_branch.clone())
+    };
+
+    if event_repo.is_some() && event_branch.is_some() {
+        return (event_repo, event_branch);
+    }
+    let Some(sid) = session_id else {
+        return (event_repo, event_branch);
+    };
+
+    // Find the most recent message in this session that has the field we are
+    // missing. We intentionally look across both directions (earlier and later
+    // by timestamp) because a batch import or a restarted daemon may have
+    // inserted the context row either way.
+    let session_branch: Option<String> = event_branch.clone().or_else(|| {
+        conn.query_row(
+            "SELECT git_branch FROM messages
+             WHERE session_id = ?1
+               AND git_branch IS NOT NULL AND git_branch != ''
+             ORDER BY timestamp DESC LIMIT 1",
+            params![sid],
+            |row| row.get::<_, Option<String>>(0),
+        )
+        .ok()
+        .flatten()
+    });
+    let session_repo: Option<String> = event_repo.clone().or_else(|| {
+        conn.query_row(
+            "SELECT repo_id FROM messages
+             WHERE session_id = ?1
+               AND repo_id IS NOT NULL AND repo_id != '' AND repo_id != 'Unassigned'
+             ORDER BY timestamp DESC LIMIT 1",
+            params![sid],
+            |row| row.get::<_, Option<String>>(0),
+        )
+        .ok()
+        .flatten()
+    });
+
+    (session_repo, session_branch)
 }
 
 #[cfg(test)]
@@ -709,6 +828,210 @@ mod tests {
             )
             .unwrap();
         assert!(stored.is_none(), "empty session_id must be stored as NULL");
+    }
+
+    // Regression tests for #303 — branch attribution on live proxy ingest.
+
+    /// `ProxyAttribution::resolve` must populate the branch when the caller
+    /// supplies a cwd that points at a git worktree, even without headers.
+    /// This is the fallback path exercised by the new socket-PID lookup and by
+    /// `budi launch` callers.
+    /// Create a throwaway directory path for a single test. Caller is
+    /// expected to create/remove the directory themselves — kept out of a
+    /// shared helper so tests can be moved into dedicated integration files
+    /// later without a cross-crate helper crate dependency.
+    fn unique_test_dir(tag: &str) -> std::path::PathBuf {
+        let path = std::env::temp_dir().join(format!(
+            "budi-proxy-303-{tag}-{}-{}",
+            std::process::id(),
+            uuid::Uuid::new_v4(),
+        ));
+        std::fs::create_dir_all(&path).unwrap();
+        path
+    }
+
+    fn git(repo: &std::path::Path, args: &[&str]) {
+        let output = std::process::Command::new("git")
+            .args(args)
+            .current_dir(repo)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&output.stderr),
+        );
+    }
+
+    #[test]
+    fn attribution_resolve_populates_branch_from_cwd_git_repo() {
+        let repo = unique_test_dir("branch-ok");
+        // `git init -b` exists on 2.28+. Fall back to renaming main so we run
+        // on older git too (older git in CI images still honors checkout -b).
+        git(&repo, &["init", "-q"]);
+        git(
+            &repo,
+            &[
+                "-c",
+                "user.email=t@t",
+                "-c",
+                "user.name=t",
+                "commit",
+                "-q",
+                "--allow-empty",
+                "-m",
+                "init",
+            ],
+        );
+        git(&repo, &["checkout", "-q", "-b", "PROJ-42-feature"]);
+
+        let attr = ProxyAttribution::resolve(None, None, repo.to_str());
+        assert_eq!(attr.git_branch, "PROJ-42-feature");
+        assert_eq!(attr.ticket_id, "PROJ-42");
+        assert_ne!(
+            attr.repo_id, UNASSIGNED_REPO,
+            "cwd-based git resolution must also populate repo_id"
+        );
+
+        let _ = std::fs::remove_dir_all(&repo);
+    }
+
+    /// Detached HEAD is explicitly treated as "no branch" — we must never emit
+    /// the literal string `HEAD` as a branch, otherwise `budi stats --branches`
+    /// accumulates a bogus `HEAD` bucket for worktrees, CI runs, and mid-rebase
+    /// sessions.
+    #[test]
+    fn attribution_resolve_detached_head_yields_empty_branch() {
+        let repo = unique_test_dir("detached");
+        git(&repo, &["init", "-q"]);
+        git(
+            &repo,
+            &[
+                "-c",
+                "user.email=t@t",
+                "-c",
+                "user.name=t",
+                "commit",
+                "-q",
+                "--allow-empty",
+                "-m",
+                "first",
+            ],
+        );
+        let sha = std::process::Command::new("git")
+            .args(["rev-parse", "HEAD"])
+            .current_dir(&repo)
+            .output()
+            .unwrap();
+        let sha = String::from_utf8(sha.stdout).unwrap().trim().to_string();
+        git(&repo, &["checkout", "-q", &sha]);
+
+        let attr = ProxyAttribution::resolve(None, None, repo.to_str());
+        assert!(
+            attr.git_branch.is_empty(),
+            "detached HEAD must not leak as a literal 'HEAD' branch, got: {:?}",
+            attr.git_branch
+        );
+        assert_eq!(attr.ticket_id, "Unassigned");
+
+        let _ = std::fs::remove_dir_all(&repo);
+    }
+
+    /// Later messages in a session inherit the branch set by an earlier
+    /// message in the same session, matching the pipeline's
+    /// `propagate_session_context` behavior but on the live ingest path.
+    #[test]
+    fn insert_proxy_message_inherits_branch_from_earlier_session_message() {
+        let conn = test_db_with_messages();
+
+        let mut first = test_event();
+        first.session_id = "sess-propagate".to_string();
+        first.timestamp = "2026-04-10T10:00:00Z".to_string();
+        first.repo_id = "github.com/test/repo".to_string();
+        first.git_branch = "PROJ-42-feature".to_string();
+        insert_proxy_message(&conn, &first).unwrap();
+
+        // Second turn in the same session arrives with no attribution — this
+        // is the common case when headers are missing and cwd could not be
+        // resolved for that particular request.
+        let mut second = test_event();
+        second.session_id = "sess-propagate".to_string();
+        second.timestamp = "2026-04-10T10:00:05Z".to_string();
+        let uuid = insert_proxy_message(&conn, &second).unwrap();
+
+        let (branch, repo): (Option<String>, Option<String>) = conn
+            .query_row(
+                "SELECT git_branch, repo_id FROM messages WHERE id = ?1",
+                params![uuid],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(branch.as_deref(), Some("PROJ-42-feature"));
+        assert_eq!(repo.as_deref(), Some("github.com/test/repo"));
+    }
+
+    /// The opposite direction: a late-arriving event that finally resolves a
+    /// branch must retroactively fill earlier rows of the same session that
+    /// went in without one. This is the race called out in #303.
+    #[test]
+    fn insert_proxy_message_backfills_earlier_session_rows_when_branch_appears() {
+        let conn = test_db_with_messages();
+
+        let mut first = test_event();
+        first.session_id = "sess-backfill".to_string();
+        first.timestamp = "2026-04-10T10:00:00Z".to_string();
+        let first_uuid = insert_proxy_message(&conn, &first).unwrap();
+
+        let mut second = test_event();
+        second.session_id = "sess-backfill".to_string();
+        second.timestamp = "2026-04-10T10:00:05Z".to_string();
+        second.repo_id = "github.com/test/repo".to_string();
+        second.git_branch = "PROJ-42-feature".to_string();
+        insert_proxy_message(&conn, &second).unwrap();
+
+        let (branch, repo): (Option<String>, Option<String>) = conn
+            .query_row(
+                "SELECT git_branch, repo_id FROM messages WHERE id = ?1",
+                params![first_uuid],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(
+            branch.as_deref(),
+            Some("PROJ-42-feature"),
+            "earlier message must be backfilled with the later session branch"
+        );
+        assert_eq!(repo.as_deref(), Some("github.com/test/repo"));
+    }
+
+    /// Backfill must be scoped to the affected session — sibling sessions
+    /// keep their own attribution (including their own missing state).
+    #[test]
+    fn insert_proxy_message_backfill_is_scoped_to_session() {
+        let conn = test_db_with_messages();
+
+        let mut a = test_event();
+        a.session_id = "sess-a".to_string();
+        a.timestamp = "2026-04-10T10:00:00Z".to_string();
+        let a_uuid = insert_proxy_message(&conn, &a).unwrap();
+
+        let mut b = test_event();
+        b.session_id = "sess-b".to_string();
+        b.timestamp = "2026-04-10T10:00:01Z".to_string();
+        b.git_branch = "OTHER-9-fix".to_string();
+        insert_proxy_message(&conn, &b).unwrap();
+
+        let branch: Option<String> = conn
+            .query_row(
+                "SELECT git_branch FROM messages WHERE id = ?1",
+                params![a_uuid],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!(
+            branch.is_none(),
+            "session A must not inherit session B's branch, got: {branch:?}"
+        );
     }
 
     #[test]

--- a/scripts/e2e/test_303_branch_attribution.sh
+++ b/scripts/e2e/test_303_branch_attribution.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+# End-to-end regression for issue #303: verify that live proxy traffic ends up
+# with a real `git_branch` on the `messages` row (not `(untagged)`), including
+# the session-level propagation that backfills earlier rows when a later
+# request in the same session finally carries attribution.
+#
+# - Isolates HOME to a temp dir.
+# - Starts a mock Anthropic upstream.
+# - Starts the real release `budi-daemon`.
+# - Drives three proxied requests in one session: the first two have no
+#   attribution headers, the third supplies `X-Budi-Branch`. After the third,
+#   every row in the session must carry that branch.
+# - Verifies `budi stats --branches` reports the branch (not `(untagged)`).
+# - Verifies `budi doctor` branch-attribution check is green.
+#
+# Negative-path check: revert the session-level backfill in
+# `crates/budi-core/src/proxy.rs::insert_proxy_message` and this script must
+# fail on the "earlier rows adopted the branch" assertion.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BUDI="$ROOT/target/release/budi"
+BUDI_DAEMON="$ROOT/target/release/budi-daemon"
+
+if [[ ! -x "$BUDI" || ! -x "$BUDI_DAEMON" ]]; then
+  echo "error: release binaries not built. run \`cargo build --release\` first." >&2
+  exit 2
+fi
+
+TMPDIR_ROOT="$(mktemp -d -t budi-e2e-303-XXXXXX)"
+export HOME="$TMPDIR_ROOT"
+mkdir -p "$HOME/.config/budi"
+
+DAEMON_PORT=17879
+PROXY_PORT=19879
+UPSTREAM_PORT=19334
+
+cleanup() {
+  local status=$?
+  { kill "${DAEMON_PID:-}" 2>/dev/null || true; } >/dev/null 2>&1
+  { kill "${UPSTREAM_PID:-}" 2>/dev/null || true; } >/dev/null 2>&1
+  pkill -f "budi-daemon serve --host 127.0.0.1 --port $DAEMON_PORT" >/dev/null 2>&1 || true
+  pkill -f "mock_upstream.py $UPSTREAM_PORT" >/dev/null 2>&1 || true
+  if [[ "${KEEP_TMP:-0}" == "1" ]]; then
+    echo "[e2e] leaving tmp: $TMPDIR_ROOT"
+  else
+    rm -rf "$TMPDIR_ROOT"
+  fi
+  exit $status
+}
+trap cleanup EXIT INT TERM
+
+echo "[e2e] HOME=$HOME"
+
+REPO_ROOT="$HOME/repo"
+mkdir -p "$REPO_ROOT/.budi"
+cat >"$REPO_ROOT/.budi/budi.toml" <<EOF
+daemon_host = "127.0.0.1"
+daemon_port = $DAEMON_PORT
+
+[proxy]
+enabled = true
+port = $PROXY_PORT
+EOF
+(cd "$REPO_ROOT" && git init -q 2>/dev/null || true)
+
+cat >"$TMPDIR_ROOT/mock_upstream.py" <<'PY'
+import http.server, json, sys
+
+class H(http.server.BaseHTTPRequestHandler):
+    def do_POST(self):
+        n = int(self.headers.get("Content-Length", "0") or 0)
+        _ = self.rfile.read(n)
+        body = {
+            "id": "msg_e2e_303",
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-sonnet-4-6",
+            "content": [{"type": "text", "text": "ok"}],
+            "stop_reason": "end_turn",
+            "usage": {"input_tokens": 42, "output_tokens": 7,
+                      "cache_creation_input_tokens": 0,
+                      "cache_read_input_tokens": 0},
+        }
+        payload = json.dumps(body).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def log_message(self, *a, **k):
+        pass
+
+port = int(sys.argv[1])
+http.server.HTTPServer(("127.0.0.1", port), H).serve_forever()
+PY
+
+echo "[e2e] starting mock upstream on :$UPSTREAM_PORT"
+python3 "$TMPDIR_ROOT/mock_upstream.py" "$UPSTREAM_PORT" >"$TMPDIR_ROOT/upstream.log" 2>&1 &
+UPSTREAM_PID=$!
+for _ in {1..30}; do
+  if curl -s -o /dev/null -w "%{http_code}" --max-time 1 "http://127.0.0.1:$UPSTREAM_PORT/" | grep -qE "^[45]"; then
+    break
+  fi
+  sleep 0.1
+done
+
+echo "[e2e] starting budi-daemon on :$DAEMON_PORT / proxy :$PROXY_PORT"
+BUDI_ANTHROPIC_UPSTREAM="http://127.0.0.1:$UPSTREAM_PORT" \
+BUDI_OPENAI_UPSTREAM="http://127.0.0.1:$UPSTREAM_PORT" \
+RUST_LOG=info \
+  "$BUDI_DAEMON" serve \
+    --host 127.0.0.1 \
+    --port $DAEMON_PORT \
+    --proxy-port $PROXY_PORT \
+    >"$TMPDIR_ROOT/daemon.log" 2>&1 &
+DAEMON_PID=$!
+
+for _ in {1..50}; do
+  if curl -s -o /dev/null -w "%{http_code}" --max-time 1 "http://127.0.0.1:$DAEMON_PORT/health" | grep -q "^200"; then
+    break
+  fi
+  sleep 0.1
+done
+for _ in {1..50}; do
+  if curl -s -o /dev/null -w "%{http_code}" --max-time 1 -X POST -H "content-type: application/json" -d '{}' "http://127.0.0.1:$PROXY_PORT/v1/messages" | grep -qE "^(2|4|5)[0-9]{2}$"; then
+    break
+  fi
+  sleep 0.1
+done
+
+SESSION_ID="e2e-sess-303-$(date +%s)"
+BRANCH="PROJ-303-branch-attribution"
+
+send() {
+  local label="$1"; shift
+  echo "[e2e] proxy request: $label"
+  local status
+  status=$(curl -s -o "$TMPDIR_ROOT/${label}.json" -w "%{http_code}" --max-time 5 \
+    -X POST \
+    -H "content-type: application/json" \
+    -H "x-budi-session: $SESSION_ID" \
+    "$@" \
+    -d '{"model":"claude-sonnet-4-6","messages":[{"role":"user","content":"hi"}]}' \
+    "http://127.0.0.1:$PROXY_PORT/v1/messages")
+  if [[ "$status" != "200" ]]; then
+    echo "[e2e] FAIL: $label returned $status" >&2
+    tail -n 60 "$TMPDIR_ROOT/daemon.log" >&2 || true
+    exit 1
+  fi
+}
+
+send "req1-no-attribution"
+send "req2-no-attribution"
+send "req3-with-branch" -H "x-budi-branch: $BRANCH" -H "x-budi-repo: github.com/siropkin/budi"
+
+# Let spawn_blocking DB writes land.
+sleep 1
+
+DB="$HOME/.local/share/budi/analytics.db"
+echo "[e2e] DB rows for session:"
+sqlite3 "$DB" "SELECT id, session_id, git_branch, repo_id FROM messages WHERE session_id = '$SESSION_ID';"
+
+TOTAL=$(sqlite3 "$DB" "SELECT COUNT(*) FROM messages WHERE session_id = '$SESSION_ID';")
+if [[ "$TOTAL" != "3" ]]; then
+  echo "[e2e] FAIL: expected 3 rows for session, got $TOTAL" >&2
+  exit 1
+fi
+
+WITH_BRANCH=$(sqlite3 "$DB" "SELECT COUNT(*) FROM messages WHERE session_id = '$SESSION_ID' AND git_branch = '$BRANCH';")
+if [[ "$WITH_BRANCH" != "3" ]]; then
+  echo "[e2e] FAIL: expected all 3 rows to carry branch '$BRANCH' (session propagation/backfill), got $WITH_BRANCH" >&2
+  echo "[e2e] rows:" >&2
+  sqlite3 "$DB" "SELECT id, git_branch FROM messages WHERE session_id = '$SESSION_ID';" >&2
+  exit 1
+fi
+echo "[e2e] OK: all 3 session rows share branch '$BRANCH'"
+
+# Exercise the same query that `budi stats --branches` issues, via the daemon
+# HTTP API. We cannot reliably invoke the `budi` CLI here because the CLI's
+# `load_config` path reads `<BUDI_HOME>/repos/<hash>/budi.toml`, not the
+# `$REPO_ROOT/.budi/budi.toml` we create — so the CLI would talk to whatever
+# default-port daemon is present on the developer machine and return a stale
+# 500. The daemon endpoint under test is the exact one the CLI calls, so
+# hitting it here is a genuine regression guard for #303.
+SINCE_TS="$(date -u -v0H -v0M -v0S +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+           || date -u --date="today 00:00:00" +%Y-%m-%dT%H:%M:%SZ)"
+BRANCHES_JSON="$(curl -s --max-time 5 \
+  "http://127.0.0.1:$DAEMON_PORT/analytics/branches?limit=20&since=$SINCE_TS")"
+echo "[e2e] /analytics/branches -> $BRANCHES_JSON"
+if ! echo "$BRANCHES_JSON" | grep -Fq "\"git_branch\":\"$BRANCH\""; then
+  echo "[e2e] FAIL: /analytics/branches did not surface branch '$BRANCH'" >&2
+  exit 1
+fi
+echo "[e2e] OK: branch '$BRANCH' visible via /analytics/branches (what \`budi stats --branches\` queries)"
+
+# `budi doctor` reads the analytics DB directly via `BUDI_HOME` (=$HOME/.local/share/budi
+# here), not the daemon HTTP client, so it runs cleanly inside the isolated
+# test HOME without fighting the developer-machine daemon.
+echo "[e2e] budi doctor (branch attribution section):"
+DOCTOR_OUT="$(cd "$REPO_ROOT" && "$BUDI" doctor --repo-root "$REPO_ROOT" 2>&1 || true)"
+echo "$DOCTOR_OUT" | grep -E "branch attribution" || {
+  echo "[e2e] FAIL: budi doctor did not print a branch-attribution check" >&2
+  echo "$DOCTOR_OUT" | tail -n 40 >&2
+  exit 1
+}
+if echo "$DOCTOR_OUT" | grep -q "Branch attribution is broken"; then
+  echo "[e2e] FAIL: budi doctor reported a red branch-attribution result" >&2
+  echo "$DOCTOR_OUT" | tail -n 40 >&2
+  exit 1
+fi
+echo "[e2e] OK: budi doctor branch-attribution check is not red"
+
+echo "[e2e] PASS"


### PR DESCRIPTION
## Summary

`budi stats --branches` was collapsing all live proxy traffic into `(untagged)` even when individual requests knew their branch. Two distinct defects on the live ingest path:

1. **No session-level context propagation on live ingest.** `Pipeline::process` (which runs `propagate_session_context`) only runs during batch `budi import`. Live proxy writes went straight to `insert_proxy_message`, so the first turns of any session that lacked attribution stayed NULL forever — and even when a later turn in the same session resolved `X-Budi-Branch` / cwd-based branch, it was isolated on that one row.
2. **Detached-HEAD pollution.** `git rev-parse --abbrev-ref HEAD` returns the literal `HEAD` in detached state (worktrees, mid-rebase, CI). That value was silently adopted and showed up as a `HEAD` branch bucket.

### Fixes

- `resolve_git_branch` normalizes `"HEAD"` -> empty so callers fall through cleanly.
- `insert_proxy_message` now mirrors `propagate_session_context` directly:
  - **Forward inheritance:** if the incoming event has no branch/repo but a prior row in the same session does, adopt it.
  - **Backward backfill:** if the incoming event *has* branch/repo, UPDATE any earlier same-session rows that were NULL. This is the common case — agents emit the first few messages before the CLI has time to resolve attribution.
- Backfill is strictly session-scoped; a unit test (`insert_proxy_message_backfill_is_scoped_to_session`) guards that session A never adopts session B's branch.

### Diagnostics

- `analytics::branch_attribution_stats(conn)` returns per-provider 7-day counts of assistant rows missing `git_branch` / `repo_id` / `cwd`.
- `budi doctor` prints that row and flags >10% yellow, >50% red, matching the visibility contract used for #302's session-visibility check.

### SOUL.md

Documents the new resolution priority order (header -> cwd -> session propagation -> Unassigned), the detached-HEAD normalization, and the two `budi doctor` attribution checks.

## Test plan

- [x] `cargo test --workspace --lib` — 339 passed.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --all -- --check` — clean.
- [x] New unit tests in `crates/budi-core/src/proxy.rs`:
  - `attribution_resolve_populates_branch_from_cwd_git_repo`
  - `attribution_resolve_detached_head_yields_empty_branch`
  - `insert_proxy_message_inherits_branch_from_earlier_session_message`
  - `insert_proxy_message_backfills_earlier_session_rows_when_branch_appears`
  - `insert_proxy_message_backfill_is_scoped_to_session`
- [x] New unit test in `crates/budi-core/src/analytics/tests.rs`:
  - `branch_attribution_stats_reports_missing_branch_within_7d`
- [x] `bash scripts/e2e/test_303_branch_attribution.sh` — drives three proxied requests in one session (two with no headers, one with `X-Budi-Branch`), asserts all three rows end up with the branch, the daemon endpoint surfaces it, and `budi doctor` branch-attribution is not red. Negative-path: reverting the backfill UPDATE in `insert_proxy_message` fails the "earlier rows adopted the branch" assertion.

Closes #303

Made with [Cursor](https://cursor.com)