### PR TITLE
[8.1][R1.0.3] feat: promote ticket_id to first-class CLI dimension

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,10 +288,13 @@ budi stats --models                # model usage breakdown
 budi stats --projects              # repos ranked by cost
 budi stats --branches              # branches ranked by cost
 budi stats --branch <name>         # cost for a specific branch
+budi stats --tickets               # tickets ranked by cost (sourced from ticket_id tag)
+budi stats --ticket <id>           # cost for a specific ticket, with per-branch breakdown
 budi stats --provider codex        # filter stats to a single provider
-budi stats --tag ticket_id         # cost per ticket
+budi stats --tag ticket_id         # cost per ticket value (raw tag view)
 budi stats --tag ticket_prefix     # cost per team prefix
 budi sessions                      # list recent sessions with cost and health
+budi sessions --ticket <id>        # sessions tagged with a ticket id
 budi sessions <id>                 # session detail: cost, models, health, tags
 budi health                        # session health vitals for most recent session
 budi health --session <id>         # health vitals for a specific session

--- a/SOUL.md
+++ b/SOUL.md
@@ -193,7 +193,7 @@ in [#302](https://github.com/siropkin/budi/issues/302) / #303 / #304 / #305):
 
 - **`ticket_id`** — promoted to a first-class CLI dimension in 8.1 (R1.0.3,
   #304). The git enricher emits a `ticket_id` tag (and `ticket_prefix`)
-  whenever `git_branch` matches the recognised pattern (e.g. `PAVA-2057`),
+  whenever `git_branch` matches the recognised pattern (e.g. `ENG-123`),
   so ticket attribution rides on top of the branch attribution rules above
   with no extra wiring. Surfaces:
   - `budi stats --tickets` — list ranked by cost, with `(untagged)` bucket.

--- a/SOUL.md
+++ b/SOUL.md
@@ -191,6 +191,18 @@ in [#302](https://github.com/siropkin/budi/issues/302) / #303 / #304 / #305):
   explicitly normalized to empty so that worktrees, mid-rebase sessions, and
   CI runs do not pollute the branches list with a bogus `HEAD` bucket.
 
+- **`ticket_id`** — promoted to a first-class CLI dimension in 8.1 (R1.0.3,
+  #304). The git enricher emits a `ticket_id` tag (and `ticket_prefix`)
+  whenever `git_branch` matches the recognised pattern (e.g. `PAVA-2057`),
+  so ticket attribution rides on top of the branch attribution rules above
+  with no extra wiring. Surfaces:
+  - `budi stats --tickets` — list ranked by cost, with `(untagged)` bucket.
+  - `budi stats --ticket <ID>` — detail view with per-branch breakdown.
+  - `budi sessions --ticket <ID>` — sessions tagged with the ticket.
+  - `GET /analytics/tickets` and `/analytics/tickets/{ticket_id}` mirror
+    `/analytics/branches{/branch}` so future cloud/dashboard work can adopt
+    the same data contract.
+
 `budi doctor` runs two attribution checks:
 
 - **Session visibility** for the `today`, `7d`, and `30d` windows (R1.0.1,

--- a/crates/budi-cli/src/client.rs
+++ b/crates/budi-cli/src/client.rs
@@ -15,7 +15,7 @@ use std::time::Duration;
 use anyhow::{Context, Result};
 use budi_core::analytics::{
     BranchCost, ModelUsage, PaginatedSessions, ProviderStats, RepoUsage, SessionHealth,
-    SessionListEntry, SessionTag, TagCost, UsageSummary,
+    SessionListEntry, SessionTag, TagCost, TicketCost, TicketCostDetail, UsageSummary,
 };
 use budi_core::config::{self, BudiConfig};
 use budi_core::cost::CostEstimate;
@@ -34,6 +34,22 @@ fn analytics_branch_detail_url(base_url: &str, branch: &str) -> Result<String> {
         .push("analytics")
         .push("branches")
         .push(branch);
+    Ok(url.to_string())
+}
+
+/// Build `GET .../analytics/tickets/{ticket_id}` with correct path encoding.
+/// Mirrors `analytics_branch_detail_url` so ticket IDs containing `-` or `/`
+/// (rare, but possible if a future provider chooses richer IDs) round-trip
+/// through the daemon untouched.
+fn analytics_ticket_detail_url(base_url: &str, ticket_id: &str) -> Result<String> {
+    let normalized = format!("{}/", base_url.trim_end_matches('/'));
+    let mut url = reqwest::Url::parse(&normalized)
+        .with_context(|| format!("invalid daemon base URL: {base_url}"))?;
+    url.path_segments_mut()
+        .map_err(|_| anyhow::anyhow!("invalid daemon base URL: {base_url}"))?
+        .push("analytics")
+        .push("tickets")
+        .push(ticket_id);
     Ok(url.to_string())
 }
 
@@ -394,6 +410,72 @@ impl DaemonClient {
         Ok(Some(serde_json::from_value(val)?))
     }
 
+    /// `GET /analytics/tickets` — per-ticket cost roll-up. Matches the
+    /// daemon's `TicketListParams` shape (date window + dimension filters +
+    /// limit). Used by `budi stats --tickets`.
+    pub fn tickets(
+        &self,
+        since: Option<&str>,
+        until: Option<&str>,
+        limit: usize,
+    ) -> Result<Vec<TicketCost>> {
+        let mut params: Vec<(&str, String)> = Vec::new();
+        if let Some(s) = since {
+            params.push(("since", s.to_string()));
+        }
+        if let Some(u) = until {
+            params.push(("until", u.to_string()));
+        }
+        params.push(("limit", limit.to_string()));
+        let resp = self
+            .client
+            .get(format!("{}/analytics/tickets", self.base_url))
+            .query(&params)
+            .send()
+            .map_err(describe_send_error)?;
+        let resp = check_response(resp)?;
+        Ok(resp.json()?)
+    }
+
+    /// `GET /analytics/tickets/{id}` — single-ticket detail with per-branch
+    /// breakdown. Returns `Ok(None)` for an unknown ticket id (mirrors
+    /// `branch_detail`).
+    pub fn ticket_detail(
+        &self,
+        ticket_id: &str,
+        repo_id: Option<&str>,
+        since: Option<&str>,
+        until: Option<&str>,
+    ) -> Result<Option<TicketCostDetail>> {
+        let mut params: Vec<(&str, &str)> = Vec::new();
+        if let Some(repo) = repo_id {
+            params.push(("repo_id", repo));
+        }
+        if let Some(s) = since {
+            params.push(("since", s));
+        }
+        if let Some(u) = until {
+            params.push(("until", u));
+        }
+        let url = analytics_ticket_detail_url(&self.base_url, ticket_id)
+            .with_context(|| format!("invalid daemon base URL or ticket: {ticket_id:?}"))?;
+        let resp = self
+            .client
+            .get(url)
+            .query(&params)
+            .send()
+            .map_err(describe_send_error)?;
+        if resp.status() == reqwest::StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+        let resp = check_response(resp)?;
+        let val: Value = resp.json()?;
+        if val.is_null() {
+            return Ok(None);
+        }
+        Ok(Some(serde_json::from_value(val)?))
+    }
+
     pub fn models(&self, since: Option<&str>, until: Option<&str>) -> Result<Vec<ModelUsage>> {
         let mut params = Vec::new();
         if let Some(s) = since {
@@ -467,6 +549,7 @@ impl DaemonClient {
         since: Option<&str>,
         until: Option<&str>,
         search: Option<&str>,
+        ticket: Option<&str>,
         limit: usize,
         offset: usize,
     ) -> Result<PaginatedSessions> {
@@ -479,6 +562,9 @@ impl DaemonClient {
         }
         if let Some(q) = search {
             params.push(("search", q.to_string()));
+        }
+        if let Some(t) = ticket {
+            params.push(("ticket", t.to_string()));
         }
         params.push(("sort_by", "started_at".to_string()));
         params.push(("limit", limit.to_string()));

--- a/crates/budi-cli/src/commands/sessions.rs
+++ b/crates/budi-cli/src/commands/sessions.rs
@@ -9,6 +9,7 @@ use super::ansi;
 pub fn cmd_sessions(
     period: StatsPeriod,
     search: Option<&str>,
+    ticket: Option<&str>,
     limit: usize,
     json_output: bool,
 ) -> Result<()> {
@@ -17,7 +18,7 @@ pub fn cmd_sessions(
     )?;
 
     let (since, until) = period_date_range(period);
-    let sessions = client.sessions(since.as_deref(), until.as_deref(), search, limit, 0)?;
+    let sessions = client.sessions(since.as_deref(), until.as_deref(), search, ticket, limit, 0)?;
 
     if json_output {
         println!("{}", serde_json::to_string_pretty(&sessions)?);
@@ -33,11 +34,20 @@ pub fn cmd_sessions(
     let reset = ansi("\x1b[0m");
 
     println!();
-    println!(
-        "  {bold_cyan} Sessions{reset} — {bold}{}{reset} {dim}({} total){reset}",
-        period_label(period),
-        sessions.total_count
-    );
+    if let Some(t) = ticket {
+        println!(
+            "  {bold_cyan} Sessions{reset} — {bold}{}{reset} {dim}(ticket: {}, {} total){reset}",
+            period_label(period),
+            t,
+            sessions.total_count
+        );
+    } else {
+        println!(
+            "  {bold_cyan} Sessions{reset} — {bold}{}{reset} {dim}({} total){reset}",
+            period_label(period),
+            sessions.total_count
+        );
+    }
     println!("  {dim}{}{reset}", "─".repeat(80));
 
     if sessions.sessions.is_empty() {

--- a/crates/budi-cli/src/commands/stats.rs
+++ b/crates/budi-cli/src/commands/stats.rs
@@ -56,6 +56,8 @@ pub fn cmd_stats(
     projects: bool,
     branches: bool,
     branch: Option<String>,
+    tickets: bool,
+    ticket: Option<String>,
     repo: Option<String>,
     models: bool,
     provider: Option<String>,
@@ -67,12 +69,29 @@ pub fn cmd_stats(
     // user-friendly shortcuts that resolve to their canonical form.
     let provider = provider.map(|p| normalize_provider(&p)).transpose()?;
 
+    // `--repo` is a filter for `--branch` or `--ticket` — surface the
+    // misuse early instead of silently ignoring it. Clap's `requires` only
+    // takes a single arg, so the cross-flag check lives here.
+    if repo.is_some() && branch.is_none() && ticket.is_none() {
+        anyhow::bail!(
+            "--repo requires either --branch <NAME> or --ticket <ID> to scope the filter"
+        );
+    }
+
     let client = DaemonClient::connect().context(
         "Could not reach budi daemon. Run `budi init` to set up, or `budi doctor` to diagnose.",
     )?;
 
     if let Some(ref tag_filter) = tag {
         return cmd_stats_tags(&client, period, tag_filter, json_output);
+    }
+
+    if let Some(ref tk) = ticket {
+        return cmd_stats_ticket_detail(&client, period, tk, repo.as_deref(), json_output);
+    }
+
+    if tickets {
+        return cmd_stats_tickets(&client, period, json_output);
     }
 
     if let Some(ref br) = branch {
@@ -465,6 +484,161 @@ fn cmd_stats_branch_detail(
             println!("  No data found for branch '{}'.", branch);
             println!("  Tip: run `budi import` first if you haven't imported data yet.");
             println!("  Run `budi stats --branches` to see available branches.");
+        }
+    }
+
+    println!();
+    Ok(())
+}
+
+/// `--tickets` view: tickets ranked by cost. Mirrors `cmd_stats_branches`.
+///
+/// The list always carries an `(untagged)` row so users can see how much
+/// activity is *not* attributed to a ticket — that bucket should shrink as
+/// teams adopt ticket-bearing branch names.
+fn cmd_stats_tickets(client: &DaemonClient, period: StatsPeriod, json_output: bool) -> Result<()> {
+    let (since, until) = period_date_range(period);
+    let tickets = client.tickets(since.as_deref(), until.as_deref(), 30)?;
+
+    if json_output {
+        println!("{}", serde_json::to_string_pretty(&tickets)?);
+        return Ok(());
+    }
+
+    let period_label = period_label(period);
+
+    let bold_cyan = ansi("\x1b[1;36m");
+    let bold = ansi("\x1b[1m");
+    let dim = ansi("\x1b[90m");
+    let cyan = ansi("\x1b[36m");
+    let yellow = ansi("\x1b[33m");
+    let reset = ansi("\x1b[0m");
+
+    println!();
+    println!(
+        "  {bold_cyan} Tickets{reset} — {bold}{}{reset}",
+        period_label
+    );
+    println!("  {dim}{}{reset}", "─".repeat(60));
+
+    if tickets.is_empty() {
+        println!("  No ticket data for this period.");
+        println!("  Tip: branch names need to contain a ticket id (e.g. PAVA-123).");
+        println!();
+        return Ok(());
+    }
+
+    let max_cost = tickets
+        .iter()
+        .map(|t| t.cost_cents)
+        .fold(0.0_f64, f64::max)
+        .max(0.01);
+    for t in &tickets {
+        let bar_len = ((t.cost_cents / max_cost) * 16.0) as usize;
+        let bar: String = "\u{2588}".repeat(bar_len);
+        let branch_label = if t.top_branch.is_empty() {
+            "--".to_string()
+        } else {
+            t.top_branch.clone()
+        };
+        println!(
+            "    {bold}{:<24}{reset} {yellow}{:>8}{reset}  {dim}{:<24}{reset}  {cyan}{}{reset}",
+            t.ticket_id,
+            format_cost_cents(t.cost_cents),
+            branch_label,
+            bar
+        );
+    }
+
+    println!();
+    Ok(())
+}
+
+/// `--ticket <ID>` detail view. Mirrors `cmd_stats_branch_detail`, plus a
+/// per-branch breakdown so the user can see which branches charged cost to
+/// the ticket (handy for stacked PRs / multi-branch work).
+fn cmd_stats_ticket_detail(
+    client: &DaemonClient,
+    period: StatsPeriod,
+    ticket: &str,
+    repo: Option<&str>,
+    json_output: bool,
+) -> Result<()> {
+    let (since, until) = period_date_range(period);
+    let result = client.ticket_detail(ticket, repo, since.as_deref(), until.as_deref())?;
+
+    if json_output {
+        println!("{}", serde_json::to_string_pretty(&result)?);
+        return Ok(());
+    }
+
+    let period_label = period_label(period);
+
+    let bold_cyan = ansi("\x1b[1;36m");
+    let bold = ansi("\x1b[1m");
+    let dim = ansi("\x1b[90m");
+    let yellow = ansi("\x1b[33m");
+    let reset = ansi("\x1b[0m");
+
+    println!();
+    println!(
+        "  {bold_cyan} Ticket{reset} {bold}{}{reset} — {dim}{}{reset}",
+        ticket, period_label
+    );
+    if let Some(repo_id) = repo {
+        println!("  {bold}Repo filter{reset} {}", repo_id);
+    }
+    println!("  {dim}{}{reset}", "─".repeat(50));
+
+    match result {
+        Some(t) => {
+            if !t.repo_id.is_empty() {
+                println!("  {bold}Repo{reset}       {}", t.repo_id);
+            }
+            if !t.ticket_prefix.is_empty() {
+                println!("  {bold}Prefix{reset}     {}", t.ticket_prefix);
+            }
+            println!("  {bold}Sessions{reset}   {}", t.session_count);
+            println!("  {bold}Messages{reset}   {}", t.message_count);
+            println!(
+                "  {bold}Input{reset}      {}",
+                format_tokens(t.input_tokens)
+            );
+            println!(
+                "  {bold}Output{reset}     {}",
+                format_tokens(t.output_tokens)
+            );
+            println!(
+                "  {bold}Est. cost{reset}  {yellow}{}{reset}",
+                format_cost_cents(t.cost_cents)
+            );
+
+            if !t.branches.is_empty() {
+                println!();
+                println!("  {bold}Branches{reset}");
+                for br in &t.branches {
+                    let repo_label = if br.repo_id.is_empty() {
+                        "--".to_string()
+                    } else {
+                        br.repo_id
+                            .rsplit('/')
+                            .next()
+                            .unwrap_or(&br.repo_id)
+                            .to_string()
+                    };
+                    println!(
+                        "    {bold}{:<28}{reset} {yellow}{:>8}{reset}  {dim}{}{reset}",
+                        br.git_branch,
+                        format_cost_cents(br.cost_cents),
+                        repo_label
+                    );
+                }
+            }
+        }
+        None => {
+            println!("  No data found for ticket '{}'.", ticket);
+            println!("  Tip: run `budi import` first if you haven't imported data yet.");
+            println!("  Run `budi stats --tickets` to see available tickets.");
         }
     }
 

--- a/crates/budi-cli/src/main.rs
+++ b/crates/budi-cli/src/main.rs
@@ -77,8 +77,8 @@ Examples:
   budi stats --branch main         Cost details for a specific branch
   budi stats --branch main --repo github.com/acme/app
   budi stats --tickets             Tickets ranked by cost (today)
-  budi stats --ticket PAVA-2057    Cost details for a specific ticket
-  budi stats --ticket PAVA-2057 --repo github.com/acme/app
+  budi stats --ticket ENG-123      Cost details for a specific ticket
+  budi stats --ticket ENG-123 --repo github.com/acme/app
   budi stats --projects -p all     All-time project costs
   budi stats --tag activity        Cost by activity type
   budi stats --provider cursor     Filter to Cursor only
@@ -102,7 +102,7 @@ Examples:
         /// dimension alongside branches and repos.
         #[arg(long, default_value_t = false)]
         tickets: bool,
-        /// Show cost details for a specific ticket id (e.g. PAVA-2057).
+        /// Show cost details for a specific ticket id (e.g. ENG-123).
         /// Mirrors `--branch <NAME>` and includes a per-branch breakdown
         /// of where the ticket was worked on.
         #[arg(long, value_name = "ID")]
@@ -165,7 +165,7 @@ Examples:
   budi sessions                    Recent sessions (today)
   budi sessions -p week            This week's sessions
   budi sessions --search claude    Filter by search term
-  budi sessions --ticket PAVA-2057 Sessions tagged with a ticket
+  budi sessions --ticket ENG-123   Sessions tagged with a ticket
   budi sessions <session-id>       Show detail for a specific session
   budi sessions --format json      JSON output for scripting")]
     Sessions {
@@ -178,7 +178,7 @@ Examples:
         /// Filter sessions by search term (model, repo, branch, provider)
         #[arg(long)]
         search: Option<String>,
-        /// Filter sessions by ticket id (e.g. PAVA-2057). Matches the
+        /// Filter sessions by ticket id (e.g. ENG-123). Matches the
         /// `ticket_id` tag emitted by the git enricher when the branch name
         /// contains a recognised ID.
         #[arg(long, value_name = "ID")]

--- a/crates/budi-cli/src/main.rs
+++ b/crates/budi-cli/src/main.rs
@@ -65,9 +65,9 @@ enum Commands {
         #[arg(long, hide = true)]
         repo_root: Option<PathBuf>,
     },
-    /// Show usage analytics (only one view flag at a time: --projects, --branches, --branch, --models, or --tag)
+    /// Show usage analytics (only one view flag at a time: --projects, --branches, --branch, --tickets, --ticket, --models, or --tag)
     #[command(
-        group(clap::ArgGroup::new("view").multiple(false).args(["projects", "branches", "branch", "models", "tag"])),
+        group(clap::ArgGroup::new("view").multiple(false).args(["projects", "branches", "branch", "tickets", "ticket", "models", "tag"])),
         after_help = "\
 Examples:
   budi stats                       Today's cost summary (default)
@@ -76,6 +76,9 @@ Examples:
   budi stats --branches            Branches ranked by cost (today)
   budi stats --branch main         Cost details for a specific branch
   budi stats --branch main --repo github.com/acme/app
+  budi stats --tickets             Tickets ranked by cost (today)
+  budi stats --ticket PAVA-2057    Cost details for a specific ticket
+  budi stats --ticket PAVA-2057 --repo github.com/acme/app
   budi stats --projects -p all     All-time project costs
   budi stats --tag activity        Cost by activity type
   budi stats --provider cursor     Filter to Cursor only
@@ -94,8 +97,18 @@ Examples:
         /// Show cost for a specific branch
         #[arg(long)]
         branch: Option<String>,
-        /// Optional repository filter for --branch (recommended when branch names repeat)
-        #[arg(long, requires = "branch")]
+        /// Show tickets ranked by cost (sourced from the `ticket_id` tag).
+        /// Mirrors `--branches` so ticket attribution is a first-class CLI
+        /// dimension alongside branches and repos.
+        #[arg(long, default_value_t = false)]
+        tickets: bool,
+        /// Show cost details for a specific ticket id (e.g. PAVA-2057).
+        /// Mirrors `--branch <NAME>` and includes a per-branch breakdown
+        /// of where the ticket was worked on.
+        #[arg(long, value_name = "ID")]
+        ticket: Option<String>,
+        /// Optional repository filter for --branch or --ticket (recommended when branch/ticket names repeat across repos)
+        #[arg(long)]
         repo: Option<String>,
         /// Show model usage breakdown
         #[arg(long, default_value_t = false)]
@@ -152,6 +165,7 @@ Examples:
   budi sessions                    Recent sessions (today)
   budi sessions -p week            This week's sessions
   budi sessions --search claude    Filter by search term
+  budi sessions --ticket PAVA-2057 Sessions tagged with a ticket
   budi sessions <session-id>       Show detail for a specific session
   budi sessions --format json      JSON output for scripting")]
     Sessions {
@@ -164,6 +178,11 @@ Examples:
         /// Filter sessions by search term (model, repo, branch, provider)
         #[arg(long)]
         search: Option<String>,
+        /// Filter sessions by ticket id (e.g. PAVA-2057). Matches the
+        /// `ticket_id` tag emitted by the git enricher when the branch name
+        /// contains a recognised ID.
+        #[arg(long, value_name = "ID")]
+        ticket: Option<String>,
         /// Max sessions to show (default: 20)
         #[arg(long, default_value_t = 20)]
         limit: usize,
@@ -344,6 +363,8 @@ fn main() -> Result<()> {
             projects,
             branches,
             branch,
+            tickets,
+            ticket,
             repo,
             models,
             provider,
@@ -356,6 +377,8 @@ fn main() -> Result<()> {
                 projects,
                 branches,
                 branch,
+                tickets,
+                ticket,
                 repo,
                 models,
                 provider,
@@ -400,6 +423,7 @@ fn main() -> Result<()> {
             session_id,
             period,
             search,
+            ticket,
             limit,
             format,
         } => {
@@ -407,7 +431,13 @@ fn main() -> Result<()> {
             if let Some(id) = session_id {
                 commands::sessions::cmd_session_detail(&id, json_output)
             } else {
-                commands::sessions::cmd_sessions(period, search.as_deref(), limit, json_output)
+                commands::sessions::cmd_sessions(
+                    period,
+                    search.as_deref(),
+                    ticket.as_deref(),
+                    limit,
+                    json_output,
+                )
             }
         }
         Commands::Status => commands::status::cmd_status(),
@@ -481,6 +511,82 @@ mod tests {
         match cli.command {
             Commands::Doctor { deep, .. } => assert!(deep),
             _ => panic!("expected doctor command"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_stats_tickets_flag() {
+        let cli =
+            Cli::try_parse_from(["budi", "stats", "--tickets"]).expect("budi stats --tickets");
+        match cli.command {
+            Commands::Stats {
+                tickets, ticket, ..
+            } => {
+                assert!(tickets);
+                assert!(ticket.is_none());
+            }
+            _ => panic!("expected stats command"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_stats_ticket_value_flag() {
+        let cli = Cli::try_parse_from(["budi", "stats", "--ticket", "PAVA-2057"])
+            .expect("budi stats --ticket PAVA-2057");
+        match cli.command {
+            Commands::Stats {
+                tickets, ticket, ..
+            } => {
+                assert!(!tickets);
+                assert_eq!(ticket.as_deref(), Some("PAVA-2057"));
+            }
+            _ => panic!("expected stats command"),
+        }
+    }
+
+    #[test]
+    fn cli_stats_view_flags_are_mutually_exclusive() {
+        // --tickets vs --ticket
+        assert!(Cli::try_parse_from(["budi", "stats", "--tickets", "--ticket", "X-1"]).is_err());
+        // --tickets vs --branches
+        assert!(Cli::try_parse_from(["budi", "stats", "--tickets", "--branches"]).is_err());
+        // --ticket vs --branch
+        assert!(
+            Cli::try_parse_from(["budi", "stats", "--ticket", "X-1", "--branch", "main"]).is_err()
+        );
+        // --tickets vs --models
+        assert!(Cli::try_parse_from(["budi", "stats", "--tickets", "--models"]).is_err());
+    }
+
+    #[test]
+    fn cli_stats_ticket_accepts_repo_filter() {
+        let cli = Cli::try_parse_from([
+            "budi",
+            "stats",
+            "--ticket",
+            "PAVA-2057",
+            "--repo",
+            "siropkin/budi",
+        ])
+        .expect("budi stats --ticket --repo");
+        match cli.command {
+            Commands::Stats { ticket, repo, .. } => {
+                assert_eq!(ticket.as_deref(), Some("PAVA-2057"));
+                assert_eq!(repo.as_deref(), Some("siropkin/budi"));
+            }
+            _ => panic!("expected stats command"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_sessions_ticket_flag() {
+        let cli = Cli::try_parse_from(["budi", "sessions", "--ticket", "PAVA-2057"])
+            .expect("budi sessions --ticket parses");
+        match cli.command {
+            Commands::Sessions { ticket, .. } => {
+                assert_eq!(ticket.as_deref(), Some("PAVA-2057"));
+            }
+            _ => panic!("expected sessions command"),
         }
     }
 }

--- a/crates/budi-core/src/analytics/queries.rs
+++ b/crates/budi-core/src/analytics/queries.rs
@@ -1693,7 +1693,7 @@ fn tag_stats_branch_from_messages(
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct TicketCost {
     pub ticket_id: String,
-    /// Prefix of the ticket id, e.g. `PAVA` for `PAVA-2057`. Empty when
+    /// Prefix of the ticket id, e.g. `ENG` for `ENG-123`. Empty when
     /// the value has no `-` (covers the `(untagged)` row).
     pub ticket_prefix: String,
     pub session_count: u64,

--- a/crates/budi-core/src/analytics/queries.rs
+++ b/crates/budi-core/src/analytics/queries.rs
@@ -1681,6 +1681,430 @@ fn tag_stats_branch_from_messages(
 }
 
 // ---------------------------------------------------------------------------
+// Ticket Cost
+// ---------------------------------------------------------------------------
+
+/// Per-ticket aggregate cost row used by `GET /analytics/tickets`
+/// and the `budi stats --tickets` CLI view.
+///
+/// Tickets are sourced from the `ticket_id` tag emitted by `GitEnricher`
+/// when a recognised ID appears in `git_branch`. Messages with no `ticket_id`
+/// tag collapse into a single `(untagged)` bucket so the total stays whole.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct TicketCost {
+    pub ticket_id: String,
+    /// Prefix of the ticket id, e.g. `PAVA` for `PAVA-2057`. Empty when
+    /// the value has no `-` (covers the `(untagged)` row).
+    pub ticket_prefix: String,
+    pub session_count: u64,
+    pub message_count: u64,
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub cache_read_tokens: u64,
+    pub cache_creation_tokens: u64,
+    pub cost_cents: f64,
+    /// Dominant branch (highest cost) carrying this ticket. Empty for the
+    /// `(untagged)` row.
+    #[serde(default)]
+    pub top_branch: String,
+    /// Dominant repo (highest cost) carrying this ticket. Empty for the
+    /// `(untagged)` row.
+    #[serde(default)]
+    pub top_repo_id: String,
+}
+
+/// Per-branch breakdown attached to a single ticket detail response.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct TicketBranchBreakdown {
+    pub git_branch: String,
+    pub repo_id: String,
+    pub message_count: u64,
+    pub session_count: u64,
+    pub cost_cents: f64,
+}
+
+/// Detail payload for `GET /analytics/tickets/{ticket_id}` and
+/// `budi stats --ticket <ID>`.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct TicketCostDetail {
+    pub ticket_id: String,
+    pub ticket_prefix: String,
+    pub session_count: u64,
+    pub message_count: u64,
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub cache_read_tokens: u64,
+    pub cache_creation_tokens: u64,
+    pub cost_cents: f64,
+    /// Dominant repo (or empty when ambiguous / unattributed).
+    pub repo_id: String,
+    /// Per-branch attribution for cost charged to this ticket.
+    pub branches: Vec<TicketBranchBreakdown>,
+}
+
+const TICKET_TAG_KEY: &str = "ticket_id";
+
+/// Query cost grouped by ticket, sorted by cost descending. Includes an
+/// `(untagged)` bucket for assistant messages that have no `ticket_id` tag.
+pub fn ticket_cost(
+    conn: &Connection,
+    since: Option<&str>,
+    until: Option<&str>,
+    limit: usize,
+) -> Result<Vec<TicketCost>> {
+    let filters = DimensionFilters::default();
+    ticket_cost_with_filters(conn, since, until, &filters, limit)
+}
+
+pub fn ticket_cost_with_filters(
+    conn: &Connection,
+    since: Option<&str>,
+    until: Option<&str>,
+    filters: &DimensionFilters,
+    limit: usize,
+) -> Result<Vec<TicketCost>> {
+    // Tagged path: join messages → tags(ticket_id) and split cost
+    // proportionally when one message carries multiple ticket IDs (rare,
+    // but matches the existing tag_stats behaviour for fairness).
+    let mut conditions = vec!["m.role = 'assistant'".to_string()];
+    let mut param_values: Vec<String> = Vec::new();
+    let mut idx = 0usize;
+    if let Some(s) = since {
+        idx += 1;
+        param_values.push(s.to_string());
+        conditions.push(format!("m.timestamp >= ?{idx}"));
+    }
+    if let Some(u) = until {
+        idx += 1;
+        param_values.push(u.to_string());
+        conditions.push(format!("m.timestamp < ?{idx}"));
+    }
+    let model_expr = normalized_model_expr("m.model");
+    let project_expr = normalized_project_expr("m.repo_id");
+    let branch_expr = normalized_branch_expr("m.git_branch");
+    apply_dimension_filters(
+        &mut conditions,
+        &mut param_values,
+        filters,
+        "COALESCE(m.provider, 'claude_code')",
+        &model_expr,
+        &project_expr,
+        &branch_expr,
+    );
+    let where_clause = format!("WHERE {}", conditions.join(" AND "));
+
+    // Build the (untagged) UNION clause — assistant messages that have no
+    // ticket_id tag at all, after dimension/date filters.
+    let untagged_conditions: Vec<String> = conditions
+        .iter()
+        .map(|c| c.replace("m.role = 'assistant'", "m2.role = 'assistant'"))
+        .collect();
+    // The above only renames the role predicate; date and dimension predicates
+    // already reference `m.*` columns, so re-alias the table prefix as well.
+    let untagged_conditions: Vec<String> = untagged_conditions
+        .into_iter()
+        .map(|c| c.replace("m.", "m2."))
+        .collect();
+    let untagged_where = format!("WHERE {}", untagged_conditions.join(" AND "));
+
+    let limit_param_idx = param_values.len() + 1;
+    param_values.push(limit.to_string());
+
+    let sql = format!(
+        "WITH msg_val_counts AS (
+             SELECT message_id, COUNT(*) AS n_values
+             FROM tags
+             WHERE key = '{TICKET_TAG_KEY}'
+             GROUP BY message_id
+         ),
+         tagged AS (
+             SELECT t.value AS ticket_id,
+                    m.session_id,
+                    m.repo_id,
+                    m.git_branch,
+                    m.input_tokens,
+                    m.output_tokens,
+                    m.cache_read_tokens,
+                    m.cache_creation_tokens,
+                    m.cost_cents,
+                    mvc.n_values
+             FROM tags t
+             JOIN msg_val_counts mvc ON mvc.message_id = t.message_id
+             JOIN messages m ON m.id = t.message_id
+             {where_clause}
+             AND t.key = '{TICKET_TAG_KEY}'
+         ),
+         per_ticket AS (
+             SELECT ticket_id,
+                    COUNT(DISTINCT session_id) AS sess,
+                    COUNT(*) AS cnt,
+                    COALESCE(SUM(input_tokens / n_values), 0) AS inp,
+                    COALESCE(SUM(output_tokens / n_values), 0) AS outp,
+                    COALESCE(SUM(cache_read_tokens / n_values), 0) AS cache_r,
+                    COALESCE(SUM(cache_creation_tokens / n_values), 0) AS cache_c,
+                    COALESCE(SUM(cost_cents / n_values), 0.0) AS cost
+             FROM tagged
+             GROUP BY ticket_id
+         ),
+         top_branch AS (
+             SELECT ticket_id,
+                    CASE
+                        WHEN COALESCE(git_branch, '') LIKE 'refs/heads/%'
+                            THEN SUBSTR(COALESCE(git_branch, ''), 12)
+                        ELSE COALESCE(git_branch, '')
+                    END AS branch_value,
+                    SUM(cost_cents / n_values) AS branch_cost
+             FROM tagged
+             GROUP BY ticket_id, branch_value
+         ),
+         top_branch_pick AS (
+             SELECT ticket_id, branch_value
+             FROM (
+                 SELECT ticket_id, branch_value, branch_cost,
+                        ROW_NUMBER() OVER (
+                            PARTITION BY ticket_id
+                            ORDER BY branch_cost DESC, branch_value ASC
+                        ) AS rn
+                 FROM top_branch
+                 WHERE branch_value != ''
+             )
+             WHERE rn = 1
+         ),
+         top_repo AS (
+             SELECT ticket_id,
+                    COALESCE(repo_id, '') AS repo_value,
+                    SUM(cost_cents / n_values) AS repo_cost
+             FROM tagged
+             GROUP BY ticket_id, repo_value
+         ),
+         top_repo_pick AS (
+             SELECT ticket_id, repo_value
+             FROM (
+                 SELECT ticket_id, repo_value, repo_cost,
+                        ROW_NUMBER() OVER (
+                            PARTITION BY ticket_id
+                            ORDER BY repo_cost DESC, repo_value ASC
+                        ) AS rn
+                 FROM top_repo
+                 WHERE repo_value != '' AND repo_value != 'unknown'
+             )
+             WHERE rn = 1
+         )
+         SELECT pt.ticket_id,
+                pt.sess, pt.cnt,
+                pt.inp, pt.outp, pt.cache_r, pt.cache_c, pt.cost,
+                COALESCE(tbp.branch_value, '') AS top_branch,
+                COALESCE(trp.repo_value, '') AS top_repo
+         FROM per_ticket pt
+         LEFT JOIN top_branch_pick tbp ON tbp.ticket_id = pt.ticket_id
+         LEFT JOIN top_repo_pick trp ON trp.ticket_id = pt.ticket_id
+
+         UNION ALL
+
+         SELECT '{UNTAGGED_DIMENSION}' AS ticket_id,
+                COUNT(DISTINCT m2.session_id) AS sess,
+                COUNT(*) AS cnt,
+                COALESCE(SUM(m2.input_tokens), 0) AS inp,
+                COALESCE(SUM(m2.output_tokens), 0) AS outp,
+                COALESCE(SUM(m2.cache_read_tokens), 0) AS cache_r,
+                COALESCE(SUM(m2.cache_creation_tokens), 0) AS cache_c,
+                COALESCE(SUM(m2.cost_cents), 0.0) AS cost,
+                '' AS top_branch,
+                '' AS top_repo
+         FROM messages m2
+         {untagged_where}
+         AND NOT EXISTS (
+             SELECT 1 FROM tags t2
+             WHERE t2.message_id = m2.id AND t2.key = '{TICKET_TAG_KEY}'
+         )
+
+         ORDER BY cost DESC
+         LIMIT ?{limit_param_idx}",
+    );
+
+    // (untagged) sub-query reuses the same positional date/dimension params,
+    // so the param list is shared 1:1.
+    let param_refs: Vec<&dyn rusqlite::types::ToSql> = param_values
+        .iter()
+        .map(|s| s as &dyn rusqlite::types::ToSql)
+        .collect();
+    let mut stmt = conn.prepare(&sql)?;
+    let rows: Vec<TicketCost> = stmt
+        .query_map(param_refs.as_slice(), |row| {
+            let ticket_id: String = row.get(0)?;
+            let ticket_prefix = ticket_prefix_of(&ticket_id);
+            Ok(TicketCost {
+                ticket_id,
+                ticket_prefix,
+                session_count: row.get(1)?,
+                message_count: row.get(2)?,
+                input_tokens: row.get(3)?,
+                output_tokens: row.get(4)?,
+                cache_read_tokens: row.get(5)?,
+                cache_creation_tokens: row.get(6)?,
+                cost_cents: row.get(7)?,
+                top_branch: row.get(8)?,
+                top_repo_id: row.get(9)?,
+            })
+        })?
+        .filter_map(|r| r.ok())
+        // Drop the (untagged) row when it carries zero cost AND zero messages
+        // to avoid noise on a freshly-imported DB.
+        .filter(|tc| !(tc.ticket_id == UNTAGGED_DIMENSION && tc.message_count == 0))
+        .collect();
+
+    Ok(rows)
+}
+
+/// Detail view for a single ticket: totals, dominant repo, and per-branch
+/// breakdown. Returns `None` when no assistant messages carry the ticket
+/// in the requested window.
+pub fn ticket_cost_single(
+    conn: &Connection,
+    ticket_id: &str,
+    repo_id: Option<&str>,
+    since: Option<&str>,
+    until: Option<&str>,
+) -> Result<Option<TicketCostDetail>> {
+    let mut conditions = vec![
+        "m.role = 'assistant'".to_string(),
+        "t.key = ?1".to_string(),
+        "t.value = ?2".to_string(),
+    ];
+    let mut param_values: Vec<String> = vec![TICKET_TAG_KEY.to_string(), ticket_id.to_string()];
+    let mut idx = 2usize;
+
+    if let Some(repo) = repo_id {
+        idx += 1;
+        param_values.push(repo.to_string());
+        conditions.push(format!("COALESCE(m.repo_id, '') = ?{idx}"));
+    }
+    if let Some(s) = since {
+        idx += 1;
+        param_values.push(s.to_string());
+        conditions.push(format!("m.timestamp >= ?{idx}"));
+    }
+    if let Some(u) = until {
+        idx += 1;
+        param_values.push(u.to_string());
+        conditions.push(format!("m.timestamp < ?{idx}"));
+    }
+    let where_clause = format!("WHERE {}", conditions.join(" AND "));
+
+    // Totals. Use the same proportional split on multi-value ticket tags.
+    let totals_sql = format!(
+        "WITH msg_val_counts AS (
+             SELECT message_id, COUNT(*) AS n_values
+             FROM tags
+             WHERE key = ?1
+             GROUP BY message_id
+         )
+         SELECT COUNT(DISTINCT m.session_id) AS sess,
+                COUNT(*) AS cnt,
+                COALESCE(SUM(m.input_tokens / mvc.n_values), 0) AS inp,
+                COALESCE(SUM(m.output_tokens / mvc.n_values), 0) AS outp,
+                COALESCE(SUM(m.cache_read_tokens / mvc.n_values), 0) AS cache_r,
+                COALESCE(SUM(m.cache_creation_tokens / mvc.n_values), 0) AS cache_c,
+                COALESCE(SUM(m.cost_cents / mvc.n_values), 0.0) AS cost,
+                CASE WHEN COUNT(DISTINCT COALESCE(m.repo_id, '')) = 1
+                     THEN COALESCE(MIN(m.repo_id), '')
+                     ELSE '' END AS repo
+         FROM tags t
+         JOIN msg_val_counts mvc ON mvc.message_id = t.message_id
+         JOIN messages m ON m.id = t.message_id
+         {where_clause}",
+    );
+
+    let param_refs: Vec<&dyn rusqlite::types::ToSql> = param_values
+        .iter()
+        .map(|s| s as &dyn rusqlite::types::ToSql)
+        .collect();
+    let mut stmt = conn.prepare(&totals_sql)?;
+    let totals = stmt.query_row(param_refs.as_slice(), |row| {
+        Ok((
+            row.get::<_, u64>(0)?,
+            row.get::<_, u64>(1)?,
+            row.get::<_, u64>(2)?,
+            row.get::<_, u64>(3)?,
+            row.get::<_, u64>(4)?,
+            row.get::<_, u64>(5)?,
+            row.get::<_, f64>(6)?,
+            row.get::<_, String>(7)?,
+        ))
+    });
+    let (sess, cnt, inp, outp, cache_r, cache_c, cost, repo) = match totals {
+        Ok(row) => row,
+        Err(rusqlite::Error::QueryReturnedNoRows) => return Ok(None),
+        Err(e) => return Err(e.into()),
+    };
+    if cnt == 0 {
+        return Ok(None);
+    }
+
+    // Per-branch breakdown — same proportional split.
+    let branches_sql = format!(
+        "WITH msg_val_counts AS (
+             SELECT message_id, COUNT(*) AS n_values
+             FROM tags
+             WHERE key = ?1
+             GROUP BY message_id
+         )
+         SELECT COALESCE(NULLIF(
+                    CASE
+                        WHEN COALESCE(m.git_branch, '') LIKE 'refs/heads/%'
+                            THEN SUBSTR(COALESCE(m.git_branch, ''), 12)
+                        ELSE COALESCE(m.git_branch, '')
+                    END,
+                    ''
+                ), '{UNTAGGED_DIMENSION}') AS branch_value,
+                COALESCE(m.repo_id, '') AS repo_value,
+                COUNT(DISTINCT m.session_id) AS sess,
+                COUNT(*) AS cnt,
+                COALESCE(SUM(m.cost_cents / mvc.n_values), 0.0) AS cost
+         FROM tags t
+         JOIN msg_val_counts mvc ON mvc.message_id = t.message_id
+         JOIN messages m ON m.id = t.message_id
+         {where_clause}
+         GROUP BY branch_value, repo_value
+         ORDER BY cost DESC, branch_value ASC",
+    );
+    let mut stmt = conn.prepare(&branches_sql)?;
+    let branches: Vec<TicketBranchBreakdown> = stmt
+        .query_map(param_refs.as_slice(), |row| {
+            Ok(TicketBranchBreakdown {
+                git_branch: row.get(0)?,
+                repo_id: row.get(1)?,
+                session_count: row.get(2)?,
+                message_count: row.get(3)?,
+                cost_cents: row.get(4)?,
+            })
+        })?
+        .filter_map(|r| r.ok())
+        .collect();
+
+    Ok(Some(TicketCostDetail {
+        ticket_prefix: ticket_prefix_of(ticket_id),
+        ticket_id: ticket_id.to_string(),
+        session_count: sess,
+        message_count: cnt,
+        input_tokens: inp,
+        output_tokens: outp,
+        cache_read_tokens: cache_r,
+        cache_creation_tokens: cache_c,
+        cost_cents: cost,
+        repo_id: repo,
+        branches,
+    }))
+}
+
+fn ticket_prefix_of(ticket: &str) -> String {
+    ticket
+        .split_once('-')
+        .map(|(prefix, _)| prefix.to_string())
+        .unwrap_or_default()
+}
+
+// ---------------------------------------------------------------------------
 // Model Usage
 // ---------------------------------------------------------------------------
 

--- a/crates/budi-core/src/analytics/sessions.rs
+++ b/crates/budi-core/src/analytics/sessions.rs
@@ -170,6 +170,7 @@ pub fn session_visibility(conn: &Connection) -> Result<Vec<SessionVisibilityWind
                 sort_asc: false,
                 limit: 1,
                 offset: 0,
+                ticket: None,
             },
         )?;
         let returned_sessions = paginated.total_count;
@@ -291,6 +292,11 @@ pub struct SessionListParams<'a> {
     pub sort_asc: bool,
     pub limit: usize,
     pub offset: usize,
+    /// Restrict the result to sessions that have at least one assistant
+    /// message tagged with this `ticket_id`. Promoted to a first-class
+    /// session filter in 8.1 so `budi sessions --ticket PAVA-2057` works
+    /// the same way `--branch` does for branches.
+    pub ticket: Option<&'a str>,
 }
 
 fn parse_models_csv(raw: Option<String>) -> Vec<String> {
@@ -411,6 +417,19 @@ pub fn session_list_with_filters(
         ));
     }
     apply_session_dimension_filters(&mut conditions, &mut param_values, filters);
+    if let Some(ticket) = p.ticket
+        && !ticket.is_empty()
+    {
+        // Restrict to assistant messages that carry the requested `ticket_id`
+        // tag. Mirrors how `branches`/`projects` filter via DimensionFilters,
+        // but tickets live in `tags` (not on the message row), so we use
+        // EXISTS instead of a column predicate.
+        param_values.push(ticket.to_string());
+        let idx = param_values.len();
+        conditions.push(format!(
+            "EXISTS (SELECT 1 FROM tags tk WHERE tk.message_id = m.id AND tk.key = 'ticket_id' AND tk.value = ?{idx})"
+        ));
+    }
     let where_clause = format!("WHERE {}", conditions.join(" AND "));
 
     // Count total matching sessions using only the filter params (no limit/offset)

--- a/crates/budi-core/src/analytics/sessions.rs
+++ b/crates/budi-core/src/analytics/sessions.rs
@@ -294,7 +294,7 @@ pub struct SessionListParams<'a> {
     pub offset: usize,
     /// Restrict the result to sessions that have at least one assistant
     /// message tagged with this `ticket_id`. Promoted to a first-class
-    /// session filter in 8.1 so `budi sessions --ticket PAVA-2057` works
+    /// session filter in 8.1 so `budi sessions --ticket ENG-123` works
     /// the same way `--branch` does for branches.
     pub ticket: Option<&'a str>,
 }

--- a/crates/budi-core/src/analytics/tests.rs
+++ b/crates/budi-core/src/analytics/tests.rs
@@ -1629,6 +1629,7 @@ fn session_list_returns_sessions() {
             sort_asc: false,
             limit: 50,
             offset: 0,
+            ticket: None,
         },
     )
     .unwrap();
@@ -1661,6 +1662,7 @@ fn session_list_uses_structured_models_array() {
             sort_asc: false,
             limit: 50,
             offset: 0,
+            ticket: None,
         },
     )
     .unwrap();
@@ -1723,6 +1725,7 @@ fn session_list_returns_session_for_today_window_with_local_midnight_utc_since()
             sort_asc: false,
             limit: 50,
             offset: 0,
+            ticket: None,
         },
         &DimensionFilters::default(),
     )
@@ -1898,6 +1901,7 @@ fn session_list_window_compares_correctly_across_provider_timestamp_formats() {
             sort_asc: false,
             limit: 50,
             offset: 0,
+            ticket: None,
         },
         &DimensionFilters::default(),
     )
@@ -1919,6 +1923,7 @@ fn session_list_window_compares_correctly_across_provider_timestamp_formats() {
             sort_asc: false,
             limit: 50,
             offset: 0,
+            ticket: None,
         },
         &DimensionFilters::default(),
     )
@@ -1952,6 +1957,7 @@ fn session_list_ignores_empty_string_session_id() {
             sort_asc: false,
             limit: 50,
             offset: 0,
+            ticket: None,
         },
         &DimensionFilters::default(),
     )
@@ -1995,6 +2001,7 @@ fn session_list_with_dimension_filters() {
             sort_asc: false,
             limit: 50,
             offset: 0,
+            ticket: None,
         },
         &filters,
     )
@@ -2218,6 +2225,221 @@ fn branch_cost_untagged() {
     let branches = branch_cost(&conn, None, None, 10).unwrap();
     assert_eq!(branches.len(), 1);
     assert_eq!(branches[0].git_branch, "(untagged)");
+}
+
+// ---------------------------------------------------------------------------
+// Ticket cost (R1.0.3 / #304)
+// ---------------------------------------------------------------------------
+//
+// These tests cover the contract that 8.1 promotes ticket attribution to a
+// first-class CLI dimension:
+//   1. `--tickets` lists tickets by cost, with `(untagged)` for the bucket
+//      of assistant messages that have no `ticket_id` tag.
+//   2. `--ticket <ID>` returns a single detail row + per-branch breakdown.
+//   3. The session list filter restricts results to sessions tagged with
+//      the requested ticket.
+// All three rely on the `ticket_id` tag emitted by `GitEnricher`; the tests
+// inject the tag directly so they don't depend on enricher behaviour.
+
+fn ticket_msg(uuid: &str, session_id: &str, branch: &str, repo: &str, cost: f64) -> ParsedMessage {
+    let mut m = assistant_msg(uuid, session_id, cost);
+    m.git_branch = Some(branch.to_string());
+    m.repo_id = Some(repo.to_string());
+    m
+}
+
+fn ticket_tags(values: &[&str]) -> Vec<Tag> {
+    values
+        .iter()
+        .map(|v| Tag {
+            key: "ticket_id".to_string(),
+            value: (*v).to_string(),
+        })
+        .collect()
+}
+
+#[test]
+fn ticket_cost_groups_by_ticket() {
+    // Two tickets, with PAVA-1 carrying more cost than PAVA-2 across two
+    // sessions; PAVA-2 has a single session. Expect cost-desc ordering and
+    // session_count to count *distinct* sessions per ticket.
+    let mut conn = test_db();
+    let m1 = ticket_msg("tk-1", "s1", "PAVA-1-foo", "repo-a", 4.0);
+    let m2 = ticket_msg("tk-2", "s2", "PAVA-1-foo", "repo-a", 6.0);
+    let m3 = ticket_msg("tk-3", "s3", "PAVA-2-bar", "repo-b", 3.0);
+    let tags = vec![
+        ticket_tags(&["PAVA-1"]),
+        ticket_tags(&["PAVA-1"]),
+        ticket_tags(&["PAVA-2"]),
+    ];
+    ingest_messages(&mut conn, &[m1, m2, m3], Some(&tags)).unwrap();
+
+    let tickets = ticket_cost(&conn, None, None, 10).unwrap();
+    let pava1 = tickets.iter().find(|t| t.ticket_id == "PAVA-1").unwrap();
+    let pava2 = tickets.iter().find(|t| t.ticket_id == "PAVA-2").unwrap();
+    assert_eq!(pava1.session_count, 2, "PAVA-1 spans two sessions");
+    assert_eq!(pava1.message_count, 2);
+    assert!((pava1.cost_cents - 10.0).abs() < 0.01);
+    assert_eq!(pava1.ticket_prefix, "PAVA");
+    assert_eq!(pava1.top_branch, "PAVA-1-foo");
+    assert_eq!(pava1.top_repo_id, "repo-a");
+    assert_eq!(pava2.session_count, 1);
+    assert!((pava2.cost_cents - 3.0).abs() < 0.01);
+    // Cost-desc ordering is the contract surfaced by `budi stats --tickets`.
+    let pava1_idx = tickets
+        .iter()
+        .position(|t| t.ticket_id == "PAVA-1")
+        .unwrap();
+    let pava2_idx = tickets
+        .iter()
+        .position(|t| t.ticket_id == "PAVA-2")
+        .unwrap();
+    assert!(pava1_idx < pava2_idx);
+}
+
+#[test]
+fn ticket_cost_includes_untagged_bucket() {
+    // One tagged ticket and one bare assistant message → expect the
+    // (untagged) row to appear so the total reconciles with the global
+    // cost summary, never silently disappears.
+    let mut conn = test_db();
+    let m1 = ticket_msg("tk-u-1", "s1", "PAVA-9", "repo", 5.0);
+    let m2 = assistant_msg("tk-u-2", "s2", 7.0); // no branch, no ticket
+    ingest_messages(
+        &mut conn,
+        &[m1, m2],
+        Some(&[ticket_tags(&["PAVA-9"]), Vec::new()]),
+    )
+    .unwrap();
+
+    let tickets = ticket_cost(&conn, None, None, 10).unwrap();
+    let untagged = tickets
+        .iter()
+        .find(|t| t.ticket_id == "(untagged)")
+        .expect("untagged ticket bucket present");
+    assert!((untagged.cost_cents - 7.0).abs() < 0.01);
+    assert_eq!(untagged.message_count, 1);
+    assert_eq!(untagged.ticket_prefix, "");
+    assert_eq!(untagged.top_branch, "");
+}
+
+#[test]
+fn ticket_cost_single_returns_detail_with_branches() {
+    // PAVA-7 is worked on across two branches in the same repo. Detail
+    // view should attribute cost per branch and pick the dominant repo.
+    let mut conn = test_db();
+    let m1 = ticket_msg("tk-d-1", "s1", "PAVA-7-impl", "repo-a", 8.0);
+    let m2 = ticket_msg("tk-d-2", "s2", "PAVA-7-test", "repo-a", 2.0);
+    let tags = vec![ticket_tags(&["PAVA-7"]), ticket_tags(&["PAVA-7"])];
+    ingest_messages(&mut conn, &[m1, m2], Some(&tags)).unwrap();
+
+    let detail = ticket_cost_single(&conn, "PAVA-7", None, None, None)
+        .unwrap()
+        .expect("ticket detail present");
+    assert_eq!(detail.ticket_id, "PAVA-7");
+    assert_eq!(detail.ticket_prefix, "PAVA");
+    assert_eq!(detail.session_count, 2);
+    assert_eq!(detail.message_count, 2);
+    assert_eq!(detail.repo_id, "repo-a");
+    assert!((detail.cost_cents - 10.0).abs() < 0.01);
+    assert_eq!(detail.branches.len(), 2);
+    // Cost-desc ordering of the branch breakdown.
+    assert_eq!(detail.branches[0].git_branch, "PAVA-7-impl");
+    assert!((detail.branches[0].cost_cents - 8.0).abs() < 0.01);
+
+    let missing = ticket_cost_single(&conn, "DOES-NOT-EXIST", None, None, None).unwrap();
+    assert!(missing.is_none());
+}
+
+#[test]
+fn ticket_cost_single_can_filter_by_repo() {
+    // The same ticket id exists in two repos (rare, but possible when teams
+    // share IDs across services). `--repo` should narrow the result so the
+    // CLI can disambiguate.
+    let mut conn = test_db();
+    let m1 = ticket_msg("tk-r-1", "s1", "PAVA-3", "repo-a", 4.0);
+    let m2 = ticket_msg("tk-r-2", "s2", "PAVA-3", "repo-b", 6.0);
+    let tags = vec![ticket_tags(&["PAVA-3"]), ticket_tags(&["PAVA-3"])];
+    ingest_messages(&mut conn, &[m1, m2], Some(&tags)).unwrap();
+
+    let only_a = ticket_cost_single(&conn, "PAVA-3", Some("repo-a"), None, None)
+        .unwrap()
+        .unwrap();
+    assert_eq!(only_a.repo_id, "repo-a");
+    assert!((only_a.cost_cents - 4.0).abs() < 0.01);
+    assert_eq!(only_a.message_count, 1);
+
+    let none = ticket_cost_single(&conn, "PAVA-3", Some("repo-c"), None, None).unwrap();
+    assert!(none.is_none());
+}
+
+#[test]
+fn ticket_cost_splits_cost_for_multi_ticket_message() {
+    // Reuse the proportional-split contract that `tag_stats` already gives
+    // ticket tags so users see a fair number when one message touches two
+    // tickets (e.g. cross-cutting refactor).
+    let mut conn = test_db();
+    let m = ticket_msg("tk-multi", "s1", "PAVA-1+PAVA-2", "repo", 10.0);
+    let tags = vec![ticket_tags(&["PAVA-1", "PAVA-2"])];
+    ingest_messages(&mut conn, &[m], Some(&tags)).unwrap();
+
+    let tickets = ticket_cost(&conn, None, None, 10).unwrap();
+    let p1 = tickets.iter().find(|t| t.ticket_id == "PAVA-1").unwrap();
+    let p2 = tickets.iter().find(|t| t.ticket_id == "PAVA-2").unwrap();
+    assert!((p1.cost_cents - 5.0).abs() < 0.01);
+    assert!((p2.cost_cents - 5.0).abs() < 0.01);
+}
+
+#[test]
+fn session_list_filters_by_ticket() {
+    // The session list filter is the third surface added in 8.1 — without it,
+    // `budi sessions --ticket PAVA-9` would have to client-side filter and
+    // would misreport `total_count`.
+    let mut conn = test_db();
+    let m1 = ticket_msg("sess-tk-1", "s1", "PAVA-9", "repo", 5.0);
+    let m2 = assistant_msg("sess-tk-2", "s2", 7.0); // unrelated session
+    ingest_messages(
+        &mut conn,
+        &[m1, m2],
+        Some(&[ticket_tags(&["PAVA-9"]), Vec::new()]),
+    )
+    .unwrap();
+
+    let filtered = session_list(
+        &conn,
+        &SessionListParams {
+            since: None,
+            until: None,
+            search: None,
+            sort_by: None,
+            sort_asc: false,
+            limit: 50,
+            offset: 0,
+            ticket: Some("PAVA-9"),
+        },
+    )
+    .unwrap();
+    assert_eq!(filtered.total_count, 1);
+    assert_eq!(filtered.sessions.len(), 1);
+    assert_eq!(filtered.sessions[0].id, "s1");
+
+    // A ticket that does not exist filters everything out.
+    let none = session_list(
+        &conn,
+        &SessionListParams {
+            since: None,
+            until: None,
+            search: None,
+            sort_by: None,
+            sort_asc: false,
+            limit: 50,
+            offset: 0,
+            ticket: Some("NOPE-1"),
+        },
+    )
+    .unwrap();
+    assert_eq!(none.total_count, 0);
+    assert!(none.sessions.is_empty());
 }
 
 #[test]

--- a/crates/budi-core/src/proxy.rs
+++ b/crates/budi-core/src/proxy.rs
@@ -800,6 +800,7 @@ mod tests {
                 sort_asc: false,
                 limit: 50,
                 offset: 0,
+                ticket: None,
             },
             &crate::analytics::DimensionFilters::default(),
         )

--- a/crates/budi-daemon/src/main.rs
+++ b/crates/budi-daemon/src/main.rs
@@ -107,6 +107,11 @@ fn build_router(app_state: AppState) -> Router {
             "/analytics/branches/{branch}",
             get(a::analytics_branch_detail),
         )
+        .route("/analytics/tickets", get(a::analytics_tickets))
+        .route(
+            "/analytics/tickets/{ticket_id}",
+            get(a::analytics_ticket_detail),
+        )
         .route("/analytics/providers", get(a::analytics_providers))
         .route("/analytics/statusline", get(a::analytics_statusline))
         .route(

--- a/crates/budi-daemon/src/routes/analytics.rs
+++ b/crates/budi-daemon/src/routes/analytics.rs
@@ -719,7 +719,7 @@ pub struct SessionsQueryParams {
     pub sort_asc: Option<bool>,
     pub limit: Option<usize>,
     pub offset: Option<usize>,
-    /// Filter to sessions tagged with the given `ticket_id` (e.g. `PAVA-2057`).
+    /// Filter to sessions tagged with the given `ticket_id` (e.g. `ENG-123`).
     /// Wired in by 8.1 so `budi sessions --ticket <ID>` mirrors `--branch`.
     pub ticket: Option<String>,
     #[serde(flatten)]

--- a/crates/budi-daemon/src/routes/analytics.rs
+++ b/crates/budi-daemon/src/routes/analytics.rs
@@ -511,6 +511,77 @@ pub async fn analytics_branch_detail(
     }
 }
 
+// ---------------------------------------------------------------------------
+// Tickets — first-class CLI dimension wired in 8.1 (#304)
+// ---------------------------------------------------------------------------
+
+/// `GET /analytics/tickets` query params. Mirrors `ListParams` so the same
+/// `--provider`/`--model`/`--repo` slicing offered by `--branches` is also
+/// available for `--tickets`.
+#[derive(serde::Deserialize)]
+pub struct TicketListParams {
+    pub since: Option<String>,
+    pub until: Option<String>,
+    pub limit: Option<usize>,
+    #[serde(flatten)]
+    pub filters: DimensionParams,
+}
+
+#[derive(serde::Deserialize)]
+pub struct TicketDetailParams {
+    pub since: Option<String>,
+    pub until: Option<String>,
+    pub repo_id: Option<String>,
+}
+
+pub async fn analytics_tickets(
+    Query(params): Query<TicketListParams>,
+) -> Result<Json<Vec<analytics::TicketCost>>, (StatusCode, Json<serde_json::Value>)> {
+    let limit = params.limit.unwrap_or(20).min(200);
+    let filters = parse_dimension_filters(&params.filters);
+    let result = tokio::task::spawn_blocking(move || {
+        let db_path = analytics::db_path()?;
+        let conn = analytics::open_db(&db_path)?;
+        analytics::ticket_cost_with_filters(
+            &conn,
+            params.since.as_deref(),
+            params.until.as_deref(),
+            &filters,
+            limit,
+        )
+    })
+    .await
+    .map_err(|e| internal_error(anyhow::anyhow!("{e}")))?
+    .map_err(internal_error)?;
+
+    Ok(Json(result))
+}
+
+pub async fn analytics_ticket_detail(
+    Path(ticket_id): Path<String>,
+    Query(params): Query<TicketDetailParams>,
+) -> Result<Json<analytics::TicketCostDetail>, (StatusCode, Json<serde_json::Value>)> {
+    let result = tokio::task::spawn_blocking(move || {
+        let db_path = analytics::db_path()?;
+        let conn = analytics::open_db(&db_path)?;
+        analytics::ticket_cost_single(
+            &conn,
+            &ticket_id,
+            params.repo_id.as_deref(),
+            params.since.as_deref(),
+            params.until.as_deref(),
+        )
+    })
+    .await
+    .map_err(|e| internal_error(anyhow::anyhow!("{e}")))?
+    .map_err(internal_error)?;
+
+    match result {
+        Some(detail) => Ok(Json(detail)),
+        None => Err(not_found("ticket not found")),
+    }
+}
+
 pub async fn analytics_schema_version()
 -> Result<Json<SchemaVersionResponse>, (StatusCode, Json<serde_json::Value>)> {
     let result = tokio::task::spawn_blocking(move || -> anyhow::Result<SchemaVersionResponse> {
@@ -648,6 +719,9 @@ pub struct SessionsQueryParams {
     pub sort_asc: Option<bool>,
     pub limit: Option<usize>,
     pub offset: Option<usize>,
+    /// Filter to sessions tagged with the given `ticket_id` (e.g. `PAVA-2057`).
+    /// Wired in by 8.1 so `budi sessions --ticket <ID>` mirrors `--branch`.
+    pub ticket: Option<String>,
     #[serde(flatten)]
     pub filters: DimensionParams,
 }
@@ -678,6 +752,7 @@ pub async fn analytics_sessions(
                 sort_asc: params.sort_asc.unwrap_or(false),
                 limit: params.limit.unwrap_or(50).min(200),
                 offset: params.offset.unwrap_or(0),
+                ticket: params.ticket.as_deref(),
             },
             &filters,
         )?;


### PR DESCRIPTION
## Summary
- Adds `budi stats --tickets` (list ranked by cost) and `budi stats --ticket <ID>` (detail view) alongside `--branches`/`--branch`. Both join the `view` arg-group so they remain mutually exclusive with the existing flags. `--repo` is now usable with either `--branch` or `--ticket`.
- Adds `GET /analytics/tickets` and `GET /analytics/tickets/{id}` daemon endpoints with new `TicketCost` / `TicketCostDetail` payloads. List view includes the dominant branch + repo per ticket and an `(untagged)` bucket so totals stay whole. Single message carrying multiple `ticket_id` tags has its cost split proportionally (mirrors tag_stats).
- Extends `budi sessions --ticket <ID>` (and the underlying `session_list_with_filters` plumbing) so attribution is queryable across the existing session views.
- Updates `README.md` ("Monitoring and analytics") and `SOUL.md` ("Attribution contract (R1.0)") to document ticket as a first-class dimension. Tickets continue to be sourced from `GitEnricher`'s existing `ticket_id` tag — no regex or Linear/Jira API changes (out of scope per ticket).

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (345 budi-core + 26 budi-daemon + 54 budi-cli, all green)
- [x] New regression tests:
  - `analytics::tests::ticket_cost_groups_by_ticket`
  - `analytics::tests::ticket_cost_includes_untagged_bucket`
  - `analytics::tests::ticket_cost_splits_cost_for_multi_ticket_message`
  - `analytics::tests::ticket_cost_single_returns_detail_with_branches`
  - `analytics::tests::ticket_cost_single_can_filter_by_repo`
  - `analytics::tests::session_list_filters_by_ticket`
  - `tests::cli_parses_stats_tickets_flag` / `cli_parses_stats_ticket_value_flag`
  - `tests::cli_stats_view_flags_are_mutually_exclusive`
  - `tests::cli_stats_ticket_accepts_repo_filter`
  - `tests::cli_parses_sessions_ticket_flag`

Closes #304

Made with [Cursor](https://cursor.com)