### PR TITLE
[8.1][R1.4] Track file-level attribution from tool activity (#292)

### DIFF
--- a/SOUL.md
+++ b/SOUL.md
@@ -269,6 +269,46 @@ in [#302](https://github.com/siropkin/budi/issues/302) / #303 / #304 / #305):
     mirror the ticket endpoints so future cloud/dashboard work can adopt
     the same data contract.
 
+- **`file_path`** — per-file attribution added in R1.4
+  ([#292](https://github.com/siropkin/budi/issues/292)). When an assistant
+  message uses a file-aware tool (Claude Code's `Read` / `Write` / `Edit` /
+  `MultiEdit` / `NotebookEdit` / `Grep` / `Glob`, Cursor's `edit_file` /
+  `read_file` / `write_file` / `search_replace` / `delete_file` / …) the
+  pipeline extracts raw candidate paths from the tool-call arguments and
+  runs them through `file_attribution::attribute_files`, which:
+    1. Rejects URL schemes other than `file://`.
+    2. Normalizes Windows separators to forward slashes.
+    3. Strips absolute paths against the message's `cwd` / resolved repo
+       root. Anything that cannot be proven to sit inside the repo root
+       is **dropped** — we never record outside-of-repo paths, mtimes,
+       sizes, or file contents. See
+       [ADR-0083](docs/adr/0083-privacy-constraints.md).
+    4. Collapses `.` / `..` segments; traversals that would escape the
+       repo are dropped.
+    5. Caps per-message tag fan-out at
+       `file_attribution::MAX_FILES_PER_MESSAGE` (16) to keep payloads
+       small on pathological Grep/Glob output.
+
+  Every accepted path is emitted as a `file_path` tag (multi-valued);
+  a sibling `file_path_source` (`tool_arg` when the path came directly
+  from a known argument, `cwd_relative` when it was normalized from an
+  absolute path against the message cwd) and `file_path_confidence`
+  (`high` / `medium`) are written once per message so provenance is
+  queryable the same way as `ticket_source` / `activity_source`.
+
+  Surfaces:
+  - `budi stats --files` — files ranked by cost, with `(untagged)`
+    bucket and a `src=…` column showing the dominant source. Long
+    paths are truncated in the CLI output; full paths stay available
+    via `--file <PATH>` and `--format json`.
+  - `budi stats --file <PATH>` — detail view with per-branch **and**
+    per-ticket breakdowns, so you can see which tickets charged cost
+    to a particular file.
+  - `GET /analytics/files` and `/analytics/files/{*path}` mirror the
+    ticket / activity endpoints; the path segment is validated to be
+    repo-relative (no leading `/`, no `..`, no Windows separators, no
+    URL scheme) before hitting SQLite.
+
 `budi doctor` runs three attribution checks:
 
 - **Session visibility** for the `today`, `7d`, and `30d` windows (R1.0.1,
@@ -333,12 +373,12 @@ in [#302](https://github.com/siropkin/budi/issues/302) / #303 / #304 / #305):
 - CostEnricher is the single source of truth for cost - sets cost_cents during pipeline. Skips if cost already set (API data)
 - `budi init` prompts for per-agent enablement (Claude Code, Codex CLI, Cursor, Copilot CLI), persists choices to `~/.config/budi/agents.toml`, and auto-configures proxy routing for enabled agents (shell profile + Cursor/Codex settings). `budi enable/disable <agent>` updates this config later. Legacy installs (no `agents.toml`) treat all available agents as enabled for backward compatibility. After configuring CLI agents (Claude, Codex, Copilot), both `budi init` and `budi enable` warn that a shell restart is required for proxy env vars to take effect and suggest `budi launch <agent>` for immediate routing. `budi doctor` detects when proxy env vars are configured in the shell profile but not set in the current process.
 - `budi init` configures integrations (statusline, extension) for enabled agents
-- Tags are auto-detected (`provider`, `model`, `tool`, `tool_use_id`, `ticket_id`, `activity`, and conditional tags like `cost_confidence` / `speed`) + custom rules via `~/.config/budi/tags.toml`
+- Tags are auto-detected (`provider`, `model`, `tool`, `tool_use_id`, `ticket_id`, `ticket_source`, `activity`, `activity_source`, `activity_confidence`, `file_path`, `file_path_source`, `file_path_confidence`, and conditional tags like `cost_confidence` / `speed`) + custom rules via `~/.config/budi/tags.toml`
 - git_branch is a column on messages (not a tag) for fast queries
 - **Session health**: Four vitals computed per session - context growth (context-size growth), cache reuse (cache hit rate), cost acceleration (per-reply cost growth), retry loops (currently disabled — hook ingestion removed in 8.0; `hook_events` table no longer exists in schema v1). Each vital has green/yellow/red state. New sessions start green - the default is always positive; vitals only degrade to yellow/red when there is clear evidence of a problem. Tips are provider-aware via `ProviderKind` enum (Claude Code -> `/compact`/`/clear`, Cursor -> "new composer session", Other -> neutral). When no session ID is provided, health auto-select prefers the latest session with assistant activity, then falls back to session timestamps. Statusline "coach" mode shows health icon + session cost + tip. Dashboard session detail page has a health panel with vitals grid and tips section.
 - **Cursor extension** ([siropkin/budi-cursor](https://github.com/siropkin/budi-cursor)): VS Code extension that shows session health in the status bar (aggregated health circles) and a side panel (session details, vitals, tips, session list). Installed via VS Code Marketplace or `budi integrations install --with cursor-extension`. Communicates with daemon via HTTP and spawns `budi statusline --format json`. Writes `~/.local/share/budi/cursor-sessions.json` (v1 contract, ADR-0086 §3.4) to signal the active workspace. Checks daemon `api_version` on startup and warns if incompatible.
 - **Cloud dashboard** ([siropkin/budi-cloud](https://github.com/siropkin/budi-cloud)) is a Next.js 16 app deployed to app.getbudi.dev. Uses Supabase Auth (GitHub/Google/magic link) for web sign-in. Dashboard pages: Overview, Team, Models, Repos, Sessions, Settings. Manager role sees all org data; member sees own data.
-- Analytics endpoints: `/analytics/summary`, `/analytics/filter-options`, `/analytics/messages`, `/analytics/messages/{message_uuid}/detail`, `/analytics/projects`, `/analytics/cost`, `/analytics/models`, `/analytics/activity` (activity chart timeline), `/analytics/activities`, `/analytics/activities/{name}` (activity buckets — #305), `/analytics/branches`, `/analytics/branches/{branch}`, `/analytics/tickets`, `/analytics/tickets/{ticket_id}`, `/analytics/tags`, `/analytics/providers`, `/analytics/statusline`, `/analytics/cache-efficiency`, `/analytics/session-cost-curve`, `/analytics/cost-confidence`, `/analytics/subagent-cost`, `/analytics/sessions`, `/analytics/sessions/{id}`, `/analytics/sessions/{id}/messages`, `/analytics/sessions/{id}/curve`, `/analytics/sessions/{id}/tags`, `/analytics/session-health`, `/analytics/session-audit` (session attribution stats for debugging ingestion)
+- Analytics endpoints: `/analytics/summary`, `/analytics/filter-options`, `/analytics/messages`, `/analytics/messages/{message_uuid}/detail`, `/analytics/projects`, `/analytics/cost`, `/analytics/models`, `/analytics/activity` (activity chart timeline), `/analytics/activities`, `/analytics/activities/{name}` (activity buckets — #305), `/analytics/branches`, `/analytics/branches/{branch}`, `/analytics/tickets`, `/analytics/tickets/{ticket_id}`, `/analytics/files`, `/analytics/files/{*path}`, `/analytics/tags`, `/analytics/providers`, `/analytics/statusline`, `/analytics/cache-efficiency`, `/analytics/session-cost-curve`, `/analytics/cost-confidence`, `/analytics/subagent-cost`, `/analytics/sessions`, `/analytics/sessions/{id}`, `/analytics/sessions/{id}/messages`, `/analytics/sessions/{id}/curve`, `/analytics/sessions/{id}/tags`, `/analytics/session-health`, `/analytics/session-audit` (session attribution stats for debugging ingestion)
 - Admin endpoints (loopback-only): `/admin/providers` (registered providers), `/admin/schema` (schema version), `/admin/migrate` (run migration), `/admin/repair` (repair schema drift + run migration), `/admin/integrations/install` (integration installer orchestration)
 - Sync mutation endpoints (loopback-only): `/sync` (30-day), `/sync/all` (full history), `/sync/reset` (wipe sync state + full re-sync)
 - Sync status endpoint: `/sync/status` (syncing flag + last_synced)

--- a/crates/budi-cli/src/client.rs
+++ b/crates/budi-cli/src/client.rs
@@ -14,9 +14,9 @@ use std::time::Duration;
 
 use anyhow::{Context, Result};
 use budi_core::analytics::{
-    ActivityCost, ActivityCostDetail, BranchCost, ModelUsage, PaginatedSessions, ProviderStats,
-    RepoUsage, SessionHealth, SessionListEntry, SessionTag, TagCost, TicketCost, TicketCostDetail,
-    UsageSummary,
+    ActivityCost, ActivityCostDetail, BranchCost, FileCost, FileCostDetail, ModelUsage,
+    PaginatedSessions, ProviderStats, RepoUsage, SessionHealth, SessionListEntry, SessionTag,
+    TagCost, TicketCost, TicketCostDetail, UsageSummary,
 };
 use budi_core::config::{self, BudiConfig};
 use budi_core::cost::CostEstimate;
@@ -66,6 +66,29 @@ fn analytics_activity_detail_url(base_url: &str, activity: &str) -> Result<Strin
         .push("analytics")
         .push("activities")
         .push(activity);
+    Ok(url.to_string())
+}
+
+/// Build `GET .../analytics/files/{path}` with per-segment encoding.
+///
+/// File paths are repo-relative and forward-slashed (see
+/// `file_attribution::attribute_files`). We split on `/` and push each
+/// segment individually so slashes stay structural (axum's `{*file_path}`
+/// wildcard receives them as a single joined path) and every other
+/// character gets percent-encoded correctly.
+fn analytics_file_detail_url(base_url: &str, file_path: &str) -> Result<String> {
+    let normalized = format!("{}/", base_url.trim_end_matches('/'));
+    let mut url = reqwest::Url::parse(&normalized)
+        .with_context(|| format!("invalid daemon base URL: {base_url}"))?;
+    {
+        let mut segs = url
+            .path_segments_mut()
+            .map_err(|_| anyhow::anyhow!("invalid daemon base URL: {base_url}"))?;
+        segs.push("analytics").push("files");
+        for segment in file_path.split('/').filter(|s| !s.is_empty()) {
+            segs.push(segment);
+        }
+    }
     Ok(url.to_string())
 }
 
@@ -541,6 +564,70 @@ impl DaemonClient {
         }
         let url = analytics_activity_detail_url(&self.base_url, activity)
             .with_context(|| format!("invalid daemon base URL or activity: {activity:?}"))?;
+        let resp = self
+            .client
+            .get(url)
+            .query(&params)
+            .send()
+            .map_err(describe_send_error)?;
+        if resp.status() == reqwest::StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+        let resp = check_response(resp)?;
+        let val: Value = resp.json()?;
+        if val.is_null() {
+            return Ok(None);
+        }
+        Ok(Some(serde_json::from_value(val)?))
+    }
+
+    /// `GET /analytics/files` — per-file cost roll-up. Used by
+    /// `budi stats --files`. Mirrors `tickets` / `activities`.
+    pub fn files(
+        &self,
+        since: Option<&str>,
+        until: Option<&str>,
+        limit: usize,
+    ) -> Result<Vec<FileCost>> {
+        let mut params: Vec<(&str, String)> = Vec::new();
+        if let Some(s) = since {
+            params.push(("since", s.to_string()));
+        }
+        if let Some(u) = until {
+            params.push(("until", u.to_string()));
+        }
+        params.push(("limit", limit.to_string()));
+        let resp = self
+            .client
+            .get(format!("{}/analytics/files", self.base_url))
+            .query(&params)
+            .send()
+            .map_err(describe_send_error)?;
+        let resp = check_response(resp)?;
+        Ok(resp.json()?)
+    }
+
+    /// `GET /analytics/files/{path}` — single-file detail with per-branch
+    /// and per-ticket breakdowns. Returns `Ok(None)` for an unknown file.
+    pub fn file_detail(
+        &self,
+        file_path: &str,
+        repo_id: Option<&str>,
+        since: Option<&str>,
+        until: Option<&str>,
+    ) -> Result<Option<FileCostDetail>> {
+        let mut params: Vec<(&str, &str)> = Vec::new();
+        if let Some(repo) = repo_id {
+            params.push(("repo_id", repo));
+        }
+        if let Some(s) = since {
+            params.push(("since", s));
+        }
+        if let Some(u) = until {
+            params.push(("until", u));
+        }
+        let url = analytics_file_detail_url(&self.base_url, file_path)
+            .with_context(|| format!("invalid daemon base URL or file: {file_path:?}"))?;
         let resp = self
             .client
             .get(url)

--- a/crates/budi-cli/src/commands/stats.rs
+++ b/crates/budi-cli/src/commands/stats.rs
@@ -60,6 +60,8 @@ pub fn cmd_stats(
     ticket: Option<String>,
     activities: bool,
     activity: Option<String>,
+    files: bool,
+    file: Option<String>,
     repo: Option<String>,
     models: bool,
     provider: Option<String>,
@@ -71,13 +73,27 @@ pub fn cmd_stats(
     // user-friendly shortcuts that resolve to their canonical form.
     let provider = provider.map(|p| normalize_provider(&p)).transpose()?;
 
-    // `--repo` is a filter for `--branch`, `--ticket`, or `--activity` —
-    // surface the misuse early instead of silently ignoring it. Clap's
-    // `requires` only takes a single arg, so the cross-flag check lives here.
-    if repo.is_some() && branch.is_none() && ticket.is_none() && activity.is_none() {
+    // `--repo` is a filter for `--branch`, `--ticket`, `--activity`, or
+    // `--file` — surface the misuse early instead of silently ignoring it.
+    // Clap's `requires` only takes a single arg, so the cross-flag check
+    // lives here.
+    if repo.is_some()
+        && branch.is_none()
+        && ticket.is_none()
+        && activity.is_none()
+        && file.is_none()
+    {
         anyhow::bail!(
-            "--repo requires --branch <NAME>, --ticket <ID>, or --activity <NAME> to scope the filter"
+            "--repo requires --branch <NAME>, --ticket <ID>, --activity <NAME>, or --file <PATH> to scope the filter"
         );
+    }
+
+    // `--file <PATH>` must be a repo-relative forward-slashed path. The
+    // pipeline never stores absolute / traversal paths (see ADR-0083 and
+    // `file_attribution::normalize_one`), so validate early with a clear
+    // error rather than silently returning "file not found".
+    if let Some(ref f) = file {
+        validate_file_path_arg(f)?;
     }
 
     let client = DaemonClient::connect().context(
@@ -86,6 +102,14 @@ pub fn cmd_stats(
 
     if let Some(ref tag_filter) = tag {
         return cmd_stats_tags(&client, period, tag_filter, json_output);
+    }
+
+    if let Some(ref f) = file {
+        return cmd_stats_file_detail(&client, period, f, repo.as_deref(), json_output);
+    }
+
+    if files {
+        return cmd_stats_files(&client, period, json_output);
     }
 
     if let Some(ref ac) = activity {
@@ -835,6 +859,225 @@ fn cmd_stats_activity_detail(
             println!("  No data found for activity '{}'.", activity);
             println!("  Tip: run `budi import` first if you haven't imported data yet.");
             println!("  Run `budi stats --activities` to see available activities.");
+        }
+    }
+
+    println!();
+    Ok(())
+}
+
+/// Validate a `--file <PATH>` argument. Rejects absolute paths, paths
+/// with `..` traversal, Windows separators, and URL schemes. The
+/// pipeline would never emit such a value as a `file_path` tag
+/// (`file_attribution::normalize_one` strips them), so surfacing a clear
+/// error here is more useful than a silent 404 from the daemon.
+fn validate_file_path_arg(path: &str) -> Result<()> {
+    let trimmed = path.trim();
+    if trimmed.is_empty() {
+        anyhow::bail!("--file path must not be empty");
+    }
+    if trimmed.starts_with('/') {
+        anyhow::bail!(
+            "--file must be a repo-relative path (no leading '/'); try a path like src/main.rs"
+        );
+    }
+    if trimmed.contains('\\') {
+        anyhow::bail!("--file path uses forward slashes only, even on Windows");
+    }
+    if trimmed.contains("..") {
+        anyhow::bail!("--file path must not contain '..' (repo-relative only)");
+    }
+    if trimmed.contains("://") {
+        anyhow::bail!("--file path must not contain a URL scheme");
+    }
+    Ok(())
+}
+
+/// `--files` list view. Mirrors `cmd_stats_tickets` / `cmd_stats_activities`:
+/// files come from the `file_path` tag emitted by `FileEnricher` when an
+/// assistant message's tool-call arguments point inside the repo root. The
+/// output always carries an `(untagged)` row so users can see how much
+/// activity isn't attributed to a file — that bucket should shrink as
+/// tool-arg coverage improves. Added in R1.4 (#292).
+fn cmd_stats_files(client: &DaemonClient, period: StatsPeriod, json_output: bool) -> Result<()> {
+    let (since, until) = period_date_range(period);
+    let files = client.files(since.as_deref(), until.as_deref(), 30)?;
+
+    if json_output {
+        println!("{}", serde_json::to_string_pretty(&files)?);
+        return Ok(());
+    }
+
+    let period_label = period_label(period);
+
+    let bold_cyan = ansi("\x1b[1;36m");
+    let bold = ansi("\x1b[1m");
+    let dim = ansi("\x1b[90m");
+    let cyan = ansi("\x1b[36m");
+    let yellow = ansi("\x1b[33m");
+    let reset = ansi("\x1b[0m");
+
+    println!();
+    println!("  {bold_cyan} Files{reset} — {bold}{}{reset}", period_label);
+    println!("  {dim}{}{reset}", "─".repeat(72));
+
+    if files.is_empty() {
+        println!("  No file data for this period.");
+        println!(
+            "  Tip: file paths are extracted from tool-call arguments (Read/Write/Edit, etc)."
+        );
+        println!();
+        return Ok(());
+    }
+
+    let max_cost = files
+        .iter()
+        .map(|f| f.cost_cents)
+        .fold(0.0_f64, f64::max)
+        .max(0.01);
+    for f in &files {
+        let bar_len = ((f.cost_cents / max_cost) * 16.0) as usize;
+        let bar: String = "\u{2588}".repeat(bar_len);
+        let ticket_label = if f.top_ticket_id.is_empty() {
+            "--".to_string()
+        } else {
+            f.top_ticket_id.clone()
+        };
+        let source_label = if f.source.is_empty() {
+            "--".to_string()
+        } else {
+            f.source.clone()
+        };
+        // Truncate very long paths so the row stays readable in narrow
+        // terminals. Full paths remain visible via `--file <PATH>` and
+        // `--format json`.
+        let path_label = if f.file_path.chars().count() > 40 {
+            let tail: String = f.file_path.chars().rev().take(37).collect();
+            let tail: String = tail.chars().rev().collect();
+            format!("…{tail}")
+        } else {
+            f.file_path.clone()
+        };
+        println!(
+            "    {bold}{:<40}{reset} {yellow}{:>8}{reset}  {dim}src={:<12}{reset}  {dim}{:<14}{reset}  {cyan}{}{reset}",
+            path_label,
+            format_cost_cents(f.cost_cents),
+            source_label,
+            ticket_label,
+            bar
+        );
+    }
+
+    println!();
+    Ok(())
+}
+
+/// `--file <PATH>` detail view. Mirrors `cmd_stats_ticket_detail`, plus a
+/// per-ticket breakdown so users can see which tickets drove cost on a
+/// particular file (complements the per-branch view).
+fn cmd_stats_file_detail(
+    client: &DaemonClient,
+    period: StatsPeriod,
+    file_path: &str,
+    repo: Option<&str>,
+    json_output: bool,
+) -> Result<()> {
+    let (since, until) = period_date_range(period);
+    let result = client.file_detail(file_path, repo, since.as_deref(), until.as_deref())?;
+
+    if json_output {
+        println!("{}", serde_json::to_string_pretty(&result)?);
+        return Ok(());
+    }
+
+    let period_label = period_label(period);
+
+    let bold_cyan = ansi("\x1b[1;36m");
+    let bold = ansi("\x1b[1m");
+    let dim = ansi("\x1b[90m");
+    let yellow = ansi("\x1b[33m");
+    let reset = ansi("\x1b[0m");
+
+    println!();
+    println!(
+        "  {bold_cyan} File{reset} {bold}{}{reset} — {dim}{}{reset}",
+        file_path, period_label
+    );
+    if let Some(repo_id) = repo {
+        println!("  {bold}Repo filter{reset} {}", repo_id);
+    }
+    println!("  {dim}{}{reset}", "─".repeat(50));
+
+    match result {
+        Some(f) => {
+            if !f.repo_id.is_empty() {
+                println!("  {bold}Repo{reset}       {}", f.repo_id);
+            }
+            if !f.source.is_empty() {
+                println!(
+                    "  {bold}Source{reset}     {} {dim}(confidence: {}){reset}",
+                    f.source,
+                    if f.confidence.is_empty() {
+                        "--"
+                    } else {
+                        &f.confidence
+                    }
+                );
+            }
+            println!("  {bold}Sessions{reset}   {}", f.session_count);
+            println!("  {bold}Messages{reset}   {}", f.message_count);
+            println!(
+                "  {bold}Input{reset}      {}",
+                format_tokens(f.input_tokens)
+            );
+            println!(
+                "  {bold}Output{reset}     {}",
+                format_tokens(f.output_tokens)
+            );
+            println!(
+                "  {bold}Est. cost{reset}  {yellow}{}{reset}",
+                format_cost_cents(f.cost_cents)
+            );
+
+            if !f.branches.is_empty() {
+                println!();
+                println!("  {bold}Branches{reset}");
+                for br in &f.branches {
+                    let repo_label = if br.repo_id.is_empty() {
+                        "--".to_string()
+                    } else {
+                        br.repo_id
+                            .rsplit('/')
+                            .next()
+                            .unwrap_or(&br.repo_id)
+                            .to_string()
+                    };
+                    println!(
+                        "    {bold}{:<28}{reset} {yellow}{:>8}{reset}  {dim}{}{reset}",
+                        br.git_branch,
+                        format_cost_cents(br.cost_cents),
+                        repo_label
+                    );
+                }
+            }
+
+            if !f.tickets.is_empty() {
+                println!();
+                println!("  {bold}Tickets{reset}");
+                for tk in &f.tickets {
+                    println!(
+                        "    {bold}{:<28}{reset} {yellow}{:>8}{reset}  {dim}{} msgs{reset}",
+                        tk.ticket_id,
+                        format_cost_cents(tk.cost_cents),
+                        tk.message_count
+                    );
+                }
+            }
+        }
+        None => {
+            println!("  No data found for file '{}'.", file_path);
+            println!("  Tip: run `budi import` first if you haven't imported data yet.");
+            println!("  Run `budi stats --files` to see available files.");
         }
     }
 

--- a/crates/budi-cli/src/main.rs
+++ b/crates/budi-cli/src/main.rs
@@ -65,9 +65,9 @@ enum Commands {
         #[arg(long, hide = true)]
         repo_root: Option<PathBuf>,
     },
-    /// Show usage analytics (only one view flag at a time: --projects, --branches, --branch, --tickets, --ticket, --activities, --activity, --models, or --tag)
+    /// Show usage analytics (only one view flag at a time: --projects, --branches, --branch, --tickets, --ticket, --activities, --activity, --files, --file, --models, or --tag)
     #[command(
-        group(clap::ArgGroup::new("view").multiple(false).args(["projects", "branches", "branch", "tickets", "ticket", "activities", "activity", "models", "tag"])),
+        group(clap::ArgGroup::new("view").multiple(false).args(["projects", "branches", "branch", "tickets", "ticket", "activities", "activity", "files", "file", "models", "tag"])),
         after_help = "\
 Examples:
   budi stats                       Today's cost summary (default)
@@ -81,6 +81,8 @@ Examples:
   budi stats --ticket ENG-123 --repo github.com/acme/app
   budi stats --activities          Activities ranked by cost (today)
   budi stats --activity bugfix     Cost details for a specific activity
+  budi stats --files               Files ranked by cost (today)
+  budi stats --file src/main.rs    Cost details for a specific file
   budi stats --projects -p all     All-time project costs
   budi stats --tag activity        Raw cost breakdown by the activity tag
   budi stats --provider cursor     Filter to Cursor only
@@ -119,8 +121,21 @@ Examples:
         /// breakdown so you can see where each kind of work was done.
         #[arg(long, value_name = "NAME")]
         activity: Option<String>,
-        /// Optional repository filter for --branch, --ticket, or --activity
-        /// (recommended when names repeat across repos).
+        /// Show files ranked by cost (sourced from the `file_path` tag
+        /// emitted by the pipeline when tool-call arguments point at a
+        /// file inside the repo root). Mirrors `--tickets` / `--activities`
+        /// so file-level attribution is a first-class CLI dimension.
+        /// Added in R1.4 (#292).
+        #[arg(long, default_value_t = false)]
+        files: bool,
+        /// Show cost details for a specific file (repo-relative path,
+        /// forward-slashed, inside the repo root). Mirrors `--ticket <ID>`
+        /// and includes per-branch and per-ticket breakdowns so you can see
+        /// which tickets touched the file. Added in R1.4 (#292).
+        #[arg(long, value_name = "PATH")]
+        file: Option<String>,
+        /// Optional repository filter for --branch, --ticket, --activity,
+        /// or --file (recommended when names repeat across repos).
         #[arg(long)]
         repo: Option<String>,
         /// Show model usage breakdown
@@ -386,6 +401,8 @@ fn main() -> Result<()> {
             ticket,
             activities,
             activity,
+            files,
+            file,
             repo,
             models,
             provider,
@@ -402,6 +419,8 @@ fn main() -> Result<()> {
                 ticket,
                 activities,
                 activity,
+                files,
+                file,
                 repo,
                 models,
                 provider,
@@ -684,6 +703,73 @@ mod tests {
         match cli.command {
             Commands::Stats { activity, repo, .. } => {
                 assert_eq!(activity.as_deref(), Some("bugfix"));
+                assert_eq!(repo.as_deref(), Some("siropkin/budi"));
+            }
+            _ => panic!("expected stats command"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_stats_files_flag() {
+        let cli =
+            Cli::try_parse_from(["budi", "stats", "--files"]).expect("budi stats --files parses");
+        match cli.command {
+            Commands::Stats { files, file, .. } => {
+                assert!(files);
+                assert!(file.is_none());
+            }
+            _ => panic!("expected stats command"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_stats_file_value_flag() {
+        let cli = Cli::try_parse_from(["budi", "stats", "--file", "crates/budi-core/src/lib.rs"])
+            .expect("budi stats --file <path> parses");
+        match cli.command {
+            Commands::Stats { files, file, .. } => {
+                assert!(!files);
+                assert_eq!(file.as_deref(), Some("crates/budi-core/src/lib.rs"));
+            }
+            _ => panic!("expected stats command"),
+        }
+    }
+
+    #[test]
+    fn cli_stats_file_is_mutually_exclusive_with_other_views() {
+        // --files vs --tickets / --branches / --file / --models etc.
+        assert!(
+            Cli::try_parse_from(["budi", "stats", "--files", "--tickets"]).is_err(),
+            "--files and --tickets must be mutually exclusive"
+        );
+        assert!(
+            Cli::try_parse_from(["budi", "stats", "--files", "--activities"]).is_err(),
+            "--files and --activities must be mutually exclusive"
+        );
+        assert!(
+            Cli::try_parse_from(["budi", "stats", "--files", "--file", "x.rs"]).is_err(),
+            "--files and --file must be mutually exclusive"
+        );
+        assert!(
+            Cli::try_parse_from(["budi", "stats", "--file", "x.rs", "--models"]).is_err(),
+            "--file and --models must be mutually exclusive"
+        );
+    }
+
+    #[test]
+    fn cli_stats_file_accepts_repo_filter() {
+        let cli = Cli::try_parse_from([
+            "budi",
+            "stats",
+            "--file",
+            "src/main.rs",
+            "--repo",
+            "siropkin/budi",
+        ])
+        .expect("budi stats --file --repo parses");
+        match cli.command {
+            Commands::Stats { file, repo, .. } => {
+                assert_eq!(file.as_deref(), Some("src/main.rs"));
                 assert_eq!(repo.as_deref(), Some("siropkin/budi"));
             }
             _ => panic!("expected stats command"),

--- a/crates/budi-core/src/analytics/queries.rs
+++ b/crates/budi-core/src/analytics/queries.rs
@@ -3863,3 +3863,594 @@ fn filter_options_from_rollups(
         branches: distinct_rollup_values(conn, window, "git_branch", limit)?,
     })
 }
+
+// ---------------------------------------------------------------------------
+// Files — per-file cost attribution (R1.4, #292)
+//
+// Files come from the `file_path` tag emitted by `FileEnricher` when an
+// assistant message's tool-use arguments point at a file inside the
+// resolved repo root. The analytics layer joins `messages → tags` and
+// splits cost proportionally when a single message carries multiple
+// files, mirroring the ticket / activity roll-ups so the three dimensions
+// compose cleanly.
+// ---------------------------------------------------------------------------
+
+const FILE_TAG_KEY: &str = crate::tag_keys::FILE_PATH;
+const FILE_SOURCE_TAG_KEY: &str = crate::tag_keys::FILE_PATH_SOURCE;
+const FILE_CONFIDENCE_TAG_KEY: &str = crate::tag_keys::FILE_PATH_CONFIDENCE;
+
+/// Per-file aggregate cost row used by `GET /analytics/files` and the
+/// `budi stats --files` CLI view. Mirrors [`TicketCost`] — same shape,
+/// swapped dimension — so clients can render one component for both.
+///
+/// The list always carries an `(untagged)` row (assistant messages with
+/// no `file_path` tag) so users can see how much activity is *not*
+/// attributed to a file; that bucket should shrink as tool-arg coverage
+/// improves.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct FileCost {
+    pub file_path: String,
+    pub session_count: u64,
+    pub message_count: u64,
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub cache_read_tokens: u64,
+    pub cache_creation_tokens: u64,
+    pub cost_cents: f64,
+    /// Dominant repo (highest cost) for this file. Empty for the
+    /// `(untagged)` row or when provenance is ambiguous.
+    #[serde(default)]
+    pub top_repo_id: String,
+    /// Dominant branch (highest cost) for this file. Empty for the
+    /// `(untagged)` row.
+    #[serde(default)]
+    pub top_branch: String,
+    /// Dominant ticket id (highest cost) for this file, derived from
+    /// the same message's `ticket_id` tag. Empty when the file was not
+    /// worked on a ticket-bearing branch.
+    #[serde(default)]
+    pub top_ticket_id: String,
+    /// Dominant `file_path_source` (`tool_arg` or `cwd_relative`).
+    #[serde(default)]
+    pub source: String,
+}
+
+/// Per-branch breakdown attached to a single file detail response.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct FileBranchBreakdown {
+    pub git_branch: String,
+    pub repo_id: String,
+    pub message_count: u64,
+    pub session_count: u64,
+    pub cost_cents: f64,
+}
+
+/// Per-ticket breakdown attached to a single file detail response.
+/// Separate struct from [`FileBranchBreakdown`] so the wire format can
+/// evolve independently as ticket attribution gets richer.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct FileTicketBreakdown {
+    pub ticket_id: String,
+    pub message_count: u64,
+    pub session_count: u64,
+    pub cost_cents: f64,
+}
+
+/// Detail payload for `GET /analytics/files/{path}` and `budi stats
+/// --file <PATH>`. Mirrors [`TicketCostDetail`].
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct FileCostDetail {
+    pub file_path: String,
+    pub session_count: u64,
+    pub message_count: u64,
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub cache_read_tokens: u64,
+    pub cache_creation_tokens: u64,
+    pub cost_cents: f64,
+    pub repo_id: String,
+    pub branches: Vec<FileBranchBreakdown>,
+    pub tickets: Vec<FileTicketBreakdown>,
+    /// Dominant `file_path_source` for the selection.
+    #[serde(default)]
+    pub source: String,
+    /// Dominant `file_path_confidence` for the selection.
+    #[serde(default)]
+    pub confidence: String,
+}
+
+/// Query cost grouped by file path, sorted by cost descending. Includes
+/// an `(untagged)` bucket for assistant messages that have no `file_path`
+/// tag. Same proportional-split semantics as [`ticket_cost`].
+pub fn file_cost(
+    conn: &Connection,
+    since: Option<&str>,
+    until: Option<&str>,
+    limit: usize,
+) -> Result<Vec<FileCost>> {
+    let filters = DimensionFilters::default();
+    file_cost_with_filters(conn, since, until, &filters, limit)
+}
+
+pub fn file_cost_with_filters(
+    conn: &Connection,
+    since: Option<&str>,
+    until: Option<&str>,
+    filters: &DimensionFilters,
+    limit: usize,
+) -> Result<Vec<FileCost>> {
+    let mut conditions = vec!["m.role = 'assistant'".to_string()];
+    let mut param_values: Vec<String> = Vec::new();
+    let mut idx = 0usize;
+    if let Some(s) = since {
+        idx += 1;
+        param_values.push(s.to_string());
+        conditions.push(format!("m.timestamp >= ?{idx}"));
+    }
+    if let Some(u) = until {
+        idx += 1;
+        param_values.push(u.to_string());
+        conditions.push(format!("m.timestamp < ?{idx}"));
+    }
+    let model_expr = normalized_model_expr("m.model");
+    let project_expr = normalized_project_expr("m.repo_id");
+    let branch_expr = normalized_branch_expr("m.git_branch");
+    apply_dimension_filters(
+        &mut conditions,
+        &mut param_values,
+        filters,
+        "COALESCE(m.provider, 'claude_code')",
+        &model_expr,
+        &project_expr,
+        &branch_expr,
+    );
+    let where_clause = format!("WHERE {}", conditions.join(" AND "));
+
+    // (untagged) clause re-aliases to m2.*.
+    let untagged_conditions: Vec<String> = conditions
+        .iter()
+        .map(|c| c.replace("m.role = 'assistant'", "m2.role = 'assistant'"))
+        .collect();
+    let untagged_conditions: Vec<String> = untagged_conditions
+        .into_iter()
+        .map(|c| c.replace("m.", "m2."))
+        .collect();
+    let untagged_where = format!("WHERE {}", untagged_conditions.join(" AND "));
+
+    let limit_param_idx = param_values.len() + 1;
+    param_values.push(limit.to_string());
+
+    let sql = format!(
+        "WITH msg_val_counts AS (
+             SELECT message_id, COUNT(*) AS n_values
+             FROM tags
+             WHERE key = '{FILE_TAG_KEY}'
+             GROUP BY message_id
+         ),
+         msg_source AS (
+             SELECT message_id, MIN(value) AS source_value
+             FROM tags
+             WHERE key = '{FILE_SOURCE_TAG_KEY}'
+             GROUP BY message_id
+         ),
+         msg_ticket AS (
+             SELECT message_id, MIN(value) AS ticket_value
+             FROM tags
+             WHERE key = '{TICKET_TAG_KEY}'
+             GROUP BY message_id
+         ),
+         tagged AS (
+             SELECT t.value AS file_path,
+                    m.session_id,
+                    m.repo_id,
+                    m.git_branch,
+                    m.input_tokens,
+                    m.output_tokens,
+                    m.cache_read_tokens,
+                    m.cache_creation_tokens,
+                    m.cost_cents,
+                    mvc.n_values,
+                    COALESCE(ms.source_value, '') AS file_source,
+                    COALESCE(mt.ticket_value, '') AS ticket_value
+             FROM tags t
+             JOIN msg_val_counts mvc ON mvc.message_id = t.message_id
+             JOIN messages m ON m.id = t.message_id
+             LEFT JOIN msg_source ms ON ms.message_id = t.message_id
+             LEFT JOIN msg_ticket mt ON mt.message_id = t.message_id
+             {where_clause}
+             AND t.key = '{FILE_TAG_KEY}'
+         ),
+         per_file AS (
+             SELECT file_path,
+                    COUNT(DISTINCT session_id) AS sess,
+                    COUNT(*) AS cnt,
+                    COALESCE(SUM(input_tokens / n_values), 0) AS inp,
+                    COALESCE(SUM(output_tokens / n_values), 0) AS outp,
+                    COALESCE(SUM(cache_read_tokens / n_values), 0) AS cache_r,
+                    COALESCE(SUM(cache_creation_tokens / n_values), 0) AS cache_c,
+                    COALESCE(SUM(cost_cents / n_values), 0.0) AS cost
+             FROM tagged
+             GROUP BY file_path
+         ),
+         top_repo AS (
+             SELECT file_path,
+                    COALESCE(repo_id, '') AS repo_value,
+                    SUM(cost_cents / n_values) AS repo_cost
+             FROM tagged
+             GROUP BY file_path, repo_value
+         ),
+         top_repo_pick AS (
+             SELECT file_path, repo_value
+             FROM (
+                 SELECT file_path, repo_value, repo_cost,
+                        ROW_NUMBER() OVER (
+                            PARTITION BY file_path
+                            ORDER BY repo_cost DESC, repo_value ASC
+                        ) AS rn
+                 FROM top_repo
+                 WHERE repo_value != '' AND repo_value != 'unknown'
+             )
+             WHERE rn = 1
+         ),
+         top_branch AS (
+             SELECT file_path,
+                    CASE
+                        WHEN COALESCE(git_branch, '') LIKE 'refs/heads/%'
+                            THEN SUBSTR(COALESCE(git_branch, ''), 12)
+                        ELSE COALESCE(git_branch, '')
+                    END AS branch_value,
+                    SUM(cost_cents / n_values) AS branch_cost
+             FROM tagged
+             GROUP BY file_path, branch_value
+         ),
+         top_branch_pick AS (
+             SELECT file_path, branch_value
+             FROM (
+                 SELECT file_path, branch_value, branch_cost,
+                        ROW_NUMBER() OVER (
+                            PARTITION BY file_path
+                            ORDER BY branch_cost DESC, branch_value ASC
+                        ) AS rn
+                 FROM top_branch
+                 WHERE branch_value != ''
+             )
+             WHERE rn = 1
+         ),
+         top_ticket AS (
+             SELECT file_path,
+                    ticket_value,
+                    SUM(cost_cents / n_values) AS ticket_cost
+             FROM tagged
+             GROUP BY file_path, ticket_value
+         ),
+         top_ticket_pick AS (
+             SELECT file_path, ticket_value
+             FROM (
+                 SELECT file_path, ticket_value, ticket_cost,
+                        ROW_NUMBER() OVER (
+                            PARTITION BY file_path
+                            ORDER BY ticket_cost DESC, ticket_value ASC
+                        ) AS rn
+                 FROM top_ticket
+                 WHERE ticket_value != ''
+             )
+             WHERE rn = 1
+         ),
+         top_source AS (
+             SELECT file_path,
+                    file_source AS source_value,
+                    SUM(cost_cents / n_values) AS source_cost
+             FROM tagged
+             GROUP BY file_path, source_value
+         ),
+         top_source_pick AS (
+             SELECT file_path, source_value
+             FROM (
+                 SELECT file_path, source_value, source_cost,
+                        ROW_NUMBER() OVER (
+                            PARTITION BY file_path
+                            ORDER BY source_cost DESC, source_value ASC
+                        ) AS rn
+                 FROM top_source
+                 WHERE source_value != ''
+             )
+             WHERE rn = 1
+         )
+         SELECT pf.file_path,
+                pf.sess, pf.cnt,
+                pf.inp, pf.outp, pf.cache_r, pf.cache_c, pf.cost,
+                COALESCE(trp.repo_value, '') AS top_repo,
+                COALESCE(tbp.branch_value, '') AS top_branch,
+                COALESCE(ttp.ticket_value, '') AS top_ticket,
+                COALESCE(tsp.source_value, '') AS file_source
+         FROM per_file pf
+         LEFT JOIN top_repo_pick trp ON trp.file_path = pf.file_path
+         LEFT JOIN top_branch_pick tbp ON tbp.file_path = pf.file_path
+         LEFT JOIN top_ticket_pick ttp ON ttp.file_path = pf.file_path
+         LEFT JOIN top_source_pick tsp ON tsp.file_path = pf.file_path
+
+         UNION ALL
+
+         SELECT '{UNTAGGED_DIMENSION}' AS file_path,
+                COUNT(DISTINCT m2.session_id) AS sess,
+                COUNT(*) AS cnt,
+                COALESCE(SUM(m2.input_tokens), 0) AS inp,
+                COALESCE(SUM(m2.output_tokens), 0) AS outp,
+                COALESCE(SUM(m2.cache_read_tokens), 0) AS cache_r,
+                COALESCE(SUM(m2.cache_creation_tokens), 0) AS cache_c,
+                COALESCE(SUM(m2.cost_cents), 0.0) AS cost,
+                '' AS top_repo,
+                '' AS top_branch,
+                '' AS top_ticket,
+                '' AS file_source
+         FROM messages m2
+         {untagged_where}
+         AND NOT EXISTS (
+             SELECT 1 FROM tags t2
+             WHERE t2.message_id = m2.id AND t2.key = '{FILE_TAG_KEY}'
+         )
+
+         ORDER BY cost DESC
+         LIMIT ?{limit_param_idx}",
+    );
+
+    let param_refs: Vec<&dyn rusqlite::types::ToSql> = param_values
+        .iter()
+        .map(|s| s as &dyn rusqlite::types::ToSql)
+        .collect();
+    let mut stmt = conn.prepare(&sql)?;
+    let rows: Vec<FileCost> = stmt
+        .query_map(param_refs.as_slice(), |row| {
+            Ok(FileCost {
+                file_path: row.get(0)?,
+                session_count: row.get(1)?,
+                message_count: row.get(2)?,
+                input_tokens: row.get(3)?,
+                output_tokens: row.get(4)?,
+                cache_read_tokens: row.get(5)?,
+                cache_creation_tokens: row.get(6)?,
+                cost_cents: row.get(7)?,
+                top_repo_id: row.get(8)?,
+                top_branch: row.get(9)?,
+                top_ticket_id: row.get(10)?,
+                source: row.get(11)?,
+            })
+        })?
+        .filter_map(|r| r.ok())
+        // Drop the (untagged) row when empty to avoid noise on freshly-imported DBs.
+        .filter(|fc| !(fc.file_path == UNTAGGED_DIMENSION && fc.message_count == 0))
+        .collect();
+
+    Ok(rows)
+}
+
+/// Detail view for a single file: totals + dominant repo + per-branch and
+/// per-ticket breakdowns. Returns `None` when no assistant messages carry
+/// the file in the requested window.
+pub fn file_cost_single(
+    conn: &Connection,
+    file_path: &str,
+    repo_id: Option<&str>,
+    since: Option<&str>,
+    until: Option<&str>,
+) -> Result<Option<FileCostDetail>> {
+    let mut conditions = vec![
+        "m.role = 'assistant'".to_string(),
+        "t.key = ?1".to_string(),
+        "t.value = ?2".to_string(),
+    ];
+    let mut param_values: Vec<String> = vec![FILE_TAG_KEY.to_string(), file_path.to_string()];
+    let mut idx = 2usize;
+    if let Some(repo) = repo_id {
+        idx += 1;
+        param_values.push(repo.to_string());
+        conditions.push(format!("COALESCE(m.repo_id, '') = ?{idx}"));
+    }
+    if let Some(s) = since {
+        idx += 1;
+        param_values.push(s.to_string());
+        conditions.push(format!("m.timestamp >= ?{idx}"));
+    }
+    if let Some(u) = until {
+        idx += 1;
+        param_values.push(u.to_string());
+        conditions.push(format!("m.timestamp < ?{idx}"));
+    }
+    let where_clause = format!("WHERE {}", conditions.join(" AND "));
+
+    let totals_sql = format!(
+        "WITH msg_val_counts AS (
+             SELECT message_id, COUNT(*) AS n_values
+             FROM tags
+             WHERE key = ?1
+             GROUP BY message_id
+         ),
+         msg_source AS (
+             SELECT message_id, MIN(value) AS source_value
+             FROM tags
+             WHERE key = '{FILE_SOURCE_TAG_KEY}'
+             GROUP BY message_id
+         ),
+         msg_confidence AS (
+             SELECT message_id, MIN(value) AS confidence_value
+             FROM tags
+             WHERE key = '{FILE_CONFIDENCE_TAG_KEY}'
+             GROUP BY message_id
+         ),
+         selected AS (
+             SELECT m.id AS message_id,
+                    m.session_id,
+                    m.repo_id,
+                    m.input_tokens,
+                    m.output_tokens,
+                    m.cache_read_tokens,
+                    m.cache_creation_tokens,
+                    m.cost_cents,
+                    mvc.n_values,
+                    COALESCE(ms.source_value, '') AS file_source,
+                    COALESCE(mc.confidence_value, '') AS file_confidence
+             FROM tags t
+             JOIN msg_val_counts mvc ON mvc.message_id = t.message_id
+             JOIN messages m ON m.id = t.message_id
+             LEFT JOIN msg_source ms ON ms.message_id = t.message_id
+             LEFT JOIN msg_confidence mc ON mc.message_id = t.message_id
+             {where_clause}
+         ),
+         source_pick AS (
+             SELECT file_source,
+                    SUM(cost_cents / n_values) AS source_cost
+             FROM selected
+             WHERE file_source != ''
+             GROUP BY file_source
+             ORDER BY source_cost DESC, file_source ASC
+             LIMIT 1
+         ),
+         confidence_pick AS (
+             SELECT file_confidence,
+                    SUM(cost_cents / n_values) AS confidence_cost
+             FROM selected
+             WHERE file_confidence != ''
+             GROUP BY file_confidence
+             ORDER BY confidence_cost DESC, file_confidence ASC
+             LIMIT 1
+         )
+         SELECT COUNT(DISTINCT session_id) AS sess,
+                COUNT(*) AS cnt,
+                COALESCE(SUM(input_tokens / n_values), 0) AS inp,
+                COALESCE(SUM(output_tokens / n_values), 0) AS outp,
+                COALESCE(SUM(cache_read_tokens / n_values), 0) AS cache_r,
+                COALESCE(SUM(cache_creation_tokens / n_values), 0) AS cache_c,
+                COALESCE(SUM(cost_cents / n_values), 0.0) AS cost,
+                CASE WHEN COUNT(DISTINCT COALESCE(repo_id, '')) = 1
+                     THEN COALESCE(MIN(repo_id), '')
+                     ELSE '' END AS repo,
+                COALESCE((SELECT file_source FROM source_pick), '') AS src,
+                COALESCE((SELECT file_confidence FROM confidence_pick), '') AS conf
+         FROM selected"
+    );
+
+    let param_refs: Vec<&dyn rusqlite::types::ToSql> = param_values
+        .iter()
+        .map(|s| s as &dyn rusqlite::types::ToSql)
+        .collect();
+    let mut stmt = conn.prepare(&totals_sql)?;
+    let totals = stmt.query_row(param_refs.as_slice(), |row| {
+        Ok((
+            row.get::<_, u64>(0)?,
+            row.get::<_, u64>(1)?,
+            row.get::<_, u64>(2)?,
+            row.get::<_, u64>(3)?,
+            row.get::<_, u64>(4)?,
+            row.get::<_, u64>(5)?,
+            row.get::<_, f64>(6)?,
+            row.get::<_, String>(7)?,
+            row.get::<_, String>(8)?,
+            row.get::<_, String>(9)?,
+        ))
+    });
+    let (sess, cnt, inp, outp, cache_r, cache_c, cost, repo, src, conf) = match totals {
+        Ok(row) => row,
+        Err(rusqlite::Error::QueryReturnedNoRows) => return Ok(None),
+        Err(e) => return Err(e.into()),
+    };
+    if cnt == 0 {
+        return Ok(None);
+    }
+
+    // Per-branch breakdown.
+    let branches_sql = format!(
+        "WITH msg_val_counts AS (
+             SELECT message_id, COUNT(*) AS n_values
+             FROM tags
+             WHERE key = ?1
+             GROUP BY message_id
+         )
+         SELECT COALESCE(NULLIF(
+                    CASE
+                        WHEN COALESCE(m.git_branch, '') LIKE 'refs/heads/%'
+                            THEN SUBSTR(COALESCE(m.git_branch, ''), 12)
+                        ELSE COALESCE(m.git_branch, '')
+                    END,
+                    ''
+                ), '{UNTAGGED_DIMENSION}') AS branch_value,
+                COALESCE(m.repo_id, '') AS repo_value,
+                COUNT(DISTINCT m.session_id) AS sess,
+                COUNT(*) AS cnt,
+                COALESCE(SUM(m.cost_cents / mvc.n_values), 0.0) AS cost
+         FROM tags t
+         JOIN msg_val_counts mvc ON mvc.message_id = t.message_id
+         JOIN messages m ON m.id = t.message_id
+         {where_clause}
+         GROUP BY branch_value, repo_value
+         ORDER BY cost DESC, branch_value ASC"
+    );
+    let mut stmt = conn.prepare(&branches_sql)?;
+    let branches: Vec<FileBranchBreakdown> = stmt
+        .query_map(param_refs.as_slice(), |row| {
+            Ok(FileBranchBreakdown {
+                git_branch: row.get(0)?,
+                repo_id: row.get(1)?,
+                session_count: row.get(2)?,
+                message_count: row.get(3)?,
+                cost_cents: row.get(4)?,
+            })
+        })?
+        .filter_map(|r| r.ok())
+        .collect();
+
+    // Per-ticket breakdown — joins the same selected rows to their
+    // `ticket_id` sibling tag (when present).
+    let tickets_sql = format!(
+        "WITH msg_val_counts AS (
+             SELECT message_id, COUNT(*) AS n_values
+             FROM tags
+             WHERE key = ?1
+             GROUP BY message_id
+         ),
+         msg_ticket AS (
+             SELECT message_id, MIN(value) AS ticket_value
+             FROM tags
+             WHERE key = '{TICKET_TAG_KEY}'
+             GROUP BY message_id
+         )
+         SELECT COALESCE(NULLIF(mt.ticket_value, ''), '{UNTAGGED_DIMENSION}') AS ticket_value,
+                COUNT(DISTINCT m.session_id) AS sess,
+                COUNT(*) AS cnt,
+                COALESCE(SUM(m.cost_cents / mvc.n_values), 0.0) AS cost
+         FROM tags t
+         JOIN msg_val_counts mvc ON mvc.message_id = t.message_id
+         JOIN messages m ON m.id = t.message_id
+         LEFT JOIN msg_ticket mt ON mt.message_id = m.id
+         {where_clause}
+         GROUP BY ticket_value
+         ORDER BY cost DESC, ticket_value ASC"
+    );
+    let mut stmt = conn.prepare(&tickets_sql)?;
+    let tickets: Vec<FileTicketBreakdown> = stmt
+        .query_map(param_refs.as_slice(), |row| {
+            Ok(FileTicketBreakdown {
+                ticket_id: row.get(0)?,
+                session_count: row.get(1)?,
+                message_count: row.get(2)?,
+                cost_cents: row.get(3)?,
+            })
+        })?
+        .filter_map(|r| r.ok())
+        .collect();
+
+    Ok(Some(FileCostDetail {
+        file_path: file_path.to_string(),
+        session_count: sess,
+        message_count: cnt,
+        input_tokens: inp,
+        output_tokens: outp,
+        cache_read_tokens: cache_r,
+        cache_creation_tokens: cache_c,
+        cost_cents: cost,
+        repo_id: repo,
+        branches,
+        tickets,
+        source: src,
+        confidence: conf,
+    }))
+}

--- a/crates/budi-core/src/analytics/tests.rs
+++ b/crates/budi-core/src/analytics/tests.rs
@@ -73,6 +73,7 @@ fn ingest_and_query() {
             prompt_category_confidence: None,
             tool_names: Vec::new(),
             tool_use_ids: Vec::new(),
+            tool_files: Vec::new(),
         },
         ParsedMessage {
             uuid: "a1".to_string(),
@@ -103,6 +104,7 @@ fn ingest_and_query() {
             prompt_category_confidence: None,
             tool_names: Vec::new(),
             tool_use_ids: Vec::new(),
+            tool_files: Vec::new(),
         },
     ];
 
@@ -153,6 +155,7 @@ fn rollups_track_message_updates_and_deletes() {
         prompt_category_confidence: None,
         tool_names: Vec::new(),
         tool_use_ids: Vec::new(),
+        tool_files: Vec::new(),
     };
     ingest_messages(&mut conn, &[msg], None).unwrap();
 
@@ -208,6 +211,7 @@ fn rollups_are_used_only_for_hour_aligned_ranges() {
         prompt_category_confidence: None,
         tool_names: Vec::new(),
         tool_use_ids: Vec::new(),
+        tool_files: Vec::new(),
     };
     ingest_messages(&mut conn, &[msg], None).unwrap();
 
@@ -281,6 +285,7 @@ fn rollup_summary_latency_smoke_on_large_dataset() {
             prompt_category_confidence: None,
             tool_names: Vec::new(),
             tool_use_ids: Vec::new(),
+            tool_files: Vec::new(),
         });
     }
     ingest_messages(&mut conn, &messages, None).unwrap();
@@ -333,6 +338,7 @@ fn cost_cents_baked_at_ingest() {
         prompt_category_confidence: None,
         tool_names: Vec::new(),
         tool_use_ids: Vec::new(),
+        tool_files: Vec::new(),
     };
     // CostEnricher is the single source of truth for cost_cents
     CostEnricher.enrich(&mut msg);
@@ -408,6 +414,7 @@ fn last_seen_derived_from_messages() {
             prompt_category_confidence: None,
             tool_names: Vec::new(),
             tool_use_ids: Vec::new(),
+            tool_files: Vec::new(),
         },
         ParsedMessage {
             uuid: "m2".to_string(),
@@ -438,6 +445,7 @@ fn last_seen_derived_from_messages() {
             prompt_category_confidence: None,
             tool_names: Vec::new(),
             tool_use_ids: Vec::new(),
+            tool_files: Vec::new(),
         },
     ];
     ingest_messages(&mut conn, &msgs, None).unwrap();
@@ -485,6 +493,7 @@ fn newest_ingested_data_uses_assistant_rows() {
             prompt_category_confidence: None,
             tool_names: Vec::new(),
             tool_use_ids: Vec::new(),
+            tool_files: Vec::new(),
         },
         ParsedMessage {
             uuid: "a-only".to_string(),
@@ -515,6 +524,7 @@ fn newest_ingested_data_uses_assistant_rows() {
             prompt_category_confidence: None,
             tool_names: Vec::new(),
             tool_use_ids: Vec::new(),
+            tool_files: Vec::new(),
         },
     ];
     ingest_messages(&mut conn, &msgs, None).unwrap();
@@ -553,6 +563,7 @@ fn sample_messages() -> Vec<ParsedMessage> {
             prompt_category_confidence: None,
             tool_names: Vec::new(),
             tool_use_ids: Vec::new(),
+            tool_files: Vec::new(),
         },
         ParsedMessage {
             uuid: "a1".to_string(),
@@ -583,6 +594,7 @@ fn sample_messages() -> Vec<ParsedMessage> {
             prompt_category_confidence: None,
             tool_names: Vec::new(),
             tool_use_ids: Vec::new(),
+            tool_files: Vec::new(),
         },
         ParsedMessage {
             uuid: "u2".to_string(),
@@ -613,6 +625,7 @@ fn sample_messages() -> Vec<ParsedMessage> {
             prompt_category_confidence: None,
             tool_names: Vec::new(),
             tool_use_ids: Vec::new(),
+            tool_files: Vec::new(),
         },
     ]
 }
@@ -808,6 +821,7 @@ fn messages_with_cache_patterns() -> Vec<ParsedMessage> {
             prompt_category_confidence: None,
             tool_names: Vec::new(),
             tool_use_ids: Vec::new(),
+            tool_files: Vec::new(),
         },
         ParsedMessage {
             uuid: "t2".to_string(),
@@ -838,6 +852,7 @@ fn messages_with_cache_patterns() -> Vec<ParsedMessage> {
             prompt_category_confidence: None,
             tool_names: Vec::new(),
             tool_use_ids: Vec::new(),
+            tool_files: Vec::new(),
         },
         ParsedMessage {
             uuid: "t3".to_string(),
@@ -868,6 +883,7 @@ fn messages_with_cache_patterns() -> Vec<ParsedMessage> {
             prompt_category_confidence: None,
             tool_names: Vec::new(),
             tool_use_ids: Vec::new(),
+            tool_files: Vec::new(),
         },
     ]
 }
@@ -964,6 +980,7 @@ fn multi_provider_ingest_and_query() {
             prompt_category_confidence: None,
             tool_names: Vec::new(),
             tool_use_ids: Vec::new(),
+            tool_files: Vec::new(),
         },
         ParsedMessage {
             uuid: "cc-a1".to_string(),
@@ -994,6 +1011,7 @@ fn multi_provider_ingest_and_query() {
             prompt_category_confidence: None,
             tool_names: Vec::new(),
             tool_use_ids: Vec::new(),
+            tool_files: Vec::new(),
         },
     ];
 
@@ -1027,6 +1045,7 @@ fn multi_provider_ingest_and_query() {
             prompt_category_confidence: None,
             tool_names: Vec::new(),
             tool_use_ids: Vec::new(),
+            tool_files: Vec::new(),
         },
         ParsedMessage {
             uuid: "cu-a1".to_string(),
@@ -1057,6 +1076,7 @@ fn multi_provider_ingest_and_query() {
             prompt_category_confidence: None,
             tool_names: Vec::new(),
             tool_use_ids: Vec::new(),
+            tool_files: Vec::new(),
         },
     ];
 
@@ -1122,6 +1142,7 @@ fn cross_parse_dedup_by_request_id() {
         prompt_category_confidence: None,
         tool_names: Vec::new(),
         tool_use_ids: Vec::new(),
+        tool_files: Vec::new(),
     };
     ingest_messages(&mut conn, &[intermediate], None).unwrap();
 
@@ -1159,6 +1180,7 @@ fn cross_parse_dedup_by_request_id() {
         prompt_category_confidence: None,
         tool_names: Vec::new(),
         tool_use_ids: Vec::new(),
+        tool_files: Vec::new(),
     };
     ingest_messages(&mut conn, &[final_entry], None).unwrap();
 
@@ -1211,6 +1233,7 @@ fn cross_parse_dedup_keeps_higher_output() {
         prompt_category_confidence: None,
         tool_names: Vec::new(),
         tool_use_ids: Vec::new(),
+        tool_files: Vec::new(),
     };
     ingest_messages(&mut conn, &[final_entry], None).unwrap();
 
@@ -1243,6 +1266,7 @@ fn cross_parse_dedup_keeps_higher_output() {
         prompt_category_confidence: None,
         tool_names: Vec::new(),
         tool_use_ids: Vec::new(),
+        tool_files: Vec::new(),
     };
     ingest_messages(&mut conn, &[intermediate], None).unwrap();
 
@@ -1293,6 +1317,7 @@ fn no_request_id_no_dedup() {
         prompt_category_confidence: None,
         tool_names: Vec::new(),
         tool_use_ids: Vec::new(),
+        tool_files: Vec::new(),
     };
     ingest_messages(&mut conn, &[msg1], None).unwrap();
 
@@ -1325,6 +1350,7 @@ fn no_request_id_no_dedup() {
         prompt_category_confidence: None,
         tool_names: Vec::new(),
         tool_use_ids: Vec::new(),
+        tool_files: Vec::new(),
     };
     ingest_messages(&mut conn, &[msg2], None).unwrap();
 
@@ -1389,6 +1415,7 @@ fn jsonl_dedup_matches_otel_by_fingerprint_within_window() {
         prompt_category_confidence: None,
         tool_names: Vec::new(),
         tool_use_ids: Vec::new(),
+        tool_files: Vec::new(),
     };
     ingest_messages(&mut conn, &[msg], None).unwrap();
 
@@ -1516,6 +1543,7 @@ fn session_cost_curve_buckets() {
             prompt_category_confidence: None,
             tool_names: Vec::new(),
             tool_use_ids: Vec::new(),
+            tool_files: Vec::new(),
         });
     }
     ingest_messages(&mut conn, &msgs, None).unwrap();
@@ -1559,6 +1587,7 @@ fn cost_confidence_stats_groups_correctly() {
             prompt_category_confidence: None,
             tool_names: Vec::new(),
             tool_use_ids: Vec::new(),
+            tool_files: Vec::new(),
         },
         ParsedMessage {
             uuid: "conf-2".to_string(),
@@ -1589,6 +1618,7 @@ fn cost_confidence_stats_groups_correctly() {
             prompt_category_confidence: None,
             tool_names: Vec::new(),
             tool_use_ids: Vec::new(),
+            tool_files: Vec::new(),
         },
     ];
     ingest_messages(&mut conn, &msgs, None).unwrap();
@@ -1634,6 +1664,7 @@ fn subagent_cost_stats_splits_correctly() {
             prompt_category_confidence: None,
             tool_names: Vec::new(),
             tool_use_ids: Vec::new(),
+            tool_files: Vec::new(),
         },
         ParsedMessage {
             uuid: "sub-1".to_string(),
@@ -1664,6 +1695,7 @@ fn subagent_cost_stats_splits_correctly() {
             prompt_category_confidence: None,
             tool_names: Vec::new(),
             tool_use_ids: Vec::new(),
+            tool_files: Vec::new(),
         },
     ];
     ingest_messages(&mut conn, &msgs, None).unwrap();
@@ -2185,6 +2217,7 @@ fn assistant_msg(uuid: &str, session_id: &str, cost_cents: f64) -> ParsedMessage
         prompt_category_confidence: None,
         tool_names: Vec::new(),
         tool_use_ids: Vec::new(),
+        tool_files: Vec::new(),
     }
 }
 
@@ -2781,6 +2814,155 @@ fn activity_cost_single_can_filter_by_repo() {
     assert!((only_a.cost_cents - 4.0).abs() < 0.01);
 
     let none = activity_cost_single(&conn, "bugfix", Some("repo-c"), None, None).unwrap();
+    assert!(none.is_none());
+}
+
+// ---------------------------------------------------------------------------
+// File cost (R1.4 / #292)
+// ---------------------------------------------------------------------------
+//
+// Mirrors the ticket / activity roll-up contract. Tests inject the tags
+// directly so they don't depend on `FileEnricher` (which does its own
+// normalization, covered in `file_attribution::tests`).
+
+fn file_msg(uuid: &str, session_id: &str, branch: &str, repo: &str, cost: f64) -> ParsedMessage {
+    let mut m = assistant_msg(uuid, session_id, cost);
+    m.git_branch = Some(branch.to_string());
+    m.repo_id = Some(repo.to_string());
+    m
+}
+
+fn file_tags(values: &[&str]) -> Vec<Tag> {
+    values
+        .iter()
+        .map(|v| Tag {
+            key: "file_path".to_string(),
+            value: (*v).to_string(),
+        })
+        .collect()
+}
+
+#[test]
+fn file_cost_groups_by_file() {
+    // Two files touched across two sessions; splits cost proportionally
+    // on multi-file messages and sorts cost-descending.
+    let mut conn = test_db();
+    let m1 = file_msg("fc-1", "s1", "main", "repo-a", 10.0);
+    let m2 = file_msg("fc-2", "s2", "main", "repo-a", 4.0);
+    // Multi-file message: splits 4.0 across two files.
+    let m3 = file_msg("fc-3", "s3", "main", "repo-a", 4.0);
+    let tags = vec![
+        file_tags(&["src/main.rs"]),
+        file_tags(&["src/main.rs"]),
+        file_tags(&["src/main.rs", "Cargo.toml"]),
+    ];
+    ingest_messages(&mut conn, &[m1, m2, m3], Some(&tags)).unwrap();
+
+    let rows = file_cost(&conn, None, None, 10).unwrap();
+    let main_rs = rows.iter().find(|r| r.file_path == "src/main.rs").unwrap();
+    // 10.0 + 4.0 + (4.0/2 = 2.0) = 16.0
+    assert!((main_rs.cost_cents - 16.0).abs() < 0.01);
+    assert_eq!(main_rs.message_count, 3);
+    assert_eq!(main_rs.session_count, 3);
+    assert_eq!(main_rs.top_repo_id, "repo-a");
+    assert_eq!(main_rs.top_branch, "main");
+
+    let cargo = rows.iter().find(|r| r.file_path == "Cargo.toml").unwrap();
+    assert!((cargo.cost_cents - 2.0).abs() < 0.01);
+
+    let main_idx = rows
+        .iter()
+        .position(|r| r.file_path == "src/main.rs")
+        .unwrap();
+    let cargo_idx = rows
+        .iter()
+        .position(|r| r.file_path == "Cargo.toml")
+        .unwrap();
+    assert!(main_idx < cargo_idx, "cost-desc ordering");
+}
+
+#[test]
+fn file_cost_includes_untagged_bucket() {
+    // A tagged file + a bare assistant message → the (untagged) row
+    // should appear so totals reconcile with `usage_summary`.
+    let mut conn = test_db();
+    let m1 = file_msg("fc-u-1", "s1", "main", "repo", 5.0);
+    let m2 = assistant_msg("fc-u-2", "s2", 7.0);
+    ingest_messages(
+        &mut conn,
+        &[m1, m2],
+        Some(&[file_tags(&["src/main.rs"]), Vec::new()]),
+    )
+    .unwrap();
+
+    let rows = file_cost(&conn, None, None, 10).unwrap();
+    let untagged = rows
+        .iter()
+        .find(|r| r.file_path == "(untagged)")
+        .expect("untagged file bucket present");
+    assert!((untagged.cost_cents - 7.0).abs() < 0.01);
+    assert_eq!(untagged.message_count, 1);
+}
+
+#[test]
+fn file_cost_single_returns_detail_with_branches_and_tickets() {
+    // Same file touched on two branches and on two tickets — detail view
+    // must attribute cost per branch and per ticket.
+    let mut conn = test_db();
+    let m1 = file_msg("fcd-1", "s1", "feat/a", "repo-a", 6.0);
+    let m2 = file_msg("fcd-2", "s2", "feat/b", "repo-a", 4.0);
+    let mut tags_1 = file_tags(&["src/main.rs"]);
+    tags_1.push(Tag {
+        key: "ticket_id".to_string(),
+        value: "PAVA-1".to_string(),
+    });
+    let mut tags_2 = file_tags(&["src/main.rs"]);
+    tags_2.push(Tag {
+        key: "ticket_id".to_string(),
+        value: "PAVA-2".to_string(),
+    });
+    ingest_messages(&mut conn, &[m1, m2], Some(&[tags_1, tags_2])).unwrap();
+
+    let detail = file_cost_single(&conn, "src/main.rs", None, None, None)
+        .unwrap()
+        .expect("file detail present");
+    assert_eq!(detail.file_path, "src/main.rs");
+    assert_eq!(detail.session_count, 2);
+    assert_eq!(detail.message_count, 2);
+    assert_eq!(detail.repo_id, "repo-a");
+    assert!((detail.cost_cents - 10.0).abs() < 0.01);
+    assert_eq!(detail.branches.len(), 2);
+    let branch_a = detail
+        .branches
+        .iter()
+        .find(|b| b.git_branch == "feat/a")
+        .unwrap();
+    assert!((branch_a.cost_cents - 6.0).abs() < 0.01);
+    assert_eq!(detail.tickets.len(), 2);
+
+    let missing = file_cost_single(&conn, "does/not/exist.rs", None, None, None).unwrap();
+    assert!(missing.is_none());
+}
+
+#[test]
+fn file_cost_single_can_filter_by_repo() {
+    let mut conn = test_db();
+    let m1 = file_msg("fcr-1", "s1", "main", "repo-a", 3.0);
+    let m2 = file_msg("fcr-2", "s2", "main", "repo-b", 5.0);
+    ingest_messages(
+        &mut conn,
+        &[m1, m2],
+        Some(&[file_tags(&["src/lib.rs"]), file_tags(&["src/lib.rs"])]),
+    )
+    .unwrap();
+
+    let only_a = file_cost_single(&conn, "src/lib.rs", Some("repo-a"), None, None)
+        .unwrap()
+        .unwrap();
+    assert_eq!(only_a.repo_id, "repo-a");
+    assert!((only_a.cost_cents - 3.0).abs() < 0.01);
+
+    let none = file_cost_single(&conn, "src/lib.rs", Some("repo-c"), None, None).unwrap();
     assert!(none.is_none());
 }
 
@@ -3420,6 +3602,7 @@ fn health_msg(
         prompt_category_confidence: None,
         tool_names: Vec::new(),
         tool_use_ids: Vec::new(),
+        tool_files: Vec::new(),
     }
 }
 

--- a/crates/budi-core/src/file_attribution.rs
+++ b/crates/budi-core/src/file_attribution.rs
@@ -1,0 +1,517 @@
+//! File-level attribution for AI tool activity (R1.4, #292).
+//!
+//! Given tool-call arguments from a supported provider, extract and
+//! normalize file paths so we can answer "which files did the AI touch"
+//! per ticket / branch / repo / activity — without storing file contents
+//! or diffs, and without surfacing absolute paths from the user's disk.
+//!
+//! ## Contract (ADR-0083)
+//!
+//! 1. Stored values are always repo-relative, forward-slashed, and
+//!    strictly inside the resolved repo root.
+//! 2. Absolute paths are stripped against the message `cwd` / repo root
+//!    before storage. If the path cannot be proven to sit inside the
+//!    repo, it is dropped — we never record "unattached" absolute paths.
+//! 3. `..` segments that would escape the repo root are dropped.
+//! 4. Maximum of [`MAX_FILES_PER_MESSAGE`] files per message; excess
+//!    paths are truncated. This keeps per-message payloads small and
+//!    caps the "pathological tool-use output" case.
+//! 5. Only paths are recorded. No contents, diffs, mtimes, or sizes.
+//!
+//! The actual tag emission lives in `pipeline::enrichers::FileEnricher`,
+//! which calls [`attribute_files`] to convert raw candidate paths into
+//! the canonical form plus a dominant source/confidence label.
+
+use std::path::{Component, Path, PathBuf};
+
+/// Per-message cap on the number of file tags emitted. Picked to keep
+/// worst-case tag fan-out in the same order of magnitude as the other
+/// multi-valued tags (`tool`, `tool_use_id`) even for Grep/Glob-heavy
+/// messages.
+pub const MAX_FILES_PER_MESSAGE: usize = 16;
+
+/// Path came from a known tool file argument (e.g. `file_path` on
+/// Read/Write/Edit) and was already repo-relative.
+pub const FILE_SOURCE_TOOL_ARG: &str = "tool_arg";
+/// Path came from a known tool file argument but was absolute; it was
+/// successfully stripped against cwd / the resolved repo root to make
+/// it repo-relative.
+pub const FILE_SOURCE_CWD_RELATIVE: &str = "cwd_relative";
+
+/// Attribution was verbatim from a tool argument (already repo-relative).
+pub const FILE_CONFIDENCE_HIGH: &str = "high";
+/// Attribution required normalization against cwd/repo; still deterministic
+/// but one step removed from the raw argument.
+pub const FILE_CONFIDENCE_MEDIUM: &str = "medium";
+
+/// Extract candidate file paths from a Claude Code `tool_use` block and
+/// push them into `out`. `tool_name` is the tool's display name (e.g.
+/// `Read`, `Write`, `Edit`, `Grep`, `Glob`). `input` is the raw JSON
+/// value from the tool_use block's `input` field.
+///
+/// Unknown tools are ignored — we only extract from tools whose file
+/// arguments are well-defined. Bash, WebFetch, Task, TodoWrite, etc. are
+/// deliberately not parsed in 8.1 because their arguments are free-form
+/// and would require speculative parsing (see #292 non-goals).
+pub fn collect_claude_tool_paths(
+    tool_name: &str,
+    input: &serde_json::Value,
+    out: &mut Vec<String>,
+) {
+    // Claude Code tool input shapes. Normalised to lowercase so any future
+    // provider that forwards the same names in a different case stays
+    // covered without a brittle exact-match.
+    let lower = tool_name.trim().to_ascii_lowercase();
+    match lower.as_str() {
+        // Single file path.
+        "read" | "write" | "edit" | "multiedit" => {
+            push_str(input.get("file_path"), out);
+        }
+        // Jupyter notebook tools (file_path and notebook_path forms).
+        "notebookread" | "notebookedit" => {
+            push_str(input.get("notebook_path"), out);
+            push_str(input.get("file_path"), out);
+        }
+        // Grep: `path` optionally scopes the search; include it when present
+        // so "files touched by a search" is queryable.
+        "grep" => {
+            push_str(input.get("path"), out);
+        }
+        // Glob: `path` is the search root, `pattern` is the glob itself.
+        // The glob pattern can contain `*`/`?` — we still record it for the
+        // "files the AI was looking at" signal; consumers can detect it by
+        // its unresolved wildcards.
+        "glob" => {
+            push_str(input.get("path"), out);
+            push_str(input.get("pattern"), out);
+        }
+        _ => {}
+    }
+}
+
+/// Extract candidate file paths from a Cursor tool_calls entry. Cursor
+/// argument shapes vary by version, so we read the union of known fields.
+/// See `providers::cursor` for the CursorToolCall glue.
+pub fn collect_cursor_tool_paths(tool_name: &str, args: &serde_json::Value, out: &mut Vec<String>) {
+    let lower = tool_name.trim().to_ascii_lowercase();
+    // Cursor's first-party tool names in use today: read_file, edit_file,
+    // write_file, search_replace, codebase_search, grep_search, glob_file_search,
+    // delete_file, file_search. We intentionally stay lenient on shape.
+    match lower.as_str() {
+        "read_file" | "edit_file" | "write_file" | "search_replace" | "delete_file"
+        | "file_search" | "apply_patch" => {
+            push_str(args.get("target_file"), out);
+            push_str(args.get("file_path"), out);
+            push_str(args.get("path"), out);
+            push_str(args.get("filePath"), out);
+        }
+        "grep_search" | "grep" => {
+            push_str(args.get("path"), out);
+            push_str(args.get("include_pattern"), out);
+        }
+        "glob_file_search" | "glob" => {
+            push_str(args.get("path"), out);
+            push_str(args.get("glob_pattern"), out);
+            push_str(args.get("pattern"), out);
+        }
+        "codebase_search" => {
+            push_str(args.get("path"), out);
+        }
+        _ => {
+            // Unknown tool: be generous but bounded — a single `file_path`
+            // / `target_file` field is a very strong signal across the
+            // Cursor extension ecosystem and cheap to opt into.
+            push_str(args.get("target_file"), out);
+            push_str(args.get("file_path"), out);
+        }
+    }
+}
+
+fn push_str(v: Option<&serde_json::Value>, out: &mut Vec<String>) {
+    if let Some(s) = v.and_then(|v| v.as_str()) {
+        let trimmed = s.trim();
+        if !trimmed.is_empty() {
+            out.push(trimmed.to_string());
+        }
+    }
+}
+
+/// Outcome of normalizing a set of raw candidate paths for a single
+/// assistant message.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct FileAttribution {
+    /// Canonical repo-relative paths, deduplicated and capped.
+    pub paths: Vec<String>,
+    /// Dominant source label across the accepted paths. `None` when
+    /// `paths` is empty.
+    pub source: Option<&'static str>,
+    /// Confidence label for the batch. `None` when `paths` is empty.
+    pub confidence: Option<&'static str>,
+    /// Count of raw candidates dropped because they failed the privacy
+    /// / repo-membership contract. Useful for the doctor check and
+    /// regression tests.
+    pub dropped: usize,
+}
+
+/// Normalize a batch of raw candidate paths against `cwd` and the
+/// resolved `repo_root`. Returns the canonical repo-relative set plus a
+/// dominant (source, confidence) label, or empty when no candidates
+/// survive the privacy filter.
+///
+/// `repo_root` is the filesystem path of the message's repo root (as
+/// determined by walking up from `cwd` to the enclosing `.git` dir). It
+/// is required for absolute-path normalization; when `None`, absolute
+/// paths are dropped.
+pub fn attribute_files(
+    raw: &[String],
+    cwd: Option<&str>,
+    repo_root: Option<&Path>,
+) -> FileAttribution {
+    let cwd_path: Option<PathBuf> = cwd.and_then(|s| {
+        let trimmed = s.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(PathBuf::from(trimmed))
+        }
+    });
+
+    let mut seen = std::collections::HashSet::new();
+    let mut accepted: Vec<(String, &'static str, &'static str)> = Vec::new();
+    let mut dropped = 0usize;
+
+    for raw_path in raw {
+        match normalize_one(raw_path, cwd_path.as_deref(), repo_root) {
+            Some((rel, source, confidence)) => {
+                if accepted.len() >= MAX_FILES_PER_MESSAGE {
+                    // Truncation is also a drop for the purposes of the
+                    // doctor check — it tells us the cap is biting.
+                    dropped += 1;
+                    continue;
+                }
+                if seen.insert(rel.clone()) {
+                    accepted.push((rel, source, confidence));
+                }
+            }
+            None => dropped += 1,
+        }
+    }
+
+    if accepted.is_empty() {
+        return FileAttribution {
+            dropped,
+            ..FileAttribution::default()
+        };
+    }
+
+    // Dominant source: if any path needed cwd_relative normalization the
+    // message as a whole is "cwd_relative"; otherwise it is "tool_arg".
+    // Same story for confidence — any normalization drops the batch from
+    // `high` to `medium`.
+    let mut source = FILE_SOURCE_TOOL_ARG;
+    let mut confidence = FILE_CONFIDENCE_HIGH;
+    for (_, s, c) in &accepted {
+        if *s == FILE_SOURCE_CWD_RELATIVE {
+            source = FILE_SOURCE_CWD_RELATIVE;
+        }
+        if *c == FILE_CONFIDENCE_MEDIUM {
+            confidence = FILE_CONFIDENCE_MEDIUM;
+        }
+    }
+
+    let mut paths: Vec<String> = accepted.into_iter().map(|(p, _, _)| p).collect();
+    paths.sort();
+
+    FileAttribution {
+        paths,
+        source: Some(source),
+        confidence: Some(confidence),
+        dropped,
+    }
+}
+
+/// Normalize one raw path. Returns `(repo_relative_path, source, confidence)`
+/// on success, `None` when the candidate fails the privacy contract.
+fn normalize_one(
+    raw: &str,
+    cwd: Option<&Path>,
+    repo_root: Option<&Path>,
+) -> Option<(String, &'static str, &'static str)> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    // Normalize Windows-style separators so the wire format is stable
+    // whether the agent ran on macOS, Linux, or Windows.
+    let normalized = trimmed.replace('\\', "/");
+
+    // Strip file:// scheme — some providers emit that form for file
+    // arguments. Protocol-qualified URLs for anything else are dropped.
+    let without_scheme = if let Some(rest) = normalized.strip_prefix("file://") {
+        rest.to_string()
+    } else if normalized.contains("://") {
+        return None;
+    } else {
+        normalized
+    };
+
+    let as_path = Path::new(&without_scheme);
+
+    if as_path.is_absolute() {
+        let base = repo_root.or(cwd)?;
+        let rel = as_path.strip_prefix(base).ok()?;
+        let cleaned = clean_relative(rel)?;
+        if cleaned.is_empty() {
+            return None;
+        }
+        return Some((cleaned, FILE_SOURCE_CWD_RELATIVE, FILE_CONFIDENCE_MEDIUM));
+    }
+
+    // Relative path. If we have a cwd + repo root, join cwd with the
+    // raw relative path and resolve via `clean_absolute` so that `..`
+    // segments are evaluated against the full cwd + input chain (e.g.
+    // `../sibling.rs` from `<repo>/src` is really `<repo>/sibling.rs`,
+    // which is still inside the repo). Without a cwd we fall back to
+    // cleaning the relative path in isolation and reject any `..` that
+    // cannot be resolved within the path itself.
+    if let (Some(cwd_path), Some(root)) = (cwd, repo_root) {
+        let joined = cwd_path.join(Path::new(&without_scheme));
+        // Canonicalize by string-walking rather than touching the FS so
+        // tests are deterministic and privacy never depends on the
+        // current working directory of the process.
+        let resolved = clean_absolute(&joined)?;
+        if !resolved.starts_with(root) {
+            return None;
+        }
+        let rel = resolved.strip_prefix(root).ok()?;
+        let rel_str = path_to_forward_slash(rel);
+        if rel_str.is_empty() {
+            return None;
+        }
+        return Some((rel_str, FILE_SOURCE_TOOL_ARG, FILE_CONFIDENCE_HIGH));
+    }
+
+    let cleaned = clean_relative(Path::new(&without_scheme))?;
+    if cleaned.is_empty() {
+        return None;
+    }
+    Some((cleaned, FILE_SOURCE_TOOL_ARG, FILE_CONFIDENCE_HIGH))
+}
+
+/// Clean a relative path: drop leading `./`, collapse inner `.`, and
+/// reject if any `..` cannot be resolved inside the path (meaning it
+/// would escape the base). Returns a forward-slashed string.
+fn clean_relative(rel: &Path) -> Option<String> {
+    let mut parts: Vec<String> = Vec::new();
+    for comp in rel.components() {
+        match comp {
+            Component::CurDir => {}
+            Component::Normal(os) => {
+                let s = os.to_str()?;
+                parts.push(s.to_string());
+            }
+            Component::ParentDir => {
+                parts.pop()?;
+            }
+            Component::RootDir | Component::Prefix(_) => return None,
+        }
+    }
+    Some(parts.join("/"))
+}
+
+/// Resolve an absolute path string-wise (no FS access) so it can be
+/// compared against `repo_root`. Returns `None` if the path escapes
+/// its root via unresolved `..`.
+fn clean_absolute(path: &Path) -> Option<PathBuf> {
+    let mut out = PathBuf::new();
+    for comp in path.components() {
+        match comp {
+            Component::Prefix(_) | Component::RootDir => out.push(comp.as_os_str()),
+            Component::CurDir => {}
+            Component::Normal(os) => out.push(os),
+            Component::ParentDir => {
+                // Refuse to pop past the root so the repo-membership check
+                // in the caller cannot be bypassed.
+                if !out.pop() {
+                    return None;
+                }
+            }
+        }
+    }
+    Some(out)
+}
+
+fn path_to_forward_slash(p: &Path) -> String {
+    p.components()
+        .filter_map(|c| match c {
+            Component::Normal(os) => os.to_str().map(|s| s.to_string()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    fn raw(list: &[&str]) -> Vec<String> {
+        list.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn relative_path_without_cwd_is_accepted_as_high_confidence() {
+        let a = attribute_files(&raw(&["src/main.rs", "Cargo.toml"]), None, None);
+        assert_eq!(a.paths, vec!["Cargo.toml", "src/main.rs"]);
+        assert_eq!(a.source, Some(FILE_SOURCE_TOOL_ARG));
+        assert_eq!(a.confidence, Some(FILE_CONFIDENCE_HIGH));
+        assert_eq!(a.dropped, 0);
+    }
+
+    #[test]
+    fn absolute_path_normalized_against_cwd_is_medium_confidence() {
+        let root = Path::new("/home/dev/repo");
+        let a = attribute_files(
+            &raw(&["/home/dev/repo/src/main.rs"]),
+            Some("/home/dev/repo"),
+            Some(root),
+        );
+        assert_eq!(a.paths, vec!["src/main.rs"]);
+        assert_eq!(a.source, Some(FILE_SOURCE_CWD_RELATIVE));
+        assert_eq!(a.confidence, Some(FILE_CONFIDENCE_MEDIUM));
+    }
+
+    #[test]
+    fn absolute_path_outside_repo_is_dropped() {
+        let root = Path::new("/home/dev/repo");
+        let a = attribute_files(
+            &raw(&["/etc/passwd", "/home/dev/other/file.rs"]),
+            Some("/home/dev/repo"),
+            Some(root),
+        );
+        assert!(
+            a.paths.is_empty(),
+            "must never retain outside-of-repo paths"
+        );
+        assert_eq!(a.source, None);
+        assert_eq!(a.dropped, 2);
+    }
+
+    #[test]
+    fn parent_escape_is_dropped() {
+        let root = Path::new("/home/dev/repo");
+        let a = attribute_files(
+            &raw(&["../other.rs"]),
+            Some("/home/dev/repo/src"),
+            Some(root),
+        );
+        assert_eq!(a.paths, vec!["other.rs".to_string()]);
+
+        let a2 = attribute_files(
+            &raw(&["../../../etc/passwd"]),
+            Some("/home/dev/repo/src"),
+            Some(root),
+        );
+        assert!(
+            a2.paths.is_empty(),
+            "parent traversal that escapes repo must drop"
+        );
+    }
+
+    #[test]
+    fn absolute_path_without_repo_root_is_dropped() {
+        let a = attribute_files(&raw(&["/Users/dev/secret.rs"]), None, None);
+        assert!(a.paths.is_empty());
+        assert_eq!(a.dropped, 1);
+    }
+
+    #[test]
+    fn caps_at_max_files_per_message() {
+        let mut list = Vec::new();
+        for i in 0..(MAX_FILES_PER_MESSAGE + 4) {
+            list.push(format!("src/f{i}.rs"));
+        }
+        let a = attribute_files(&list, None, None);
+        assert_eq!(a.paths.len(), MAX_FILES_PER_MESSAGE);
+        assert_eq!(a.dropped, 4);
+    }
+
+    #[test]
+    fn deduplicates_paths() {
+        let a = attribute_files(&raw(&["src/a.rs", "src/a.rs", "src/b.rs"]), None, None);
+        assert_eq!(a.paths, vec!["src/a.rs", "src/b.rs"]);
+    }
+
+    #[test]
+    fn rejects_non_file_schemes() {
+        let a = attribute_files(
+            &raw(&["https://example.com/evil.rs", "scp://host/file"]),
+            None,
+            None,
+        );
+        assert!(a.paths.is_empty());
+    }
+
+    #[test]
+    fn accepts_file_url_scheme() {
+        let root = Path::new("/home/dev/repo");
+        let a = attribute_files(
+            &raw(&["file:///home/dev/repo/src/x.rs"]),
+            Some("/home/dev/repo"),
+            Some(root),
+        );
+        assert_eq!(a.paths, vec!["src/x.rs"]);
+    }
+
+    #[test]
+    fn normalizes_windows_separators() {
+        let a = attribute_files(&raw(&["src\\main.rs"]), None, None);
+        assert_eq!(a.paths, vec!["src/main.rs"]);
+    }
+
+    #[test]
+    fn collect_claude_read_write_edit_extracts_file_path() {
+        let mut out = Vec::new();
+        let input = serde_json::json!({ "file_path": "crates/budi-core/src/lib.rs" });
+        collect_claude_tool_paths("Read", &input, &mut out);
+        collect_claude_tool_paths("Edit", &input, &mut out);
+        collect_claude_tool_paths("Write", &input, &mut out);
+        assert_eq!(
+            out,
+            vec![
+                "crates/budi-core/src/lib.rs".to_string(),
+                "crates/budi-core/src/lib.rs".to_string(),
+                "crates/budi-core/src/lib.rs".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn collect_claude_ignores_unknown_tool() {
+        let mut out = Vec::new();
+        let input = serde_json::json!({ "command": "rm -rf /" });
+        collect_claude_tool_paths("Bash", &input, &mut out);
+        assert!(out.is_empty(), "Bash must not surface as a file tool");
+    }
+
+    #[test]
+    fn collect_cursor_extracts_target_file_and_path() {
+        let mut out = Vec::new();
+        let args = serde_json::json!({
+            "target_file": "src/main.rs",
+            "instructions": "edit this",
+        });
+        collect_cursor_tool_paths("edit_file", &args, &mut out);
+        assert_eq!(out, vec!["src/main.rs".to_string()]);
+    }
+
+    #[test]
+    fn collect_cursor_unknown_tool_is_lenient_for_file_path() {
+        let mut out = Vec::new();
+        let args = serde_json::json!({ "file_path": "README.md" });
+        collect_cursor_tool_paths("some_future_tool", &args, &mut out);
+        assert_eq!(out, vec!["README.md".to_string()]);
+    }
+}

--- a/crates/budi-core/src/file_attribution.rs
+++ b/crates/budi-core/src/file_attribution.rs
@@ -370,12 +370,33 @@ mod tests {
         assert_eq!(a.dropped, 0);
     }
 
+    // Absolute-path normalization is inherently platform-specific: a leading
+    // `/` is absolute on Unix but not on Windows (Windows requires a drive or
+    // UNC prefix). We cover both shapes so Windows CI exercises the same
+    // `cwd_relative` / `medium` contract without relying on accidental
+    // path-syntax coincidences.
+
+    #[cfg(unix)]
     #[test]
-    fn absolute_path_normalized_against_cwd_is_medium_confidence() {
+    fn absolute_path_normalized_against_cwd_is_medium_confidence_unix() {
         let root = Path::new("/home/dev/repo");
         let a = attribute_files(
             &raw(&["/home/dev/repo/src/main.rs"]),
             Some("/home/dev/repo"),
+            Some(root),
+        );
+        assert_eq!(a.paths, vec!["src/main.rs"]);
+        assert_eq!(a.source, Some(FILE_SOURCE_CWD_RELATIVE));
+        assert_eq!(a.confidence, Some(FILE_CONFIDENCE_MEDIUM));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn absolute_path_normalized_against_cwd_is_medium_confidence_windows() {
+        let root = Path::new(r"C:\dev\repo");
+        let a = attribute_files(
+            &raw(&[r"C:\dev\repo\src\main.rs"]),
+            Some(r"C:\dev\repo"),
             Some(root),
         );
         assert_eq!(a.paths, vec!["src/main.rs"]);

--- a/crates/budi-core/src/jsonl.rs
+++ b/crates/budi-core/src/jsonl.rs
@@ -181,6 +181,11 @@ pub struct ParsedMessage {
     pub tool_names: Vec<String>,
     /// Tool-use block IDs emitted by assistant content blocks.
     pub tool_use_ids: Vec<String>,
+    /// Raw file paths extracted from tool-call arguments (e.g. Read/Write/Edit
+    /// `file_path`, Grep/Glob `path`/`pattern`). Normalized to repo-relative
+    /// paths later by `FileEnricher` under ADR-0083 privacy rules; see
+    /// `crate::file_attribution`. Added in R1.4 (#292).
+    pub tool_files: Vec<String>,
 }
 
 impl Default for ParsedMessage {
@@ -214,17 +219,19 @@ impl Default for ParsedMessage {
             prompt_category_confidence: None,
             tool_names: Vec::new(),
             tool_use_ids: Vec::new(),
+            tool_files: Vec::new(),
         }
     }
 }
 
 fn extract_assistant_tool_metadata(
     content: Option<&Vec<serde_json::Value>>,
-) -> (Vec<String>, Vec<String>) {
+) -> (Vec<String>, Vec<String>, Vec<String>) {
     let mut names = std::collections::HashSet::new();
     let mut tool_use_ids = std::collections::HashSet::new();
+    let mut files: Vec<String> = Vec::new();
     let Some(blocks) = content else {
-        return (Vec::new(), Vec::new());
+        return (Vec::new(), Vec::new(), Vec::new());
     };
 
     for block in blocks {
@@ -232,11 +239,10 @@ fn extract_assistant_tool_metadata(
         if block_type != "tool_use" {
             continue;
         }
-        if let Some(name) = block.get("name").and_then(|v| v.as_str()) {
-            let normalized = name.trim();
-            if !normalized.is_empty() {
-                names.insert(normalized.to_string());
-            }
+        let tool_name = block.get("name").and_then(|v| v.as_str()).unwrap_or("");
+        let trimmed = tool_name.trim();
+        if !trimmed.is_empty() {
+            names.insert(trimmed.to_string());
         }
         if let Some(id) = block.get("id").and_then(|v| v.as_str()) {
             let normalized = id.trim();
@@ -244,13 +250,19 @@ fn extract_assistant_tool_metadata(
                 tool_use_ids.insert(normalized.to_string());
             }
         }
+        // R1.4 (#292): collect raw file paths from known tool args. The
+        // actual repo-relative normalization + privacy filtering happens
+        // later in `FileEnricher` once `cwd` / `repo_id` are resolved.
+        if let Some(input) = block.get("input") {
+            crate::file_attribution::collect_claude_tool_paths(trimmed, input, &mut files);
+        }
     }
 
     let mut out: Vec<String> = names.into_iter().collect();
     out.sort();
     let mut out_ids: Vec<String> = tool_use_ids.into_iter().collect();
     out_ids.sort();
-    (out, out_ids)
+    (out, out_ids, files)
 }
 
 /// Parse a single JSONL line into a `ParsedMessage`, if relevant.
@@ -323,6 +335,7 @@ fn parse_line(line: &str) -> Option<ParsedMessage> {
                 prompt_category_confidence,
                 tool_names: Vec::new(),
                 tool_use_ids: Vec::new(),
+                tool_files: Vec::new(),
             })
         }
         TranscriptEntry::Assistant(a) => {
@@ -330,7 +343,7 @@ fn parse_line(line: &str) -> Option<ParsedMessage> {
                 return None;
             }
             let usage = a.message.usage.as_ref();
-            let (tool_names, tool_use_ids) =
+            let (tool_names, tool_use_ids, tool_files) =
                 extract_assistant_tool_metadata(a.message.content.as_ref());
             // Extract 1-hour cache tier tokens from cache_creation breakdown
             let cache_1h = usage
@@ -372,6 +385,7 @@ fn parse_line(line: &str) -> Option<ParsedMessage> {
                 prompt_category_confidence: None,
                 tool_names,
                 tool_use_ids,
+                tool_files,
             })
         }
         TranscriptEntry::Other => None,
@@ -391,7 +405,8 @@ fn parse_flat_line(line: &str) -> Option<ParsedMessage> {
                 return None;
             }
             let usage = flat.usage.as_ref();
-            let (tool_names, tool_use_ids) = extract_assistant_tool_metadata(flat.content.as_ref());
+            let (tool_names, tool_use_ids, tool_files) =
+                extract_assistant_tool_metadata(flat.content.as_ref());
             let cache_1h = usage
                 .and_then(|u| u.cache_creation.as_ref())
                 .map(|cc| cc.ephemeral_1h_input_tokens)
@@ -433,6 +448,7 @@ fn parse_flat_line(line: &str) -> Option<ParsedMessage> {
                 prompt_category_confidence: None,
                 tool_names,
                 tool_use_ids,
+                tool_files,
             })
         }
         "user" => Some(ParsedMessage {

--- a/crates/budi-core/src/lib.rs
+++ b/crates/budi-core/src/lib.rs
@@ -3,6 +3,7 @@ pub mod autostart;
 pub mod cloud_sync;
 pub mod config;
 pub mod cost;
+pub mod file_attribution;
 pub mod hooks;
 pub mod identity;
 pub mod integrations;

--- a/crates/budi-core/src/pipeline/enrichers.rs
+++ b/crates/budi-core/src/pipeline/enrichers.rs
@@ -4,9 +4,10 @@ use std::path::Path;
 
 use crate::analytics::Tag;
 use crate::config::TagsConfig;
+use crate::file_attribution;
 use crate::jsonl::ParsedMessage;
 use crate::pipeline::{Enricher, extract_ticket_from_branch, glob_match};
-use crate::repo_id::RepoIdCache;
+use crate::repo_id::{RepoIdCache, repo_root_for};
 use crate::tag_keys as tk;
 
 // ---------------------------------------------------------------------------
@@ -117,6 +118,92 @@ impl Enricher for ToolEnricher {
                     value: normalized.to_string(),
                 });
             }
+        }
+        tags
+    }
+}
+
+// ---------------------------------------------------------------------------
+// FileEnricher — turns raw tool_files into repo-relative file_path tags
+// ---------------------------------------------------------------------------
+
+/// Emits per-file tags from `ParsedMessage::tool_files` after normalizing
+/// each path against the message's `cwd` / resolved repo root. Always
+/// runs **after** `GitEnricher` so `cwd` and `repo_id` are set, and so
+/// the repo-root walk resolves the same identity analytics will join
+/// against. See R1.4 (#292) and ADR-0083.
+///
+/// Emitted tags:
+/// - `file_path` — one per accepted file (multi-valued tag).
+/// - `file_path_source` — dominant source (`tool_arg` or `cwd_relative`).
+/// - `file_path_confidence` — dominant confidence (`high` or `medium`).
+///
+/// The source/confidence pair is recorded once per message because in
+/// practice all files on a given assistant message came from the same
+/// extractor pass and share the same provenance. Sibling tags mirror
+/// the R1.2 (#222) `activity_source` / `activity_confidence` shape so
+/// downstream queries can use the same pattern.
+pub struct FileEnricher {
+    /// Per-cwd cache so repeated messages in a session don't re-walk the
+    /// filesystem for every tool-use block.
+    cache: std::collections::HashMap<String, Option<std::path::PathBuf>>,
+}
+
+impl Default for FileEnricher {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl FileEnricher {
+    pub fn new() -> Self {
+        Self {
+            cache: std::collections::HashMap::new(),
+        }
+    }
+
+    fn repo_root(&mut self, cwd: &str) -> Option<std::path::PathBuf> {
+        if let Some(hit) = self.cache.get(cwd) {
+            return hit.clone();
+        }
+        let resolved = repo_root_for(std::path::Path::new(cwd));
+        self.cache.insert(cwd.to_string(), resolved.clone());
+        resolved
+    }
+}
+
+impl Enricher for FileEnricher {
+    fn enrich(&mut self, msg: &mut ParsedMessage) -> Vec<Tag> {
+        if msg.role != "assistant" || msg.tool_files.is_empty() {
+            return Vec::new();
+        }
+        let repo_root = msg.cwd.as_deref().and_then(|cwd| self.repo_root(cwd));
+        let attribution = file_attribution::attribute_files(
+            &msg.tool_files,
+            msg.cwd.as_deref(),
+            repo_root.as_deref(),
+        );
+        if attribution.paths.is_empty() {
+            return Vec::new();
+        }
+        let mut tags = Vec::with_capacity(attribution.paths.len() + 2);
+        for path in attribution.paths {
+            tags.push(Tag {
+                key: tk::FILE_PATH.to_string(),
+                value: path,
+            });
+        }
+        if let Some(source) = attribution.source {
+            tags.push(Tag {
+                key: tk::FILE_PATH_SOURCE.to_string(),
+                value: source.to_string(),
+            });
+        }
+        if let Some(confidence) = attribution.confidence {
+            tags.push(Tag {
+                key: tk::FILE_PATH_CONFIDENCE.to_string(),
+                value: confidence.to_string(),
+            });
         }
         tags
     }
@@ -725,5 +812,67 @@ mod tests {
         // Web search: 10 * $0.01 = $0.10 (NOT multiplied by fast)
         // Total: $30.10 = 3010 cents
         assert_eq!(msg.cost_cents.unwrap(), 3010.0);
+    }
+
+    // ---- FileEnricher --------------------------------------------------
+
+    #[test]
+    fn file_enricher_ignores_user_messages() {
+        let mut enricher = FileEnricher::new();
+        let mut msg = test_msg();
+        msg.role = "user".to_string();
+        msg.tool_files = vec!["src/main.rs".into()];
+        assert!(enricher.enrich(&mut msg).is_empty());
+    }
+
+    #[test]
+    fn file_enricher_skips_when_no_tool_files() {
+        let mut enricher = FileEnricher::new();
+        let mut msg = test_msg();
+        msg.role = "assistant".to_string();
+        msg.tool_files.clear();
+        assert!(enricher.enrich(&mut msg).is_empty());
+    }
+
+    #[test]
+    fn file_enricher_emits_repo_relative_file_tags_without_cwd() {
+        let mut enricher = FileEnricher::new();
+        let mut msg = test_msg();
+        msg.role = "assistant".to_string();
+        msg.cwd = None;
+        msg.tool_files = vec!["src/main.rs".into(), "README.md".into()];
+        let tags = enricher.enrich(&mut msg);
+
+        let files: Vec<&str> = tags
+            .iter()
+            .filter(|t| t.key == tk::FILE_PATH)
+            .map(|t| t.value.as_str())
+            .collect();
+        assert_eq!(files, vec!["README.md", "src/main.rs"]);
+
+        assert!(
+            tags.iter()
+                .any(|t| t.key == tk::FILE_PATH_SOURCE && t.value == "tool_arg")
+        );
+        assert!(
+            tags.iter()
+                .any(|t| t.key == tk::FILE_PATH_CONFIDENCE && t.value == "high")
+        );
+    }
+
+    #[test]
+    fn file_enricher_drops_absolute_path_without_repo_root() {
+        // With no cwd/repo-root signal, absolute paths are privacy-sensitive
+        // and must be dropped — this is the ADR-0083 invariant.
+        let mut enricher = FileEnricher::new();
+        let mut msg = test_msg();
+        msg.role = "assistant".to_string();
+        msg.cwd = None;
+        msg.tool_files = vec!["/Users/dev/secret.rs".into()];
+        let tags = enricher.enrich(&mut msg);
+        assert!(
+            !tags.iter().any(|t| t.key == tk::FILE_PATH),
+            "absolute path must not leak into file_path tags"
+        );
     }
 }

--- a/crates/budi-core/src/pipeline/mod.rs
+++ b/crates/budi-core/src/pipeline/mod.rs
@@ -26,12 +26,16 @@ impl Pipeline {
         //   1. IdentityEnricher — populates local identity tags (user/platform/machine/git_user)
         //   2. GitEnricher   — sets repo_id for glob_match (MUST run before TagEnricher)
         //   3. ToolEnricher  — emits per-message tool tags from parsed tool calls
-        //   4. CostEnricher  — calculates cost_cents and cost_confidence
-        //   5. TagEnricher   — applies user rules (depends on repo_id, model, cost_confidence)
+        //   4. FileEnricher  — R1.4 (#292) turns raw tool_files into repo-relative
+        //                       file_path tags; MUST run after GitEnricher so cwd is
+        //                       resolved and the repo-root walk lines up with repo_id
+        //   5. CostEnricher  — calculates cost_cents and cost_confidence
+        //   6. TagEnricher   — applies user rules (depends on repo_id, model, cost_confidence)
         let enrichers: Vec<Box<dyn Enricher>> = vec![
             Box::new(enrichers::IdentityEnricher::new()),
             Box::new(enrichers::GitEnricher::new()),
             Box::new(enrichers::ToolEnricher),
+            Box::new(enrichers::FileEnricher::new()),
             Box::new(enrichers::CostEnricher),
             Box::new(enrichers::TagEnricher::new(tags_config)),
         ];
@@ -534,6 +538,7 @@ mod tests {
             prompt_category_confidence: None,
             tool_names: Vec::new(),
             tool_use_ids: Vec::new(),
+            tool_files: Vec::new(),
         }
     }
 

--- a/crates/budi-core/src/providers/codex.rs
+++ b/crates/budi-core/src/providers/codex.rs
@@ -281,6 +281,7 @@ fn parse_token_count(
         prompt_category_confidence: None,
         tool_names: Vec::new(),
         tool_use_ids: Vec::new(),
+        tool_files: Vec::new(),
     })
 }
 

--- a/crates/budi-core/src/providers/copilot.rs
+++ b/crates/budi-core/src/providers/copilot.rs
@@ -307,6 +307,7 @@ fn parse_usage_event(
         prompt_category_confidence: None,
         tool_names: Vec::new(),
         tool_use_ids: Vec::new(),
+        tool_files: Vec::new(),
     })
 }
 

--- a/crates/budi-core/src/providers/cursor.rs
+++ b/crates/budi-core/src/providers/cursor.rs
@@ -830,6 +830,7 @@ fn usage_events_to_messages(
                 prompt_category_confidence: None,
                 tool_names: Vec::new(),
                 tool_use_ids: Vec::new(),
+                tool_files: Vec::new(),
             }
         })
         .collect()
@@ -1292,6 +1293,12 @@ fn cursor_prompt_text(message: Option<&CursorMessage>) -> Option<String> {
 #[derive(Debug, Deserialize)]
 struct CursorToolCall {
     name: Option<String>,
+    /// Tool-call arguments. Cursor version churn means the exact shape is
+    /// not stable, so we accept any JSON value and let
+    /// `crate::file_attribution` pick out file-path fields it recognises
+    /// (`file_path`, `target_file`, `path`, `pattern`). Added in R1.4 (#292).
+    #[serde(default, alias = "arguments", alias = "input")]
+    args: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1354,14 +1361,24 @@ fn parse_cursor_line(
     let msg_cwd = entry.cwd.or_else(|| cwd.map(|s| s.to_string()));
     let git_branch = msg_cwd.as_deref().and_then(resolve_git_branch_from_head);
 
-    let mut tool_names: Vec<String> = entry
+    // R1.4 (#292): collect tool names + raw file paths from tool args. We
+    // walk the list once so we pick both up atomically per message.
+    let mut tool_names: Vec<String> = Vec::new();
+    let mut tool_files: Vec<String> = Vec::new();
+    for call in entry
         .tool_calls
         .or(entry.tool_calls_alt)
         .unwrap_or_default()
-        .into_iter()
-        .filter_map(|t| t.name.map(|n| n.trim().to_string()))
-        .filter(|n| !n.is_empty())
-        .collect();
+    {
+        let name = call.name.unwrap_or_default();
+        let trimmed = name.trim().to_string();
+        if !trimmed.is_empty() {
+            tool_names.push(trimmed.clone());
+        }
+        if let Some(args) = call.args.as_ref() {
+            crate::file_attribution::collect_cursor_tool_paths(&trimmed, args, &mut tool_files);
+        }
+    }
     tool_names.sort();
     tool_names.dedup();
 
@@ -1411,6 +1428,7 @@ fn parse_cursor_line(
                 prompt_category_confidence,
                 tool_names: Vec::new(),
                 tool_use_ids: Vec::new(),
+                tool_files: Vec::new(),
             })
         }
         "assistant" | "ai" | "model" => {
@@ -1444,6 +1462,7 @@ fn parse_cursor_line(
                 prompt_category_confidence: None,
                 tool_names,
                 tool_use_ids: Vec::new(),
+                tool_files,
             })
         }
         _ => None,

--- a/crates/budi-core/src/repo_id.rs
+++ b/crates/budi-core/src/repo_id.rs
@@ -52,6 +52,15 @@ impl RepoIdCache {
     }
 }
 
+/// Walk up from `start` to find the enclosing repo root (directory
+/// containing `.git`). Used by `FileEnricher` to normalize tool-call
+/// file paths against the same root that defines `repo_id`, so the
+/// "inside the repo" privacy check matches what analytics see. Added
+/// in R1.4 (#292).
+pub fn repo_root_for(cwd: &Path) -> Option<PathBuf> {
+    find_git_root(cwd).map(|root| crate::config::resolve_storage_root(&root))
+}
+
 /// Walk up from `start` to find a directory containing `.git`.
 fn find_git_root(start: &Path) -> Option<PathBuf> {
     let mut current = start.to_path_buf();

--- a/crates/budi-core/src/tag_keys.rs
+++ b/crates/budi-core/src/tag_keys.rs
@@ -38,6 +38,30 @@ pub const DURATION: &str = "duration";
 pub const TOOL: &str = "tool";
 pub const TOOL_USE_ID: &str = "tool_use_id";
 
+/// Repo-relative file path derived from a tool-call argument (e.g. the
+/// `file_path` input of Read/Write/Edit, Cursor's `target_file`, etc.).
+/// One tag per file on the assistant message. Added in R1.4 (#292).
+///
+/// Contract: value is always repo-relative, forward-slashed, and
+/// inside the resolved repo root. Absolute paths and paths that
+/// escape the repo are dropped before this tag is emitted — see
+/// `crate::file_attribution` and ADR-0083.
+pub const FILE_PATH: &str = "file_path";
+/// Where the file path came from. Stable values:
+/// - `tool_arg` — extracted directly from a known tool file argument
+///   (Read/Write/Edit/NotebookEdit/Grep/Glob/Cursor equivalents).
+/// - `cwd_relative` — path was absolute; stripped against the message
+///   cwd / resolved repo root.
+///
+/// Emitted once per message as a sibling to `file_path` so the source
+/// is queryable the same way R1.2 (#222) did for `activity_source`.
+pub const FILE_PATH_SOURCE: &str = "file_path_source";
+/// Confidence in the file-path attribution. Stable values: `high`
+/// (path was already repo-relative from a known arg), `medium`
+/// (normalized from an absolute path against cwd/repo). Emitted once
+/// per message.
+pub const FILE_PATH_CONFIDENCE: &str = "file_path_confidence";
+
 /// Identity tags: constant for the entire session, deduplicated to one
 /// assistant message per session.
 pub const SESSION_IDENTITY_KEYS: &[&str] = &[

--- a/crates/budi-daemon/src/main.rs
+++ b/crates/budi-daemon/src/main.rs
@@ -117,6 +117,11 @@ fn build_router(app_state: AppState) -> Router {
             "/analytics/activities/{activity}",
             get(a::analytics_activity_detail),
         )
+        .route("/analytics/files", get(a::analytics_files))
+        .route(
+            "/analytics/files/{*file_path}",
+            get(a::analytics_file_detail),
+        )
         .route("/analytics/providers", get(a::analytics_providers))
         .route("/analytics/statusline", get(a::analytics_statusline))
         .route(

--- a/crates/budi-daemon/src/routes/analytics.rs
+++ b/crates/budi-daemon/src/routes/analytics.rs
@@ -656,6 +656,98 @@ pub async fn analytics_activity_detail(
     }
 }
 
+// ---------------------------------------------------------------------------
+// Files — per-file attribution wired in 8.1 R1.4 (#292)
+//
+// Mirrors the ticket/activity endpoints so the CLI exposes one consistent
+// shape: `--files` lists top files, `--file <PATH>` shows a single file's
+// detail with per-branch and per-ticket breakdowns.
+//
+// The path segment is URL-encoded by callers because repo-relative paths
+// routinely contain slashes. We validate it in the handler to avoid
+// surprises in paths that include path traversal tokens.
+// ---------------------------------------------------------------------------
+
+#[derive(serde::Deserialize)]
+pub struct FileListParams {
+    pub since: Option<String>,
+    pub until: Option<String>,
+    pub limit: Option<usize>,
+    #[serde(flatten)]
+    pub filters: DimensionParams,
+}
+
+#[derive(serde::Deserialize)]
+pub struct FileDetailParams {
+    pub since: Option<String>,
+    pub until: Option<String>,
+    pub repo_id: Option<String>,
+}
+
+pub async fn analytics_files(
+    Query(params): Query<FileListParams>,
+) -> Result<Json<Vec<analytics::FileCost>>, (StatusCode, Json<serde_json::Value>)> {
+    let limit = params.limit.unwrap_or(20).min(200);
+    let filters = parse_dimension_filters(&params.filters);
+    let result = tokio::task::spawn_blocking(move || {
+        let db_path = analytics::db_path()?;
+        let conn = analytics::open_db(&db_path)?;
+        analytics::file_cost_with_filters(
+            &conn,
+            params.since.as_deref(),
+            params.until.as_deref(),
+            &filters,
+            limit,
+        )
+    })
+    .await
+    .map_err(|e| internal_error(anyhow::anyhow!("{e}")))?
+    .map_err(internal_error)?;
+
+    Ok(Json(result))
+}
+
+pub async fn analytics_file_detail(
+    Path(file_path): Path<String>,
+    Query(params): Query<FileDetailParams>,
+) -> Result<Json<analytics::FileCostDetail>, (StatusCode, Json<serde_json::Value>)> {
+    // Reject absolute paths and traversal tokens early. `FileEnricher`
+    // never stores such values, so clients asking for them can't match a
+    // row anyway; returning 400 is clearer than a silent 404.
+    if file_path.starts_with('/')
+        || file_path.contains("..")
+        || file_path.contains('\\')
+        || file_path.contains("://")
+    {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({
+                "error": "file path must be repo-relative, forward-slashed, and inside the repo root"
+            })),
+        ));
+    }
+
+    let result = tokio::task::spawn_blocking(move || {
+        let db_path = analytics::db_path()?;
+        let conn = analytics::open_db(&db_path)?;
+        analytics::file_cost_single(
+            &conn,
+            &file_path,
+            params.repo_id.as_deref(),
+            params.since.as_deref(),
+            params.until.as_deref(),
+        )
+    })
+    .await
+    .map_err(|e| internal_error(anyhow::anyhow!("{e}")))?
+    .map_err(internal_error)?;
+
+    match result {
+        Some(detail) => Ok(Json(detail)),
+        None => Err(not_found("file not found")),
+    }
+}
+
 pub async fn analytics_schema_version()
 -> Result<Json<SchemaVersionResponse>, (StatusCode, Json<serde_json::Value>)> {
     let result = tokio::task::spawn_blocking(move || -> anyhow::Result<SchemaVersionResponse> {


### PR DESCRIPTION
## Summary

Make "which files did the AI touch" a first-class, privacy-safe analytics
dimension for Budi 8.1. The pipeline now extracts file paths from the
arguments of file-aware tool calls (Claude Code `Read` / `Write` / `Edit` /
`MultiEdit` / `NotebookEdit` / `Grep` / `Glob` and Cursor's `edit_file` /
`read_file` / `write_file` / `search_replace` / `delete_file` / …),
normalizes them to repo-relative, forward-slashed paths inside the resolved
repo root, and emits them as `file_path` tags — alongside sibling
`file_path_source` / `file_path_confidence` provenance tags mirroring the
R1.0–R1.3 ticket / activity contracts.

**Pipeline**
- New `crates/budi-core/src/file_attribution.rs` implements extraction
  (per-provider `collect_claude_tool_paths` / `collect_cursor_tool_paths`)
  and `attribute_files`, which enforces the ADR-0083 contract: absolute
  paths are stripped against cwd/repo root or dropped; `..` escapes are
  dropped; non-`file://` URL schemes are rejected; per-message fan-out is
  capped at `MAX_FILES_PER_MESSAGE` (16).
- `ParsedMessage` gains `tool_files` carrying the raw candidate paths
  pulled by `jsonl.rs` (Claude Code `tool_use` blocks) and
  `providers::cursor` (Cursor `tool_calls.args`) at parse time.
- New `FileEnricher` runs after `GitEnricher` in the default pipeline so
  `cwd` / `repo_id` are resolved before normalization, and uses a per-cwd
  cache to avoid re-walking the filesystem for repeated messages in a
  session.

**Analytics + surfaces**
- `analytics::file_cost` / `file_cost_single` with proportional
  multi-file cost split, `(untagged)` bucket, and top-repo / top-branch /
  top-ticket / top-source picks per file.
- Daemon routes `GET /analytics/files` and
  `GET /analytics/files/{*path}` (wildcard catch-all — paths contain
  slashes) with server-side validation that rejects absolute paths,
  `..`, Windows separators, and URL schemes before hitting SQLite.
- CLI: `budi stats --files` lists files ranked by cost;
  `budi stats --file <PATH>` shows detail with per-branch **and**
  per-ticket breakdowns so users can see which tickets drove cost on a
  particular file. Mirrors `--tickets` / `--activities` so operators
  don't learn a new query shape. The same path validation runs
  client-side for clearer errors.
- SOUL.md gets a `file_path` section describing the extraction
  contract, privacy guarantees, tag shape, and CLI/HTTP surfaces; the
  auto-detected tag list and analytics-endpoint list are updated.

## Risks

- **Privacy** is the core risk and is handled by three layers (see
  ADR-0083): normalizer drops outside-of-repo paths, `FileEnricher` only
  emits tags for accepted paths, daemon + CLI reject malformed paths
  before query. Regression tests pin each invariant
  (`absolute_path_outside_repo_is_dropped`,
  `absolute_path_without_repo_root_is_dropped`,
  `file_enricher_drops_absolute_path_without_repo_root`,
  `parent_escape_is_dropped`, `rejects_non_file_schemes`).
- **Schema**: no migration required — `file_path` tags land in the
  existing `tags` table. Pre-R1.4 rows silently fall into the
  `(untagged)` bucket and become tagged as new data is ingested.
- **Fan-out**: the 16-file per-message cap keeps worst-case storage
  bounded even on Grep/Glob-heavy assistant turns; `dropped` is
  returned from `attribute_files` for future observability if needed.
- **Wildcard route**: the `{*file_path}` axum wildcard accepts anything,
  so daemon + CLI validation is what keeps bad inputs out. Both layers
  reject the same patterns.
- **Tool coverage**: only the known file-aware tool names emit paths
  today. Unknown Cursor tools fall back to a lenient check on
  `target_file` / `file_path`; unknown Claude tools emit nothing. This
  is intentional — false positives would leak non-file arguments (e.g.
  Bash commands) as "files".

## Validation

- `cargo fmt --all` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace` — **487 tests pass** (63 CLI + 398 core + 26
  daemon). New test coverage:
  - `file_attribution::tests::*` (14 tests) covering extraction per
    provider, normalization, privacy guards, traversal, dedup, capping,
    and URL schemes.
  - `pipeline::enrichers::tests::file_enricher_*` (4 tests) covering
    user-message skip, empty-paths skip, repo-relative emission, and
    the privacy guard against absolute paths without repo context.
  - `analytics::tests::file_cost_*` (4 tests) covering grouping,
    untagged bucket, detail + per-branch + per-ticket breakdowns, and
    repo filtering.
  - `main::tests::cli_*_file*` (4 tests) covering `--files` / `--file`
    parsing, mutual exclusion, and `--repo` scoping.

## Test plan

- [ ] `cargo test --workspace` green locally (done)
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` green
      locally (done)
- [ ] Manual smoke: after merge, on a dev workstation with recent
      transcripts, run `budi import` then `budi stats --files` and
      verify (a) non-empty list, (b) paths are repo-relative, (c) no
      absolute paths or `..` tokens appear in the output or the raw
      `tags` table.
- [ ] Manual smoke: `budi stats --file crates/budi-core/src/lib.rs`
      surfaces per-branch and per-ticket breakdowns with
      cost-desc ordering.

Closes #292

cc @siropkin — unblocks R1.5+ since file-level attribution was the last
R1 signal the dashboard/CLI needs before surface alignment.

Made with [Cursor](https://cursor.com)