### PR TITLE
[8.2][R1.1] ADR-0089: JSONL tailing as sole live path; supersede ADR-0082 (#317)

### DIFF
--- a/docs/adr/0081-product-contract-and-deprecation-policy.md
+++ b/docs/adr/0081-product-contract-and-deprecation-policy.md
@@ -1,9 +1,11 @@
 # ADR-0081: 8.0 Product Contract and Deprecation Policy
 
 - **Date**: 2026-04-10
-- **Status**: Implemented
+- **Status**: Implemented (amended — see banner)
 - **Issue**: [#81](https://github.com/siropkin/budi/issues/81)
 - **Milestone**: 8.0.0
+
+> **Amended by [ADR-0089](./0089-reverse-proxy-first-jsonl-tailing-as-sole-live-path.md) (2026-04-17).** The §Provider System note that "JSONL file sync will be removed from the continuous sync loop when proxy mode ships (R2)" is **rescinded**. In Budi 8.2+, JSONL tailing **is** the continuous sync loop. The `Provider` trait is extended with `watch_roots()` to serve it. The rest of this ADR's deprecation policy framework stands as written.
 
 ## Context
 

--- a/docs/adr/0082-proxy-compatibility-matrix-and-gateway-contract.md
+++ b/docs/adr/0082-proxy-compatibility-matrix-and-gateway-contract.md
@@ -1,10 +1,12 @@
 # ADR-0082: Proxy Compatibility Matrix and Local Gateway Contract
 
 - **Date**: 2026-04-10
-- **Status**: Implemented
+- **Status**: Superseded by [ADR-0089](./0089-reverse-proxy-first-jsonl-tailing-as-sole-live-path.md) (2026-04-17)
 - **Issue**: [#82](https://github.com/siropkin/budi/issues/82)
 - **Milestone**: 8.0.0
 - **Depends on**: [ADR-0081](./0081-product-contract-and-deprecation-policy.md)
+
+> **Superseded by [ADR-0089](./0089-reverse-proxy-first-jsonl-tailing-as-sole-live-path.md) (2026-04-17).** Budi 8.2 replaces proxy-first ingestion with JSONL tailing as the sole live path. The compatibility matrix, gateway contract, streaming behavior, and `X-Budi-*` attribution header protocol described below are retired in 8.2 R2.1. Agent compatibility in 8.2+ is a function of `Provider::watch_roots()` + `Provider::parse_file`, not of proxy base-URL configuration. The record below is preserved for historical context only.
 
 ## Context
 

--- a/docs/adr/0088-8x-local-developer-first-product-contract.md
+++ b/docs/adr/0088-8x-local-developer-first-product-contract.md
@@ -1,10 +1,12 @@
 # ADR-0088: 8.x Local-Developer-First Product Contract
 
 - **Date**: 2026-04-17
-- **Status**: Accepted
+- **Status**: Accepted (amended — see banner)
 - **Issue**: [#216](https://github.com/siropkin/budi/issues/216)
 - **Milestone**: 8.1.0
 - **Depends on**: [ADR-0081](./0081-product-contract-and-deprecation-policy.md), [ADR-0082](./0082-proxy-compatibility-matrix-and-gateway-contract.md), [ADR-0083](./0083-cloud-ingest-identity-and-privacy-contract.md), [ADR-0086](./0086-extraction-boundaries.md), [ADR-0087](./0087-cloud-infrastructure-and-deployment.md)
+
+> **Amended by [ADR-0089](./0089-reverse-proxy-first-jsonl-tailing-as-sole-live-path.md) (2026-04-17).** §2's table row naming the proxy as "Sole live ingestion path (ADR-0082)" is replaced: in 8.2+, the tailer is the sole live ingestion path (ADR-0089); it filesystem-watches agent transcripts and there is no proxy. §5's language about "rule-based activity/ticket/branch/file/outcome signals inside the proxy + pipeline" is replaced with "inside the pipeline, over JSONL tailed from agent transcripts." The rest of this ADR — persona priority (§1), local vs cloud boundary (§2 remainder), round order (§3), statusline contract (§4), classification intent (§5 intent), cloud scope for 8.1 (§6), and deprecation policy (§7) — stands as written. The 8.1 surfaces referenced here all shipped against the proxy path because 8.1 predates the pivot; 8.2 R1/R2 execute the reversal.
 
 ## Context
 

--- a/docs/adr/0089-reverse-proxy-first-jsonl-tailing-as-sole-live-path.md
+++ b/docs/adr/0089-reverse-proxy-first-jsonl-tailing-as-sole-live-path.md
@@ -1,0 +1,191 @@
+# ADR-0089: Reverse Proxy-First Architecture — JSONL Tailing as Sole Live Path
+
+- **Date**: 2026-04-17
+- **Status**: Proposed
+- **Issue**: [#317](https://github.com/siropkin/budi/issues/317)
+- **Milestone**: 8.2.0 (epic: [#316](https://github.com/siropkin/budi/issues/316))
+- **Supersedes**: [ADR-0082](./0082-proxy-compatibility-matrix-and-gateway-contract.md)
+- **Amends**: [ADR-0081](./0081-product-contract-and-deprecation-policy.md) §Provider System, [ADR-0088](./0088-8x-local-developer-first-product-contract.md) §2 and §5
+
+## Context
+
+ADR-0081 declared Budi 8.0's product contract with a hard choice: the proxy would be "the sole live ingestion path," JSONL file sync would be "removed from the continuous sync loop when proxy mode ships," and adding a new agent would reduce to documenting its base URL configuration. ADR-0082 operationalized that into a compatibility matrix, a gateway contract, and an attribution protocol based on `X-Budi-Repo` / `X-Budi-Branch` / `X-Budi-Cwd` / `X-Budi-Session` request headers. ADR-0088 reaffirmed the proxy as the sole live ingestion path in the 8.x local-developer-first contract.
+
+Three things happened in practice between 8.0 and 8.1 that contradict the proxy-first contract:
+
+1. **No stock agent emits the `X-Budi-*` headers.** `budi enable <agent>`, `budi launch <agent>`, and the proxy install flow all inject `ANTHROPIC_BASE_URL` / `OPENAI_BASE_URL` / `COPILOT_PROVIDER_BASE_URL` so the agent talks to `http://localhost:9878`. None of them inject the attribution headers the proxy needs to assign `repo_id` and `git_branch`. Live proxy attribution depends on session-level backfill from later messages that happen to carry context — not on live capture.
+2. **The value-add features do not run on the proxy path.** 8.1's R1.3 ticket extraction (#221), R1.4 file-level attribution (#292), and the rest of the classification stack are implemented in `Pipeline::process` and the `Enricher` chain (`GitEnricher`, `ToolEnricher`, `FileEnricher`, `TagEnricher`). These run on JSONL import. The proxy path calls a different code path (`insert_proxy_message`) that bypasses the pipeline, reads `cwd` from headers that are empty, and leans on session-level SQL backfill to fill in the blanks. Deep classification on live proxy data is, in practice, not happening.
+3. **JSONL transcripts already carry the full context.** Claude Code, Codex, and Cursor write structured JSONL to disk with `cwd` and `gitBranch` fields on every message. `budi import` reads them today, runs `Pipeline::default_pipeline()`, and produces correctly classified rows — without needing a proxy, a base URL, or attribution headers. The 8.1 analytics the product actually ships on are already JSONL-derived.
+
+On top of the contract drift, the proxy path carries costs that the product has started paying in real user friction:
+
+- Shell profile mutation (`~/.zshrc`, `~/.bashrc`, `~/.config/fish/config.fish`) that enterprise developers flag on first install, because Budi modifying a shared dotfile during onboarding is a hard no for a non-trivial fraction of the target persona.
+- Cursor `settings.json` and `~/.codex/config.toml` mutation that breaks when users later reconfigure those tools, creating support load.
+- `budi launch <agent>` as a CLI wrapper that users won't use in practice. Developers run `claude` or `codex` or click Cursor — they do not launch agents through Budi. The launch command exists primarily because without it the attribution headers cannot be injected. See point (1).
+- A daemon-is-single-point-of-failure risk: if the Budi daemon dies, every agent that has `ANTHROPIC_BASE_URL=http://localhost:9878` exported also stops working. The "invisible background tool" persona becomes "that thing that broke my AI coding session" the first time the daemon crashes.
+- A full second protocol maintenance burden. Anthropic's Messages API and OpenAI's Chat Completions API both evolve; the proxy has to keep forwarding correctly through every version change, including streaming edge cases, tool-use block changes, and new parameters. This is protocol work that does not move the product forward.
+- The `proxy_cutoff` rule in `analytics/sync.rs`: a ~30-line dedup patch that exists only because we now have two ingestion paths racing on the same messages. It is a bug we are paying to maintain, not a feature.
+- "Unassigned" live rows in stats output because attribution cannot be resolved in real time. The most common user-visible symptom of the contract drift.
+
+The underlying problem is that the 8.0 / 8.1 architecture over-indexed on the theoretical benefits of live proxy ingestion (sub-second freshness, inline classification, single path) and under-counted the operational costs of actually making it work (header injection in agents we do not control, daemon criticality, two-code-path maintenance, onboarding surface mutation). Meanwhile, the JSONL path quietly became the one that actually delivers the product's value propositions.
+
+This ADR closes the drift by matching the contract to the implementation — and then deleting the code that supported the old contract.
+
+## Decision
+
+### 1. JSONL tailing is the sole live ingestion path
+
+Budi's live ingestion is a file watcher over agent-written transcript files. Every supported agent implements a `Provider` trait with:
+
+- `discover_files() -> Vec<DiscoveredFile>` — one-shot enumeration, used by `budi import` for backfill
+- `parse_file(path, content, offset) -> (messages, new_offset)` — incremental parse
+- `watch_roots() -> Vec<PathBuf>` — directories the daemon's tailer watches live (new in 8.2, see [#318](https://github.com/siropkin/budi/issues/318))
+- `sync_direct(...)` — optional, only for agents with a real Usage API (currently Cursor)
+
+A single daemon-side worker (new in 8.2, see [#319](https://github.com/siropkin/budi/issues/319)) uses `notify` for filesystem events, with polling fallback where needed. It maintains per-file offsets in a new `tail_offsets` table, calls `Provider::parse_file` with the stored offset on each event, feeds the resulting messages through `Pipeline::default_pipeline()`, and writes to the same `messages` / tag tables the batch `budi import` writes to. There is no second code path.
+
+### 2. The proxy is removed
+
+All of the following code is deleted in 8.2 R2.1 (#322):
+
+- `crates/budi-core/src/proxy.rs`
+- `crates/budi-daemon/src/routes/proxy.rs`
+- `crates/budi-cli/src/commands/proxy_install.rs`
+- `crates/budi-cli/src/commands/launch.rs`
+- CLI subcommands `budi launch`, `budi enable <agent>`, `budi disable <agent>`
+- Anthropic Messages + OpenAI Chat Completions protocol types that existed only for pass-through
+- Integration tests exercising proxy forwarding
+
+The `X-Budi-Repo` / `X-Budi-Branch` / `X-Budi-Cwd` / `X-Budi-Session` header contract is deprecated. No client-side tooling is ever going to emit them, and the JSONL path does not need them.
+
+### 3. The install surface stops mutating user config
+
+Starting in 8.2 R2.2 (#323) and R2.3 (#324), `budi init` does exactly four things:
+
+1. Creates the Budi data directory
+2. Registers and starts the daemon (launchd / systemd user unit / Windows Service)
+3. Prints the list of detected agents based on `Provider::watch_roots()` existence
+4. Exits
+
+No shell profile writes. No Cursor `settings.json` patching. No `~/.codex/config.toml` mutation. No prompts. No flags beyond `--cleanup`.
+
+`budi init --cleanup` is a new subcommand that removes previously-injected 8.1-era Budi blocks from shell profiles and agent configs. It is opt-in, shows a diff preview, and asks for confirmation. It is the only surviving path that writes to user config files, and it only deletes.
+
+### 4. Attribution comes from the transcript, not from headers
+
+Every supported agent already writes `cwd` and `gitBranch` into its local JSONL on every message (Claude Code, Codex, Cursor, Copilot). The `GitEnricher` consumes these directly inside the pipeline. The ticket extraction rules from ADR-0086 and #221 apply unchanged. File-level attribution (#292) continues to run in `FileEnricher`.
+
+There is no live attribution header contract. There is no session-level SQL backfill shim. There is only the pipeline, running on the transcripts the agent already writes.
+
+### 5. Latency budget: single-digit seconds is accepted
+
+All downstream Budi surfaces — `budi stats`, `budi sessions`, `budi status`, `budi statusline`, `budi doctor`, daemon analytics routes — explicitly accept tail latency on the order of 1–10 seconds. Filesystem events fire within ~1 s on all three supported OSes under normal conditions; the pipeline adds tens of milliseconds. No surface in 8.x requires sub-second freshness. The design-principles doc (§4) is rewritten to reflect this.
+
+### 6. Daemon outage does not break the user's agent
+
+Because the agent no longer routes traffic through the proxy, a Budi daemon crash is invisible to the agent. The user keeps working. When the daemon comes back, the tailer picks up from the persisted offsets and catches up. This is a hard design property, not an accident. It is also the single biggest user-facing argument for this ADR.
+
+### 7. Fallback policy: none
+
+There is no proxy fallback. There is no dual-path reconciliation. There is no "if JSONL isn't there, use the proxy" branch. Having two live paths was the bug. If a future agent cannot be tailed (no on-disk transcript), that is a scoping issue for that agent, not a license to reintroduce two paths of ingestion for everyone.
+
+The Cursor Usage API remains a **pull** used only for cost/token reconciliation where the JSONL does not carry that data. It is scheduled separately from the tailer and is not part of the live hot path. Its lag profile is measured in [#321](https://github.com/siropkin/budi/issues/321) before this ADR is promoted to `Accepted`.
+
+### 8. Plugin model is preserved
+
+The `Provider` trait is the only extension point. Adding a new agent in 8.3 (#294) is one new `Provider` impl plus its registration — no proxy adapter, no base URL matrix, no env-var injection, no shell profile work. The plugin model survives intact; what changes is that it is also the live model, not just the import model.
+
+## Consequences
+
+### Positive
+
+- **One code path, one contract.** The live ingestion path and the historical import path are the same path. Every feature (ticket extraction, file attribution, activity classification, tool outcomes) lands for both, always. No more "proxy mode doesn't do that yet."
+- **Invisible install.** The single biggest onboarding objection (shell profile mutation) is gone. `budi init` becomes a ten-second, no-decisions operation.
+- **Daemon outage is safe.** Users keep coding. Budi catches up. The "what if the daemon dies while I'm on a deadline" fear vanishes.
+- **Protocol maintenance burden drops.** Anthropic and OpenAI API evolutions are no longer Budi's problem.
+- **Code surface shrinks substantially.** 8.2 R2.1 is a net-negative LOC release — a rare and healthy property.
+- **Plugin story becomes real.** Adding Gemini CLI or Windsurf in 8.3 is one `Provider` impl away, not a proxy adapter plus a compatibility matrix plus setup docs per agent.
+
+### Negative
+
+- **Accepts 1–10 s freshness instead of sub-second.** The statusline is no longer live-live. In practice this is already the case because the statusline polls the daemon on a schedule, but it is worth naming.
+- **Forces an 8.1 → 8.2 breaking upgrade.** Users with 8.1 exports in their shell profile need to run `budi init --cleanup`. Release notes must lead on this.
+- **Concedes that agents not writing transcripts cannot be supported.** Any future agent that only holds state in-memory is out of scope for the tailer path until that agent ships a transcript option. We treat this as a scoping decision per agent, not a whole-product fallback.
+- **Cursor cost/token accuracy depends on Usage API cadence.** This is an existing limitation, but it stops being mitigated by proxy pass-through. The [#321](https://github.com/siropkin/budi/issues/321) measurement is the gate on whether any compensating work is needed.
+- **`proxy_events` rows become historical artifacts.** Their fate on upgrade is decided in [#326](https://github.com/siropkin/budi/issues/326). At minimum they are read-only; at most they are reprocessed from JSONL.
+
+### Neutral
+
+- Privacy envelope is unchanged. ADR-0083 still governs. The tailer reads the same files `budi import` already reads.
+- Cloud sync is unchanged. The cloud consumes the `messages` table regardless of which ingest path populated it.
+- Provider-scoped status contract (#224) is unchanged.
+- MCP server reintroduction (9.0) is unchanged.
+
+## Alternatives Considered
+
+### A. Keep the proxy as the sole live path and fix the attribution header gap
+
+Requires shipping a client-side shim that wraps every supported agent (`claude`, `codex`, `cursor`, `copilot`, `gh-copilot-chat`, any future agent) and injects `X-Budi-*` headers before forwarding requests to the real proxy. This is effectively building `budi launch` for every agent, forever, and convincing users to use it. Rejected as not achievable: enterprise developers will not route their agents through a Budi-provided wrapper, and there is no stable way to do it for GUI-based tools like Cursor without patching the app itself.
+
+### B. Dual-path: keep both proxy and tailer
+
+What 8.1 effectively is today, unintentionally. It keeps all the costs of the proxy (shell mutation, protocol burden, daemon criticality) while adding tailer complexity, and still requires `proxy_cutoff` dedup. The worst of both worlds on an ongoing basis. Rejected.
+
+### C. Tailer-first, proxy retained for Cursor cost capture only
+
+Considered seriously. The argument is that Cursor's JSONL does not carry per-request tokens and costs — those come back via the Usage API, which is currently polled once per `budi sync`. If the Usage API lag is materially larger than the proxy's real-time capture, Cursor users pay a visible freshness cost from this ADR.
+
+Rejected as the default, conditionally reconsiderable. [#321](https://github.com/siropkin/budi/issues/321) measures the lag empirically. If the lag is bounded and acceptable (expected outcome based on prior spot checks), the Usage API pull is sufficient. If it is not, a narrowly-scoped Cursor-only proxy passthrough for cost capture can be reintroduced as a follow-up ADR — but that reintroduction would be measured in hundreds of lines of code, not thousands, and would not touch shell profiles, `budi launch`, or the attribution model.
+
+### D. Defer the pivot to 9.0
+
+Considered. Rejected because the contract drift is visible to users today (unassigned rows, "my AI broke because the daemon died" support stories, `budi launch` as an unused subcommand that still ships) and because every release that does not reverse the contract spends cycles maintaining a path the product does not actually use. 8.2 is scoped intentionally narrow to make this a credible single-release pivot.
+
+## Amendments to Prior ADRs
+
+This ADR amends the following prior decisions. A banner pointing at this ADR is added to each affected file:
+
+### ADR-0081 §Provider System
+
+The statement that "JSONL file sync will be removed from the continuous sync loop when proxy mode ships (R2)" is rescinded. JSONL tailing **is** the continuous sync loop in 8.2 and after. The `Provider` trait is extended with `watch_roots()` to serve that loop.
+
+### ADR-0082 (entire document)
+
+Superseded. The proxy compatibility matrix, gateway contract, streaming behavior, and attribution header protocol are retired in 8.2 R2.1. Agent compatibility in 8.2+ is a function of `Provider::discover_files` + `Provider::parse_file` + `Provider::watch_roots`, not of proxy base-URL configuration.
+
+### ADR-0088 §2 and §5
+
+§2's table row "Proxy | `siropkin/budi` | Sole live ingestion path (ADR-0082)." is replaced with "Tailer | `siropkin/budi` | Sole live ingestion path (ADR-0089). Filesystem-watches agent transcripts; no proxy." The proxy row is removed entirely.
+
+§5's language on "rule-based activity/ticket/branch/file/outcome signals inside the proxy + pipeline" is replaced with "inside the pipeline, over JSONL tailed from agent transcripts." The proxy is no longer mentioned.
+
+### `docs/design-principles.md` §4 ("Proxy-First Architecture (8.0+)")
+
+Rewritten in full in [#317](https://github.com/siropkin/budi/issues/317) as "JSONL Tailing as Sole Live Path (8.2+)". The principle "Don't reintroduce hooks, OTEL, or continuous file watching for live data" is reversed: continuous file watching **is** the live data mechanism.
+
+### `SOUL.md`
+
+Any section that still describes the proxy as the live path is updated in the R1.1 PR.
+
+## Promotion Criteria
+
+This ADR is promoted from `Proposed` to `Accepted` only when all of the following are true:
+
+- [#321](https://github.com/siropkin/budi/issues/321) Cursor Usage API lag memo is merged and its recommendation is consistent with this ADR's §7
+- [#318](https://github.com/siropkin/budi/issues/318) `Provider::watch_roots()` is merged
+- [#319](https://github.com/siropkin/budi/issues/319) daemon tailer is merged behind `BUDI_LIVE_TAIL=1`
+- [#320](https://github.com/siropkin/budi/issues/320) tailer is promoted to default and proxy ingestion is short-circuited
+
+Until those gates close, this ADR remains `Proposed` and the 8.2 R2 proxy-removal work is explicitly blocked. That gating is intentional: removing the proxy before the tailer is trusted is the one failure mode this ADR is trying to avoid.
+
+## References
+
+- [ADR-0081: Product Contract and Deprecation Policy](./0081-product-contract-and-deprecation-policy.md)
+- [ADR-0082: Proxy Compatibility Matrix and Gateway Contract](./0082-proxy-compatibility-matrix-and-gateway-contract.md) (superseded by this ADR)
+- [ADR-0083: Cloud Ingest Identity and Privacy Contract](./0083-cloud-ingest-identity-and-privacy-contract.md)
+- [ADR-0086: Extraction Boundaries](./0086-extraction-boundaries.md)
+- [ADR-0088: 8.x Local-Developer-First Product Contract](./0088-8x-local-developer-first-product-contract.md) (amended by this ADR)
+- [#316](https://github.com/siropkin/budi/issues/316) — 8.2.0 Invisible Budi epic
+- [#317](https://github.com/siropkin/budi/issues/317) — this ADR's tracking issue
+- [#201](https://github.com/siropkin/budi/issues/201) — 8.1.0 epic (must ship before 8.2 work starts)
+- [#294](https://github.com/siropkin/budi/issues/294) — 8.3.0 AI coding tool coverage epic (built on the tailer)

--- a/docs/design-principles.md
+++ b/docs/design-principles.md
@@ -30,23 +30,18 @@ Prompts, code, and model responses never leave the local machine. This is struct
 - No "full upload" mode. No toggle. No exception.
 - Never-upload fields are enforced by the sync worker reading only from rollup tables
 
-## 4. Proxy-First Architecture (8.0+)
+## 4. JSONL Tailing as Sole Live Path (8.2+)
 
-The proxy is the sole live data source. Historical data (JSONL, Cursor API) is available via `budi import` for backfill only.
+> **Changed by [ADR-0089](./adr/0089-reverse-proxy-first-jsonl-tailing-as-sole-live-path.md) (2026-04-17).** The "Proxy-First Architecture (8.0+)" principle that previously held this slot is superseded. Budi 8.1.x still ships the proxy during the transition window; it is removed in Budi 8.2.0. The principle as it applies going forward is below.
 
-- Don't reintroduce hooks, OTEL, or continuous file watching for live data
-- Proxy is transparent — no SDK, no per-agent integration code for live tracking
-- Adding a new agent = documenting its base URL configuration
+Budi's live data source is a filesystem tailer over the transcript files agents already write locally. There is one live ingestion path, not two.
 
-### Auto-proxy-install (8.0+)
-
-The proxy is installed automatically for agents the user selects during `budi init`. Users should not need to remember special launch commands — tracking starts the moment they open a terminal or IDE.
-
-- **CLI agents** (Claude Code, Codex, Copilot CLI, Gemini CLI): env vars injected into the user's shell profile (`~/.zshrc`, `~/.bashrc`) inside a `# >>> budi >>> ... # <<< budi <<<` guard block
-- **IDE agents** (Cursor, Codex Desktop): config files patched directly (`Override OpenAI Base URL` in Cursor's settings.json, `openai_base_url` in `~/.codex/config.toml`)
-- **Opt-out**: `budi disable <agent>` removes the env vars or reverts config changes
-- **Bypass**: `BUDI_BYPASS=1 <agent>` skips the proxy for a single session
-- **Prerequisite**: daemon autostart (launchd/systemd) is required — if env vars point to `localhost:9878` but the daemon isn't running, API calls fail
+- Don't reintroduce the proxy, hooks, or OTEL for live data — the tailer is the live data mechanism
+- Don't mutate shell profiles, Cursor `settings.json`, `~/.codex/config.toml`, or any user config during install; `budi init` creates the data dir, registers the daemon, and exits
+- Daemon outage must not break the user's agent — the agent keeps working; Budi catches up on next tail
+- Adding a new agent = one `Provider` impl (`discover_files` + `parse_file` + `watch_roots`) — no proxy matrix, no base-URL injection, no agent wrapper
+- Latency budget: single-digit seconds end-to-end is acceptable for every downstream surface (stats, sessions, statusline, doctor, cloud sync)
+- Privacy boundary is unchanged ([ADR-0083](./adr/0083-cloud-ingest-identity-and-privacy-contract.md)): the tailer reads the same files `budi import` already reads; nothing leaves the machine
 
 ## 5. Local-First, Cloud-Optional
 


### PR DESCRIPTION
## Summary

Draft ADR-0089 proposing that Budi 8.2 reverse the 8.0/8.1 proxy-first contract and make JSONL tailing the sole live ingestion path. Supersedes ADR-0082 in full, amends ADR-0081 §Provider System and ADR-0088 §2+§5. No code changes in this PR — this is the design contract that gates the rest of the 8.2 epic.

Status of the ADR is **Proposed**. It stays `Proposed` until #318, #319, #320, and #321 all close; only then does it promote to `Accepted`.

## Why

Three things diverged between the 8.0 contract and the 8.1 reality:

1. **No stock agent emits the `X-Budi-*` headers** the proxy contract requires. `budi enable` / `budi launch` / `proxy_install` all inject `ANTHROPIC_BASE_URL` / `OPENAI_BASE_URL` / `COPILOT_PROVIDER_BASE_URL` — none inject the attribution headers the proxy needs. Live proxy attribution today falls back on session-level SQL backfill, not live capture.
2. **The value-add features don't run on the proxy path.** Ticket extraction (#221), file-level attribution (#292), and the rest of the classification stack live in `Pipeline::process` and the `Enricher` chain. Those run on JSONL import. The proxy path calls `insert_proxy_message`, which bypasses the pipeline.
3. **JSONL transcripts already carry the full context.** Claude Code, Codex, Cursor, and Copilot write structured JSONL with `cwd` and `gitBranch` on every message. `budi import` reads them, runs `Pipeline::default_pipeline()`, and produces correctly classified rows — without needing a proxy.

On top of the drift, the proxy costs real user friction: shell profile mutation, Cursor `settings.json` patching, daemon criticality (daemon down → agent down), a second protocol maintenance burden, `proxy_cutoff` dedup in `analytics/sync.rs`, and "Unassigned" live rows.

## What the ADR locks

- JSONL tailing is the sole live ingestion path. `Provider` trait grows `watch_roots()`. The daemon runs one tailer worker per provider. No second code path.
- The proxy is deleted in 8.2 R2.1 (#322): `proxy.rs`, `routes/proxy.rs`, `proxy_install.rs`, `launch.rs`, CLI subcommands `budi launch`/`enable`/`disable`, and the Anthropic/OpenAI pass-through protocol types.
- `budi init` stops mutating shell profiles, Cursor `settings.json`, and `~/.codex/config.toml`. New `budi init --cleanup` removes previously-injected 8.1-era blocks.
- Attribution comes from the transcript (`cwd` + `gitBranch`), not from headers. The `X-Budi-*` header contract is deprecated.
- Latency budget: single-digit seconds is explicitly acceptable for every downstream surface.
- Daemon outage does not break the user's agent. Hard design property.
- No fallback policy. Two live paths was the bug we are fixing.
- Plugin model intact: adding a new agent in 8.3 (#294) is one `Provider` impl, no proxy adapter.

## Alternatives considered

A. Keep the proxy and fix the header gap with a client-side shim — rejected (shim per agent, GUI tools unshimmable, users won't route AI through `budi launch`).
B. Dual-path tailer + proxy — what 8.1 effectively is today; keeps every proxy cost and adds tailer complexity. Rejected.
C. Tailer-first, proxy retained for Cursor cost capture only — conditionally reconsiderable based on the #321 Usage API lag memo; not the default.
D. Defer the pivot to 9.0 — rejected; drift is user-visible today.

## Test plan

This PR lands design text only. Validation is by review:

- [ ] Design principles §4 and SOUL.md updates follow in this PR's review cycle (separate commits may be added here based on review feedback)
- [ ] Cross-references from ADR-0081, ADR-0082, ADR-0088 to this ADR will be added in R1.2+ PRs (intentionally deferred so the ADR lands first as a standalone document)
- [ ] R1.2–R1.5 implementation PRs cite this ADR
- [ ] ADR status bumped to `Accepted` when #320 merges

## Related

- Epic: #316
- Tracking issue: #317
- Sub-issues: #318 (Provider trait), #319 (tailer), #320 (promote tailer), #321 (Cursor Usage API lag), #322 (remove proxy code), #323 (remove shell mutation), #324 (simplify init), #325 (rewrite doctor), #326 (data migration), #327 (release notes), #328 (smoke test), #329 (tag), #330 (getbudi.dev sync)
- Supersedes: ADR-0082
- Amends: ADR-0081 §Provider System, ADR-0088 §2+§5
- Note: 8.2 work **must not start** until 8.1 (#201) is shipped; this PR can be reviewed in parallel but should not merge until the 8.1 release is tagged.

Closes #317 on merge (moves ADR to `Accepted` only when #320 lands, as documented in the ADR's Promotion Criteria section).

Made with [Cursor](https://cursor.com)