### PR TITLE
[8.1][R1.0.4] feat: promote activity to first-class CLI dimension (#305)

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,11 +290,14 @@ budi stats --branches              # branches ranked by cost
 budi stats --branch <name>         # cost for a specific branch
 budi stats --tickets               # tickets ranked by cost (sourced from ticket_id tag)
 budi stats --ticket <id>           # cost for a specific ticket, with per-branch breakdown
+budi stats --activities            # activities ranked by cost (bugfix, refactor, …)
+budi stats --activity <name>       # cost for a specific activity, with per-branch breakdown
 budi stats --provider codex        # filter stats to a single provider
 budi stats --tag ticket_id         # cost per ticket value (raw tag view)
 budi stats --tag ticket_prefix     # cost per team prefix
 budi sessions                      # list recent sessions with cost and health
 budi sessions --ticket <id>        # sessions tagged with a ticket id
+budi sessions --activity <name>    # sessions tagged with an activity (bugfix, refactor, …)
 budi sessions <id>                 # session detail: cost, models, health, tags
 budi health                        # session health vitals for most recent session
 budi health --session <id>         # health vitals for a specific session

--- a/SOUL.md
+++ b/SOUL.md
@@ -203,7 +203,29 @@ in [#302](https://github.com/siropkin/budi/issues/302) / #303 / #304 / #305):
     `/analytics/branches{/branch}` so future cloud/dashboard work can adopt
     the same data contract.
 
-`budi doctor` runs two attribution checks:
+- **`activity`** — promoted to a first-class CLI dimension in 8.1 (R1.0.4,
+  [#305](https://github.com/siropkin/budi/issues/305)). The pipeline emits
+  an `activity` tag for every assistant message whose session has a
+  classified prompt category (bugfix, refactor, testing, feature, review,
+  ops, question, writing). Values come from the rule-based
+  `hooks::classify_prompt` and are propagated across the session by
+  `propagate_session_context`, so every assistant message in a classified
+  session carries exactly one `activity` tag. R1.0 surfaces every
+  aggregate as `source = "rule"` / `confidence = "medium"`; R1.2 (#222)
+  will refine these per-aggregate as the classifier learns additional
+  signals, without changing the wire format. Surfaces:
+  - `budi stats --activities` — list ranked by cost, with `(untagged)`
+    bucket for messages that never matched a classification rule (short
+    prompts, slash commands, metadata-only messages).
+  - `budi stats --activity <NAME>` — detail view with per-branch
+    breakdown, plus `source` and `confidence` labels.
+  - `budi sessions --activity <NAME>` — sessions tagged with the
+    activity, mirroring `--ticket`.
+  - `GET /analytics/activities` and `/analytics/activities/{name}`
+    mirror the ticket endpoints so future cloud/dashboard work can adopt
+    the same data contract.
+
+`budi doctor` runs three attribution checks:
 
 - **Session visibility** for the `today`, `7d`, and `30d` windows (R1.0.1,
   #302) — fails when a window has assistant rows but zero returned sessions.
@@ -212,6 +234,13 @@ in [#302](https://github.com/siropkin/budi/issues/302) / #303 / #304 / #305):
   at a broken attribution path for that provider (no headers, no resolvable
   cwd, session propagation not rescuing the session) even if overall cost
   numbers look healthy.
+- **Activity attribution (7d, per provider)** (R1.0.4, #305) — red when
+  100% of a provider's recent assistant rows are missing an `activity`
+  tag and it has at least 5 rows in the window (a silent classifier
+  regression). Yellow at >90% to hint at an over-aggressive skip path
+  without tripping a hard fail; a moderate missing-ratio is expected
+  because one-word prompts and slash commands never carry an `activity`
+  tag by design.
 
 ### Key concepts
 
@@ -265,7 +294,7 @@ in [#302](https://github.com/siropkin/budi/issues/302) / #303 / #304 / #305):
 - **Session health**: Four vitals computed per session - context growth (context-size growth), cache reuse (cache hit rate), cost acceleration (per-reply cost growth), retry loops (currently disabled — hook ingestion removed in 8.0; `hook_events` table no longer exists in schema v1). Each vital has green/yellow/red state. New sessions start green - the default is always positive; vitals only degrade to yellow/red when there is clear evidence of a problem. Tips are provider-aware via `ProviderKind` enum (Claude Code -> `/compact`/`/clear`, Cursor -> "new composer session", Other -> neutral). When no session ID is provided, health auto-select prefers the latest session with assistant activity, then falls back to session timestamps. Statusline "coach" mode shows health icon + session cost + tip. Dashboard session detail page has a health panel with vitals grid and tips section.
 - **Cursor extension** ([siropkin/budi-cursor](https://github.com/siropkin/budi-cursor)): VS Code extension that shows session health in the status bar (aggregated health circles) and a side panel (session details, vitals, tips, session list). Installed via VS Code Marketplace or `budi integrations install --with cursor-extension`. Communicates with daemon via HTTP and spawns `budi statusline --format json`. Writes `~/.local/share/budi/cursor-sessions.json` (v1 contract, ADR-0086 §3.4) to signal the active workspace. Checks daemon `api_version` on startup and warns if incompatible.
 - **Cloud dashboard** ([siropkin/budi-cloud](https://github.com/siropkin/budi-cloud)) is a Next.js 16 app deployed to app.getbudi.dev. Uses Supabase Auth (GitHub/Google/magic link) for web sign-in. Dashboard pages: Overview, Team, Models, Repos, Sessions, Settings. Manager role sees all org data; member sees own data.
-- Analytics endpoints: `/analytics/summary`, `/analytics/filter-options`, `/analytics/messages`, `/analytics/messages/{message_uuid}/detail`, `/analytics/projects`, `/analytics/cost`, `/analytics/models`, `/analytics/activity`, `/analytics/branches`, `/analytics/branches/{branch}`, `/analytics/tags`, `/analytics/providers`, `/analytics/statusline`, `/analytics/cache-efficiency`, `/analytics/session-cost-curve`, `/analytics/cost-confidence`, `/analytics/subagent-cost`, `/analytics/sessions`, `/analytics/sessions/{id}`, `/analytics/sessions/{id}/messages`, `/analytics/sessions/{id}/curve`, `/analytics/sessions/{id}/tags`, `/analytics/session-health`, `/analytics/session-audit` (session attribution stats for debugging ingestion)
+- Analytics endpoints: `/analytics/summary`, `/analytics/filter-options`, `/analytics/messages`, `/analytics/messages/{message_uuid}/detail`, `/analytics/projects`, `/analytics/cost`, `/analytics/models`, `/analytics/activity` (activity chart timeline), `/analytics/activities`, `/analytics/activities/{name}` (activity buckets — #305), `/analytics/branches`, `/analytics/branches/{branch}`, `/analytics/tickets`, `/analytics/tickets/{ticket_id}`, `/analytics/tags`, `/analytics/providers`, `/analytics/statusline`, `/analytics/cache-efficiency`, `/analytics/session-cost-curve`, `/analytics/cost-confidence`, `/analytics/subagent-cost`, `/analytics/sessions`, `/analytics/sessions/{id}`, `/analytics/sessions/{id}/messages`, `/analytics/sessions/{id}/curve`, `/analytics/sessions/{id}/tags`, `/analytics/session-health`, `/analytics/session-audit` (session attribution stats for debugging ingestion)
 - Admin endpoints (loopback-only): `/admin/providers` (registered providers), `/admin/schema` (schema version), `/admin/migrate` (run migration), `/admin/repair` (repair schema drift + run migration), `/admin/integrations/install` (integration installer orchestration)
 - Sync mutation endpoints (loopback-only): `/sync` (30-day), `/sync/all` (full history), `/sync/reset` (wipe sync state + full re-sync)
 - Sync status endpoint: `/sync/status` (syncing flag + last_synced)

--- a/crates/budi-cli/src/client.rs
+++ b/crates/budi-cli/src/client.rs
@@ -14,8 +14,9 @@ use std::time::Duration;
 
 use anyhow::{Context, Result};
 use budi_core::analytics::{
-    BranchCost, ModelUsage, PaginatedSessions, ProviderStats, RepoUsage, SessionHealth,
-    SessionListEntry, SessionTag, TagCost, TicketCost, TicketCostDetail, UsageSummary,
+    ActivityCost, ActivityCostDetail, BranchCost, ModelUsage, PaginatedSessions, ProviderStats,
+    RepoUsage, SessionHealth, SessionListEntry, SessionTag, TagCost, TicketCost, TicketCostDetail,
+    UsageSummary,
 };
 use budi_core::config::{self, BudiConfig};
 use budi_core::cost::CostEstimate;
@@ -50,6 +51,21 @@ fn analytics_ticket_detail_url(base_url: &str, ticket_id: &str) -> Result<String
         .push("analytics")
         .push("tickets")
         .push(ticket_id);
+    Ok(url.to_string())
+}
+
+/// Build `GET .../analytics/activities/{name}` with correct path encoding.
+/// Mirrors `analytics_ticket_detail_url` so activity values that include
+/// unusual characters (future classifier output) round-trip untouched.
+fn analytics_activity_detail_url(base_url: &str, activity: &str) -> Result<String> {
+    let normalized = format!("{}/", base_url.trim_end_matches('/'));
+    let mut url = reqwest::Url::parse(&normalized)
+        .with_context(|| format!("invalid daemon base URL: {base_url}"))?;
+    url.path_segments_mut()
+        .map_err(|_| anyhow::anyhow!("invalid daemon base URL: {base_url}"))?
+        .push("analytics")
+        .push("activities")
+        .push(activity);
     Ok(url.to_string())
 }
 
@@ -476,6 +492,72 @@ impl DaemonClient {
         Ok(Some(serde_json::from_value(val)?))
     }
 
+    /// `GET /analytics/activities` — per-activity cost roll-up. Used by
+    /// `budi stats --activities`. Mirrors `tickets` so operators can swap
+    /// `--tickets` / `--activities` without learning a new query shape.
+    pub fn activities(
+        &self,
+        since: Option<&str>,
+        until: Option<&str>,
+        limit: usize,
+    ) -> Result<Vec<ActivityCost>> {
+        let mut params: Vec<(&str, String)> = Vec::new();
+        if let Some(s) = since {
+            params.push(("since", s.to_string()));
+        }
+        if let Some(u) = until {
+            params.push(("until", u.to_string()));
+        }
+        params.push(("limit", limit.to_string()));
+        let resp = self
+            .client
+            .get(format!("{}/analytics/activities", self.base_url))
+            .query(&params)
+            .send()
+            .map_err(describe_send_error)?;
+        let resp = check_response(resp)?;
+        Ok(resp.json()?)
+    }
+
+    /// `GET /analytics/activities/{name}` — single-activity detail with
+    /// per-branch breakdown. Returns `Ok(None)` for an unknown activity
+    /// (mirrors `ticket_detail`).
+    pub fn activity_detail(
+        &self,
+        activity: &str,
+        repo_id: Option<&str>,
+        since: Option<&str>,
+        until: Option<&str>,
+    ) -> Result<Option<ActivityCostDetail>> {
+        let mut params: Vec<(&str, &str)> = Vec::new();
+        if let Some(repo) = repo_id {
+            params.push(("repo_id", repo));
+        }
+        if let Some(s) = since {
+            params.push(("since", s));
+        }
+        if let Some(u) = until {
+            params.push(("until", u));
+        }
+        let url = analytics_activity_detail_url(&self.base_url, activity)
+            .with_context(|| format!("invalid daemon base URL or activity: {activity:?}"))?;
+        let resp = self
+            .client
+            .get(url)
+            .query(&params)
+            .send()
+            .map_err(describe_send_error)?;
+        if resp.status() == reqwest::StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+        let resp = check_response(resp)?;
+        let val: Value = resp.json()?;
+        if val.is_null() {
+            return Ok(None);
+        }
+        Ok(Some(serde_json::from_value(val)?))
+    }
+
     pub fn models(&self, since: Option<&str>, until: Option<&str>) -> Result<Vec<ModelUsage>> {
         let mut params = Vec::new();
         if let Some(s) = since {
@@ -544,12 +626,14 @@ impl DaemonClient {
         Ok(resp.json()?)
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn sessions(
         &self,
         since: Option<&str>,
         until: Option<&str>,
         search: Option<&str>,
         ticket: Option<&str>,
+        activity: Option<&str>,
         limit: usize,
         offset: usize,
     ) -> Result<PaginatedSessions> {
@@ -565,6 +649,9 @@ impl DaemonClient {
         }
         if let Some(t) = ticket {
             params.push(("ticket", t.to_string()));
+        }
+        if let Some(a) = activity {
+            params.push(("activity", a.to_string()));
         }
         params.push(("sort_by", "started_at".to_string()));
         params.push(("limit", limit.to_string()));

--- a/crates/budi-cli/src/commands/doctor.rs
+++ b/crates/budi-cli/src/commands/doctor.rs
@@ -385,6 +385,55 @@ pub fn cmd_doctor(repo_root: Option<PathBuf>, deep: bool) -> Result<()> {
         }
     }
 
+    // Activity attribution: surface a recurrence of a silent classifier
+    // regression (#305 ships `activity` as a first-class dimension; if the
+    // classifier breaks, `budi stats --activities` collapses into
+    // `(untagged)` without anything else catching it). 100% missing for
+    // a provider with traffic is almost always a bug; a mid-range ratio
+    // is expected because short prompts and slash commands never carry
+    // an `activity` tag by design.
+    if let Ok(db_path) = budi_core::analytics::db_path()
+        && db_path.exists()
+        && let Ok(conn) = budi_core::analytics::open_db(&db_path)
+    {
+        match budi_core::analytics::activity_attribution_stats(&conn) {
+            Ok(stats) if stats.is_empty() => {
+                println!("  {dim}-{reset} activity attribution (7d): no assistant activity yet");
+            }
+            Ok(stats) => {
+                let yellow = super::ansi("\x1b[33m");
+                let mut any_red = false;
+                for row in &stats {
+                    let pct = row.missing_activity_ratio() * 100.0;
+                    // Only flag fully-silent providers with non-trivial
+                    // traffic — enough volume to rule out "everybody
+                    // typed a one-word prompt" coincidence.
+                    let fully_silent = pct >= 99.9 && row.total_assistant >= 5;
+                    let mark = if fully_silent {
+                        any_red = true;
+                        format!("{red}\u{2717}{reset}")
+                    } else if pct > 90.0 {
+                        format!("{yellow}!{reset}")
+                    } else {
+                        format!("{green}\u{2713}{reset}")
+                    };
+                    println!(
+                        "  {mark} activity attribution ({}, 7d): assistant={} missing_activity={} ({:.0}%)",
+                        row.provider, row.total_assistant, row.missing_activity, pct,
+                    );
+                }
+                if any_red {
+                    issues.push(
+                        "Activity classification is silent for at least one provider (100% of recent assistant rows have no `activity` tag). `budi stats --activities` will show only `(untagged)`. See #305.".into(),
+                    );
+                }
+            }
+            Err(e) => {
+                println!("  {dim}-{reset} activity attribution: could not compute ({e})");
+            }
+        }
+    }
+
     // Auto-proxy configuration checks (shell profile + IDE config files)
     {
         let agents = budi_core::config::load_agents_config()

--- a/crates/budi-cli/src/commands/sessions.rs
+++ b/crates/budi-cli/src/commands/sessions.rs
@@ -10,6 +10,7 @@ pub fn cmd_sessions(
     period: StatsPeriod,
     search: Option<&str>,
     ticket: Option<&str>,
+    activity: Option<&str>,
     limit: usize,
     json_output: bool,
 ) -> Result<()> {
@@ -18,7 +19,15 @@ pub fn cmd_sessions(
     )?;
 
     let (since, until) = period_date_range(period);
-    let sessions = client.sessions(since.as_deref(), until.as_deref(), search, ticket, limit, 0)?;
+    let sessions = client.sessions(
+        since.as_deref(),
+        until.as_deref(),
+        search,
+        ticket,
+        activity,
+        limit,
+        0,
+    )?;
 
     if json_output {
         println!("{}", serde_json::to_string_pretty(&sessions)?);
@@ -34,17 +43,27 @@ pub fn cmd_sessions(
     let reset = ansi("\x1b[0m");
 
     println!();
+    // Build a compact filter suffix so the header shows which attribution
+    // dimension scoped the result. Both ticket and activity live in the
+    // same space (tag-derived filters) and can compose in principle.
+    let mut filter_bits: Vec<String> = Vec::new();
     if let Some(t) = ticket {
+        filter_bits.push(format!("ticket: {t}"));
+    }
+    if let Some(a) = activity {
+        filter_bits.push(format!("activity: {a}"));
+    }
+    if filter_bits.is_empty() {
         println!(
-            "  {bold_cyan} Sessions{reset} — {bold}{}{reset} {dim}(ticket: {}, {} total){reset}",
+            "  {bold_cyan} Sessions{reset} — {bold}{}{reset} {dim}({} total){reset}",
             period_label(period),
-            t,
             sessions.total_count
         );
     } else {
         println!(
-            "  {bold_cyan} Sessions{reset} — {bold}{}{reset} {dim}({} total){reset}",
+            "  {bold_cyan} Sessions{reset} — {bold}{}{reset} {dim}({}, {} total){reset}",
             period_label(period),
+            filter_bits.join(", "),
             sessions.total_count
         );
     }

--- a/crates/budi-cli/src/commands/stats.rs
+++ b/crates/budi-cli/src/commands/stats.rs
@@ -58,6 +58,8 @@ pub fn cmd_stats(
     branch: Option<String>,
     tickets: bool,
     ticket: Option<String>,
+    activities: bool,
+    activity: Option<String>,
     repo: Option<String>,
     models: bool,
     provider: Option<String>,
@@ -69,12 +71,12 @@ pub fn cmd_stats(
     // user-friendly shortcuts that resolve to their canonical form.
     let provider = provider.map(|p| normalize_provider(&p)).transpose()?;
 
-    // `--repo` is a filter for `--branch` or `--ticket` — surface the
-    // misuse early instead of silently ignoring it. Clap's `requires` only
-    // takes a single arg, so the cross-flag check lives here.
-    if repo.is_some() && branch.is_none() && ticket.is_none() {
+    // `--repo` is a filter for `--branch`, `--ticket`, or `--activity` —
+    // surface the misuse early instead of silently ignoring it. Clap's
+    // `requires` only takes a single arg, so the cross-flag check lives here.
+    if repo.is_some() && branch.is_none() && ticket.is_none() && activity.is_none() {
         anyhow::bail!(
-            "--repo requires either --branch <NAME> or --ticket <ID> to scope the filter"
+            "--repo requires --branch <NAME>, --ticket <ID>, or --activity <NAME> to scope the filter"
         );
     }
 
@@ -84,6 +86,14 @@ pub fn cmd_stats(
 
     if let Some(ref tag_filter) = tag {
         return cmd_stats_tags(&client, period, tag_filter, json_output);
+    }
+
+    if let Some(ref ac) = activity {
+        return cmd_stats_activity_detail(&client, period, ac, repo.as_deref(), json_output);
+    }
+
+    if activities {
+        return cmd_stats_activities(&client, period, json_output);
     }
 
     if let Some(ref tk) = ticket {
@@ -639,6 +649,183 @@ fn cmd_stats_ticket_detail(
             println!("  No data found for ticket '{}'.", ticket);
             println!("  Tip: run `budi import` first if you haven't imported data yet.");
             println!("  Run `budi stats --tickets` to see available tickets.");
+        }
+    }
+
+    println!();
+    Ok(())
+}
+
+/// `--activities` list view. Mirrors `cmd_stats_tickets`: activities come
+/// from the `activity` tag emitted by the prompt classifier
+/// (`hooks::classify_prompt`) and propagated across the session by the
+/// pipeline. The output always carries an `(untagged)` row so users can see
+/// how much work isn't yet classified — that bucket should shrink as the
+/// classifier improves in R1.2 (#222).
+fn cmd_stats_activities(
+    client: &DaemonClient,
+    period: StatsPeriod,
+    json_output: bool,
+) -> Result<()> {
+    let (since, until) = period_date_range(period);
+    let activities = client.activities(since.as_deref(), until.as_deref(), 30)?;
+
+    if json_output {
+        println!("{}", serde_json::to_string_pretty(&activities)?);
+        return Ok(());
+    }
+
+    let period_label = period_label(period);
+
+    let bold_cyan = ansi("\x1b[1;36m");
+    let bold = ansi("\x1b[1m");
+    let dim = ansi("\x1b[90m");
+    let cyan = ansi("\x1b[36m");
+    let yellow = ansi("\x1b[33m");
+    let reset = ansi("\x1b[0m");
+
+    println!();
+    println!(
+        "  {bold_cyan} Activities{reset} — {bold}{}{reset}",
+        period_label
+    );
+    println!("  {dim}{}{reset}", "─".repeat(66));
+
+    if activities.is_empty() {
+        println!("  No activity data for this period.");
+        println!(
+            "  Tip: activity is classified from the user's prompt; run `budi doctor` to check the signal."
+        );
+        println!();
+        return Ok(());
+    }
+
+    let max_cost = activities
+        .iter()
+        .map(|a| a.cost_cents)
+        .fold(0.0_f64, f64::max)
+        .max(0.01);
+    for a in &activities {
+        let bar_len = ((a.cost_cents / max_cost) * 16.0) as usize;
+        let bar: String = "\u{2588}".repeat(bar_len);
+        let branch_label = if a.top_branch.is_empty() {
+            "--".to_string()
+        } else {
+            a.top_branch.clone()
+        };
+        let confidence_label = if a.confidence.is_empty() {
+            "--".to_string()
+        } else {
+            a.confidence.clone()
+        };
+        println!(
+            "    {bold}{:<18}{reset} {yellow}{:>8}{reset}  {dim}conf={:<6}{reset}  {dim}{:<22}{reset}  {cyan}{}{reset}",
+            a.activity,
+            format_cost_cents(a.cost_cents),
+            confidence_label,
+            branch_label,
+            bar
+        );
+    }
+
+    println!();
+    Ok(())
+}
+
+/// `--activity <NAME>` detail view. Mirrors `cmd_stats_ticket_detail`, plus
+/// the classification `source`/`confidence` contract so the user can tell
+/// at a glance whether the label comes from rules (R1.0) or a richer
+/// classifier landing in R1.2 (#222).
+fn cmd_stats_activity_detail(
+    client: &DaemonClient,
+    period: StatsPeriod,
+    activity: &str,
+    repo: Option<&str>,
+    json_output: bool,
+) -> Result<()> {
+    let (since, until) = period_date_range(period);
+    let result = client.activity_detail(activity, repo, since.as_deref(), until.as_deref())?;
+
+    if json_output {
+        println!("{}", serde_json::to_string_pretty(&result)?);
+        return Ok(());
+    }
+
+    let period_label = period_label(period);
+
+    let bold_cyan = ansi("\x1b[1;36m");
+    let bold = ansi("\x1b[1m");
+    let dim = ansi("\x1b[90m");
+    let yellow = ansi("\x1b[33m");
+    let reset = ansi("\x1b[0m");
+
+    println!();
+    println!(
+        "  {bold_cyan} Activity{reset} {bold}{}{reset} — {dim}{}{reset}",
+        activity, period_label
+    );
+    if let Some(repo_id) = repo {
+        println!("  {bold}Repo filter{reset} {}", repo_id);
+    }
+    println!("  {dim}{}{reset}", "─".repeat(50));
+
+    match result {
+        Some(a) => {
+            if !a.repo_id.is_empty() {
+                println!("  {bold}Repo{reset}       {}", a.repo_id);
+            }
+            if !a.source.is_empty() {
+                println!(
+                    "  {bold}Source{reset}     {} {dim}(confidence: {}){reset}",
+                    a.source,
+                    if a.confidence.is_empty() {
+                        "--"
+                    } else {
+                        &a.confidence
+                    }
+                );
+            }
+            println!("  {bold}Sessions{reset}   {}", a.session_count);
+            println!("  {bold}Messages{reset}   {}", a.message_count);
+            println!(
+                "  {bold}Input{reset}      {}",
+                format_tokens(a.input_tokens)
+            );
+            println!(
+                "  {bold}Output{reset}     {}",
+                format_tokens(a.output_tokens)
+            );
+            println!(
+                "  {bold}Est. cost{reset}  {yellow}{}{reset}",
+                format_cost_cents(a.cost_cents)
+            );
+
+            if !a.branches.is_empty() {
+                println!();
+                println!("  {bold}Branches{reset}");
+                for br in &a.branches {
+                    let repo_label = if br.repo_id.is_empty() {
+                        "--".to_string()
+                    } else {
+                        br.repo_id
+                            .rsplit('/')
+                            .next()
+                            .unwrap_or(&br.repo_id)
+                            .to_string()
+                    };
+                    println!(
+                        "    {bold}{:<28}{reset} {yellow}{:>8}{reset}  {dim}{}{reset}",
+                        br.git_branch,
+                        format_cost_cents(br.cost_cents),
+                        repo_label
+                    );
+                }
+            }
+        }
+        None => {
+            println!("  No data found for activity '{}'.", activity);
+            println!("  Tip: run `budi import` first if you haven't imported data yet.");
+            println!("  Run `budi stats --activities` to see available activities.");
         }
     }
 

--- a/crates/budi-cli/src/main.rs
+++ b/crates/budi-cli/src/main.rs
@@ -65,9 +65,9 @@ enum Commands {
         #[arg(long, hide = true)]
         repo_root: Option<PathBuf>,
     },
-    /// Show usage analytics (only one view flag at a time: --projects, --branches, --branch, --tickets, --ticket, --models, or --tag)
+    /// Show usage analytics (only one view flag at a time: --projects, --branches, --branch, --tickets, --ticket, --activities, --activity, --models, or --tag)
     #[command(
-        group(clap::ArgGroup::new("view").multiple(false).args(["projects", "branches", "branch", "tickets", "ticket", "models", "tag"])),
+        group(clap::ArgGroup::new("view").multiple(false).args(["projects", "branches", "branch", "tickets", "ticket", "activities", "activity", "models", "tag"])),
         after_help = "\
 Examples:
   budi stats                       Today's cost summary (default)
@@ -79,8 +79,10 @@ Examples:
   budi stats --tickets             Tickets ranked by cost (today)
   budi stats --ticket ENG-123      Cost details for a specific ticket
   budi stats --ticket ENG-123 --repo github.com/acme/app
+  budi stats --activities          Activities ranked by cost (today)
+  budi stats --activity bugfix     Cost details for a specific activity
   budi stats --projects -p all     All-time project costs
-  budi stats --tag activity        Cost by activity type
+  budi stats --tag activity        Raw cost breakdown by the activity tag
   budi stats --provider cursor     Filter to Cursor only
   budi stats --format json         JSON output for scripting"
     )]
@@ -107,7 +109,18 @@ Examples:
         /// of where the ticket was worked on.
         #[arg(long, value_name = "ID")]
         ticket: Option<String>,
-        /// Optional repository filter for --branch or --ticket (recommended when branch/ticket names repeat across repos)
+        /// Show activities ranked by cost (sourced from the `activity` tag
+        /// emitted by the prompt classifier). Mirrors `--tickets` so
+        /// activity attribution is a first-class CLI dimension.
+        #[arg(long, default_value_t = false)]
+        activities: bool,
+        /// Show cost details for a specific activity (e.g. `bugfix`,
+        /// `refactor`). Mirrors `--ticket <ID>` and includes a per-branch
+        /// breakdown so you can see where each kind of work was done.
+        #[arg(long, value_name = "NAME")]
+        activity: Option<String>,
+        /// Optional repository filter for --branch, --ticket, or --activity
+        /// (recommended when names repeat across repos).
         #[arg(long)]
         repo: Option<String>,
         /// Show model usage breakdown
@@ -166,6 +179,7 @@ Examples:
   budi sessions -p week            This week's sessions
   budi sessions --search claude    Filter by search term
   budi sessions --ticket ENG-123   Sessions tagged with a ticket
+  budi sessions --activity bugfix  Sessions classified as bug-fix work
   budi sessions <session-id>       Show detail for a specific session
   budi sessions --format json      JSON output for scripting")]
     Sessions {
@@ -183,6 +197,11 @@ Examples:
         /// contains a recognised ID.
         #[arg(long, value_name = "ID")]
         ticket: Option<String>,
+        /// Filter sessions by activity (e.g. `bugfix`, `refactor`). Matches
+        /// the `activity` tag emitted by the prompt classifier; promoted to
+        /// a first-class session filter in 8.1 (#305).
+        #[arg(long, value_name = "NAME")]
+        activity: Option<String>,
         /// Max sessions to show (default: 20)
         #[arg(long, default_value_t = 20)]
         limit: usize,
@@ -365,6 +384,8 @@ fn main() -> Result<()> {
             branch,
             tickets,
             ticket,
+            activities,
+            activity,
             repo,
             models,
             provider,
@@ -379,6 +400,8 @@ fn main() -> Result<()> {
                 branch,
                 tickets,
                 ticket,
+                activities,
+                activity,
                 repo,
                 models,
                 provider,
@@ -424,6 +447,7 @@ fn main() -> Result<()> {
             period,
             search,
             ticket,
+            activity,
             limit,
             format,
         } => {
@@ -435,6 +459,7 @@ fn main() -> Result<()> {
                     period,
                     search.as_deref(),
                     ticket.as_deref(),
+                    activity.as_deref(),
                     limit,
                     json_output,
                 )
@@ -585,6 +610,96 @@ mod tests {
         match cli.command {
             Commands::Sessions { ticket, .. } => {
                 assert_eq!(ticket.as_deref(), Some("PAVA-2057"));
+            }
+            _ => panic!("expected sessions command"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_stats_activities_flag() {
+        let cli = Cli::try_parse_from(["budi", "stats", "--activities"])
+            .expect("budi stats --activities parses");
+        match cli.command {
+            Commands::Stats {
+                activities,
+                activity,
+                ..
+            } => {
+                assert!(activities);
+                assert!(activity.is_none());
+            }
+            _ => panic!("expected stats command"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_stats_activity_value_flag() {
+        let cli = Cli::try_parse_from(["budi", "stats", "--activity", "bugfix"])
+            .expect("budi stats --activity bugfix parses");
+        match cli.command {
+            Commands::Stats {
+                activities,
+                activity,
+                ..
+            } => {
+                assert!(!activities);
+                assert_eq!(activity.as_deref(), Some("bugfix"));
+            }
+            _ => panic!("expected stats command"),
+        }
+    }
+
+    #[test]
+    fn cli_stats_activity_is_mutually_exclusive_with_other_views() {
+        // --activities vs --tickets / --branches / --activity / --models
+        assert!(
+            Cli::try_parse_from(["budi", "stats", "--activities", "--tickets"]).is_err(),
+            "--activities and --tickets must be mutually exclusive"
+        );
+        assert!(
+            Cli::try_parse_from(["budi", "stats", "--activities", "--branches"]).is_err(),
+            "--activities and --branches must be mutually exclusive"
+        );
+        assert!(
+            Cli::try_parse_from(["budi", "stats", "--activities", "--activity", "bugfix"]).is_err(),
+            "--activities and --activity must be mutually exclusive"
+        );
+        assert!(
+            Cli::try_parse_from(["budi", "stats", "--activity", "bugfix", "--models"]).is_err(),
+            "--activity and --models must be mutually exclusive"
+        );
+    }
+
+    #[test]
+    fn cli_stats_activity_accepts_repo_filter() {
+        let cli = Cli::try_parse_from([
+            "budi",
+            "stats",
+            "--activity",
+            "bugfix",
+            "--repo",
+            "siropkin/budi",
+        ])
+        .expect("budi stats --activity --repo parses");
+        match cli.command {
+            Commands::Stats { activity, repo, .. } => {
+                assert_eq!(activity.as_deref(), Some("bugfix"));
+                assert_eq!(repo.as_deref(), Some("siropkin/budi"));
+            }
+            _ => panic!("expected stats command"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_sessions_activity_flag() {
+        let cli = Cli::try_parse_from(["budi", "sessions", "--activity", "bugfix"])
+            .expect("budi sessions --activity parses");
+        match cli.command {
+            Commands::Sessions {
+                ticket, activity, ..
+            } => {
+                assert!(ticket.is_none());
+                assert_eq!(activity.as_deref(), Some("bugfix"));
             }
             _ => panic!("expected sessions command"),
         }

--- a/crates/budi-core/src/analytics/queries.rs
+++ b/crates/budi-core/src/analytics/queries.rs
@@ -2105,6 +2105,462 @@ fn ticket_prefix_of(ticket: &str) -> String {
 }
 
 // ---------------------------------------------------------------------------
+// Activities — first-class CLI dimension wired in 8.1 (#305)
+//
+// Activities come from the `activity` tag emitted by the pipeline when
+// `hooks::classify_prompt` recognises an intent in a user prompt (e.g.
+// "bugfix", "refactor", "testing"). The intent is propagated across every
+// assistant message in the session via `propagate_session_context`, so each
+// assistant row either carries exactly one `activity` tag or none at all.
+//
+// R1.0 treats every aggregate as `source = "rule"` / `confidence = "medium"`
+// because today the only producer is the rule-based classifier. R1.2 (#222)
+// will extend the classifier and can update these fields per-aggregate
+// without breaking the wire format.
+// ---------------------------------------------------------------------------
+
+pub(crate) const ACTIVITY_TAG_KEY: &str = crate::tag_keys::ACTIVITY;
+
+/// Canonical classification source label for rule-derived activities.
+/// Stays stable across the 8.1 release so dashboards can pin on it; R1.2
+/// may introduce additional sources alongside this one.
+pub const ACTIVITY_SOURCE_RULE: &str = "rule";
+
+/// Baseline confidence for rule-derived activities in 8.1.
+pub const ACTIVITY_CONFIDENCE_MEDIUM: &str = "medium";
+
+/// Per-activity aggregate cost row used by `GET /analytics/activities` and
+/// the `budi stats --activities` CLI view.
+///
+/// Activities are sourced from the `activity` tag emitted by the pipeline's
+/// prompt classifier. Messages with no `activity` tag collapse into a single
+/// `(untagged)` bucket so the total stays whole (same contract as
+/// `ticket_cost`).
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ActivityCost {
+    pub activity: String,
+    pub session_count: u64,
+    pub message_count: u64,
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub cache_read_tokens: u64,
+    pub cache_creation_tokens: u64,
+    pub cost_cents: f64,
+    /// Dominant branch (highest cost) carrying this activity. Empty for
+    /// the `(untagged)` row.
+    #[serde(default)]
+    pub top_branch: String,
+    /// Dominant repo (highest cost) carrying this activity. Empty for the
+    /// `(untagged)` row.
+    #[serde(default)]
+    pub top_repo_id: String,
+    /// Where this activity label came from. `"rule"` in R1.0; reserved for
+    /// future per-aggregate sources in R1.2 (#222).
+    #[serde(default)]
+    pub source: String,
+    /// How confident the aggregate is in the label. `"medium"` baseline in
+    /// R1.0; R1.2 may downgrade to `"low"` for ambiguous prompts or promote
+    /// to `"high"` when a stronger signal lands. `""` for the
+    /// `(untagged)` row to make the absence explicit.
+    #[serde(default)]
+    pub confidence: String,
+}
+
+/// Per-branch breakdown attached to a single activity detail response.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ActivityBranchBreakdown {
+    pub git_branch: String,
+    pub repo_id: String,
+    pub message_count: u64,
+    pub session_count: u64,
+    pub cost_cents: f64,
+}
+
+/// Detail payload for `GET /analytics/activities/{name}` and
+/// `budi stats --activity <name>`.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ActivityCostDetail {
+    pub activity: String,
+    pub session_count: u64,
+    pub message_count: u64,
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub cache_read_tokens: u64,
+    pub cache_creation_tokens: u64,
+    pub cost_cents: f64,
+    /// Dominant repo (empty when ambiguous / unattributed).
+    pub repo_id: String,
+    /// Per-branch attribution for cost charged to this activity.
+    pub branches: Vec<ActivityBranchBreakdown>,
+    /// Classification source — see `ActivityCost::source`.
+    #[serde(default)]
+    pub source: String,
+    /// Classification confidence — see `ActivityCost::confidence`.
+    #[serde(default)]
+    pub confidence: String,
+}
+
+/// Query cost grouped by activity, sorted by cost descending. Includes an
+/// `(untagged)` bucket for assistant messages that have no `activity` tag.
+pub fn activity_cost(
+    conn: &Connection,
+    since: Option<&str>,
+    until: Option<&str>,
+    limit: usize,
+) -> Result<Vec<ActivityCost>> {
+    let filters = DimensionFilters::default();
+    activity_cost_with_filters(conn, since, until, &filters, limit)
+}
+
+pub fn activity_cost_with_filters(
+    conn: &Connection,
+    since: Option<&str>,
+    until: Option<&str>,
+    filters: &DimensionFilters,
+    limit: usize,
+) -> Result<Vec<ActivityCost>> {
+    // Tagged path: join messages → tags(activity). An assistant message
+    // should carry at most one activity tag (see pipeline contract), but
+    // we still divide by n_values defensively so the total reconciles if
+    // a future enricher emits more than one value.
+    let mut conditions = vec!["m.role = 'assistant'".to_string()];
+    let mut param_values: Vec<String> = Vec::new();
+    let mut idx = 0usize;
+    if let Some(s) = since {
+        idx += 1;
+        param_values.push(s.to_string());
+        conditions.push(format!("m.timestamp >= ?{idx}"));
+    }
+    if let Some(u) = until {
+        idx += 1;
+        param_values.push(u.to_string());
+        conditions.push(format!("m.timestamp < ?{idx}"));
+    }
+    let model_expr = normalized_model_expr("m.model");
+    let project_expr = normalized_project_expr("m.repo_id");
+    let branch_expr = normalized_branch_expr("m.git_branch");
+    apply_dimension_filters(
+        &mut conditions,
+        &mut param_values,
+        filters,
+        "COALESCE(m.provider, 'claude_code')",
+        &model_expr,
+        &project_expr,
+        &branch_expr,
+    );
+    let where_clause = format!("WHERE {}", conditions.join(" AND "));
+
+    let untagged_conditions: Vec<String> = conditions
+        .iter()
+        .map(|c| c.replace("m.role = 'assistant'", "m2.role = 'assistant'"))
+        .collect();
+    let untagged_conditions: Vec<String> = untagged_conditions
+        .into_iter()
+        .map(|c| c.replace("m.", "m2."))
+        .collect();
+    let untagged_where = format!("WHERE {}", untagged_conditions.join(" AND "));
+
+    let limit_param_idx = param_values.len() + 1;
+    param_values.push(limit.to_string());
+
+    let sql = format!(
+        "WITH msg_val_counts AS (
+             SELECT message_id, COUNT(*) AS n_values
+             FROM tags
+             WHERE key = '{ACTIVITY_TAG_KEY}'
+             GROUP BY message_id
+         ),
+         tagged AS (
+             SELECT t.value AS activity,
+                    m.session_id,
+                    m.repo_id,
+                    m.git_branch,
+                    m.input_tokens,
+                    m.output_tokens,
+                    m.cache_read_tokens,
+                    m.cache_creation_tokens,
+                    m.cost_cents,
+                    mvc.n_values
+             FROM tags t
+             JOIN msg_val_counts mvc ON mvc.message_id = t.message_id
+             JOIN messages m ON m.id = t.message_id
+             {where_clause}
+             AND t.key = '{ACTIVITY_TAG_KEY}'
+         ),
+         per_activity AS (
+             SELECT activity,
+                    COUNT(DISTINCT session_id) AS sess,
+                    COUNT(*) AS cnt,
+                    COALESCE(SUM(input_tokens / n_values), 0) AS inp,
+                    COALESCE(SUM(output_tokens / n_values), 0) AS outp,
+                    COALESCE(SUM(cache_read_tokens / n_values), 0) AS cache_r,
+                    COALESCE(SUM(cache_creation_tokens / n_values), 0) AS cache_c,
+                    COALESCE(SUM(cost_cents / n_values), 0.0) AS cost
+             FROM tagged
+             GROUP BY activity
+         ),
+         top_branch AS (
+             SELECT activity,
+                    CASE
+                        WHEN COALESCE(git_branch, '') LIKE 'refs/heads/%'
+                            THEN SUBSTR(COALESCE(git_branch, ''), 12)
+                        ELSE COALESCE(git_branch, '')
+                    END AS branch_value,
+                    SUM(cost_cents / n_values) AS branch_cost
+             FROM tagged
+             GROUP BY activity, branch_value
+         ),
+         top_branch_pick AS (
+             SELECT activity, branch_value
+             FROM (
+                 SELECT activity, branch_value, branch_cost,
+                        ROW_NUMBER() OVER (
+                            PARTITION BY activity
+                            ORDER BY branch_cost DESC, branch_value ASC
+                        ) AS rn
+                 FROM top_branch
+                 WHERE branch_value != ''
+             )
+             WHERE rn = 1
+         ),
+         top_repo AS (
+             SELECT activity,
+                    COALESCE(repo_id, '') AS repo_value,
+                    SUM(cost_cents / n_values) AS repo_cost
+             FROM tagged
+             GROUP BY activity, repo_value
+         ),
+         top_repo_pick AS (
+             SELECT activity, repo_value
+             FROM (
+                 SELECT activity, repo_value, repo_cost,
+                        ROW_NUMBER() OVER (
+                            PARTITION BY activity
+                            ORDER BY repo_cost DESC, repo_value ASC
+                        ) AS rn
+                 FROM top_repo
+                 WHERE repo_value != '' AND repo_value != 'unknown'
+             )
+             WHERE rn = 1
+         )
+         SELECT pa.activity,
+                pa.sess, pa.cnt,
+                pa.inp, pa.outp, pa.cache_r, pa.cache_c, pa.cost,
+                COALESCE(tbp.branch_value, '') AS top_branch,
+                COALESCE(trp.repo_value, '') AS top_repo
+         FROM per_activity pa
+         LEFT JOIN top_branch_pick tbp ON tbp.activity = pa.activity
+         LEFT JOIN top_repo_pick trp ON trp.activity = pa.activity
+
+         UNION ALL
+
+         SELECT '{UNTAGGED_DIMENSION}' AS activity,
+                COUNT(DISTINCT m2.session_id) AS sess,
+                COUNT(*) AS cnt,
+                COALESCE(SUM(m2.input_tokens), 0) AS inp,
+                COALESCE(SUM(m2.output_tokens), 0) AS outp,
+                COALESCE(SUM(m2.cache_read_tokens), 0) AS cache_r,
+                COALESCE(SUM(m2.cache_creation_tokens), 0) AS cache_c,
+                COALESCE(SUM(m2.cost_cents), 0.0) AS cost,
+                '' AS top_branch,
+                '' AS top_repo
+         FROM messages m2
+         {untagged_where}
+         AND NOT EXISTS (
+             SELECT 1 FROM tags t2
+             WHERE t2.message_id = m2.id AND t2.key = '{ACTIVITY_TAG_KEY}'
+         )
+
+         ORDER BY cost DESC
+         LIMIT ?{limit_param_idx}",
+    );
+
+    let param_refs: Vec<&dyn rusqlite::types::ToSql> = param_values
+        .iter()
+        .map(|s| s as &dyn rusqlite::types::ToSql)
+        .collect();
+    let mut stmt = conn.prepare(&sql)?;
+    let rows: Vec<ActivityCost> = stmt
+        .query_map(param_refs.as_slice(), |row| {
+            let activity: String = row.get(0)?;
+            let (source, confidence) = activity_classification_labels(&activity);
+            Ok(ActivityCost {
+                activity,
+                session_count: row.get(1)?,
+                message_count: row.get(2)?,
+                input_tokens: row.get(3)?,
+                output_tokens: row.get(4)?,
+                cache_read_tokens: row.get(5)?,
+                cache_creation_tokens: row.get(6)?,
+                cost_cents: row.get(7)?,
+                top_branch: row.get(8)?,
+                top_repo_id: row.get(9)?,
+                source: source.to_string(),
+                confidence: confidence.to_string(),
+            })
+        })?
+        .filter_map(|r| r.ok())
+        .filter(|ac| !(ac.activity == UNTAGGED_DIMENSION && ac.message_count == 0))
+        .collect();
+
+    Ok(rows)
+}
+
+/// Detail view for a single activity: totals, dominant repo, and per-branch
+/// breakdown. Returns `None` when no assistant messages carry the activity
+/// in the requested window.
+pub fn activity_cost_single(
+    conn: &Connection,
+    activity: &str,
+    repo_id: Option<&str>,
+    since: Option<&str>,
+    until: Option<&str>,
+) -> Result<Option<ActivityCostDetail>> {
+    let mut conditions = vec![
+        "m.role = 'assistant'".to_string(),
+        "t.key = ?1".to_string(),
+        "t.value = ?2".to_string(),
+    ];
+    let mut param_values: Vec<String> = vec![ACTIVITY_TAG_KEY.to_string(), activity.to_string()];
+    let mut idx = 2usize;
+
+    if let Some(repo) = repo_id {
+        idx += 1;
+        param_values.push(repo.to_string());
+        conditions.push(format!("COALESCE(m.repo_id, '') = ?{idx}"));
+    }
+    if let Some(s) = since {
+        idx += 1;
+        param_values.push(s.to_string());
+        conditions.push(format!("m.timestamp >= ?{idx}"));
+    }
+    if let Some(u) = until {
+        idx += 1;
+        param_values.push(u.to_string());
+        conditions.push(format!("m.timestamp < ?{idx}"));
+    }
+    let where_clause = format!("WHERE {}", conditions.join(" AND "));
+
+    let totals_sql = format!(
+        "WITH msg_val_counts AS (
+             SELECT message_id, COUNT(*) AS n_values
+             FROM tags
+             WHERE key = ?1
+             GROUP BY message_id
+         )
+         SELECT COUNT(DISTINCT m.session_id) AS sess,
+                COUNT(*) AS cnt,
+                COALESCE(SUM(m.input_tokens / mvc.n_values), 0) AS inp,
+                COALESCE(SUM(m.output_tokens / mvc.n_values), 0) AS outp,
+                COALESCE(SUM(m.cache_read_tokens / mvc.n_values), 0) AS cache_r,
+                COALESCE(SUM(m.cache_creation_tokens / mvc.n_values), 0) AS cache_c,
+                COALESCE(SUM(m.cost_cents / mvc.n_values), 0.0) AS cost,
+                CASE WHEN COUNT(DISTINCT COALESCE(m.repo_id, '')) = 1
+                     THEN COALESCE(MIN(m.repo_id), '')
+                     ELSE '' END AS repo
+         FROM tags t
+         JOIN msg_val_counts mvc ON mvc.message_id = t.message_id
+         JOIN messages m ON m.id = t.message_id
+         {where_clause}",
+    );
+
+    let param_refs: Vec<&dyn rusqlite::types::ToSql> = param_values
+        .iter()
+        .map(|s| s as &dyn rusqlite::types::ToSql)
+        .collect();
+    let mut stmt = conn.prepare(&totals_sql)?;
+    let totals = stmt.query_row(param_refs.as_slice(), |row| {
+        Ok((
+            row.get::<_, u64>(0)?,
+            row.get::<_, u64>(1)?,
+            row.get::<_, u64>(2)?,
+            row.get::<_, u64>(3)?,
+            row.get::<_, u64>(4)?,
+            row.get::<_, u64>(5)?,
+            row.get::<_, f64>(6)?,
+            row.get::<_, String>(7)?,
+        ))
+    });
+    let (sess, cnt, inp, outp, cache_r, cache_c, cost, repo) = match totals {
+        Ok(row) => row,
+        Err(rusqlite::Error::QueryReturnedNoRows) => return Ok(None),
+        Err(e) => return Err(e.into()),
+    };
+    if cnt == 0 {
+        return Ok(None);
+    }
+
+    let branches_sql = format!(
+        "WITH msg_val_counts AS (
+             SELECT message_id, COUNT(*) AS n_values
+             FROM tags
+             WHERE key = ?1
+             GROUP BY message_id
+         )
+         SELECT COALESCE(NULLIF(
+                    CASE
+                        WHEN COALESCE(m.git_branch, '') LIKE 'refs/heads/%'
+                            THEN SUBSTR(COALESCE(m.git_branch, ''), 12)
+                        ELSE COALESCE(m.git_branch, '')
+                    END,
+                    ''
+                ), '{UNTAGGED_DIMENSION}') AS branch_value,
+                COALESCE(m.repo_id, '') AS repo_value,
+                COUNT(DISTINCT m.session_id) AS sess,
+                COUNT(*) AS cnt,
+                COALESCE(SUM(m.cost_cents / mvc.n_values), 0.0) AS cost
+         FROM tags t
+         JOIN msg_val_counts mvc ON mvc.message_id = t.message_id
+         JOIN messages m ON m.id = t.message_id
+         {where_clause}
+         GROUP BY branch_value, repo_value
+         ORDER BY cost DESC, branch_value ASC",
+    );
+    let mut stmt = conn.prepare(&branches_sql)?;
+    let branches: Vec<ActivityBranchBreakdown> = stmt
+        .query_map(param_refs.as_slice(), |row| {
+            Ok(ActivityBranchBreakdown {
+                git_branch: row.get(0)?,
+                repo_id: row.get(1)?,
+                session_count: row.get(2)?,
+                message_count: row.get(3)?,
+                cost_cents: row.get(4)?,
+            })
+        })?
+        .filter_map(|r| r.ok())
+        .collect();
+
+    let (source, confidence) = activity_classification_labels(activity);
+    Ok(Some(ActivityCostDetail {
+        activity: activity.to_string(),
+        session_count: sess,
+        message_count: cnt,
+        input_tokens: inp,
+        output_tokens: outp,
+        cache_read_tokens: cache_r,
+        cache_creation_tokens: cache_c,
+        cost_cents: cost,
+        repo_id: repo,
+        branches,
+        source: source.to_string(),
+        confidence: confidence.to_string(),
+    }))
+}
+
+/// Return the `(source, confidence)` labels for an activity aggregate.
+///
+/// R1.0 has a single producer (rule-based `classify_prompt`), so every
+/// tagged value shares the same labels. `(untagged)` reports empty strings
+/// so callers can render `--` without having to special-case it.
+fn activity_classification_labels(activity: &str) -> (&'static str, &'static str) {
+    if activity == UNTAGGED_DIMENSION {
+        ("", "")
+    } else {
+        (ACTIVITY_SOURCE_RULE, ACTIVITY_CONFIDENCE_MEDIUM)
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Model Usage
 // ---------------------------------------------------------------------------
 

--- a/crates/budi-core/src/analytics/sessions.rs
+++ b/crates/budi-core/src/analytics/sessions.rs
@@ -171,6 +171,7 @@ pub fn session_visibility(conn: &Connection) -> Result<Vec<SessionVisibilityWind
                 limit: 1,
                 offset: 0,
                 ticket: None,
+                activity: None,
             },
         )?;
         let returned_sessions = paginated.total_count;
@@ -249,6 +250,66 @@ pub fn branch_attribution_stats(conn: &Connection) -> Result<Vec<BranchAttributi
     Ok(rows)
 }
 
+/// Per-provider counts of assistant rows in the last 7 days that are missing
+/// the `activity` tag. Drives the `budi doctor` activity-attribution check
+/// wired in 8.1 (#305) so a silent regression of the prompt classifier
+/// becomes visible the same way #303's branch-attribution drop does.
+///
+/// A high missing-ratio usually means the classifier never matched the
+/// user prompt — either the prompt was too short, the pipeline is broken,
+/// or hooks are disabled for that provider.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ActivityAttributionProvider {
+    pub provider: String,
+    pub total_assistant: u64,
+    pub missing_activity: u64,
+}
+
+impl ActivityAttributionProvider {
+    pub fn missing_activity_ratio(&self) -> f64 {
+        if self.total_assistant == 0 {
+            0.0
+        } else {
+            self.missing_activity as f64 / self.total_assistant as f64
+        }
+    }
+}
+
+/// 7-day activity-attribution health per provider.
+///
+/// The window matches `branch_attribution_stats` so the doctor output
+/// stays consistent: a short outage overnight should not flip either
+/// check red, a regression lasting a day should show up immediately.
+pub fn activity_attribution_stats(conn: &Connection) -> Result<Vec<ActivityAttributionProvider>> {
+    let since = (chrono::Utc::now() - chrono::Duration::days(7)).to_rfc3339();
+
+    let mut stmt = conn.prepare(
+        "SELECT COALESCE(m.provider, 'claude_code') AS p,
+                COUNT(*) AS total,
+                SUM(
+                    CASE WHEN NOT EXISTS (
+                        SELECT 1 FROM tags t
+                        WHERE t.message_id = m.id AND t.key = 'activity'
+                    ) THEN 1 ELSE 0 END
+                ) AS missing_activity
+         FROM messages m
+         WHERE m.role = 'assistant' AND m.timestamp >= ?1
+         GROUP BY p
+         ORDER BY total DESC",
+    )?;
+    let rows = stmt
+        .query_map(params![since], |row| {
+            Ok(ActivityAttributionProvider {
+                provider: row.get(0)?,
+                total_assistant: row.get::<_, i64>(1)? as u64,
+                missing_activity: row.get::<_, i64>(2)? as u64,
+            })
+        })?
+        .filter_map(|r| r.ok())
+        .collect();
+    Ok(rows)
+}
+
 // ---------------------------------------------------------------------------
 // Session List
 // ---------------------------------------------------------------------------
@@ -297,6 +358,11 @@ pub struct SessionListParams<'a> {
     /// session filter in 8.1 so `budi sessions --ticket ENG-123` works
     /// the same way `--branch` does for branches.
     pub ticket: Option<&'a str>,
+    /// Restrict the result to sessions that have at least one assistant
+    /// message tagged with this `activity` value (e.g. `bugfix`,
+    /// `refactor`). Promoted to a first-class session filter in 8.1 so
+    /// `budi sessions --activity bugfix` mirrors `--ticket`. See #305.
+    pub activity: Option<&'a str>,
 }
 
 fn parse_models_csv(raw: Option<String>) -> Vec<String> {
@@ -428,6 +494,18 @@ pub fn session_list_with_filters(
         let idx = param_values.len();
         conditions.push(format!(
             "EXISTS (SELECT 1 FROM tags tk WHERE tk.message_id = m.id AND tk.key = 'ticket_id' AND tk.value = ?{idx})"
+        ));
+    }
+    if let Some(activity) = p.activity
+        && !activity.is_empty()
+    {
+        // Mirror the `ticket` filter: activities live in the `tags` table
+        // under the `activity` key (see `tag_keys::ACTIVITY`), so we scope
+        // with EXISTS rather than a column predicate.
+        param_values.push(activity.to_string());
+        let idx = param_values.len();
+        conditions.push(format!(
+            "EXISTS (SELECT 1 FROM tags ta WHERE ta.message_id = m.id AND ta.key = 'activity' AND ta.value = ?{idx})"
         ));
     }
     let where_clause = format!("WHERE {}", conditions.join(" AND "));

--- a/crates/budi-core/src/analytics/tests.rs
+++ b/crates/budi-core/src/analytics/tests.rs
@@ -1630,6 +1630,7 @@ fn session_list_returns_sessions() {
             limit: 50,
             offset: 0,
             ticket: None,
+            activity: None,
         },
     )
     .unwrap();
@@ -1663,6 +1664,7 @@ fn session_list_uses_structured_models_array() {
             limit: 50,
             offset: 0,
             ticket: None,
+            activity: None,
         },
     )
     .unwrap();
@@ -1726,6 +1728,7 @@ fn session_list_returns_session_for_today_window_with_local_midnight_utc_since()
             limit: 50,
             offset: 0,
             ticket: None,
+            activity: None,
         },
         &DimensionFilters::default(),
     )
@@ -1902,6 +1905,7 @@ fn session_list_window_compares_correctly_across_provider_timestamp_formats() {
             limit: 50,
             offset: 0,
             ticket: None,
+            activity: None,
         },
         &DimensionFilters::default(),
     )
@@ -1924,6 +1928,7 @@ fn session_list_window_compares_correctly_across_provider_timestamp_formats() {
             limit: 50,
             offset: 0,
             ticket: None,
+            activity: None,
         },
         &DimensionFilters::default(),
     )
@@ -1958,6 +1963,7 @@ fn session_list_ignores_empty_string_session_id() {
             limit: 50,
             offset: 0,
             ticket: None,
+            activity: None,
         },
         &DimensionFilters::default(),
     )
@@ -2002,6 +2008,7 @@ fn session_list_with_dimension_filters() {
             limit: 50,
             offset: 0,
             ticket: None,
+            activity: None,
         },
         &filters,
     )
@@ -2416,6 +2423,7 @@ fn session_list_filters_by_ticket() {
             limit: 50,
             offset: 0,
             ticket: Some("PAVA-9"),
+            activity: None,
         },
     )
     .unwrap();
@@ -2435,6 +2443,214 @@ fn session_list_filters_by_ticket() {
             limit: 50,
             offset: 0,
             ticket: Some("NOPE-1"),
+            activity: None,
+        },
+    )
+    .unwrap();
+    assert_eq!(none.total_count, 0);
+    assert!(none.sessions.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// Activities — R1.0 (#305)
+//
+// Activities live in the `tags` table under the `activity` key (see
+// `tag_keys::ACTIVITY`). The tests mirror the ticket suite so regressions
+// on either surface are easy to diff, and they seed the tag directly so
+// they don't depend on the classifier or pipeline.
+// ---------------------------------------------------------------------------
+
+fn activity_tags(values: &[&str]) -> Vec<Tag> {
+    values
+        .iter()
+        .map(|v| Tag {
+            key: "activity".to_string(),
+            value: (*v).to_string(),
+        })
+        .collect()
+}
+
+fn activity_msg(
+    uuid: &str,
+    session_id: &str,
+    branch: &str,
+    repo: &str,
+    cost: f64,
+) -> ParsedMessage {
+    let mut m = assistant_msg(uuid, session_id, cost);
+    m.git_branch = Some(branch.to_string());
+    m.repo_id = Some(repo.to_string());
+    m
+}
+
+#[test]
+fn activity_cost_groups_by_activity() {
+    // `bugfix` and `refactor` each span their own sessions and `bugfix`
+    // outweighs `refactor` on cost. We expect cost-desc ordering and
+    // `session_count` reporting distinct sessions.
+    let mut conn = test_db();
+    let m1 = activity_msg("ac-1", "s1", "feat/login", "repo-a", 4.0);
+    let m2 = activity_msg("ac-2", "s2", "feat/login", "repo-a", 6.0);
+    let m3 = activity_msg("ac-3", "s3", "refactor/api", "repo-b", 3.0);
+    let tags = vec![
+        activity_tags(&["bugfix"]),
+        activity_tags(&["bugfix"]),
+        activity_tags(&["refactor"]),
+    ];
+    ingest_messages(&mut conn, &[m1, m2, m3], Some(&tags)).unwrap();
+
+    let activities = activity_cost(&conn, None, None, 10).unwrap();
+    let bug = activities
+        .iter()
+        .find(|a| a.activity == "bugfix")
+        .expect("bugfix present");
+    let refac = activities
+        .iter()
+        .find(|a| a.activity == "refactor")
+        .expect("refactor present");
+    assert_eq!(bug.session_count, 2, "bugfix spans two sessions");
+    assert_eq!(bug.message_count, 2);
+    assert!((bug.cost_cents - 10.0).abs() < 0.01);
+    assert_eq!(bug.top_branch, "feat/login");
+    assert_eq!(bug.top_repo_id, "repo-a");
+    assert_eq!(bug.source, "rule", "R1.0 labels rule-derived activities");
+    assert_eq!(bug.confidence, "medium");
+    assert!((refac.cost_cents - 3.0).abs() < 0.01);
+    // Cost-desc ordering is the contract surfaced by `budi stats --activities`.
+    let bug_idx = activities
+        .iter()
+        .position(|a| a.activity == "bugfix")
+        .unwrap();
+    let refac_idx = activities
+        .iter()
+        .position(|a| a.activity == "refactor")
+        .unwrap();
+    assert!(bug_idx < refac_idx);
+}
+
+#[test]
+fn activity_cost_includes_untagged_bucket() {
+    // One tagged activity and one bare assistant message → expect the
+    // `(untagged)` row to appear with empty source/confidence so the
+    // total reconciles with the global cost summary, never silently
+    // disappears.
+    let mut conn = test_db();
+    let m1 = activity_msg("ac-u-1", "s1", "main", "repo", 5.0);
+    let m2 = assistant_msg("ac-u-2", "s2", 7.0);
+    ingest_messages(
+        &mut conn,
+        &[m1, m2],
+        Some(&[activity_tags(&["bugfix"]), Vec::new()]),
+    )
+    .unwrap();
+
+    let activities = activity_cost(&conn, None, None, 10).unwrap();
+    let untagged = activities
+        .iter()
+        .find(|a| a.activity == "(untagged)")
+        .expect("untagged activity bucket present");
+    assert!((untagged.cost_cents - 7.0).abs() < 0.01);
+    assert_eq!(untagged.message_count, 1);
+    assert_eq!(untagged.top_branch, "");
+    assert_eq!(
+        untagged.source, "",
+        "untagged bucket advertises an explicit absence"
+    );
+    assert_eq!(untagged.confidence, "");
+}
+
+#[test]
+fn activity_cost_single_returns_detail_with_branches() {
+    // `bugfix` worked across two branches in the same repo. Detail view
+    // should attribute cost per branch and pick the dominant repo.
+    let mut conn = test_db();
+    let m1 = activity_msg("ac-d-1", "s1", "fix/a", "repo-a", 8.0);
+    let m2 = activity_msg("ac-d-2", "s2", "fix/b", "repo-a", 2.0);
+    let tags = vec![activity_tags(&["bugfix"]), activity_tags(&["bugfix"])];
+    ingest_messages(&mut conn, &[m1, m2], Some(&tags)).unwrap();
+
+    let detail = activity_cost_single(&conn, "bugfix", None, None, None)
+        .unwrap()
+        .expect("activity detail present");
+    assert_eq!(detail.activity, "bugfix");
+    assert_eq!(detail.session_count, 2);
+    assert_eq!(detail.message_count, 2);
+    assert_eq!(detail.repo_id, "repo-a");
+    assert!((detail.cost_cents - 10.0).abs() < 0.01);
+    assert_eq!(detail.branches.len(), 2);
+    assert_eq!(detail.branches[0].git_branch, "fix/a");
+    assert!((detail.branches[0].cost_cents - 8.0).abs() < 0.01);
+    assert_eq!(detail.source, "rule");
+    assert_eq!(detail.confidence, "medium");
+
+    let missing = activity_cost_single(&conn, "does-not-exist", None, None, None).unwrap();
+    assert!(missing.is_none());
+}
+
+#[test]
+fn activity_cost_single_can_filter_by_repo() {
+    let mut conn = test_db();
+    let m1 = activity_msg("ac-r-1", "s1", "main", "repo-a", 4.0);
+    let m2 = activity_msg("ac-r-2", "s2", "main", "repo-b", 6.0);
+    let tags = vec![activity_tags(&["bugfix"]), activity_tags(&["bugfix"])];
+    ingest_messages(&mut conn, &[m1, m2], Some(&tags)).unwrap();
+
+    let only_a = activity_cost_single(&conn, "bugfix", Some("repo-a"), None, None)
+        .unwrap()
+        .unwrap();
+    assert_eq!(only_a.repo_id, "repo-a");
+    assert!((only_a.cost_cents - 4.0).abs() < 0.01);
+
+    let none = activity_cost_single(&conn, "bugfix", Some("repo-c"), None, None).unwrap();
+    assert!(none.is_none());
+}
+
+#[test]
+fn session_list_filters_by_activity() {
+    // The session list filter is the third surface added in 8.1 (#305) —
+    // without it, `budi sessions --activity bugfix` would have to
+    // client-side filter and would misreport `total_count`.
+    let mut conn = test_db();
+    let m1 = activity_msg("sess-ac-1", "s1", "fix/a", "repo", 5.0);
+    let m2 = assistant_msg("sess-ac-2", "s2", 7.0);
+    ingest_messages(
+        &mut conn,
+        &[m1, m2],
+        Some(&[activity_tags(&["bugfix"]), Vec::new()]),
+    )
+    .unwrap();
+
+    let filtered = session_list(
+        &conn,
+        &SessionListParams {
+            since: None,
+            until: None,
+            search: None,
+            sort_by: None,
+            sort_asc: false,
+            limit: 50,
+            offset: 0,
+            ticket: None,
+            activity: Some("bugfix"),
+        },
+    )
+    .unwrap();
+    assert_eq!(filtered.total_count, 1);
+    assert_eq!(filtered.sessions.len(), 1);
+    assert_eq!(filtered.sessions[0].id, "s1");
+
+    let none = session_list(
+        &conn,
+        &SessionListParams {
+            since: None,
+            until: None,
+            search: None,
+            sort_by: None,
+            sort_asc: false,
+            limit: 50,
+            offset: 0,
+            ticket: None,
+            activity: Some("nope"),
         },
     )
     .unwrap();

--- a/crates/budi-core/src/proxy.rs
+++ b/crates/budi-core/src/proxy.rs
@@ -801,6 +801,7 @@ mod tests {
                 limit: 50,
                 offset: 0,
                 ticket: None,
+                activity: None,
             },
             &crate::analytics::DimensionFilters::default(),
         )

--- a/crates/budi-daemon/src/main.rs
+++ b/crates/budi-daemon/src/main.rs
@@ -112,6 +112,11 @@ fn build_router(app_state: AppState) -> Router {
             "/analytics/tickets/{ticket_id}",
             get(a::analytics_ticket_detail),
         )
+        .route("/analytics/activities", get(a::analytics_activities))
+        .route(
+            "/analytics/activities/{activity}",
+            get(a::analytics_activity_detail),
+        )
         .route("/analytics/providers", get(a::analytics_providers))
         .route("/analytics/statusline", get(a::analytics_statusline))
         .route(

--- a/crates/budi-daemon/src/routes/analytics.rs
+++ b/crates/budi-daemon/src/routes/analytics.rs
@@ -582,6 +582,80 @@ pub async fn analytics_ticket_detail(
     }
 }
 
+// ---------------------------------------------------------------------------
+// Activities — first-class CLI dimension wired in 8.1 (#305)
+//
+// Same shape as the ticket endpoints so the CLI can mirror `--tickets` /
+// `--ticket` with `--activities` / `--activity` and operators don't need
+// to learn a second query surface. Activities come from the `activity`
+// tag emitted by the prompt classifier (`hooks::classify_prompt`).
+// ---------------------------------------------------------------------------
+
+/// `GET /analytics/activities` query params. Mirrors `TicketListParams`.
+#[derive(serde::Deserialize)]
+pub struct ActivityListParams {
+    pub since: Option<String>,
+    pub until: Option<String>,
+    pub limit: Option<usize>,
+    #[serde(flatten)]
+    pub filters: DimensionParams,
+}
+
+#[derive(serde::Deserialize)]
+pub struct ActivityDetailParams {
+    pub since: Option<String>,
+    pub until: Option<String>,
+    pub repo_id: Option<String>,
+}
+
+pub async fn analytics_activities(
+    Query(params): Query<ActivityListParams>,
+) -> Result<Json<Vec<analytics::ActivityCost>>, (StatusCode, Json<serde_json::Value>)> {
+    let limit = params.limit.unwrap_or(20).min(200);
+    let filters = parse_dimension_filters(&params.filters);
+    let result = tokio::task::spawn_blocking(move || {
+        let db_path = analytics::db_path()?;
+        let conn = analytics::open_db(&db_path)?;
+        analytics::activity_cost_with_filters(
+            &conn,
+            params.since.as_deref(),
+            params.until.as_deref(),
+            &filters,
+            limit,
+        )
+    })
+    .await
+    .map_err(|e| internal_error(anyhow::anyhow!("{e}")))?
+    .map_err(internal_error)?;
+
+    Ok(Json(result))
+}
+
+pub async fn analytics_activity_detail(
+    Path(activity): Path<String>,
+    Query(params): Query<ActivityDetailParams>,
+) -> Result<Json<analytics::ActivityCostDetail>, (StatusCode, Json<serde_json::Value>)> {
+    let result = tokio::task::spawn_blocking(move || {
+        let db_path = analytics::db_path()?;
+        let conn = analytics::open_db(&db_path)?;
+        analytics::activity_cost_single(
+            &conn,
+            &activity,
+            params.repo_id.as_deref(),
+            params.since.as_deref(),
+            params.until.as_deref(),
+        )
+    })
+    .await
+    .map_err(|e| internal_error(anyhow::anyhow!("{e}")))?
+    .map_err(internal_error)?;
+
+    match result {
+        Some(detail) => Ok(Json(detail)),
+        None => Err(not_found("activity not found")),
+    }
+}
+
 pub async fn analytics_schema_version()
 -> Result<Json<SchemaVersionResponse>, (StatusCode, Json<serde_json::Value>)> {
     let result = tokio::task::spawn_blocking(move || -> anyhow::Result<SchemaVersionResponse> {
@@ -722,6 +796,10 @@ pub struct SessionsQueryParams {
     /// Filter to sessions tagged with the given `ticket_id` (e.g. `ENG-123`).
     /// Wired in by 8.1 so `budi sessions --ticket <ID>` mirrors `--branch`.
     pub ticket: Option<String>,
+    /// Filter to sessions tagged with the given `activity` (e.g. `bugfix`).
+    /// Wired in by 8.1 (#305) so `budi sessions --activity bugfix` mirrors
+    /// `--ticket`.
+    pub activity: Option<String>,
     #[serde(flatten)]
     pub filters: DimensionParams,
 }
@@ -753,6 +831,7 @@ pub async fn analytics_sessions(
                 limit: params.limit.unwrap_or(50).min(200),
                 offset: params.offset.unwrap_or(0),
                 ticket: params.ticket.as_deref(),
+                activity: params.activity.as_deref(),
             },
             &filters,
         )?;


### PR DESCRIPTION
## Summary

- Promotes the `activity` tag (bugfix, refactor, testing, feature, review, ops, question, writing) to a first-class CLI dimension alongside branches and tickets — `budi stats --activities`, `budi stats --activity <NAME>`, and `budi sessions --activity <NAME>` — mirroring the surface added for tickets in #304.
- Introduces `GET /analytics/activities` / `/analytics/activities/{name}` plus an `?activity=` filter on `/analytics/sessions`, with new `ActivityCost` / `ActivityCostDetail` models that carry baseline `source = "rule"` / `confidence = "medium"` labels so R1.2 (#222) can refine them later without a wire-format break.
- Adds a 7-day `budi doctor` activity-attribution check (red when a provider with ≥5 recent rows has 100% missing `activity`, yellow at >90% missing) so a silent classifier regression surfaces the same way #303's branch-attribution check surfaces missing `git_branch`.

## Risks / Compatibility

- Additive only: no existing endpoints or CLI flags change shape; the two new `source` / `confidence` JSON fields use `#[serde(default)]` so older consumers continue to deserialize.
- `SessionListParams` grew an `activity: Option<&str>` field; all five in-repo call sites were updated, and tests/proxy/cloud-sync builds are green.
- The new doctor check is deliberately conservative: it only fails red when a provider has ≥5 assistant rows in the last 7 days and all of them lack an `activity` tag, which avoids false positives on fresh installs and one-word-prompt workflows.

## Validation

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — **435 tests pass**, including the four new analytics regression tests (`activity_cost_groups_by_activity`, `activity_cost_includes_untagged_bucket`, `activity_cost_single_returns_detail_with_branches`, `activity_cost_single_can_filter_by_repo`, `session_list_filters_by_activity`) and four new CLI parser tests (`cli_parses_stats_activities_flag`, `cli_parses_stats_activity_value_flag`, `cli_stats_activity_is_mutually_exclusive_with_other_views`, `cli_stats_activity_accepts_repo_filter`, `cli_parses_sessions_activity_flag`).
- [ ] Manual smoke: `budi stats --activities`, `budi stats --activity bugfix`, `budi sessions --activity bugfix` against a populated local DB (recommend before merge).
- [ ] Manual smoke: `budi doctor` against a DB with and without the `activity` tag to confirm the new check renders green / yellow / red correctly.

Closes #305

Made with [Cursor](https://cursor.com)