### PR TITLE
[8.1][R1.3] Promote ticket attribution and branch classification to first-class analytics (#221)

### DIFF
--- a/SOUL.md
+++ b/SOUL.md
@@ -192,12 +192,36 @@ in [#302](https://github.com/siropkin/budi/issues/302) / #303 / #304 / #305):
   CI runs do not pollute the branches list with a bogus `HEAD` bucket.
 
 - **`ticket_id`** — promoted to a first-class CLI dimension in 8.1 (R1.0.3,
-  #304). The git enricher emits a `ticket_id` tag (and `ticket_prefix`)
-  whenever `git_branch` matches the recognised pattern (e.g. `ENG-123`),
-  so ticket attribution rides on top of the branch attribution rules above
-  with no extra wiring. Surfaces:
-  - `budi stats --tickets` — list ranked by cost, with `(untagged)` bucket.
-  - `budi stats --ticket <ID>` — detail view with per-branch breakdown.
+  #304) and further hardened in R1.3
+  ([#221](https://github.com/siropkin/budi/issues/221)). Both the batch
+  pipeline (`GitEnricher`) and the live proxy
+  (`ProxyAttribution::resolve`) now share one extractor —
+  `pipeline::extract_ticket_from_branch` — which (1) filters integration
+  branches (`main`, `master`, `develop`, `HEAD`), (2) prefers the canonical
+  alphanumeric pattern (e.g. `ENG-123`, `PAVA-2120` anywhere in the
+  branch), then (3) falls back to a numeric-only id for branches like
+  `feature/1234` or `42-quick-fix`. Every emitted `ticket_id` tag is paired
+  with:
+    - `ticket_prefix` — alphabetic prefix (`ENG`, `PAVA`), or empty for
+      numeric-only ids; and
+    - `ticket_source` — explains how the id was derived: `branch` for the
+      alphanumeric pattern, `branch_numeric` for the numeric fallback.
+      Reserved for future `header` / `hint` sources from a smarter client
+      shim. Mirrors the `activity_source` contract so every first-class
+      attribution dimension carries its own provenance.
+
+  Messages without a recognised ticket emit no `ticket_id` tag (no legacy
+  `Unassigned` sentinel); they surface as `(untagged)` in the tickets
+  list, keeping bucket semantics consistent across branch / ticket /
+  activity views.
+
+  Surfaces:
+  - `budi stats --tickets` — list ranked by cost, with `(untagged)`
+    bucket and a `src=…` column showing the dominant `ticket_source`.
+  - `budi stats --ticket <ID>` — detail view with per-branch breakdown
+    and a `Source` row. Legacy rows without a `ticket_source` sibling
+    tag default to `branch` (the only pre-R1.3 pipeline producer) so
+    older DBs stay readable without a reindex.
   - `budi sessions --ticket <ID>` — sessions tagged with the ticket.
   - `GET /analytics/tickets` and `/analytics/tickets/{ticket_id}` mirror
     `/analytics/branches{/branch}` so future cloud/dashboard work can adopt

--- a/crates/budi-cli/src/commands/stats.rs
+++ b/crates/budi-cli/src/commands/stats.rs
@@ -551,10 +551,16 @@ fn cmd_stats_tickets(client: &DaemonClient, period: StatsPeriod, json_output: bo
         } else {
             t.top_branch.clone()
         };
+        let source_label = if t.source.is_empty() {
+            "--".to_string()
+        } else {
+            t.source.clone()
+        };
         println!(
-            "    {bold}{:<24}{reset} {yellow}{:>8}{reset}  {dim}{:<24}{reset}  {cyan}{}{reset}",
+            "    {bold}{:<24}{reset} {yellow}{:>8}{reset}  {dim}src={:<15}{reset}  {dim}{:<24}{reset}  {cyan}{}{reset}",
             t.ticket_id,
             format_cost_cents(t.cost_cents),
+            source_label,
             branch_label,
             bar
         );
@@ -607,6 +613,9 @@ fn cmd_stats_ticket_detail(
             }
             if !t.ticket_prefix.is_empty() {
                 println!("  {bold}Prefix{reset}     {}", t.ticket_prefix);
+            }
+            if !t.source.is_empty() {
+                println!("  {bold}Source{reset}     {}", t.source);
             }
             println!("  {bold}Sessions{reset}   {}", t.session_count);
             println!("  {bold}Messages{reset}   {}", t.message_count);

--- a/crates/budi-core/src/analytics/queries.rs
+++ b/crates/budi-core/src/analytics/queries.rs
@@ -1711,6 +1711,13 @@ pub struct TicketCost {
     /// `(untagged)` row.
     #[serde(default)]
     pub top_repo_id: String,
+    /// Where the ticket id was derived from — `"branch"` (alphanumeric
+    /// pattern) or `"branch_numeric"` (ADR-0082 §9 fallback). Empty for
+    /// the `(untagged)` row. Legacy rows with no `ticket_source` sibling
+    /// tag fall back to `"branch"` so older DBs stay readable. See R1.3
+    /// (#221).
+    #[serde(default)]
+    pub source: String,
 }
 
 /// Per-branch breakdown attached to a single ticket detail response.
@@ -1740,9 +1747,20 @@ pub struct TicketCostDetail {
     pub repo_id: String,
     /// Per-branch attribution for cost charged to this ticket.
     pub branches: Vec<TicketBranchBreakdown>,
+    /// Where the ticket id was derived from. See `TicketCost::source`.
+    #[serde(default)]
+    pub source: String,
 }
 
 const TICKET_TAG_KEY: &str = "ticket_id";
+const TICKET_SOURCE_TAG_KEY: &str = "ticket_source";
+
+/// Canonical fallback source for legacy rows (pre-R1.3) that carry a
+/// `ticket_id` tag but no sibling `ticket_source` tag. The alphanumeric
+/// extractor was the only producer before R1.3 — everything else was
+/// proxy-only — so this default keeps analytics consistent without a
+/// reindex.
+pub const TICKET_SOURCE_BRANCH: &str = crate::pipeline::TICKET_SOURCE_BRANCH;
 
 /// Query cost grouped by ticket, sorted by cost descending. Includes an
 /// `(untagged)` bucket for assistant messages that have no `ticket_id` tag.
@@ -1817,6 +1835,12 @@ pub fn ticket_cost_with_filters(
              WHERE key = '{TICKET_TAG_KEY}'
              GROUP BY message_id
          ),
+         msg_source AS (
+             SELECT message_id, MIN(value) AS source_value
+             FROM tags
+             WHERE key = '{TICKET_SOURCE_TAG_KEY}'
+             GROUP BY message_id
+         ),
          tagged AS (
              SELECT t.value AS ticket_id,
                     m.session_id,
@@ -1827,10 +1851,12 @@ pub fn ticket_cost_with_filters(
                     m.cache_read_tokens,
                     m.cache_creation_tokens,
                     m.cost_cents,
-                    mvc.n_values
+                    mvc.n_values,
+                    COALESCE(ms.source_value, '') AS ticket_source
              FROM tags t
              JOIN msg_val_counts mvc ON mvc.message_id = t.message_id
              JOIN messages m ON m.id = t.message_id
+             LEFT JOIN msg_source ms ON ms.message_id = t.message_id
              {where_clause}
              AND t.key = '{TICKET_TAG_KEY}'
          ),
@@ -1889,15 +1915,37 @@ pub fn ticket_cost_with_filters(
                  WHERE repo_value != '' AND repo_value != 'unknown'
              )
              WHERE rn = 1
+         ),
+         top_source AS (
+             SELECT ticket_id,
+                    ticket_source AS source_value,
+                    SUM(cost_cents / n_values) AS source_cost
+             FROM tagged
+             GROUP BY ticket_id, source_value
+         ),
+         top_source_pick AS (
+             SELECT ticket_id, source_value
+             FROM (
+                 SELECT ticket_id, source_value, source_cost,
+                        ROW_NUMBER() OVER (
+                            PARTITION BY ticket_id
+                            ORDER BY source_cost DESC, source_value ASC
+                        ) AS rn
+                 FROM top_source
+                 WHERE source_value != ''
+             )
+             WHERE rn = 1
          )
          SELECT pt.ticket_id,
                 pt.sess, pt.cnt,
                 pt.inp, pt.outp, pt.cache_r, pt.cache_c, pt.cost,
                 COALESCE(tbp.branch_value, '') AS top_branch,
-                COALESCE(trp.repo_value, '') AS top_repo
+                COALESCE(trp.repo_value, '') AS top_repo,
+                COALESCE(tsp.source_value, '{TICKET_SOURCE_BRANCH}') AS ticket_source
          FROM per_ticket pt
          LEFT JOIN top_branch_pick tbp ON tbp.ticket_id = pt.ticket_id
          LEFT JOIN top_repo_pick trp ON trp.ticket_id = pt.ticket_id
+         LEFT JOIN top_source_pick tsp ON tsp.ticket_id = pt.ticket_id
 
          UNION ALL
 
@@ -1910,7 +1958,8 @@ pub fn ticket_cost_with_filters(
                 COALESCE(SUM(m2.cache_creation_tokens), 0) AS cache_c,
                 COALESCE(SUM(m2.cost_cents), 0.0) AS cost,
                 '' AS top_branch,
-                '' AS top_repo
+                '' AS top_repo,
+                '' AS ticket_source
          FROM messages m2
          {untagged_where}
          AND NOT EXISTS (
@@ -1945,6 +1994,7 @@ pub fn ticket_cost_with_filters(
                 cost_cents: row.get(7)?,
                 top_branch: row.get(8)?,
                 top_repo_id: row.get(9)?,
+                source: row.get(10)?,
             })
         })?
         .filter_map(|r| r.ok())
@@ -1992,27 +2042,61 @@ pub fn ticket_cost_single(
     let where_clause = format!("WHERE {}", conditions.join(" AND "));
 
     // Totals. Use the same proportional split on multi-value ticket tags.
+    // `source` picks the dominant `ticket_source` sibling tag across the
+    // selected messages (by cost, then name). Legacy rows without a
+    // `ticket_source` tag fall back to the alphanumeric `branch` source in
+    // the caller so the detail view always has something to print.
     let totals_sql = format!(
         "WITH msg_val_counts AS (
              SELECT message_id, COUNT(*) AS n_values
              FROM tags
              WHERE key = ?1
              GROUP BY message_id
+         ),
+         msg_source AS (
+             SELECT message_id, MIN(value) AS source_value
+             FROM tags
+             WHERE key = '{TICKET_SOURCE_TAG_KEY}'
+             GROUP BY message_id
+         ),
+         selected AS (
+             SELECT m.id AS message_id,
+                    m.session_id,
+                    m.repo_id,
+                    m.input_tokens,
+                    m.output_tokens,
+                    m.cache_read_tokens,
+                    m.cache_creation_tokens,
+                    m.cost_cents,
+                    mvc.n_values,
+                    COALESCE(ms.source_value, '') AS ticket_source
+             FROM tags t
+             JOIN msg_val_counts mvc ON mvc.message_id = t.message_id
+             JOIN messages m ON m.id = t.message_id
+             LEFT JOIN msg_source ms ON ms.message_id = t.message_id
+             {where_clause}
+         ),
+         source_pick AS (
+             SELECT ticket_source,
+                    SUM(cost_cents / n_values) AS source_cost
+             FROM selected
+             WHERE ticket_source != ''
+             GROUP BY ticket_source
+             ORDER BY source_cost DESC, ticket_source ASC
+             LIMIT 1
          )
-         SELECT COUNT(DISTINCT m.session_id) AS sess,
+         SELECT COUNT(DISTINCT session_id) AS sess,
                 COUNT(*) AS cnt,
-                COALESCE(SUM(m.input_tokens / mvc.n_values), 0) AS inp,
-                COALESCE(SUM(m.output_tokens / mvc.n_values), 0) AS outp,
-                COALESCE(SUM(m.cache_read_tokens / mvc.n_values), 0) AS cache_r,
-                COALESCE(SUM(m.cache_creation_tokens / mvc.n_values), 0) AS cache_c,
-                COALESCE(SUM(m.cost_cents / mvc.n_values), 0.0) AS cost,
-                CASE WHEN COUNT(DISTINCT COALESCE(m.repo_id, '')) = 1
-                     THEN COALESCE(MIN(m.repo_id), '')
-                     ELSE '' END AS repo
-         FROM tags t
-         JOIN msg_val_counts mvc ON mvc.message_id = t.message_id
-         JOIN messages m ON m.id = t.message_id
-         {where_clause}",
+                COALESCE(SUM(input_tokens / n_values), 0) AS inp,
+                COALESCE(SUM(output_tokens / n_values), 0) AS outp,
+                COALESCE(SUM(cache_read_tokens / n_values), 0) AS cache_r,
+                COALESCE(SUM(cache_creation_tokens / n_values), 0) AS cache_c,
+                COALESCE(SUM(cost_cents / n_values), 0.0) AS cost,
+                CASE WHEN COUNT(DISTINCT COALESCE(repo_id, '')) = 1
+                     THEN COALESCE(MIN(repo_id), '')
+                     ELSE '' END AS repo,
+                COALESCE((SELECT ticket_source FROM source_pick), '') AS src
+         FROM selected",
     );
 
     let param_refs: Vec<&dyn rusqlite::types::ToSql> = param_values
@@ -2030,9 +2114,10 @@ pub fn ticket_cost_single(
             row.get::<_, u64>(5)?,
             row.get::<_, f64>(6)?,
             row.get::<_, String>(7)?,
+            row.get::<_, String>(8)?,
         ))
     });
-    let (sess, cnt, inp, outp, cache_r, cache_c, cost, repo) = match totals {
+    let (sess, cnt, inp, outp, cache_r, cache_c, cost, repo, src) = match totals {
         Ok(row) => row,
         Err(rusqlite::Error::QueryReturnedNoRows) => return Ok(None),
         Err(e) => return Err(e.into()),
@@ -2082,6 +2167,16 @@ pub fn ticket_cost_single(
         .filter_map(|r| r.ok())
         .collect();
 
+    // Legacy rows lack a `ticket_source` sibling tag; before R1.3
+    // (#221) only the alphanumeric extractor produced `ticket_id` tags
+    // in pipeline writes, so treat the empty source as `branch` for
+    // the detail view.
+    let source = if src.is_empty() {
+        TICKET_SOURCE_BRANCH.to_string()
+    } else {
+        src
+    };
+
     Ok(Some(TicketCostDetail {
         ticket_prefix: ticket_prefix_of(ticket_id),
         ticket_id: ticket_id.to_string(),
@@ -2094,6 +2189,7 @@ pub fn ticket_cost_single(
         cost_cents: cost,
         repo_id: repo,
         branches,
+        source,
     }))
 }
 

--- a/crates/budi-core/src/analytics/tests.rs
+++ b/crates/budi-core/src/analytics/tests.rs
@@ -2518,6 +2518,119 @@ fn session_list_filters_by_ticket() {
 }
 
 // ---------------------------------------------------------------------------
+// Ticket source — R1.3 (#221)
+// ---------------------------------------------------------------------------
+//
+// R1.3 promotes `ticket_source` to a first-class sibling of `ticket_id`
+// so analytics can explain how an id was derived (alphanumeric `branch`
+// pattern vs `branch_numeric` fallback). The list and detail views must
+// surface the dominant source per ticket, and legacy rows that only
+// carry a `ticket_id` tag (pre-R1.3) must keep working by defaulting to
+// `branch` — the only pre-R1.3 pipeline producer.
+
+fn ticket_tags_with_source(ticket: &str, source: &str) -> Vec<Tag> {
+    vec![
+        Tag {
+            key: "ticket_id".to_string(),
+            value: ticket.to_string(),
+        },
+        Tag {
+            key: "ticket_source".to_string(),
+            value: source.to_string(),
+        },
+    ]
+}
+
+#[test]
+fn ticket_cost_surfaces_source_per_ticket() {
+    // Two tickets with explicit, distinct sources. Expect each row to
+    // carry its own `source` so the CLI `src=…` column is reliable.
+    let mut conn = test_db();
+    let m1 = ticket_msg("tk-src-1", "s1", "PAVA-11-alpha", "repo", 5.0);
+    let m2 = ticket_msg("tk-src-2", "s2", "1234-numeric", "repo", 3.0);
+    ingest_messages(
+        &mut conn,
+        &[m1, m2],
+        Some(&[
+            ticket_tags_with_source("PAVA-11", "branch"),
+            ticket_tags_with_source("1234", "branch_numeric"),
+        ]),
+    )
+    .unwrap();
+
+    let tickets = ticket_cost(&conn, None, None, 10).unwrap();
+    let alpha = tickets.iter().find(|t| t.ticket_id == "PAVA-11").unwrap();
+    let numeric = tickets.iter().find(|t| t.ticket_id == "1234").unwrap();
+    assert_eq!(alpha.source, "branch");
+    assert_eq!(numeric.source, "branch_numeric");
+}
+
+#[test]
+fn ticket_cost_defaults_legacy_source_to_branch() {
+    // Pre-R1.3 DBs only carry the `ticket_id` tag. The loader falls back
+    // to `branch` so older data stays readable without a reindex.
+    let mut conn = test_db();
+    let m1 = ticket_msg("tk-legacy-1", "s1", "PAVA-42-impl", "repo", 4.0);
+    ingest_messages(&mut conn, &[m1], Some(&[ticket_tags(&["PAVA-42"])])).unwrap();
+
+    let tickets = ticket_cost(&conn, None, None, 10).unwrap();
+    let pava42 = tickets.iter().find(|t| t.ticket_id == "PAVA-42").unwrap();
+    assert_eq!(
+        pava42.source, "branch",
+        "legacy rows default to the alphanumeric source"
+    );
+}
+
+#[test]
+fn ticket_cost_untagged_row_has_empty_source() {
+    // The `(untagged)` bucket has no derivation, so its source column is
+    // empty — rendered as `--` by the CLI.
+    let mut conn = test_db();
+    let m = assistant_msg("tk-src-unt", "s1", 3.0);
+    ingest_messages(&mut conn, &[m], Some(&[Vec::new()])).unwrap();
+
+    let tickets = ticket_cost(&conn, None, None, 10).unwrap();
+    let untagged = tickets
+        .iter()
+        .find(|t| t.ticket_id == "(untagged)")
+        .unwrap();
+    assert_eq!(untagged.source, "");
+}
+
+#[test]
+fn ticket_cost_single_surfaces_source() {
+    // The detail view must carry the dominant source too; it drives the
+    // `Source` row in `budi stats --ticket <ID>`.
+    let mut conn = test_db();
+    let m1 = ticket_msg("tk-src-d-1", "s1", "4321-fix", "repo", 6.0);
+    ingest_messages(
+        &mut conn,
+        &[m1],
+        Some(&[ticket_tags_with_source("4321", "branch_numeric")]),
+    )
+    .unwrap();
+
+    let detail = ticket_cost_single(&conn, "4321", None, None, None)
+        .unwrap()
+        .unwrap();
+    assert_eq!(detail.source, "branch_numeric");
+}
+
+#[test]
+fn ticket_cost_single_legacy_source_defaults_to_branch() {
+    // Pre-R1.3 detail rows lack a `ticket_source` tag; the detail view
+    // still needs to print something useful, so default to `branch`.
+    let mut conn = test_db();
+    let m1 = ticket_msg("tk-src-d-legacy", "s1", "PAVA-99-impl", "repo", 2.0);
+    ingest_messages(&mut conn, &[m1], Some(&[ticket_tags(&["PAVA-99"])])).unwrap();
+
+    let detail = ticket_cost_single(&conn, "PAVA-99", None, None, None)
+        .unwrap()
+        .unwrap();
+    assert_eq!(detail.source, "branch");
+}
+
+// ---------------------------------------------------------------------------
 // Activities — R1.0 (#305)
 //
 // Activities live in the `tags` table under the `activity` key (see

--- a/crates/budi-core/src/pipeline/enrichers.rs
+++ b/crates/budi-core/src/pipeline/enrichers.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 use crate::analytics::Tag;
 use crate::config::TagsConfig;
 use crate::jsonl::ParsedMessage;
-use crate::pipeline::{Enricher, extract_ticket_id, glob_match};
+use crate::pipeline::{Enricher, extract_ticket_from_branch, glob_match};
 use crate::repo_id::RepoIdCache;
 use crate::tag_keys as tk;
 
@@ -49,9 +49,14 @@ impl Enricher for GitEnricher {
             }
         }
 
-        // Extract ticket_id from git_branch (branch itself is stored as a column, not a tag)
+        // Extract ticket_id from git_branch (branch itself is stored as a
+        // column, not a tag). R1.3 (#221) unifies the extractor with the
+        // proxy ingest path so imported Claude Code / Cursor data agrees
+        // with live proxy rows — in particular, pure-numeric tickets from
+        // branches like `fix/1234-typo` (ADR-0082 §9) now tag consistently
+        // on both paths.
         if let Some(ref branch) = msg.git_branch
-            && let Some(ticket) = extract_ticket_id(branch)
+            && let Some((ticket, source)) = extract_ticket_from_branch(branch)
         {
             tags.push(Tag {
                 key: tk::TICKET_ID.to_string(),
@@ -63,6 +68,10 @@ impl Enricher for GitEnricher {
                     value: ticket[..dash].to_string(),
                 });
             }
+            tags.push(Tag {
+                key: tk::TICKET_SOURCE.to_string(),
+                value: source.to_string(),
+            });
         }
 
         tags
@@ -535,8 +544,67 @@ mod tests {
             tags.iter()
                 .any(|t| t.key == "ticket_prefix" && t.value == "PAVA")
         );
+        // R1.3 (#221): GitEnricher records the extractor source so the
+        // analytics layer can show provenance the same way R1.2 (#222)
+        // did for activity classification.
+        assert!(
+            tags.iter()
+                .any(|t| t.key == "ticket_source" && t.value == "branch"),
+            "expected ticket_source=branch tag for alphanumeric ticket, got: {tags:?}"
+        );
         assert!(!tags.iter().any(|t| t.key == "repo"));
         assert!(!tags.iter().any(|t| t.key == "branch"));
+    }
+
+    /// R1.3 (#221): the import path must also honour the ADR-0082 §9
+    /// numeric-only ticket fallback, matching the proxy ingest path.
+    /// Before R1.3, `fix/1234-typo` produced a ticket tag on the proxy
+    /// path but not on `budi import`, so analytics disagreed.
+    #[test]
+    fn git_enricher_extracts_numeric_only_ticket() {
+        let mut enricher = GitEnricher {
+            repo_cache: RepoIdCache::new(),
+        };
+        let mut msg = test_msg();
+        msg.git_branch = Some("fix/1234-typo".to_string());
+        msg.repo_id = Some("test-repo".to_string());
+        let tags = enricher.enrich(&mut msg);
+        assert!(
+            tags.iter()
+                .any(|t| t.key == "ticket_id" && t.value == "1234"),
+            "expected numeric ticket_id=1234, got: {tags:?}"
+        );
+        assert!(
+            !tags.iter().any(|t| t.key == "ticket_prefix"),
+            "numeric tickets have no prefix, got: {tags:?}"
+        );
+        assert!(
+            tags.iter()
+                .any(|t| t.key == "ticket_source" && t.value == "branch_numeric"),
+            "expected ticket_source=branch_numeric, got: {tags:?}"
+        );
+    }
+
+    /// Integration branches (main/master/develop/HEAD) never produce a
+    /// ticket tag — this pins the unified extractor's filter behaviour
+    /// on the import path.
+    #[test]
+    fn git_enricher_skips_integration_branches() {
+        let mut enricher = GitEnricher {
+            repo_cache: RepoIdCache::new(),
+        };
+        for branch in ["main", "master", "develop", "HEAD"] {
+            let mut msg = test_msg();
+            msg.git_branch = Some(branch.to_string());
+            msg.repo_id = Some("test-repo".to_string());
+            let tags = enricher.enrich(&mut msg);
+            assert!(
+                !tags
+                    .iter()
+                    .any(|t| t.key == "ticket_id" || t.key == "ticket_source"),
+                "{branch} must not produce ticket tags, got: {tags:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/budi-core/src/pipeline/mod.rs
+++ b/crates/budi-core/src/pipeline/mod.rs
@@ -244,11 +244,66 @@ pub fn glob_match(pattern: &str, text: &str) -> bool {
     pi == pat.len()
 }
 
+/// Canonical source label for tickets derived from the alphanumeric
+/// `<PREFIX>-<NUM>` pattern (e.g. `PAVA-2057`). Stable across the 8.x
+/// wire format — callers pin on this value.
+pub const TICKET_SOURCE_BRANCH: &str = "branch";
+
+/// Canonical source label for tickets derived from the pure-numeric
+/// fallback defined in ADR-0082 §9 (e.g. `1234` in `fix/1234-typo`).
+pub const TICKET_SOURCE_BRANCH_NUMERIC: &str = "branch_numeric";
+
+/// Branch names that are never tickets — integration branches and the
+/// literal detached-HEAD sentinel. Kept in one place so proxy ingest and
+/// the import pipeline agree.
+const INTEGRATION_BRANCHES: &[&str] = &["main", "master", "develop", "HEAD"];
+
 /// Extract a ticket ID (e.g. `PAVA-2057`) from a branch name.
 /// Matches `[a-zA-Z]{2,}-\d+` and returns it uppercased.
 /// Handles both standard (`PAVA-2057-fix`) and Graphite-style (`03-20-pava-2120_desc`) branches.
 /// Requires 2+ alpha chars in the prefix to avoid matching date fragments like `03-20`.
+///
+/// Backwards-compatible thin wrapper around `extract_ticket_from_branch`:
+/// callers that only care about the alphanumeric pattern still get what
+/// they expect. Use `extract_ticket_from_branch` when the call site needs
+/// to distinguish the numeric fallback or record the source.
 pub fn extract_ticket_id(branch: &str) -> Option<String> {
+    extract_ticket_alpha(branch)
+}
+
+/// Unified ticket extractor used by both the proxy ingest path and the
+/// batch import pipeline. Returns `(ticket_id, source)` where `source` is
+/// one of `TICKET_SOURCE_BRANCH` or `TICKET_SOURCE_BRANCH_NUMERIC`.
+///
+/// Behavior (R1.3, #221):
+/// 1. Integration branches (`main`, `master`, `develop`, `HEAD`) and
+///    empty branch names are never tickets.
+/// 2. Tries the alphanumeric pattern first (`[a-zA-Z]{2,}-\d+`). This
+///    covers the vast majority of enterprise dev workflows and wins over
+///    the numeric fallback so `fix/PAVA-42-and-1234` still resolves to
+///    `PAVA-42` rather than `42`.
+/// 3. Falls back to the pure-numeric pattern from ADR-0082 §9 — a
+///    leading numeric segment in the last `/`-separated path component,
+///    followed by `-` or end-of-string. This handles `fix/1234-typo`
+///    conventions that many GitHub-flow teams rely on and keeps proxy
+///    behaviour consistent with batch ingest.
+pub fn extract_ticket_from_branch(branch: &str) -> Option<(String, &'static str)> {
+    if branch.is_empty() || INTEGRATION_BRANCHES.contains(&branch) {
+        return None;
+    }
+    if let Some(id) = extract_ticket_alpha(branch) {
+        return Some((id, TICKET_SOURCE_BRANCH));
+    }
+    if let Some(id) = extract_ticket_numeric(branch) {
+        return Some((id, TICKET_SOURCE_BRANCH_NUMERIC));
+    }
+    None
+}
+
+/// Extract an alphanumeric ticket (`[a-zA-Z]{2,}-\d+`) from anywhere in
+/// the branch, uppercased. Private helper used by both `extract_ticket_id`
+/// and `extract_ticket_from_branch`.
+fn extract_ticket_alpha(branch: &str) -> Option<String> {
     let bytes = branch.as_bytes();
     let len = bytes.len();
     let mut i = 0;
@@ -280,6 +335,31 @@ pub fn extract_ticket_id(branch: &str) -> Option<String> {
         }
     }
     None
+}
+
+/// Extract a numeric-only ticket ID from the last path component of a
+/// branch name per ADR-0082 §9. Matches a leading digit run followed by
+/// `-` or end-of-string, e.g. `fix/1234-typo` → `"1234"`. Refuses bare
+/// year-style prefixes like `2024-roadmap` when they would collide with
+/// an alpha ticket (callers try alpha first).
+fn extract_ticket_numeric(branch: &str) -> Option<String> {
+    let segment = branch.rsplit('/').next().unwrap_or(branch);
+    let bytes = segment.as_bytes();
+    if bytes.is_empty() || !bytes[0].is_ascii_digit() {
+        return None;
+    }
+    let end = bytes
+        .iter()
+        .position(|&b| !b.is_ascii_digit())
+        .unwrap_or(bytes.len());
+    if end == 0 {
+        return None;
+    }
+    // Must be followed by '-' or end-of-string to be a ticket, not just any number
+    if end < bytes.len() && bytes[end] != b'-' {
+        return None;
+    }
+    Some(segment[..end].to_string())
 }
 
 #[cfg(test)]
@@ -365,6 +445,63 @@ mod tests {
         );
         // No ticket at all
         assert_eq!(extract_ticket_id("kiyoshi/pava-searchbars"), None);
+    }
+
+    // Unified extractor contract (R1.3, #221) — must agree with proxy
+    // ingest and batch import so `--tickets` tells the same story from
+    // both ingest paths.
+
+    #[test]
+    fn extract_ticket_from_branch_prefers_alpha_pattern() {
+        assert_eq!(
+            extract_ticket_from_branch("feature/PROJ-42-fix"),
+            Some(("PROJ-42".to_string(), TICKET_SOURCE_BRANCH))
+        );
+        assert_eq!(
+            extract_ticket_from_branch("03-20-pava-2120_desc"),
+            Some(("PAVA-2120".to_string(), TICKET_SOURCE_BRANCH))
+        );
+    }
+
+    #[test]
+    fn extract_ticket_from_branch_falls_back_to_numeric() {
+        // ADR-0082 §9 numeric-only fallback — matches branches like
+        // `fix/1234-typo` used by GitHub-flow teams.
+        assert_eq!(
+            extract_ticket_from_branch("fix/1234-typo"),
+            Some(("1234".to_string(), TICKET_SOURCE_BRANCH_NUMERIC))
+        );
+        assert_eq!(
+            extract_ticket_from_branch("42-stabilize-auth"),
+            Some(("42".to_string(), TICKET_SOURCE_BRANCH_NUMERIC))
+        );
+    }
+
+    #[test]
+    fn extract_ticket_from_branch_integration_branches_are_none() {
+        for b in ["main", "master", "develop", "HEAD", ""] {
+            assert_eq!(
+                extract_ticket_from_branch(b),
+                None,
+                "{b} must not be treated as a ticket"
+            );
+        }
+    }
+
+    #[test]
+    fn extract_ticket_from_branch_no_ticket_yields_none() {
+        assert_eq!(extract_ticket_from_branch("kiyoshi/pava-searchbars"), None);
+        assert_eq!(extract_ticket_from_branch("release/v1"), None);
+    }
+
+    #[test]
+    fn extract_ticket_from_branch_alpha_wins_over_numeric() {
+        // `fix/PROJ-42-and-1234` must resolve to the alpha ticket, not
+        // the trailing numeric fragment.
+        assert_eq!(
+            extract_ticket_from_branch("fix/PROJ-42-and-1234"),
+            Some(("PROJ-42".to_string(), TICKET_SOURCE_BRANCH))
+        );
     }
 
     pub fn test_msg() -> ParsedMessage {

--- a/crates/budi-core/src/proxy.rs
+++ b/crates/budi-core/src/proxy.rs
@@ -9,7 +9,7 @@ use anyhow::Result;
 use rusqlite::{Connection, params};
 use serde::{Deserialize, Serialize};
 
-use crate::pipeline::extract_ticket_id;
+use crate::pipeline::extract_ticket_from_branch;
 
 /// The fallback repo_id when attribution cannot be determined.
 pub const UNASSIGNED_REPO: &str = "Unassigned";
@@ -38,11 +38,20 @@ impl std::fmt::Display for ProxyProvider {
 }
 
 /// Attribution context resolved from request headers or git state.
+///
+/// `ticket_id` is empty (not a sentinel) when no ticket could be derived
+/// from the branch — the live insert path treats empty as "do not tag"
+/// so proxy and import paths agree on the `(untagged)` bucket. `ticket_source`
+/// records which extractor produced the id (R1.3, #221) — one of
+/// `pipeline::TICKET_SOURCE_BRANCH` / `pipeline::TICKET_SOURCE_BRANCH_NUMERIC`
+/// when `ticket_id` is set, or empty otherwise.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ProxyAttribution {
     pub repo_id: String,
     pub git_branch: String,
     pub ticket_id: String,
+    #[serde(default)]
+    pub ticket_source: String,
 }
 
 impl ProxyAttribution {
@@ -80,23 +89,23 @@ impl ProxyAttribution {
             resolved_repo
         };
 
-        let ticket_id = extract_ticket_id(&resolved_branch)
-            .or_else(|| extract_numeric_ticket(&resolved_branch))
-            .unwrap_or_else(|| "Unassigned".to_string());
-        // ADR-0082 §9: main/master/develop are integration branches, not tickets
-        let ticket_id = if matches!(
-            resolved_branch.as_str(),
-            "main" | "master" | "develop" | "HEAD" | ""
-        ) {
-            "Unassigned".to_string()
-        } else {
-            ticket_id
+        // R1.3 (#221): unified ticket extraction — the pipeline helper
+        // handles integration-branch filtering, alpha pattern, and the
+        // ADR-0082 §9 numeric fallback in one place so the proxy and
+        // `budi import` agree on what counts as a ticket. An empty
+        // `ticket_id` here means "no ticket" and `insert_proxy_message`
+        // will skip the ticket tag writes entirely — no more phantom
+        // `Unassigned` ticket bucket sitting next to `(untagged)`.
+        let (ticket_id, ticket_source) = match extract_ticket_from_branch(&resolved_branch) {
+            Some((id, source)) => (id, source.to_string()),
+            None => (String::new(), String::new()),
         };
 
         Self {
             repo_id,
             git_branch: resolved_branch,
             ticket_id,
+            ticket_source,
         }
     }
 }
@@ -120,30 +129,6 @@ fn resolve_git_branch(cwd: &std::path::Path) -> String {
     // Detached HEAD: git reports the literal "HEAD". Drop it so we never show
     // a bogus `HEAD` branch bucket in `budi stats --branches`.
     if raw == "HEAD" { String::new() } else { raw }
-}
-
-/// Extract a numeric-only ticket ID from a branch name per ADR-0082 §9.
-/// Matches the first segment after `/` or at the start that is purely numeric
-/// followed by `-` or end-of-string. E.g., `fix/1234-typo` → `"1234"`.
-fn extract_numeric_ticket(branch: &str) -> Option<String> {
-    // Take the segment after the last `/`, or the whole branch
-    let segment = branch.rsplit('/').next().unwrap_or(branch);
-    let bytes = segment.as_bytes();
-    if bytes.is_empty() || !bytes[0].is_ascii_digit() {
-        return None;
-    }
-    let end = bytes
-        .iter()
-        .position(|&b| !b.is_ascii_digit())
-        .unwrap_or(bytes.len());
-    if end == 0 {
-        return None;
-    }
-    // Must be followed by '-' or end-of-string to be a ticket, not just any number
-    if end < bytes.len() && bytes[end] != b'-' {
-        return None;
-    }
-    Some(segment[..end].to_string())
 }
 
 /// Generate a best-effort session ID when the agent does not provide one.
@@ -194,6 +179,11 @@ pub struct ProxyEvent {
     pub git_branch: String,
     #[serde(default)]
     pub ticket_id: String,
+    /// Source the ticket id was derived from (R1.3, #221). Mirrors
+    /// `pipeline::TICKET_SOURCE_BRANCH` / `_BRANCH_NUMERIC`. Empty when
+    /// `ticket_id` is empty.
+    #[serde(default)]
+    pub ticket_source: String,
     #[serde(default)]
     pub cost_cents: f64,
     /// Session correlation ID. If the agent provides one via header, use it;
@@ -391,7 +381,14 @@ pub fn insert_proxy_message(conn: &Connection, event: &ProxyEvent) -> Result<Str
         }
     }
 
-    if !event.ticket_id.is_empty() {
+    // R1.3 (#221): defence against the pre-8.1 proxy path, which stored the
+    // literal string `"Unassigned"` as `ticket_id` when the branch didn't
+    // match any pattern. After R1.3 callers produce an empty string for
+    // "no ticket" and the pipeline agrees, but we still drop the legacy
+    // sentinel here so in-flight rolling upgrades never plant a bogus
+    // `Unassigned` ticket bucket next to the analytics layer's own
+    // `(untagged)` row.
+    if !event.ticket_id.is_empty() && event.ticket_id != "Unassigned" {
         conn.execute(
             "INSERT OR IGNORE INTO tags (message_id, key, value) VALUES (?1, 'ticket_id', ?2)",
             params![uuid, event.ticket_id],
@@ -400,6 +397,12 @@ pub fn insert_proxy_message(conn: &Connection, event: &ProxyEvent) -> Result<Str
             conn.execute(
                 "INSERT OR IGNORE INTO tags (message_id, key, value) VALUES (?1, 'ticket_prefix', ?2)",
                 params![uuid, &event.ticket_id[..dash]],
+            )?;
+        }
+        if !event.ticket_source.is_empty() {
+            conn.execute(
+                "INSERT OR IGNORE INTO tags (message_id, key, value) VALUES (?1, ?2, ?3)",
+                params![uuid, crate::tag_keys::TICKET_SOURCE, event.ticket_source],
             )?;
         }
     }
@@ -597,6 +600,7 @@ mod tests {
             repo_id: String::new(),
             git_branch: String::new(),
             ticket_id: String::new(),
+            ticket_source: String::new(),
             cost_cents: 0.0,
             session_id: String::new(),
             activity: String::new(),
@@ -680,14 +684,20 @@ mod tests {
         assert_eq!(attr.repo_id, "github.com/test/repo");
         assert_eq!(attr.git_branch, "feat/PROJ-42-fix");
         assert_eq!(attr.ticket_id, "PROJ-42");
+        assert_eq!(attr.ticket_source, "branch");
     }
 
+    /// R1.3 (#221): when nothing matches we return an empty `ticket_id`
+    /// rather than the `"Unassigned"` sentinel that used to produce a
+    /// phantom ticket bucket in `budi stats --tickets`. The insert path
+    /// treats empty as "no ticket" and skips the tag writes.
     #[test]
-    fn attribution_resolve_empty_falls_back_to_unassigned() {
+    fn attribution_resolve_empty_returns_empty_ticket() {
         let attr = ProxyAttribution::resolve(None, None, None);
         assert_eq!(attr.repo_id, UNASSIGNED_REPO);
         assert!(attr.git_branch.is_empty());
-        assert_eq!(attr.ticket_id, "Unassigned");
+        assert!(attr.ticket_id.is_empty());
+        assert!(attr.ticket_source.is_empty());
     }
 
     #[test]
@@ -696,6 +706,7 @@ mod tests {
         assert_eq!(attr.repo_id, UNASSIGNED_REPO);
         assert_eq!(attr.git_branch, "ABC-123-feat");
         assert_eq!(attr.ticket_id, "ABC-123");
+        assert_eq!(attr.ticket_source, "branch");
     }
 
     #[test]
@@ -703,25 +714,29 @@ mod tests {
         let attr = ProxyAttribution::resolve(Some("my-repo"), Some("main"), None);
         assert_eq!(attr.repo_id, "my-repo");
         assert_eq!(attr.git_branch, "main");
-        assert_eq!(attr.ticket_id, "Unassigned");
+        assert!(attr.ticket_id.is_empty());
+        assert!(attr.ticket_source.is_empty());
     }
 
     #[test]
     fn attribution_resolve_numeric_only_ticket() {
         let attr = ProxyAttribution::resolve(Some("repo"), Some("fix/1234-typo"), None);
         assert_eq!(attr.ticket_id, "1234");
+        assert_eq!(attr.ticket_source, "branch_numeric");
     }
 
     #[test]
-    fn attribution_resolve_develop_branch_unassigned() {
+    fn attribution_resolve_develop_branch_no_ticket() {
         let attr = ProxyAttribution::resolve(Some("repo"), Some("develop"), None);
-        assert_eq!(attr.ticket_id, "Unassigned");
+        assert!(attr.ticket_id.is_empty());
+        assert!(attr.ticket_source.is_empty());
     }
 
     #[test]
-    fn attribution_resolve_master_branch_unassigned() {
+    fn attribution_resolve_master_branch_no_ticket() {
         let attr = ProxyAttribution::resolve(Some("repo"), Some("master"), None);
-        assert_eq!(attr.ticket_id, "Unassigned");
+        assert!(attr.ticket_id.is_empty());
+        assert!(attr.ticket_source.is_empty());
     }
 
     #[test]
@@ -777,6 +792,7 @@ mod tests {
         event.repo_id = "github.com/test/repo".to_string();
         event.git_branch = "PROJ-42-fix".to_string();
         event.ticket_id = "PROJ-42".to_string();
+        event.ticket_source = "branch".to_string();
         event.cost_cents = 2.5;
 
         let uuid = insert_proxy_message(&conn, &event).unwrap();
@@ -834,6 +850,18 @@ mod tests {
             )
             .unwrap();
         assert_eq!(prefix, "PROJ");
+
+        // R1.3 (#221): the proxy now records the extractor source so
+        // analytics can tell apart alphanumeric vs numeric tickets
+        // without re-deriving from the branch.
+        let source: String = conn
+            .query_row(
+                "SELECT value FROM tags WHERE message_id = ?1 AND key = 'ticket_source'",
+                params![uuid],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(source, "branch");
     }
 
     #[test]
@@ -850,6 +878,63 @@ mod tests {
             )
             .unwrap();
         assert_eq!(count, 0);
+    }
+
+    /// R1.3 (#221): a pre-8.1 proxy that still writes `ticket_id = "Unassigned"`
+    /// must not plant a ticket tag — otherwise `budi stats --tickets`
+    /// shows a phantom `Unassigned` row next to the analytics layer's
+    /// own `(untagged)` bucket. Insert path drops the legacy sentinel.
+    #[test]
+    fn insert_proxy_message_drops_legacy_unassigned_ticket_sentinel() {
+        let conn = test_db_with_messages();
+        let mut event = test_event();
+        event.ticket_id = "Unassigned".to_string();
+        event.ticket_source = String::new();
+        let uuid = insert_proxy_message(&conn, &event).unwrap();
+
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM tags WHERE message_id = ?1 AND key IN ('ticket_id','ticket_prefix','ticket_source')",
+                params![uuid],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            count, 0,
+            "legacy 'Unassigned' ticket_id must never be persisted as a ticket tag"
+        );
+    }
+
+    /// R1.3 (#221): numeric-only tickets from the ADR-0082 §9 fallback
+    /// must be tagged with `ticket_source = "branch_numeric"` so the
+    /// import path and analytics can tell them apart from alpha tickets.
+    #[test]
+    fn insert_proxy_message_writes_numeric_ticket_source() {
+        let conn = test_db_with_messages();
+        let mut event = test_event();
+        event.git_branch = "fix/1234-typo".to_string();
+        event.ticket_id = "1234".to_string();
+        event.ticket_source = "branch_numeric".to_string();
+        let uuid = insert_proxy_message(&conn, &event).unwrap();
+
+        let source: String = conn
+            .query_row(
+                "SELECT value FROM tags WHERE message_id = ?1 AND key = 'ticket_source'",
+                params![uuid],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(source, "branch_numeric");
+
+        // Numeric tickets have no dash, so no prefix tag.
+        let prefix_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM tags WHERE message_id = ?1 AND key = 'ticket_prefix'",
+                params![uuid],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(prefix_count, 0);
     }
 
     #[test]
@@ -1068,6 +1153,7 @@ mod tests {
         let attr = ProxyAttribution::resolve(None, None, repo.to_str());
         assert_eq!(attr.git_branch, "PROJ-42-feature");
         assert_eq!(attr.ticket_id, "PROJ-42");
+        assert_eq!(attr.ticket_source, "branch");
         assert_ne!(
             attr.repo_id, UNASSIGNED_REPO,
             "cwd-based git resolution must also populate repo_id"
@@ -1112,7 +1198,8 @@ mod tests {
             "detached HEAD must not leak as a literal 'HEAD' branch, got: {:?}",
             attr.git_branch
         );
-        assert_eq!(attr.ticket_id, "Unassigned");
+        assert!(attr.ticket_id.is_empty());
+        assert!(attr.ticket_source.is_empty());
 
         let _ = std::fs::remove_dir_all(&repo);
     }

--- a/crates/budi-core/src/tag_keys.rs
+++ b/crates/budi-core/src/tag_keys.rs
@@ -6,6 +6,13 @@
 
 pub const TICKET_ID: &str = "ticket_id";
 pub const TICKET_PREFIX: &str = "ticket_prefix";
+/// Where the ticket id was derived from. Stable values mirror the
+/// constants in `pipeline::mod` — `branch` for the alphanumeric
+/// `<PREFIX>-<NUM>` pattern and `branch_numeric` for the pure-numeric
+/// fallback from ADR-0082 §9. Reserved for future sources (e.g.
+/// `header`, `hint`) as R3 / 9.0 work on ticket enrichment lands. See
+/// R1.3 (#221).
+pub const TICKET_SOURCE: &str = "ticket_source";
 pub const USER: &str = "user";
 pub const MACHINE: &str = "machine";
 pub const PLATFORM: &str = "platform";

--- a/crates/budi-daemon/src/routes/proxy.rs
+++ b/crates/budi-daemon/src/routes/proxy.rs
@@ -710,6 +710,7 @@ fn record_event(
         repo_id: attribution.repo_id.clone(),
         git_branch: attribution.git_branch.clone(),
         ticket_id: attribution.ticket_id.clone(),
+        ticket_source: attribution.ticket_source.clone(),
         cost_cents,
         session_id: session_id.to_string(),
         activity: activity.0.clone(),

--- a/scripts/e2e/test_221_ticket_first_class.sh
+++ b/scripts/e2e/test_221_ticket_first_class.sh
@@ -1,0 +1,346 @@
+#!/usr/bin/env bash
+# End-to-end regression for issue #221 (R1.3): verify the unified ticket
+# extractor and the `ticket_source` first-class sibling tag on the live
+# proxy path.
+#
+# What this script guards:
+# - Alphanumeric branch tickets (e.g. `PROJ-221-foo`) land as
+#   `ticket_id=PROJ-221` + `ticket_prefix=PROJ` + `ticket_source=branch`.
+# - Numeric-only branch tickets (e.g. `feature/1234`) land as
+#   `ticket_id=1234` + `ticket_source=branch_numeric` + NO `ticket_prefix`
+#   (pre-R1.3 the proxy wrote numeric-only ids with no source, and the
+#   pipeline rejected them entirely).
+# - Integration branches (`main`) emit no ticket tags at all — previously
+#   the proxy wrote `ticket_id="Unassigned"`, creating a second bucket
+#   next to `(untagged)`.
+# - The legacy `"Unassigned"` sentinel is never persisted on the
+#   `ticket_id` key.
+# - `/analytics/tickets` surfaces the dominant `source` per ticket, with
+#   `branch` vs `branch_numeric` propagated correctly.
+# - `/analytics/tickets/{ID}` echoes the same source in its detail
+#   payload (feeds the `Source` row in `budi stats --ticket <ID>`).
+#
+# Negative-path proof: revert `ProxyAttribution::resolve` in
+# `crates/budi-core/src/proxy.rs` to call the old `extract_numeric_ticket`
+# / write `"Unassigned"`, and this script must fail on either the
+# numeric-source assertion or the no-Unassigned assertion.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BUDI="$ROOT/target/release/budi"
+BUDI_DAEMON="$ROOT/target/release/budi-daemon"
+
+if [[ ! -x "$BUDI" || ! -x "$BUDI_DAEMON" ]]; then
+  echo "error: release binaries not built. run \`cargo build --release\` first." >&2
+  exit 2
+fi
+
+TMPDIR_ROOT="$(mktemp -d -t budi-e2e-221-XXXXXX)"
+export HOME="$TMPDIR_ROOT"
+mkdir -p "$HOME/.config/budi"
+
+DAEMON_PORT=17881
+PROXY_PORT=19881
+UPSTREAM_PORT=19336
+
+cleanup() {
+  local status=$?
+  { kill "${DAEMON_PID:-}" 2>/dev/null || true; } >/dev/null 2>&1
+  { kill "${UPSTREAM_PID:-}" 2>/dev/null || true; } >/dev/null 2>&1
+  pkill -f "budi-daemon serve --host 127.0.0.1 --port $DAEMON_PORT" >/dev/null 2>&1 || true
+  pkill -f "mock_upstream.py $UPSTREAM_PORT" >/dev/null 2>&1 || true
+  if [[ "${KEEP_TMP:-0}" == "1" ]]; then
+    echo "[e2e] leaving tmp: $TMPDIR_ROOT"
+  else
+    rm -rf "$TMPDIR_ROOT"
+  fi
+  exit $status
+}
+trap cleanup EXIT INT TERM
+
+echo "[e2e] HOME=$HOME"
+
+REPO_ROOT="$HOME/repo"
+mkdir -p "$REPO_ROOT/.budi"
+cat >"$REPO_ROOT/.budi/budi.toml" <<EOF
+daemon_host = "127.0.0.1"
+daemon_port = $DAEMON_PORT
+
+[proxy]
+enabled = true
+port = $PROXY_PORT
+EOF
+(cd "$REPO_ROOT" && git init -q 2>/dev/null || true)
+
+cat >"$TMPDIR_ROOT/mock_upstream.py" <<'PY'
+import http.server, json, sys
+
+class H(http.server.BaseHTTPRequestHandler):
+    def do_POST(self):
+        n = int(self.headers.get("Content-Length", "0") or 0)
+        _ = self.rfile.read(n)
+        body = {
+            "id": "msg_e2e_221",
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-sonnet-4-6",
+            "content": [{"type": "text", "text": "ok"}],
+            "stop_reason": "end_turn",
+            "usage": {"input_tokens": 42, "output_tokens": 7,
+                      "cache_creation_input_tokens": 0,
+                      "cache_read_input_tokens": 0},
+        }
+        payload = json.dumps(body).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def log_message(self, *a, **k):
+        pass
+
+port = int(sys.argv[1])
+http.server.HTTPServer(("127.0.0.1", port), H).serve_forever()
+PY
+
+echo "[e2e] starting mock upstream on :$UPSTREAM_PORT"
+python3 "$TMPDIR_ROOT/mock_upstream.py" "$UPSTREAM_PORT" >"$TMPDIR_ROOT/upstream.log" 2>&1 &
+UPSTREAM_PID=$!
+for _ in {1..30}; do
+  if curl -s -o /dev/null -w "%{http_code}" --max-time 1 "http://127.0.0.1:$UPSTREAM_PORT/" | grep -qE "^[45]"; then
+    break
+  fi
+  sleep 0.1
+done
+
+echo "[e2e] starting budi-daemon on :$DAEMON_PORT / proxy :$PROXY_PORT"
+BUDI_ANTHROPIC_UPSTREAM="http://127.0.0.1:$UPSTREAM_PORT" \
+BUDI_OPENAI_UPSTREAM="http://127.0.0.1:$UPSTREAM_PORT" \
+RUST_LOG=info \
+  "$BUDI_DAEMON" serve \
+    --host 127.0.0.1 \
+    --port $DAEMON_PORT \
+    --proxy-port $PROXY_PORT \
+    >"$TMPDIR_ROOT/daemon.log" 2>&1 &
+DAEMON_PID=$!
+
+for _ in {1..50}; do
+  if curl -s -o /dev/null -w "%{http_code}" --max-time 1 "http://127.0.0.1:$DAEMON_PORT/health" | grep -q "^200"; then
+    break
+  fi
+  sleep 0.1
+done
+for _ in {1..50}; do
+  if curl -s -o /dev/null -w "%{http_code}" --max-time 1 -X POST -H "content-type: application/json" -d '{}' "http://127.0.0.1:$PROXY_PORT/v1/messages" | grep -qE "^(2|4|5)[0-9]{2}$"; then
+    break
+  fi
+  sleep 0.1
+done
+
+TS="$(date +%s)"
+ALPHA_SESSION="e2e-221-alpha-$TS"
+NUM_SESSION="e2e-221-numeric-$TS"
+MAIN_SESSION="e2e-221-main-$TS"
+
+ALPHA_BRANCH="PROJ-221-ticket-attribution"
+NUM_BRANCH="feature/1234"
+MAIN_BRANCH="main"
+
+send() {
+  local label="$1"; local session="$2"; local branch="$3"
+  echo "[e2e] proxy request: $label (session=$session, branch=$branch)"
+  local status
+  status=$(curl -s -o "$TMPDIR_ROOT/${label}.json" -w "%{http_code}" --max-time 5 \
+    -X POST \
+    -H "content-type: application/json" \
+    -H "x-budi-session: $session" \
+    -H "x-budi-branch: $branch" \
+    -H "x-budi-repo: github.com/siropkin/budi" \
+    -d '{"model":"claude-sonnet-4-6","messages":[{"role":"user","content":"hi"}]}' \
+    "http://127.0.0.1:$PROXY_PORT/v1/messages")
+  if [[ "$status" != "200" ]]; then
+    echo "[e2e] FAIL: $label returned $status" >&2
+    tail -n 60 "$TMPDIR_ROOT/daemon.log" >&2 || true
+    exit 1
+  fi
+}
+
+send "alpha"    "$ALPHA_SESSION" "$ALPHA_BRANCH"
+send "numeric"  "$NUM_SESSION"   "$NUM_BRANCH"
+send "main"     "$MAIN_SESSION"  "$MAIN_BRANCH"
+
+# Let spawn_blocking DB writes land.
+sleep 1
+
+DB="$HOME/.local/share/budi/analytics.db"
+if [[ ! -f "$DB" ]]; then
+  echo "[e2e] FAIL: analytics DB missing at $DB" >&2
+  tail -n 40 "$TMPDIR_ROOT/daemon.log" >&2 || true
+  exit 1
+fi
+
+tag_value() {
+  local mid="$1"; local key="$2"
+  sqlite3 "$DB" "SELECT value FROM tags WHERE message_id = '$mid' AND key = '$key' LIMIT 1;"
+}
+
+tag_count() {
+  local mid="$1"; local key="$2"
+  sqlite3 "$DB" "SELECT COUNT(*) FROM tags WHERE message_id = '$mid' AND key = '$key';"
+}
+
+# --- 1. Alphanumeric branch -> ticket_id + ticket_prefix + ticket_source=branch.
+MSG_ALPHA=$(sqlite3 "$DB" "SELECT id FROM messages WHERE session_id = '$ALPHA_SESSION' ORDER BY timestamp DESC LIMIT 1;")
+if [[ -z "$MSG_ALPHA" ]]; then
+  echo "[e2e] FAIL: no message row for alpha session" >&2
+  exit 1
+fi
+
+TID_A=$(tag_value "$MSG_ALPHA" ticket_id)
+TPREF_A=$(tag_value "$MSG_ALPHA" ticket_prefix)
+TSRC_A=$(tag_value "$MSG_ALPHA" ticket_source)
+echo "[e2e] alpha row tags: ticket_id=$TID_A ticket_prefix=$TPREF_A ticket_source=$TSRC_A"
+
+if [[ "$TID_A" != "PROJ-221" ]]; then
+  echo "[e2e] FAIL: expected ticket_id=PROJ-221 on alpha row, got '$TID_A'" >&2
+  sqlite3 "$DB" "SELECT key, value FROM tags WHERE message_id = '$MSG_ALPHA';" >&2
+  exit 1
+fi
+if [[ "$TPREF_A" != "PROJ" ]]; then
+  echo "[e2e] FAIL: expected ticket_prefix=PROJ on alpha row, got '$TPREF_A'" >&2
+  exit 1
+fi
+if [[ "$TSRC_A" != "branch" ]]; then
+  echo "[e2e] FAIL: expected ticket_source=branch on alpha row, got '$TSRC_A'" >&2
+  exit 1
+fi
+echo "[e2e] OK: alpha branch -> ticket_id/prefix/source all present and correct"
+
+# --- 2. Numeric-only branch -> ticket_id=1234, ticket_source=branch_numeric,
+#        and NO ticket_prefix (there is no alphabetic prefix).
+MSG_NUM=$(sqlite3 "$DB" "SELECT id FROM messages WHERE session_id = '$NUM_SESSION' ORDER BY timestamp DESC LIMIT 1;")
+if [[ -z "$MSG_NUM" ]]; then
+  echo "[e2e] FAIL: no message row for numeric session" >&2
+  exit 1
+fi
+
+TID_N=$(tag_value "$MSG_NUM" ticket_id)
+TSRC_N=$(tag_value "$MSG_NUM" ticket_source)
+TPREF_N_COUNT=$(tag_count "$MSG_NUM" ticket_prefix)
+echo "[e2e] numeric row tags: ticket_id=$TID_N ticket_source=$TSRC_N ticket_prefix_count=$TPREF_N_COUNT"
+
+if [[ "$TID_N" != "1234" ]]; then
+  echo "[e2e] FAIL: expected ticket_id=1234 on numeric row, got '$TID_N'" >&2
+  sqlite3 "$DB" "SELECT key, value FROM tags WHERE message_id = '$MSG_NUM';" >&2
+  exit 1
+fi
+if [[ "$TSRC_N" != "branch_numeric" ]]; then
+  echo "[e2e] FAIL: expected ticket_source=branch_numeric on numeric row, got '$TSRC_N'" >&2
+  echo "[e2e] (this guards the R1.3 unified extractor — pre-R1.3 the proxy wrote no source at all)" >&2
+  exit 1
+fi
+if [[ "$TPREF_N_COUNT" != "0" ]]; then
+  echo "[e2e] FAIL: expected no ticket_prefix on numeric-only ticket, got $TPREF_N_COUNT" >&2
+  exit 1
+fi
+echo "[e2e] OK: numeric branch -> ticket_id=1234 source=branch_numeric, no prefix"
+
+# --- 3. `main` branch -> no ticket tags at all.
+MSG_MAIN=$(sqlite3 "$DB" "SELECT id FROM messages WHERE session_id = '$MAIN_SESSION' ORDER BY timestamp DESC LIMIT 1;")
+TID_M_COUNT=$(tag_count "$MSG_MAIN" ticket_id)
+TSRC_M_COUNT=$(tag_count "$MSG_MAIN" ticket_source)
+echo "[e2e] main row tag counts: ticket_id=$TID_M_COUNT ticket_source=$TSRC_M_COUNT"
+if [[ "$TID_M_COUNT" != "0" ]]; then
+  echo "[e2e] FAIL: 'main' should never emit a ticket_id tag, got $TID_M_COUNT" >&2
+  sqlite3 "$DB" "SELECT key, value FROM tags WHERE message_id = '$MSG_MAIN';" >&2
+  exit 1
+fi
+if [[ "$TSRC_M_COUNT" != "0" ]]; then
+  echo "[e2e] FAIL: 'main' should never emit a ticket_source tag, got $TSRC_M_COUNT" >&2
+  exit 1
+fi
+echo "[e2e] OK: integration branch 'main' emits no ticket_* tags"
+
+# --- 4. No row, anywhere, carries the legacy "Unassigned" sentinel on
+#        the ticket_id key. Pre-R1.3 the proxy wrote that literal when
+#        attribution failed; R1.3 drops it on write.
+UNASSIGNED=$(sqlite3 "$DB" "SELECT COUNT(*) FROM tags WHERE key = 'ticket_id' AND value = 'Unassigned';")
+if [[ "$UNASSIGNED" != "0" ]]; then
+  echo "[e2e] FAIL: 'Unassigned' ticket_id sentinel leaked into DB ($UNASSIGNED rows)" >&2
+  sqlite3 "$DB" "SELECT message_id, key, value FROM tags WHERE key = 'ticket_id' AND value = 'Unassigned';" >&2
+  exit 1
+fi
+echo "[e2e] OK: no 'Unassigned' ticket_id rows (legacy sentinel retired)"
+
+# --- 5. /analytics/tickets surfaces the dominant source per ticket.
+SINCE_TS="$(date -u -v0H -v0M -v0S +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+           || date -u --date="today 00:00:00" +%Y-%m-%dT%H:%M:%SZ)"
+TICKETS_JSON="$(curl -s --max-time 5 \
+  "http://127.0.0.1:$DAEMON_PORT/analytics/tickets?limit=20&since=$SINCE_TS")"
+echo "[e2e] /analytics/tickets -> $TICKETS_JSON"
+
+python3 - "$TICKETS_JSON" <<'PY'
+import json, sys
+data = json.loads(sys.argv[1])
+by_id = {row["ticket_id"]: row for row in data}
+
+missing = [t for t in ("PROJ-221", "1234") if t not in by_id]
+if missing:
+    print(f"[e2e] FAIL: /analytics/tickets missing rows for: {missing}")
+    print(f"       saw: {sorted(by_id.keys())}")
+    sys.exit(1)
+
+alpha = by_id["PROJ-221"]
+num = by_id["1234"]
+
+if alpha.get("source") != "branch":
+    print(f"[e2e] FAIL: PROJ-221 source should be 'branch', got {alpha.get('source')!r}")
+    sys.exit(1)
+if num.get("source") != "branch_numeric":
+    print(f"[e2e] FAIL: 1234 source should be 'branch_numeric', got {num.get('source')!r}")
+    print("       (this guards the R1.3 analytics loader: ticket_source must "
+          "propagate from the tags table to the API response)")
+    sys.exit(1)
+
+# The integration-branch request must land in `(untagged)`, not a separate
+# `Unassigned` bucket.
+if "Unassigned" in by_id:
+    print("[e2e] FAIL: /analytics/tickets surfaced a legacy 'Unassigned' bucket")
+    sys.exit(1)
+if "(untagged)" not in by_id:
+    print(f"[e2e] FAIL: /analytics/tickets missing '(untagged)' bucket; saw {sorted(by_id.keys())}")
+    sys.exit(1)
+if by_id["(untagged)"].get("source"):
+    print(f"[e2e] FAIL: (untagged) row should have empty source, got {by_id['(untagged)'].get('source')!r}")
+    sys.exit(1)
+
+print(f"[e2e] OK: /analytics/tickets carries sources "
+      f"(PROJ-221={alpha['source']}, 1234={num['source']}, "
+      f"(untagged)={by_id['(untagged)'].get('source')!r})")
+PY
+
+# --- 6. /analytics/tickets/{id} echoes the dominant source in the detail
+#        payload — this feeds the `Source` row in `budi stats --ticket <ID>`.
+DETAIL_ALPHA="$(curl -s --max-time 5 \
+  "http://127.0.0.1:$DAEMON_PORT/analytics/tickets/PROJ-221?since=$SINCE_TS")"
+DETAIL_NUM="$(curl -s --max-time 5 \
+  "http://127.0.0.1:$DAEMON_PORT/analytics/tickets/1234?since=$SINCE_TS")"
+echo "[e2e] /analytics/tickets/PROJ-221 -> $DETAIL_ALPHA"
+echo "[e2e] /analytics/tickets/1234 -> $DETAIL_NUM"
+
+python3 - "$DETAIL_ALPHA" "$DETAIL_NUM" <<'PY'
+import json, sys
+alpha = json.loads(sys.argv[1])
+num = json.loads(sys.argv[2])
+
+if alpha.get("source") != "branch":
+    print(f"[e2e] FAIL: PROJ-221 detail source should be 'branch', got {alpha.get('source')!r}")
+    sys.exit(1)
+if num.get("source") != "branch_numeric":
+    print(f"[e2e] FAIL: 1234 detail source should be 'branch_numeric', got {num.get('source')!r}")
+    sys.exit(1)
+print("[e2e] OK: /analytics/tickets/{id} returns matching sources for both tickets")
+PY
+
+echo "[e2e] PASS"


### PR DESCRIPTION
## Summary

Closes #221.

R1.3 promotes `ticket_source` to a first-class sibling of `ticket_id` and
unifies the extractor so branch-derived ticket attribution is consistent
across ingestion paths.

- **Unified extractor** — `pipeline::extract_ticket_from_branch` is now the
  single source of truth for both `GitEnricher` (batch pipeline) and
  `ProxyAttribution::resolve` (live proxy). It (1) filters integration
  branches (`main`, `master`, `develop`, `HEAD`), (2) prefers the canonical
  alphanumeric pattern (e.g. `ENG-123`, `PAVA-2120`), then (3) falls back to
  numeric-only ids (e.g. `feature/1234`, `42-quick-fix`). Before R1.3 these
  rules diverged: the pipeline only accepted alphanumeric, the proxy had a
  parallel numeric extractor.
- **Explainable source** — every emitted `ticket_id` tag is paired with a
  `ticket_source` tag (`branch` for the alphanumeric pattern,
  `branch_numeric` for the numeric fallback), mirroring the R1.2
  `activity_source`/`activity_confidence` contract. The `TICKET_SOURCE`
  tag key is added alongside `TICKET_ID` and `TICKET_PREFIX`.
- **Retire the `Unassigned` literal** — the proxy path used to write a
  literal `ticket_id = "Unassigned"` when attribution failed, creating a
  confusing second bucket next to `(untagged)`. The resolver now returns
  an empty ticket id, `insert_proxy_message` skips the tag entirely, and
  a compat check drops any legacy `"Unassigned"` values still arriving
  from older clients. Unattributed messages surface uniformly as
  `(untagged)` in all tickets views.
- **Analytics surfaces** — `TicketCost` and `TicketCostDetail` gain a
  `source` field populated from the dominant `ticket_source` per ticket
  (by cost, then name). Legacy rows that only carry a `ticket_id` tag
  default to `branch` so older DBs stay readable without a reindex. The
  `(untagged)` row's source is empty.
- **CLI** — `budi stats --tickets` grows a `src=…` column; `budi stats
  --ticket <ID>` gains a `Source` row.
- **Docs** — `SOUL.md` now documents the R1.3 ticket attribution contract
  (single extractor, paired `ticket_source`, `Unassigned` retirement,
  legacy fallback).

## Risks / compatibility notes

- **DB schema** — no schema changes. `ticket_source` is just a new tag
  key in the existing `tags` table. Rows written before this change have
  a `ticket_id` without a sibling `ticket_source`; both loaders fall
  back to `branch`, which matches pre-R1.3 behaviour (the pipeline was
  alphanumeric-only).
- **Legacy `Unassigned`** — `insert_proxy_message` explicitly drops the
  legacy `"Unassigned"` value so stale clients do not resurrect the
  bucket. Existing rows in old DBs that still carry the literal
  `"Unassigned"` ticket id are left alone (no migration) but the loader
  treats them as any other ticket — users can still run
  `budi stats --ticket Unassigned` if they want to inspect old data.
- **Serde** — `ProxyAttribution.ticket_source`, `ProxyEvent.ticket_source`,
  `TicketCost.source`, and `TicketCostDetail.source` all default to empty
  via `#[serde(default)]`, so on-disk proxy events recorded before this
  change deserialize cleanly and replayed events produce no source tag.
- **Numeric fallback behavioural change** — pipeline ingest now recognises
  numeric-only branch ids where it previously did not. This is an
  intentional R1.3 goal; existing `(untagged)` messages in that shape
  will start attributing on the next ingest. `(untagged)` totals can drop
  on re-import as a result.

## Validation

- `cargo fmt --all`
- `cargo clippy --workspace --all-targets --locked -- -D warnings` — clean
- `cargo test --workspace --locked` — 376 + 26 tests pass, including the
  new R1.3 coverage:
  - `pipeline::tests::extract_ticket_from_branch_*` — alpha vs numeric
    precedence, integration branches rejected, empty input, no-ticket
    branches.
  - `pipeline::enrichers::tests::git_enricher_extracts_ticket` /
    `..._extracts_numeric_only_ticket` — `TICKET_SOURCE` tag emitted with
    the right value.
  - `proxy::tests::attribution_resolve_*` — empty / detached-HEAD /
    numeric-only / main/master/develop cases.
  - `proxy::tests::insert_proxy_message_*` — numeric ticket source
    written, `Unassigned` legacy sentinel dropped, no-ticket rows skip
    all ticket tags.
  - `analytics::tests::ticket_cost_surfaces_source_per_ticket`,
    `..._defaults_legacy_source_to_branch`, `..._untagged_row_has_empty_source`,
    `ticket_cost_single_surfaces_source`, `..._legacy_source_defaults_to_branch`.

Made with [Cursor](https://cursor.com)