### PR TITLE
[8.1][R1.5] Capture tool outcome and session work outcome signals (#293)

### DIFF
--- a/SOUL.md
+++ b/SOUL.md
@@ -309,6 +309,36 @@ in [#302](https://github.com/siropkin/budi/issues/302) / #303 / #304 / #305):
     repo-relative (no leading `/`, no `..`, no Windows separators, no
     URL scheme) before hitting SQLite.
 
+- **`tool_outcome`** — per-message tool-call outcome added in R1.5
+  ([#293](https://github.com/siropkin/budi/issues/293)). The JSONL
+  extractor reads `tool_result` blocks from user messages, keeps only
+  the `tool_use_id` and a bounded classification (`success`, `error`,
+  `denied`), and never persists the underlying content. The pipeline
+  joins these back to the originating assistant message on the next
+  pass and emits one `tool_outcome` tag per distinct outcome observed.
+  A session-scoped retry heuristic promotes a follow-up call to the
+  same tool after an `error` into `tool_outcome=retry`, so recovery
+  attempts surface without requiring provider cooperation. Sibling
+  `tool_outcome_source` (`jsonl_tool_result` when direct,
+  `heuristic_retry` when promoted) and `tool_outcome_confidence`
+  (`high` / `medium`) mirror the `activity_source` / `file_path_source`
+  contract. Messages with no tool uses carry no outcome tag. The proxy
+  ingest path does not emit outcomes in 8.1 — tool names and IDs
+  aren't captured there yet — so outcomes are import-only for now.
+
+- **`work_outcome`** (session-scoped) — derived in R1.5 from local
+  git state only. `budi session detail <id>` correlates the session's
+  `git_branch` with commits on that branch between the session's
+  start and its end + 24h grace, producing one of `committed`,
+  `branch_merged`, `no_commit`, or `unknown`. The derivation runs
+  `git` locally — no remote Git/PR API calls, no content capture —
+  and fails open to `unknown` whenever the branch is missing, is an
+  integration branch (`main`, `master`, `develop`), or the repo root
+  can't be resolved. A one-line rationale accompanies every label so
+  operators can see which rule fired. List surfaces skip the
+  derivation (one `git` invocation per session list row is too
+  expensive); only the detail view surfaces it.
+
 `budi doctor` runs three attribution checks:
 
 - **Session visibility** for the `today`, `7d`, and `30d` windows (R1.0.1,
@@ -373,7 +403,7 @@ in [#302](https://github.com/siropkin/budi/issues/302) / #303 / #304 / #305):
 - CostEnricher is the single source of truth for cost - sets cost_cents during pipeline. Skips if cost already set (API data)
 - `budi init` prompts for per-agent enablement (Claude Code, Codex CLI, Cursor, Copilot CLI), persists choices to `~/.config/budi/agents.toml`, and auto-configures proxy routing for enabled agents (shell profile + Cursor/Codex settings). `budi enable/disable <agent>` updates this config later. Legacy installs (no `agents.toml`) treat all available agents as enabled for backward compatibility. After configuring CLI agents (Claude, Codex, Copilot), both `budi init` and `budi enable` warn that a shell restart is required for proxy env vars to take effect and suggest `budi launch <agent>` for immediate routing. `budi doctor` detects when proxy env vars are configured in the shell profile but not set in the current process.
 - `budi init` configures integrations (statusline, extension) for enabled agents
-- Tags are auto-detected (`provider`, `model`, `tool`, `tool_use_id`, `ticket_id`, `ticket_source`, `activity`, `activity_source`, `activity_confidence`, `file_path`, `file_path_source`, `file_path_confidence`, and conditional tags like `cost_confidence` / `speed`) + custom rules via `~/.config/budi/tags.toml`
+- Tags are auto-detected (`provider`, `model`, `tool`, `tool_use_id`, `ticket_id`, `ticket_source`, `activity`, `activity_source`, `activity_confidence`, `file_path`, `file_path_source`, `file_path_confidence`, `tool_outcome`, `tool_outcome_source`, `tool_outcome_confidence`, and conditional tags like `cost_confidence` / `speed`) + custom rules via `~/.config/budi/tags.toml`
 - git_branch is a column on messages (not a tag) for fast queries
 - **Session health**: Four vitals computed per session - context growth (context-size growth), cache reuse (cache hit rate), cost acceleration (per-reply cost growth), retry loops (currently disabled — hook ingestion removed in 8.0; `hook_events` table no longer exists in schema v1). Each vital has green/yellow/red state. New sessions start green - the default is always positive; vitals only degrade to yellow/red when there is clear evidence of a problem. Tips are provider-aware via `ProviderKind` enum (Claude Code -> `/compact`/`/clear`, Cursor -> "new composer session", Other -> neutral). When no session ID is provided, health auto-select prefers the latest session with assistant activity, then falls back to session timestamps. Statusline "coach" mode shows health icon + session cost + tip. Dashboard session detail page has a health panel with vitals grid and tips section.
 - **Cursor extension** ([siropkin/budi-cursor](https://github.com/siropkin/budi-cursor)): VS Code extension that shows session health in the status bar (aggregated health circles) and a side panel (session details, vitals, tips, session list). Installed via VS Code Marketplace or `budi integrations install --with cursor-extension`. Communicates with daemon via HTTP and spawns `budi statusline --format json`. Writes `~/.local/share/budi/cursor-sessions.json` (v1 contract, ADR-0086 §3.4) to signal the active workspace. Checks daemon `api_version` on startup and warns if incompatible.

--- a/crates/budi-cli/src/commands/sessions.rs
+++ b/crates/budi-cli/src/commands/sessions.rs
@@ -193,6 +193,21 @@ pub fn cmd_session_detail(session_id: &str, json_output: bool) -> Result<()> {
     if !s.git_branches.is_empty() {
         println!("  {bold}Branches{reset}   {}", s.git_branches.join(", "));
     }
+    // R1.5 (#293): surface the rule-based work outcome whenever we
+    // could derive one. Rationale is intentionally shown in dim text
+    // so operators can see *why* a label was picked without it
+    // competing visually with the main session stats.
+    if let Some(ref outcome) = s.work_outcome {
+        let colored = match outcome.as_str() {
+            "committed" | "branch_merged" => format!("{green}{outcome}{reset}"),
+            "no_commit" => format!("{yellow}{outcome}{reset}"),
+            _ => outcome.to_string(),
+        };
+        println!("  {bold}Outcome{reset}    {colored}");
+        if let Some(ref rationale) = s.work_outcome_rationale {
+            println!("             {dim}{rationale}{reset}");
+        }
+    }
 
     println!();
     println!("  {bold}Messages{reset}   {}", s.message_count);

--- a/crates/budi-core/src/analytics/sessions.rs
+++ b/crates/budi-core/src/analytics/sessions.rs
@@ -335,6 +335,17 @@ pub struct SessionListEntry {
     pub health_state: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
+    /// Rule-based session → work outcome. One of
+    /// `committed`, `branch_merged`, `no_commit`, `unknown`. Only
+    /// populated by the `session_detail` endpoint; list surfaces skip
+    /// it to avoid running `git` once per row. See
+    /// `budi_core::work_outcome` and R1.5 (#293).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub work_outcome: Option<String>,
+    /// One-line rationale explaining which rule fired. Never contains
+    /// file names or commit messages (ADR-0083).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub work_outcome_rationale: Option<String>,
 }
 
 /// Paginated session list result.
@@ -698,6 +709,8 @@ pub fn session_list_with_filters(
                 cost_confidence: row.get(13)?,
                 health_state: None,
                 title: row.get(14)?,
+                work_outcome: None,
+                work_outcome_rationale: None,
             })
         })?
         .filter_map(|r| r.ok())
@@ -856,15 +869,86 @@ pub fn session_detail(conn: &Connection, session_id: &str) -> Result<Option<Sess
                 cost_confidence: row.get(12)?,
                 health_state: None,
                 title: row.get(13)?,
+                work_outcome: None,
+                work_outcome_rationale: None,
             })
         },
     );
 
     match row {
-        Ok(entry) => Ok(Some(entry)),
+        Ok(mut entry) => {
+            // R1.5 (#293): try to attach a rule-based work outcome.
+            // Pulled out into a helper so the SQL stays readable and
+            // the derivation can fail open to `None` when we lack the
+            // information to correlate with local git state.
+            if let Some((label, rationale)) = derive_session_work_outcome(conn, &entry) {
+                entry.work_outcome = Some(label);
+                entry.work_outcome_rationale = Some(rationale);
+            }
+            Ok(Some(entry))
+        }
         Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
         Err(e) => Err(e.into()),
     }
+}
+
+/// Resolve a session to a best-guess cwd by looking at the most common
+/// non-empty `cwd` field recorded on its messages. We prefer assistant
+/// messages (they carry the strongest provider-level attribution), but
+/// fall back to any message if none are available. Returns `None` when
+/// the session has no stored cwd — we deliberately do not guess a path
+/// from `repo_id` because `repo_id` is a normalized remote URL, not a
+/// filesystem path.
+fn session_cwd(conn: &Connection, session_id: &str) -> Option<String> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT cwd, COUNT(*) AS n
+             FROM messages
+             WHERE session_id = ?1 AND cwd IS NOT NULL AND cwd != ''
+             GROUP BY cwd
+             ORDER BY (role = 'assistant') DESC, n DESC
+             LIMIT 1",
+        )
+        .ok()?;
+    stmt.query_row(params![session_id], |row| row.get::<_, String>(0))
+        .ok()
+}
+
+/// Apply the rule-based session → work outcome derivation to a session
+/// list entry. Returns `None` when the inputs cannot support any rule
+/// — callers then leave `work_outcome` / `work_outcome_rationale`
+/// absent instead of showing `unknown` for rows we never even tried to
+/// correlate.
+fn derive_session_work_outcome(
+    conn: &Connection,
+    entry: &SessionListEntry,
+) -> Option<(String, String)> {
+    let branch = entry.git_branches.iter().find(|b| !b.is_empty())?.clone();
+    let cwd = session_cwd(conn, &entry.id)?;
+    let repo_root = crate::repo_id::repo_root_for(std::path::Path::new(&cwd))?;
+
+    let started = entry.started_at.as_deref().and_then(parse_rfc3339)?;
+    let ended = entry
+        .ended_at
+        .as_deref()
+        .and_then(parse_rfc3339)
+        .unwrap_or(started);
+
+    let inputs = crate::work_outcome::WorkOutcomeInputs {
+        repo_root: &repo_root,
+        branch: &branch,
+        started_at: started,
+        ended_at: ended,
+        grace: None,
+    };
+    let outcome = crate::work_outcome::derive_work_outcome(&inputs);
+    Some((outcome.label.as_str().to_string(), outcome.rationale))
+}
+
+fn parse_rfc3339(s: &str) -> Option<chrono::DateTime<chrono::Utc>> {
+    chrono::DateTime::parse_from_rfc3339(s)
+        .ok()
+        .map(|dt| dt.with_timezone(&chrono::Utc))
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/budi-core/src/analytics/tests.rs
+++ b/crates/budi-core/src/analytics/tests.rs
@@ -74,6 +74,7 @@ fn ingest_and_query() {
             tool_names: Vec::new(),
             tool_use_ids: Vec::new(),
             tool_files: Vec::new(),
+            tool_outcomes: Vec::new(),
         },
         ParsedMessage {
             uuid: "a1".to_string(),
@@ -105,6 +106,7 @@ fn ingest_and_query() {
             tool_names: Vec::new(),
             tool_use_ids: Vec::new(),
             tool_files: Vec::new(),
+            tool_outcomes: Vec::new(),
         },
     ];
 
@@ -156,6 +158,7 @@ fn rollups_track_message_updates_and_deletes() {
         tool_names: Vec::new(),
         tool_use_ids: Vec::new(),
         tool_files: Vec::new(),
+        tool_outcomes: Vec::new(),
     };
     ingest_messages(&mut conn, &[msg], None).unwrap();
 
@@ -212,6 +215,7 @@ fn rollups_are_used_only_for_hour_aligned_ranges() {
         tool_names: Vec::new(),
         tool_use_ids: Vec::new(),
         tool_files: Vec::new(),
+        tool_outcomes: Vec::new(),
     };
     ingest_messages(&mut conn, &[msg], None).unwrap();
 
@@ -286,6 +290,7 @@ fn rollup_summary_latency_smoke_on_large_dataset() {
             tool_names: Vec::new(),
             tool_use_ids: Vec::new(),
             tool_files: Vec::new(),
+            tool_outcomes: Vec::new(),
         });
     }
     ingest_messages(&mut conn, &messages, None).unwrap();
@@ -339,6 +344,7 @@ fn cost_cents_baked_at_ingest() {
         tool_names: Vec::new(),
         tool_use_ids: Vec::new(),
         tool_files: Vec::new(),
+        tool_outcomes: Vec::new(),
     };
     // CostEnricher is the single source of truth for cost_cents
     CostEnricher.enrich(&mut msg);
@@ -415,6 +421,7 @@ fn last_seen_derived_from_messages() {
             tool_names: Vec::new(),
             tool_use_ids: Vec::new(),
             tool_files: Vec::new(),
+            tool_outcomes: Vec::new(),
         },
         ParsedMessage {
             uuid: "m2".to_string(),
@@ -446,6 +453,7 @@ fn last_seen_derived_from_messages() {
             tool_names: Vec::new(),
             tool_use_ids: Vec::new(),
             tool_files: Vec::new(),
+            tool_outcomes: Vec::new(),
         },
     ];
     ingest_messages(&mut conn, &msgs, None).unwrap();
@@ -494,6 +502,7 @@ fn newest_ingested_data_uses_assistant_rows() {
             tool_names: Vec::new(),
             tool_use_ids: Vec::new(),
             tool_files: Vec::new(),
+            tool_outcomes: Vec::new(),
         },
         ParsedMessage {
             uuid: "a-only".to_string(),
@@ -525,6 +534,7 @@ fn newest_ingested_data_uses_assistant_rows() {
             tool_names: Vec::new(),
             tool_use_ids: Vec::new(),
             tool_files: Vec::new(),
+            tool_outcomes: Vec::new(),
         },
     ];
     ingest_messages(&mut conn, &msgs, None).unwrap();
@@ -564,6 +574,7 @@ fn sample_messages() -> Vec<ParsedMessage> {
             tool_names: Vec::new(),
             tool_use_ids: Vec::new(),
             tool_files: Vec::new(),
+            tool_outcomes: Vec::new(),
         },
         ParsedMessage {
             uuid: "a1".to_string(),
@@ -595,6 +606,7 @@ fn sample_messages() -> Vec<ParsedMessage> {
             tool_names: Vec::new(),
             tool_use_ids: Vec::new(),
             tool_files: Vec::new(),
+            tool_outcomes: Vec::new(),
         },
         ParsedMessage {
             uuid: "u2".to_string(),
@@ -626,6 +638,7 @@ fn sample_messages() -> Vec<ParsedMessage> {
             tool_names: Vec::new(),
             tool_use_ids: Vec::new(),
             tool_files: Vec::new(),
+            tool_outcomes: Vec::new(),
         },
     ]
 }
@@ -822,6 +835,7 @@ fn messages_with_cache_patterns() -> Vec<ParsedMessage> {
             tool_names: Vec::new(),
             tool_use_ids: Vec::new(),
             tool_files: Vec::new(),
+            tool_outcomes: Vec::new(),
         },
         ParsedMessage {
             uuid: "t2".to_string(),
@@ -853,6 +867,7 @@ fn messages_with_cache_patterns() -> Vec<ParsedMessage> {
             tool_names: Vec::new(),
             tool_use_ids: Vec::new(),
             tool_files: Vec::new(),
+            tool_outcomes: Vec::new(),
         },
         ParsedMessage {
             uuid: "t3".to_string(),
@@ -884,6 +899,7 @@ fn messages_with_cache_patterns() -> Vec<ParsedMessage> {
             tool_names: Vec::new(),
             tool_use_ids: Vec::new(),
             tool_files: Vec::new(),
+            tool_outcomes: Vec::new(),
         },
     ]
 }
@@ -981,6 +997,7 @@ fn multi_provider_ingest_and_query() {
             tool_names: Vec::new(),
             tool_use_ids: Vec::new(),
             tool_files: Vec::new(),
+            tool_outcomes: Vec::new(),
         },
         ParsedMessage {
             uuid: "cc-a1".to_string(),
@@ -1012,6 +1029,7 @@ fn multi_provider_ingest_and_query() {
             tool_names: Vec::new(),
             tool_use_ids: Vec::new(),
             tool_files: Vec::new(),
+            tool_outcomes: Vec::new(),
         },
     ];
 
@@ -1046,6 +1064,7 @@ fn multi_provider_ingest_and_query() {
             tool_names: Vec::new(),
             tool_use_ids: Vec::new(),
             tool_files: Vec::new(),
+            tool_outcomes: Vec::new(),
         },
         ParsedMessage {
             uuid: "cu-a1".to_string(),
@@ -1077,6 +1096,7 @@ fn multi_provider_ingest_and_query() {
             tool_names: Vec::new(),
             tool_use_ids: Vec::new(),
             tool_files: Vec::new(),
+            tool_outcomes: Vec::new(),
         },
     ];
 
@@ -1143,6 +1163,7 @@ fn cross_parse_dedup_by_request_id() {
         tool_names: Vec::new(),
         tool_use_ids: Vec::new(),
         tool_files: Vec::new(),
+        tool_outcomes: Vec::new(),
     };
     ingest_messages(&mut conn, &[intermediate], None).unwrap();
 
@@ -1181,6 +1202,7 @@ fn cross_parse_dedup_by_request_id() {
         tool_names: Vec::new(),
         tool_use_ids: Vec::new(),
         tool_files: Vec::new(),
+        tool_outcomes: Vec::new(),
     };
     ingest_messages(&mut conn, &[final_entry], None).unwrap();
 
@@ -1234,6 +1256,7 @@ fn cross_parse_dedup_keeps_higher_output() {
         tool_names: Vec::new(),
         tool_use_ids: Vec::new(),
         tool_files: Vec::new(),
+        tool_outcomes: Vec::new(),
     };
     ingest_messages(&mut conn, &[final_entry], None).unwrap();
 
@@ -1267,6 +1290,7 @@ fn cross_parse_dedup_keeps_higher_output() {
         tool_names: Vec::new(),
         tool_use_ids: Vec::new(),
         tool_files: Vec::new(),
+        tool_outcomes: Vec::new(),
     };
     ingest_messages(&mut conn, &[intermediate], None).unwrap();
 
@@ -1318,6 +1342,7 @@ fn no_request_id_no_dedup() {
         tool_names: Vec::new(),
         tool_use_ids: Vec::new(),
         tool_files: Vec::new(),
+        tool_outcomes: Vec::new(),
     };
     ingest_messages(&mut conn, &[msg1], None).unwrap();
 
@@ -1351,6 +1376,7 @@ fn no_request_id_no_dedup() {
         tool_names: Vec::new(),
         tool_use_ids: Vec::new(),
         tool_files: Vec::new(),
+        tool_outcomes: Vec::new(),
     };
     ingest_messages(&mut conn, &[msg2], None).unwrap();
 
@@ -1416,6 +1442,7 @@ fn jsonl_dedup_matches_otel_by_fingerprint_within_window() {
         tool_names: Vec::new(),
         tool_use_ids: Vec::new(),
         tool_files: Vec::new(),
+        tool_outcomes: Vec::new(),
     };
     ingest_messages(&mut conn, &[msg], None).unwrap();
 
@@ -1544,6 +1571,7 @@ fn session_cost_curve_buckets() {
             tool_names: Vec::new(),
             tool_use_ids: Vec::new(),
             tool_files: Vec::new(),
+            tool_outcomes: Vec::new(),
         });
     }
     ingest_messages(&mut conn, &msgs, None).unwrap();
@@ -1588,6 +1616,7 @@ fn cost_confidence_stats_groups_correctly() {
             tool_names: Vec::new(),
             tool_use_ids: Vec::new(),
             tool_files: Vec::new(),
+            tool_outcomes: Vec::new(),
         },
         ParsedMessage {
             uuid: "conf-2".to_string(),
@@ -1619,6 +1648,7 @@ fn cost_confidence_stats_groups_correctly() {
             tool_names: Vec::new(),
             tool_use_ids: Vec::new(),
             tool_files: Vec::new(),
+            tool_outcomes: Vec::new(),
         },
     ];
     ingest_messages(&mut conn, &msgs, None).unwrap();
@@ -1665,6 +1695,7 @@ fn subagent_cost_stats_splits_correctly() {
             tool_names: Vec::new(),
             tool_use_ids: Vec::new(),
             tool_files: Vec::new(),
+            tool_outcomes: Vec::new(),
         },
         ParsedMessage {
             uuid: "sub-1".to_string(),
@@ -1696,6 +1727,7 @@ fn subagent_cost_stats_splits_correctly() {
             tool_names: Vec::new(),
             tool_use_ids: Vec::new(),
             tool_files: Vec::new(),
+            tool_outcomes: Vec::new(),
         },
     ];
     ingest_messages(&mut conn, &msgs, None).unwrap();
@@ -2218,6 +2250,7 @@ fn assistant_msg(uuid: &str, session_id: &str, cost_cents: f64) -> ParsedMessage
         tool_names: Vec::new(),
         tool_use_ids: Vec::new(),
         tool_files: Vec::new(),
+        tool_outcomes: Vec::new(),
     }
 }
 
@@ -3603,6 +3636,7 @@ fn health_msg(
         tool_names: Vec::new(),
         tool_use_ids: Vec::new(),
         tool_files: Vec::new(),
+        tool_outcomes: Vec::new(),
     }
 }
 

--- a/crates/budi-core/src/jsonl.rs
+++ b/crates/budi-core/src/jsonl.rs
@@ -186,6 +186,24 @@ pub struct ParsedMessage {
     /// paths later by `FileEnricher` under ADR-0083 privacy rules; see
     /// `crate::file_attribution`. Added in R1.4 (#292).
     pub tool_files: Vec<String>,
+    /// Tool outcomes extracted from provider `tool_result` blocks on this
+    /// message (populated on **user** messages in Claude Code transcripts,
+    /// which is where tool results land). The pipeline joins these to the
+    /// originating assistant message by `tool_use_id` and emits
+    /// `tool_outcome` tags there. Added in R1.5 (#293); see ADR-0088 §5.
+    pub tool_outcomes: Vec<ToolOutcome>,
+}
+
+/// One provider-reported tool outcome. Content is never stored — we only
+/// keep the classified label and the `tool_use_id` it binds to. See
+/// ADR-0083 for the privacy contract.
+#[derive(Debug, Clone)]
+pub struct ToolOutcome {
+    pub tool_use_id: String,
+    /// Bounded label; one of `success`, `error`, `denied`. `retry` is
+    /// produced later by a session-scoped heuristic in the pipeline, not
+    /// by this extractor.
+    pub outcome: String,
 }
 
 impl Default for ParsedMessage {
@@ -220,7 +238,138 @@ impl Default for ParsedMessage {
             tool_names: Vec::new(),
             tool_use_ids: Vec::new(),
             tool_files: Vec::new(),
+            tool_outcomes: Vec::new(),
         }
+    }
+}
+
+/// Scan user-message content blocks for `tool_result` entries and return
+/// the classified outcomes (R1.5, #293).
+///
+/// Claude Code transcripts deliver tool results as `user` messages with
+/// content blocks of shape
+/// `{"type":"tool_result","tool_use_id":"...","is_error":bool,"content":...}`.
+/// We classify each one into a bounded label:
+///
+/// - `error` — `is_error: true`.
+/// - `denied` — the content text matches a small set of
+///   permission-denied sentinels used by Claude Code when the user
+///   rejects a proposed action.
+/// - `success` — otherwise.
+///
+/// The content text itself is inspected in-memory only — we never
+/// persist it. See ADR-0083 §3.
+pub(crate) fn extract_user_tool_outcomes(
+    content: Option<&Vec<serde_json::Value>>,
+) -> Vec<ToolOutcome> {
+    let Some(blocks) = content else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for block in blocks {
+        let block_type = block.get("type").and_then(|v| v.as_str()).unwrap_or("");
+        if block_type != "tool_result" {
+            continue;
+        }
+        let tool_use_id = block
+            .get("tool_use_id")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .trim()
+            .to_string();
+        if tool_use_id.is_empty() {
+            continue;
+        }
+        let is_error = block
+            .get("is_error")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let text = tool_result_text(block.get("content"));
+        let outcome = classify_tool_outcome(is_error, text.as_deref());
+        out.push(ToolOutcome {
+            tool_use_id,
+            outcome: outcome.to_string(),
+        });
+    }
+    out
+}
+
+/// Flatten a `tool_result.content` value into a plain text snippet for
+/// sentinel matching. Content may be a string, a block array with
+/// `{"type":"text","text":...}` entries, or missing. We truncate to keep
+/// the classifier cheap; sentinels we care about all fit well within the
+/// first kilobyte of content.
+fn tool_result_text(content: Option<&serde_json::Value>) -> Option<String> {
+    const MAX: usize = 2048;
+    let v = content?;
+    let mut s = match v {
+        serde_json::Value::String(s) => s.clone(),
+        serde_json::Value::Array(blocks) => blocks
+            .iter()
+            .filter_map(|b| match b {
+                serde_json::Value::String(s) => Some(s.as_str()),
+                serde_json::Value::Object(_) => b.get("text").and_then(|v| v.as_str()),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join(" "),
+        _ => return None,
+    };
+    if s.len() > MAX {
+        s.truncate(MAX);
+    }
+    if s.trim().is_empty() { None } else { Some(s) }
+}
+
+/// Bounded label constants for `tool_outcome` tag values. Pinned here so
+/// analytics, tests, and proxy/import ingest all agree.
+pub const TOOL_OUTCOME_SUCCESS: &str = "success";
+pub const TOOL_OUTCOME_ERROR: &str = "error";
+pub const TOOL_OUTCOME_DENIED: &str = "denied";
+pub const TOOL_OUTCOME_RETRY: &str = "retry";
+
+/// Source label for outcomes extracted directly from a provider
+/// `tool_result` block. Mirrors the `_SOURCE` convention used by R1.2
+/// (#222) / R1.4 (#292).
+pub const TOOL_OUTCOME_SOURCE_JSONL: &str = "jsonl_tool_result";
+/// Source label for outcomes attributed by the session-scoped retry
+/// heuristic in the pipeline.
+pub const TOOL_OUTCOME_SOURCE_HEURISTIC: &str = "heuristic_retry";
+
+/// Confidence labels used on `tool_outcome_confidence` tags. `high` for
+/// explicit `tool_result` evidence, `medium` for heuristic retry.
+pub const TOOL_OUTCOME_CONFIDENCE_HIGH: &str = "high";
+pub const TOOL_OUTCOME_CONFIDENCE_MEDIUM: &str = "medium";
+
+/// Sentinels that indicate the user rejected the tool call in Claude
+/// Code / Cursor style permission flows. Matching is case-insensitive
+/// and substring-based; we deliberately keep the list short and
+/// debuggable. Anything not on this list with `is_error=true` is still
+/// classified as `error` — we do not overfit.
+const USER_DENIAL_SENTINELS: &[&str] = &[
+    "the user doesn't want to take this action",
+    "the user doesn't want to proceed",
+    "user rejected",
+    "user denied",
+    "operation cancelled by the user",
+    "operation canceled by the user",
+    "permission denied by user",
+];
+
+/// Classify a single `tool_result` block given its `is_error` flag and
+/// flattened content text. Exposed for tests and for the proxy path (if
+/// we ever grow one that inspects follow-up request bodies).
+pub fn classify_tool_outcome(is_error: bool, text: Option<&str>) -> &'static str {
+    if let Some(t) = text {
+        let lower = t.to_ascii_lowercase();
+        if USER_DENIAL_SENTINELS.iter().any(|s| lower.contains(s)) {
+            return TOOL_OUTCOME_DENIED;
+        }
+    }
+    if is_error {
+        TOOL_OUTCOME_ERROR
+    } else {
+        TOOL_OUTCOME_SUCCESS
     }
 }
 
@@ -294,6 +443,13 @@ fn parse_line(line: &str) -> Option<ParsedMessage> {
                 }
                 None => None,
             });
+            // R1.5 (#293): scan the same content blocks for tool_result
+            // entries so the pipeline can bind outcomes back to their
+            // originating assistant message by `tool_use_id`.
+            let tool_outcomes = match u.message.as_ref().and_then(|m| m.content.as_ref()) {
+                Some(UserContent::Blocks(blocks)) => extract_user_tool_outcomes(Some(blocks)),
+                _ => Vec::new(),
+            };
             let classification = prompt_text
                 .as_deref()
                 .and_then(crate::hooks::classify_prompt_detailed);
@@ -336,6 +492,7 @@ fn parse_line(line: &str) -> Option<ParsedMessage> {
                 tool_names: Vec::new(),
                 tool_use_ids: Vec::new(),
                 tool_files: Vec::new(),
+                tool_outcomes,
             })
         }
         TranscriptEntry::Assistant(a) => {
@@ -386,6 +543,7 @@ fn parse_line(line: &str) -> Option<ParsedMessage> {
                 tool_names,
                 tool_use_ids,
                 tool_files,
+                tool_outcomes: Vec::new(),
             })
         }
         TranscriptEntry::Other => None,
@@ -449,6 +607,7 @@ fn parse_flat_line(line: &str) -> Option<ParsedMessage> {
                 tool_names,
                 tool_use_ids,
                 tool_files,
+                tool_outcomes: Vec::new(),
             })
         }
         "user" => Some(ParsedMessage {
@@ -775,5 +934,80 @@ mod tests {
         );
         let (msgs, _) = parse_transcript(content, 0);
         assert_eq!(msgs.len(), 1, "duplicate request_id should be deduped");
+    }
+
+    // -----------------------------------------------------------------------
+    // R1.5 (#293): tool_result → tool_outcome classification.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn classify_plain_success() {
+        assert_eq!(classify_tool_outcome(false, None), TOOL_OUTCOME_SUCCESS);
+        assert_eq!(
+            classify_tool_outcome(false, Some("File contents redacted")),
+            TOOL_OUTCOME_SUCCESS
+        );
+    }
+
+    #[test]
+    fn classify_error_flag_wins_when_no_denial() {
+        assert_eq!(
+            classify_tool_outcome(true, Some("network timeout")),
+            TOOL_OUTCOME_ERROR
+        );
+        assert_eq!(classify_tool_outcome(true, None), TOOL_OUTCOME_ERROR);
+    }
+
+    #[test]
+    fn classify_user_denial_sentinels() {
+        let cases = [
+            "The user doesn't want to take this action right now.",
+            "User rejected the edit.",
+            "Operation cancelled by the user",
+            "permission denied by user",
+        ];
+        for c in cases {
+            assert_eq!(
+                classify_tool_outcome(true, Some(c)),
+                TOOL_OUTCOME_DENIED,
+                "{c} should classify as denied",
+            );
+        }
+    }
+
+    #[test]
+    fn extract_user_tool_outcomes_parses_blocks() {
+        let content = serde_json::json!([
+            {"type": "tool_result", "tool_use_id": "t-1", "content": "ok"},
+            {"type": "tool_result", "tool_use_id": "t-2", "is_error": true, "content": "boom"},
+            {"type": "text", "text": "ignored"},
+        ]);
+        let blocks = content.as_array().cloned().unwrap();
+        let outcomes = extract_user_tool_outcomes(Some(&blocks));
+        assert_eq!(outcomes.len(), 2);
+        assert_eq!(outcomes[0].tool_use_id, "t-1");
+        assert_eq!(outcomes[0].outcome, TOOL_OUTCOME_SUCCESS);
+        assert_eq!(outcomes[1].tool_use_id, "t-2");
+        assert_eq!(outcomes[1].outcome, TOOL_OUTCOME_ERROR);
+    }
+
+    #[test]
+    fn extract_user_tool_outcomes_skips_missing_id() {
+        let content = serde_json::json!([
+            {"type": "tool_result", "content": "no id"},
+            {"type": "tool_result", "tool_use_id": "", "content": "empty id"},
+        ]);
+        let blocks = content.as_array().cloned().unwrap();
+        assert!(extract_user_tool_outcomes(Some(&blocks)).is_empty());
+    }
+
+    #[test]
+    fn parse_user_message_populates_tool_outcomes() {
+        let line = r#"{"parentUuid":"a1","isSidechain":false,"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"t-1","content":"ok"}]},"uuid":"u1","timestamp":"2026-03-14T18:13:42.614Z","sessionId":"s1"}"#;
+        let msg = parse_line(line).unwrap();
+        assert_eq!(msg.role, "user");
+        assert_eq!(msg.tool_outcomes.len(), 1);
+        assert_eq!(msg.tool_outcomes[0].tool_use_id, "t-1");
+        assert_eq!(msg.tool_outcomes[0].outcome, TOOL_OUTCOME_SUCCESS);
     }
 }

--- a/crates/budi-core/src/lib.rs
+++ b/crates/budi-core/src/lib.rs
@@ -17,3 +17,4 @@ pub mod proxy;
 pub mod repo_id;
 pub mod tag_keys;
 pub mod update;
+pub mod work_outcome;

--- a/crates/budi-core/src/pipeline/mod.rs
+++ b/crates/budi-core/src/pipeline/mod.rs
@@ -70,6 +70,37 @@ impl Pipeline {
 
         propagate_session_context(messages);
 
+        // R1.5 (#293): collect every `tool_result` we saw on user messages
+        // into a session-scoped map keyed by `tool_use_id`. The pipeline
+        // joins these back to the originating assistant message below.
+        // We do this as a first pass because the ordering guarantees are
+        // already established by the sort + propagation above, but we
+        // still need to know *every* outcome for a session before we
+        // decide which tag to emit for a given assistant message
+        // (especially because Claude Code delivers tool results after
+        // the assistant message that produced the tool_use).
+        let mut session_outcomes: HashMap<String, HashMap<String, String>> = HashMap::new();
+        for msg in messages.iter() {
+            if msg.role != "user" || msg.tool_outcomes.is_empty() {
+                continue;
+            }
+            let sid = msg.session_id.clone().unwrap_or_else(|| msg.uuid.clone());
+            let bucket = session_outcomes.entry(sid).or_default();
+            for o in &msg.tool_outcomes {
+                // Keep the first outcome we see for a `tool_use_id` —
+                // retries use a *different* id, so later entries can
+                // only be duplicates or out-of-order deliveries.
+                bucket
+                    .entry(o.tool_use_id.clone())
+                    .or_insert_with(|| o.outcome.clone());
+            }
+        }
+
+        // Per-session retry state: tool_name → last observed outcome on
+        // the most recent assistant message in that session. Used by the
+        // rule-based `retry` attribution below.
+        let mut last_tool_outcome: HashMap<(String, String), String> = HashMap::new();
+
         for msg in messages.iter_mut() {
             let mut msg_tags = Vec::new();
             let dedup_id = msg.session_id.clone().unwrap_or_else(|| msg.uuid.clone());
@@ -123,12 +154,153 @@ impl Pipeline {
                         });
                     }
                 }
+
+                // R1.5 (#293): tool_outcome tags. For each tool_use on
+                // this assistant message, look up the outcome reported
+                // by the next user message (already collected into
+                // `session_outcomes`). Then apply the rule-based retry
+                // heuristic so a follow-up call to the same tool after
+                // an `error` outcome in the same session surfaces as
+                // `retry` instead of just another `success`/`error`.
+                emit_tool_outcome_tags(
+                    msg,
+                    &session_outcomes,
+                    &mut last_tool_outcome,
+                    &mut msg_tags,
+                );
             }
 
             all_tags.push(msg_tags);
         }
         all_tags
     }
+}
+
+/// Emit `tool_outcome` / `tool_outcome_source` / `tool_outcome_confidence`
+/// tags on an assistant message using the session-scoped outcome map plus
+/// a rule-based retry heuristic. See ADR-0088 §5 and the constants in
+/// `crate::jsonl`.
+///
+/// Multi-valued: every distinct outcome observed across this message's
+/// tool uses produces its own `tool_outcome` tag so the analytics layer
+/// can surface "this message had one success and one error" without
+/// losing information. The sibling source/confidence tags describe the
+/// dominant provenance — `heuristic_retry` wins over `jsonl_tool_result`
+/// only if the retry attribution applied to at least one tool use on
+/// this message.
+fn emit_tool_outcome_tags(
+    msg: &crate::jsonl::ParsedMessage,
+    session_outcomes: &std::collections::HashMap<String, std::collections::HashMap<String, String>>,
+    last_tool_outcome: &mut std::collections::HashMap<(String, String), String>,
+    msg_tags: &mut Vec<Tag>,
+) {
+    use crate::jsonl as j;
+    if msg.tool_use_ids.is_empty() && msg.tool_names.is_empty() {
+        return;
+    }
+    let sid = msg.session_id.clone().unwrap_or_else(|| msg.uuid.clone());
+    let outcome_map = session_outcomes.get(&sid);
+
+    // Pair tool names with tool_use_ids by position. In practice the
+    // JSONL extractor produces parallel-indexed vectors (one entry per
+    // tool_use block) after a stable sort, so this is a best-effort
+    // join. Any mismatch (e.g. zero tool_use_ids) falls through with an
+    // empty name — we still record an outcome, we just can't promote it
+    // to `retry`.
+    let pairs: Vec<(String, String)> = msg
+        .tool_use_ids
+        .iter()
+        .enumerate()
+        .map(|(i, id)| {
+            let name = msg.tool_names.get(i).cloned().unwrap_or_default();
+            (id.clone(), name)
+        })
+        .collect();
+
+    let mut seen: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+    let mut any_heuristic = false;
+    let mut any_direct = false;
+
+    for (use_id, name) in &pairs {
+        let direct = outcome_map.and_then(|m| m.get(use_id)).cloned();
+        let prior_same_tool = if !name.is_empty() {
+            last_tool_outcome.get(&(sid.clone(), name.clone())).cloned()
+        } else {
+            None
+        };
+
+        let outcome = match (direct, prior_same_tool) {
+            (Some(_d), Some(prior)) if prior == j::TOOL_OUTCOME_ERROR => {
+                // Follow-up call to the same tool right after an error:
+                // even if the new one succeeded, surface it as a retry
+                // so analytics can see the recovery attempt.
+                any_heuristic = true;
+                j::TOOL_OUTCOME_RETRY.to_string()
+            }
+            (Some(d), _) => {
+                any_direct = true;
+                d
+            }
+            (None, Some(prior)) if prior == j::TOOL_OUTCOME_ERROR => {
+                any_heuristic = true;
+                j::TOOL_OUTCOME_RETRY.to_string()
+            }
+            (None, _) => {
+                // No outcome visible for this tool_use yet (e.g. the
+                // session was cut off before the result landed). Skip
+                // silently — the `(untagged)` bucket already covers
+                // open-ended calls.
+                continue;
+            }
+        };
+
+        // Update session state so the next assistant message in this
+        // session can detect its own retries against the *original*
+        // outcome — the one reported by `tool_result`, not the promoted
+        // `retry` label — otherwise a cascade of failures would collapse
+        // into a single retry label.
+        if !name.is_empty() {
+            let raw = outcome_map
+                .and_then(|m| m.get(use_id))
+                .cloned()
+                .unwrap_or_else(|| outcome.clone());
+            last_tool_outcome.insert((sid.clone(), name.clone()), raw);
+        }
+
+        if seen.insert(outcome.clone()) {
+            msg_tags.push(Tag {
+                key: tk::TOOL_OUTCOME.to_string(),
+                value: outcome,
+            });
+        }
+    }
+
+    if seen.is_empty() {
+        return;
+    }
+
+    // `any_direct` is implied whenever we got here without firing the
+    // heuristic (otherwise `seen` would be empty and we'd have
+    // returned), so the fallback is JSONL by construction.
+    let source = if any_heuristic {
+        j::TOOL_OUTCOME_SOURCE_HEURISTIC
+    } else {
+        let _ = any_direct;
+        j::TOOL_OUTCOME_SOURCE_JSONL
+    };
+    let confidence = if any_direct && !any_heuristic {
+        j::TOOL_OUTCOME_CONFIDENCE_HIGH
+    } else {
+        j::TOOL_OUTCOME_CONFIDENCE_MEDIUM
+    };
+    msg_tags.push(Tag {
+        key: tk::TOOL_OUTCOME_SOURCE.to_string(),
+        value: source.to_string(),
+    });
+    msg_tags.push(Tag {
+        key: tk::TOOL_OUTCOME_CONFIDENCE.to_string(),
+        value: confidence.to_string(),
+    });
 }
 
 /// Propagate git_branch, repo_id, cwd, prompt_category, and the R1.2
@@ -539,6 +711,7 @@ mod tests {
             tool_names: Vec::new(),
             tool_use_ids: Vec::new(),
             tool_files: Vec::new(),
+            tool_outcomes: Vec::new(),
         }
     }
 
@@ -726,5 +899,197 @@ mod tests {
         assert!(tool_values.contains("Read"));
         assert!(tool_values.contains("Bash"));
         assert_eq!(tool_values.len(), 2);
+    }
+
+    // R1.5 (#293) — tool outcome tagging on assistant messages.
+
+    fn outcome(id: &str, label: &str) -> crate::jsonl::ToolOutcome {
+        crate::jsonl::ToolOutcome {
+            tool_use_id: id.to_string(),
+            outcome: label.to_string(),
+        }
+    }
+
+    #[test]
+    fn tool_outcome_success_tag_on_assistant() {
+        use crate::config::TagsConfig;
+        use crate::jsonl::TOOL_OUTCOME_SUCCESS;
+        let mut pipeline = Pipeline::default_pipeline(Some(TagsConfig::default()));
+
+        let mut a1 = test_msg();
+        a1.uuid = "a1".into();
+        a1.session_id = Some("sess-1".into());
+        a1.role = "assistant".into();
+        a1.model = Some("claude-opus".into());
+        a1.output_tokens = 1;
+        a1.tool_names = vec!["Read".into()];
+        a1.tool_use_ids = vec!["t-1".into()];
+        a1.timestamp = "2026-03-14T18:13:43Z".parse().unwrap();
+
+        let mut u1 = test_msg();
+        u1.uuid = "u1".into();
+        u1.session_id = Some("sess-1".into());
+        u1.role = "user".into();
+        u1.tool_outcomes = vec![outcome("t-1", TOOL_OUTCOME_SUCCESS)];
+        u1.timestamp = "2026-03-14T18:13:44Z".parse().unwrap();
+
+        let mut msgs = vec![a1, u1];
+        let tags = pipeline.process(&mut msgs);
+        // After pipeline sort, assistant is index 0 (earlier timestamp).
+        let keys: Vec<(String, String)> = tags[0]
+            .iter()
+            .map(|t| (t.key.clone(), t.value.clone()))
+            .collect();
+        assert!(
+            keys.contains(&(tk::TOOL_OUTCOME.to_string(), "success".to_string())),
+            "expected tool_outcome=success tag, got: {keys:?}"
+        );
+        assert!(
+            keys.iter()
+                .any(|(k, v)| k == tk::TOOL_OUTCOME_SOURCE && v == "jsonl_tool_result"),
+            "expected jsonl_tool_result source, got: {keys:?}"
+        );
+        assert!(
+            keys.iter()
+                .any(|(k, v)| k == tk::TOOL_OUTCOME_CONFIDENCE && v == "high"),
+            "expected high confidence, got: {keys:?}"
+        );
+    }
+
+    #[test]
+    fn tool_outcome_retry_heuristic_promotes_second_call() {
+        use crate::config::TagsConfig;
+        use crate::jsonl::{TOOL_OUTCOME_ERROR, TOOL_OUTCOME_SUCCESS};
+        let mut pipeline = Pipeline::default_pipeline(Some(TagsConfig::default()));
+
+        // First assistant call errors, second call succeeds — retry
+        // heuristic should promote the second to `retry` with medium
+        // confidence.
+        let mut a1 = test_msg();
+        a1.uuid = "a1".into();
+        a1.session_id = Some("sess-1".into());
+        a1.role = "assistant".into();
+        a1.model = Some("claude-opus".into());
+        a1.output_tokens = 1;
+        a1.tool_names = vec!["Bash".into()];
+        a1.tool_use_ids = vec!["t-1".into()];
+        a1.timestamp = "2026-03-14T18:13:43Z".parse().unwrap();
+
+        let mut u1 = test_msg();
+        u1.uuid = "u1".into();
+        u1.session_id = Some("sess-1".into());
+        u1.role = "user".into();
+        u1.tool_outcomes = vec![outcome("t-1", TOOL_OUTCOME_ERROR)];
+        u1.timestamp = "2026-03-14T18:13:44Z".parse().unwrap();
+
+        let mut a2 = test_msg();
+        a2.uuid = "a2".into();
+        a2.session_id = Some("sess-1".into());
+        a2.role = "assistant".into();
+        a2.model = Some("claude-opus".into());
+        a2.output_tokens = 1;
+        a2.tool_names = vec!["Bash".into()];
+        a2.tool_use_ids = vec!["t-2".into()];
+        a2.timestamp = "2026-03-14T18:13:45Z".parse().unwrap();
+
+        let mut u2 = test_msg();
+        u2.uuid = "u2".into();
+        u2.session_id = Some("sess-1".into());
+        u2.role = "user".into();
+        u2.tool_outcomes = vec![outcome("t-2", TOOL_OUTCOME_SUCCESS)];
+        u2.timestamp = "2026-03-14T18:13:46Z".parse().unwrap();
+
+        let mut msgs = vec![a1, u1, a2, u2];
+        let tags = pipeline.process(&mut msgs);
+
+        // a1 (index 0 after sort) should carry `error`; a2 (index 2) should carry `retry`.
+        let a1_outcomes: Vec<&str> = tags[0]
+            .iter()
+            .filter(|t| t.key == tk::TOOL_OUTCOME)
+            .map(|t| t.value.as_str())
+            .collect();
+        assert_eq!(a1_outcomes, vec!["error"], "a1 should be labeled error");
+
+        let a2_outcomes: Vec<&str> = tags[2]
+            .iter()
+            .filter(|t| t.key == tk::TOOL_OUTCOME)
+            .map(|t| t.value.as_str())
+            .collect();
+        assert_eq!(
+            a2_outcomes,
+            vec!["retry"],
+            "a2 should be promoted to retry via the heuristic"
+        );
+
+        // Source should flip to heuristic_retry / medium on a2.
+        assert!(
+            tags[2]
+                .iter()
+                .any(|t| t.key == tk::TOOL_OUTCOME_SOURCE && t.value == "heuristic_retry"),
+            "a2 should report heuristic source, got: {:?}",
+            tags[2]
+        );
+        assert!(
+            tags[2]
+                .iter()
+                .any(|t| t.key == tk::TOOL_OUTCOME_CONFIDENCE && t.value == "medium"),
+            "a2 should report medium confidence, got: {:?}",
+            tags[2]
+        );
+    }
+
+    #[test]
+    fn tool_outcome_denied_passes_through() {
+        use crate::config::TagsConfig;
+        use crate::jsonl::TOOL_OUTCOME_DENIED;
+        let mut pipeline = Pipeline::default_pipeline(Some(TagsConfig::default()));
+
+        let mut a1 = test_msg();
+        a1.uuid = "a1".into();
+        a1.session_id = Some("sess-1".into());
+        a1.role = "assistant".into();
+        a1.model = Some("claude-opus".into());
+        a1.output_tokens = 1;
+        a1.tool_names = vec!["Edit".into()];
+        a1.tool_use_ids = vec!["t-1".into()];
+        a1.timestamp = "2026-03-14T18:13:43Z".parse().unwrap();
+
+        let mut u1 = test_msg();
+        u1.uuid = "u1".into();
+        u1.session_id = Some("sess-1".into());
+        u1.role = "user".into();
+        u1.tool_outcomes = vec![outcome("t-1", TOOL_OUTCOME_DENIED)];
+        u1.timestamp = "2026-03-14T18:13:44Z".parse().unwrap();
+
+        let mut msgs = vec![a1, u1];
+        let tags = pipeline.process(&mut msgs);
+        let outcomes: Vec<&str> = tags[0]
+            .iter()
+            .filter(|t| t.key == tk::TOOL_OUTCOME)
+            .map(|t| t.value.as_str())
+            .collect();
+        assert_eq!(outcomes, vec!["denied"]);
+    }
+
+    #[test]
+    fn tool_outcome_absent_when_no_tool_use() {
+        use crate::config::TagsConfig;
+        let mut pipeline = Pipeline::default_pipeline(Some(TagsConfig::default()));
+
+        let mut a1 = test_msg();
+        a1.uuid = "a1".into();
+        a1.session_id = Some("sess-1".into());
+        a1.role = "assistant".into();
+        a1.model = Some("claude-opus".into());
+        a1.output_tokens = 1;
+        a1.timestamp = "2026-03-14T18:13:43Z".parse().unwrap();
+
+        let mut msgs = vec![a1];
+        let tags = pipeline.process(&mut msgs);
+        assert!(
+            tags[0].iter().all(|t| t.key != tk::TOOL_OUTCOME),
+            "assistant without tool_use should not carry tool_outcome, got: {:?}",
+            tags[0]
+        );
     }
 }

--- a/crates/budi-core/src/providers/codex.rs
+++ b/crates/budi-core/src/providers/codex.rs
@@ -282,6 +282,7 @@ fn parse_token_count(
         tool_names: Vec::new(),
         tool_use_ids: Vec::new(),
         tool_files: Vec::new(),
+        tool_outcomes: Vec::new(),
     })
 }
 

--- a/crates/budi-core/src/providers/copilot.rs
+++ b/crates/budi-core/src/providers/copilot.rs
@@ -308,6 +308,7 @@ fn parse_usage_event(
         tool_names: Vec::new(),
         tool_use_ids: Vec::new(),
         tool_files: Vec::new(),
+        tool_outcomes: Vec::new(),
     })
 }
 

--- a/crates/budi-core/src/providers/cursor.rs
+++ b/crates/budi-core/src/providers/cursor.rs
@@ -831,6 +831,7 @@ fn usage_events_to_messages(
                 tool_names: Vec::new(),
                 tool_use_ids: Vec::new(),
                 tool_files: Vec::new(),
+                tool_outcomes: Vec::new(),
             }
         })
         .collect()
@@ -1429,6 +1430,7 @@ fn parse_cursor_line(
                 tool_names: Vec::new(),
                 tool_use_ids: Vec::new(),
                 tool_files: Vec::new(),
+                tool_outcomes: Vec::new(),
             })
         }
         "assistant" | "ai" | "model" => {
@@ -1463,6 +1465,7 @@ fn parse_cursor_line(
                 tool_names,
                 tool_use_ids: Vec::new(),
                 tool_files,
+                tool_outcomes: Vec::new(),
             })
         }
         _ => None,

--- a/crates/budi-core/src/tag_keys.rs
+++ b/crates/budi-core/src/tag_keys.rs
@@ -38,6 +38,37 @@ pub const DURATION: &str = "duration";
 pub const TOOL: &str = "tool";
 pub const TOOL_USE_ID: &str = "tool_use_id";
 
+/// Outcome of a tool call on an assistant message. Stable values (ADR-0088
+/// §5, R1.5 #293):
+/// - `success` — tool returned a normal result.
+/// - `error` — tool returned an error result (`is_error: true` in the
+///   Claude Code `tool_result` block, or equivalent on other providers).
+/// - `denied` — the user rejected the proposed action (detected via a
+///   small set of provider-specific sentinels in the `tool_result`
+///   content).
+/// - `retry` — a follow-up call to the same tool shortly after an
+///   `error` outcome in the same session, attributed by a rule-based
+///   heuristic rather than the `tool_result` itself.
+///
+/// One tag per distinct outcome observed on the assistant message. Empty
+/// when the message carried no tool calls or the tool calls have no
+/// corresponding `tool_result` yet (open-ended / still-in-flight).
+pub const TOOL_OUTCOME: &str = "tool_outcome";
+/// Where the outcome label came from. Stable values:
+/// - `jsonl_tool_result` — extracted from a provider `tool_result` block.
+/// - `heuristic_retry`   — attributed by the `retry` heuristic.
+///
+/// Emitted once per message as the dominant source of the outcomes on
+/// that message; mirrors R1.2 (#222) `activity_source` / R1.4 (#292)
+/// `file_path_source`.
+pub const TOOL_OUTCOME_SOURCE: &str = "tool_outcome_source";
+/// Confidence of the outcome labels on the message. Stable values:
+/// - `high`   — outcome came from an explicit `tool_result` block.
+/// - `medium` — outcome came from the rule-based retry heuristic.
+///
+/// Emitted once per message.
+pub const TOOL_OUTCOME_CONFIDENCE: &str = "tool_outcome_confidence";
+
 /// Repo-relative file path derived from a tool-call argument (e.g. the
 /// `file_path` input of Read/Write/Edit, Cursor's `target_file`, etc.).
 /// One tag per file on the assistant message. Added in R1.4 (#292).

--- a/crates/budi-core/src/work_outcome.rs
+++ b/crates/budi-core/src/work_outcome.rs
@@ -1,0 +1,500 @@
+//! Session → work outcome derivation (R1.5, #293).
+//!
+//! Given a session's `repo_id`, `git_branch`, and start/end timestamps,
+//! correlate the session with local git state to produce a bounded
+//! per-session label describing whether the AI-assisted work actually
+//! landed. This is a **rule-based** derivation — no remote git/PR API
+//! calls, no content capture, no statistics. The entire logic runs
+//! against whatever `git` CLI is on PATH (see ADR-0088 §5).
+//!
+//! ## Labels
+//!
+//! - [`WorkOutcomeLabel::Committed`] — at least one commit was authored
+//!   by the local git user on the session's branch during or shortly
+//!   after the session's active window.
+//! - [`WorkOutcomeLabel::BranchMerged`] — the session's branch was
+//!   merged into the default integration branch (typically `main` or
+//!   `master`) after the session; i.e. the work shipped. This implies
+//!   `committed` but is strictly more informative, so we surface it
+//!   separately.
+//! - [`WorkOutcomeLabel::NoCommit`] — the session ended without any
+//!   commit landing on its branch inside the correlation window; the
+//!   branch still exists locally. This is the "long agent session that
+//!   produced no code change" case the R1.5 ticket calls out.
+//! - [`WorkOutcomeLabel::Unknown`] — the inputs were insufficient to
+//!   apply any rule (missing branch, missing repo root, branch does not
+//!   exist locally, `git` is unavailable, etc.). Never treated as a
+//!   signal; analytics should show `Unknown` as a separate bucket so
+//!   users understand when derivation is possible.
+//!
+//! ## Correlation window
+//!
+//! The session window is `[started_at, ended_at + GRACE]` where
+//! `GRACE = 24h`. Commits that land within the grace period are still
+//! attributed to the session because developers routinely wrap up a
+//! task the next morning. This window is intentionally generous — the
+//! goal is to reduce false negatives (work landed but we called it
+//! `no_commit`), which would be the more damaging error. False positives
+//! are bounded by also requiring the commit to touch the same branch.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use chrono::{DateTime, Utc};
+
+/// Correlation grace window applied after `ended_at` when scanning for
+/// commits. Keeps the derivation generous enough that developers who
+/// wrap up a task the next morning still see `committed`. 24h is a
+/// round, debuggable default; callers can override for tests.
+pub const DEFAULT_GRACE: chrono::Duration = chrono::Duration::hours(24);
+
+/// Integration branches we treat as the merge target when asking
+/// whether a session's branch shipped. Same list the pipeline uses to
+/// filter out integration branches from ticket extraction, kept in sync
+/// so the two derivations agree on what "merged" means.
+const INTEGRATION_BRANCHES: &[&str] = &["main", "master", "develop"];
+
+/// Bounded set of outcome labels. Matches the set listed in #293 plus
+/// `Unknown`; analytics queries pivot on the raw string value so the
+/// variants serialize via `as_str()` rather than a derive to keep the
+/// wire format explicit and easy to reason about.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WorkOutcomeLabel {
+    Committed,
+    BranchMerged,
+    NoCommit,
+    Unknown,
+}
+
+impl WorkOutcomeLabel {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Committed => "committed",
+            Self::BranchMerged => "branch_merged",
+            Self::NoCommit => "no_commit",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+impl std::fmt::Display for WorkOutcomeLabel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Result of a single session → outcome derivation. Includes a short
+/// rationale so operators and tests can see exactly which rule fired
+/// without turning on trace logging.
+#[derive(Debug, Clone)]
+pub struct WorkOutcome {
+    pub label: WorkOutcomeLabel,
+    /// One-line human-readable explanation (e.g. "3 commits on
+    /// `PAVA-2057-fix` between 10:00 and 11:30"). Never contains file
+    /// names or commit messages — keep to counts and metadata so the
+    /// derivation stays inside ADR-0083.
+    pub rationale: String,
+}
+
+impl WorkOutcome {
+    pub fn unknown(reason: &str) -> Self {
+        Self {
+            label: WorkOutcomeLabel::Unknown,
+            rationale: reason.to_string(),
+        }
+    }
+}
+
+/// Inputs to the derivation. Kept explicit (rather than pulling from a
+/// DB row) so tests can exercise the ruleset against fixture git repos
+/// without faking a whole session record.
+#[derive(Debug, Clone)]
+pub struct WorkOutcomeInputs<'a> {
+    pub repo_root: &'a Path,
+    pub branch: &'a str,
+    pub started_at: DateTime<Utc>,
+    pub ended_at: DateTime<Utc>,
+    /// Optional grace window override. Defaults to `DEFAULT_GRACE`.
+    pub grace: Option<chrono::Duration>,
+}
+
+/// Derive the session work outcome from local git state. Returns
+/// [`WorkOutcomeLabel::Unknown`] whenever the inputs cannot support a
+/// decision — callers treat `Unknown` as "show nothing" rather than
+/// hiding the session entirely.
+pub fn derive_work_outcome(inputs: &WorkOutcomeInputs<'_>) -> WorkOutcome {
+    let branch = inputs.branch.trim();
+    if branch.is_empty() || INTEGRATION_BRANCHES.contains(&branch) {
+        return WorkOutcome::unknown("no non-integration branch on session — nothing to correlate");
+    }
+    if !inputs.repo_root.exists() || !inputs.repo_root.join(".git").exists() {
+        return WorkOutcome::unknown("repo_root is not a git working tree");
+    }
+    if !has_git_on_path() {
+        return WorkOutcome::unknown("git binary not on PATH");
+    }
+    if !branch_exists_locally(inputs.repo_root, branch) {
+        // If the branch has disappeared locally, it usually means it
+        // was merged and then deleted — the classic "shipped" end state.
+        // Confirm by looking for a reachable merge commit on a canonical
+        // integration branch instead of declaring `unknown`.
+        if branch_was_merged(inputs.repo_root, branch) {
+            return WorkOutcome {
+                label: WorkOutcomeLabel::BranchMerged,
+                rationale: format!(
+                    "branch `{branch}` no longer exists locally but is reachable from an integration branch",
+                ),
+            };
+        }
+        return WorkOutcome::unknown(&format!(
+            "branch `{branch}` not present locally; cannot correlate",
+        ));
+    }
+
+    let grace = inputs.grace.unwrap_or(DEFAULT_GRACE);
+    let since = inputs.started_at;
+    let until = inputs.ended_at + grace;
+    let unique_commits = count_commits_on_branch(inputs.repo_root, branch, since, until);
+    let merged = branch_was_merged(inputs.repo_root, branch);
+    let is_idle_at_integration = branch_shares_tip_with_integration(inputs.repo_root, branch);
+
+    // BranchMerged wins over Committed so a retrospective view of
+    // "this session shipped" shows up even when the merge itself
+    // happened slightly outside the window — what matters is that
+    // commits were introduced on the branch and the branch is now
+    // reachable from an integration branch.
+    if merged && !is_idle_at_integration {
+        // We still want to confirm that *some* history exists so an
+        // empty branch doesn't get credit. `unique_commits` can be 0
+        // post-merge (commits are now reachable from main) so rely on
+        // the tip difference instead — already established above.
+        return WorkOutcome {
+            label: WorkOutcomeLabel::BranchMerged,
+            rationale: format!(
+                "branch `{branch}` is reachable from an integration branch and has its own history",
+            ),
+        };
+    }
+
+    if unique_commits > 0 {
+        return WorkOutcome {
+            label: WorkOutcomeLabel::Committed,
+            rationale: format!(
+                "{unique_commits} commit(s) unique to `{branch}` within session window",
+            ),
+        };
+    }
+
+    WorkOutcome {
+        label: WorkOutcomeLabel::NoCommit,
+        rationale: format!(
+            "no new commits on `{branch}` between {} and {}",
+            since.to_rfc3339(),
+            until.to_rfc3339(),
+        ),
+    }
+}
+
+/// Resolve a repo root from a stored `repo_id` by checking candidate
+/// paths. Callers typically want to pass the cwd the session ran in,
+/// but for historical sessions we may only know the `repo_id`. This
+/// helper is intentionally minimal: it accepts an explicit candidate
+/// path and returns it when it looks like a git working tree.
+pub fn repo_root_candidate(path: &Path) -> Option<PathBuf> {
+    if path.join(".git").exists() {
+        Some(path.to_path_buf())
+    } else {
+        None
+    }
+}
+
+fn has_git_on_path() -> bool {
+    Command::new("git")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn branch_exists_locally(repo: &Path, branch: &str) -> bool {
+    let refname = format!("refs/heads/{branch}");
+    Command::new("git")
+        .args(["show-ref", "--verify", "--quiet", &refname])
+        .current_dir(repo)
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// Returns true when the branch's tip is the same commit as one of
+/// the integration branches. Used to distinguish an idle branch
+/// (checked out from main with no new commits) from a merged branch
+/// (merged via `--no-ff`, so its tip is strictly behind main's).
+fn branch_shares_tip_with_integration(repo: &Path, branch: &str) -> bool {
+    let Some(branch_tip) = resolve_ref(repo, branch) else {
+        return false;
+    };
+    for integration in INTEGRATION_BRANCHES {
+        if let Some(tip) = resolve_ref(repo, integration)
+            && tip == branch_tip
+        {
+            return true;
+        }
+    }
+    false
+}
+
+fn resolve_ref(repo: &Path, refname: &str) -> Option<String> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--verify", refname])
+        .current_dir(repo)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let s = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if s.is_empty() { None } else { Some(s) }
+}
+
+fn branch_was_merged(repo: &Path, branch: &str) -> bool {
+    // Try each known integration branch; any positive answer is
+    // enough. `git merge-base --is-ancestor <branch> <integration>`
+    // returns 0 if the branch is reachable from the integration branch,
+    // which is the definition we care about. Skip integration refs
+    // that don't exist locally so we don't spray `fatal:` messages to
+    // stderr on scratch repos that only carry `main`.
+    for integration in INTEGRATION_BRANCHES {
+        if resolve_ref(repo, integration).is_none() {
+            continue;
+        }
+        let ok = Command::new("git")
+            .args(["merge-base", "--is-ancestor", branch, integration])
+            .current_dir(repo)
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+        if ok {
+            return true;
+        }
+    }
+    false
+}
+
+fn count_commits_on_branch(
+    repo: &Path,
+    branch: &str,
+    since: DateTime<Utc>,
+    until: DateTime<Utc>,
+) -> u32 {
+    // Count commits *unique to the branch* within the window — i.e.
+    // commits reachable from `branch` but not from any integration
+    // branch. This keeps idle feature branches (same tip as `main`)
+    // from being credited with main's shared history just because the
+    // bootstrap commit landed inside the correlation window.
+    let mut args: Vec<String> = vec!["log".into(), branch.into()];
+    for integration in INTEGRATION_BRANCHES {
+        // `--not` excludes commits reachable from this ref. Silently
+        // skipped when the ref doesn't exist (the command still
+        // succeeds), which matches the behavior of scratch repos that
+        // only carry `main`.
+        let refname = format!("refs/heads/{integration}");
+        if Command::new("git")
+            .args(["show-ref", "--verify", "--quiet", &refname])
+            .current_dir(repo)
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false)
+            && branch != *integration
+        {
+            args.push("--not".into());
+            args.push((*integration).to_string());
+        }
+    }
+    args.push("--since".into());
+    args.push(since.to_rfc3339());
+    args.push("--until".into());
+    args.push(until.to_rfc3339());
+    args.push("--pretty=format:1".into());
+
+    let output = Command::new("git").args(&args).current_dir(repo).output();
+    match output {
+        Ok(o) if o.status.success() => String::from_utf8_lossy(&o.stdout).lines().count() as u32,
+        _ => 0,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unknown_when_branch_empty() {
+        let inputs = WorkOutcomeInputs {
+            repo_root: Path::new("/"),
+            branch: "",
+            started_at: Utc::now(),
+            ended_at: Utc::now(),
+            grace: None,
+        };
+        assert_eq!(
+            derive_work_outcome(&inputs).label,
+            WorkOutcomeLabel::Unknown
+        );
+    }
+
+    #[test]
+    fn unknown_on_integration_branch() {
+        for b in ["main", "master", "develop"] {
+            let inputs = WorkOutcomeInputs {
+                repo_root: Path::new("/"),
+                branch: b,
+                started_at: Utc::now(),
+                ended_at: Utc::now(),
+                grace: None,
+            };
+            assert_eq!(
+                derive_work_outcome(&inputs).label,
+                WorkOutcomeLabel::Unknown,
+                "{b} must not correlate as work outcome"
+            );
+        }
+    }
+
+    #[test]
+    fn labels_serialize_stable_values() {
+        assert_eq!(WorkOutcomeLabel::Committed.as_str(), "committed");
+        assert_eq!(WorkOutcomeLabel::BranchMerged.as_str(), "branch_merged");
+        assert_eq!(WorkOutcomeLabel::NoCommit.as_str(), "no_commit");
+        assert_eq!(WorkOutcomeLabel::Unknown.as_str(), "unknown");
+    }
+
+    // Integration tests below invoke the `git` binary against a scratch
+    // repo. They are gated behind a helper that returns early if `git`
+    // isn't available so CI images without it still pass.
+
+    struct ScratchRepo {
+        dir: PathBuf,
+    }
+
+    impl ScratchRepo {
+        fn new(name: &str) -> Option<Self> {
+            if !has_git_on_path() {
+                return None;
+            }
+            let base = std::env::temp_dir()
+                .join(format!("budi-work-outcome-{name}-{}", std::process::id()));
+            let _ = std::fs::remove_dir_all(&base);
+            std::fs::create_dir_all(&base).ok()?;
+            let ok = Command::new("git")
+                .args(["init", "-q", "-b", "main"])
+                .current_dir(&base)
+                .status()
+                .ok()?
+                .success();
+            if !ok {
+                return None;
+            }
+            // Configure a local identity so commits don't fail on
+            // hosts without a global git config.
+            for (k, v) in [
+                ("user.email", "test@example.invalid"),
+                ("user.name", "Budi Test"),
+                ("commit.gpgsign", "false"),
+            ] {
+                let _ = Command::new("git")
+                    .args(["config", "--local", k, v])
+                    .current_dir(&base)
+                    .status();
+            }
+            Some(Self { dir: base })
+        }
+
+        fn run(&self, args: &[&str]) -> bool {
+            Command::new("git")
+                .args(args)
+                .current_dir(&self.dir)
+                .status()
+                .map(|s| s.success())
+                .unwrap_or(false)
+        }
+
+        fn commit(&self, file: &str, content: &str, msg: &str) -> bool {
+            std::fs::write(self.dir.join(file), content).is_ok()
+                && self.run(&["add", file])
+                && self.run(&["commit", "-q", "-m", msg])
+        }
+    }
+
+    impl Drop for ScratchRepo {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.dir);
+        }
+    }
+
+    #[test]
+    fn committed_when_feature_branch_has_commits() {
+        let Some(repo) = ScratchRepo::new("committed") else {
+            return;
+        };
+        assert!(repo.commit("seed.txt", "seed", "initial"));
+        assert!(repo.run(&["checkout", "-q", "-b", "PROJ-1-feature"]));
+        let started = Utc::now() - chrono::Duration::minutes(1);
+        assert!(repo.commit("work.txt", "hi", "work"));
+        let ended = Utc::now();
+
+        let inputs = WorkOutcomeInputs {
+            repo_root: &repo.dir,
+            branch: "PROJ-1-feature",
+            started_at: started,
+            ended_at: ended,
+            grace: None,
+        };
+        let outcome = derive_work_outcome(&inputs);
+        // Branch never merged into main, so label should be Committed.
+        assert_eq!(outcome.label, WorkOutcomeLabel::Committed);
+    }
+
+    #[test]
+    fn no_commit_when_branch_is_idle() {
+        let Some(repo) = ScratchRepo::new("nocommit") else {
+            return;
+        };
+        assert!(repo.commit("seed.txt", "seed", "initial"));
+        assert!(repo.run(&["checkout", "-q", "-b", "PROJ-2-idle"]));
+
+        let inputs = WorkOutcomeInputs {
+            repo_root: &repo.dir,
+            branch: "PROJ-2-idle",
+            started_at: Utc::now() - chrono::Duration::hours(1),
+            ended_at: Utc::now(),
+            grace: Some(chrono::Duration::seconds(1)),
+        };
+        let outcome = derive_work_outcome(&inputs);
+        assert_eq!(outcome.label, WorkOutcomeLabel::NoCommit);
+    }
+
+    #[test]
+    fn branch_merged_when_reachable_from_integration() {
+        let Some(repo) = ScratchRepo::new("merged") else {
+            return;
+        };
+        assert!(repo.commit("seed.txt", "seed", "initial"));
+        assert!(repo.run(&["checkout", "-q", "-b", "PROJ-3-merged"]));
+        let started = Utc::now() - chrono::Duration::minutes(1);
+        assert!(repo.commit("merged.txt", "hi", "merged work"));
+        assert!(repo.run(&["checkout", "-q", "main"]));
+        assert!(repo.run(&["merge", "-q", "--no-ff", "PROJ-3-merged", "-m", "merge"]));
+        let ended = Utc::now();
+
+        let inputs = WorkOutcomeInputs {
+            repo_root: &repo.dir,
+            branch: "PROJ-3-merged",
+            started_at: started,
+            ended_at: ended,
+            grace: None,
+        };
+        let outcome = derive_work_outcome(&inputs);
+        assert_eq!(outcome.label, WorkOutcomeLabel::BranchMerged);
+    }
+}


### PR DESCRIPTION
## Summary

- Extract `tool_result` blocks from Claude Code JSONL user messages into a bounded `ToolOutcome { tool_use_id, outcome }` record. Only the classified label (`success` / `error` / `denied`) is persisted; the underlying content never leaves memory (ADR-0083).
- Propagate session-scoped outcomes back to the originating assistant message via a new first pass in `Pipeline::process`, and emit one `tool_outcome` tag per distinct outcome observed. A rule-based retry heuristic promotes a follow-up call to the same tool after an `error` into `tool_outcome=retry`. Sibling `tool_outcome_source` (`jsonl_tool_result` / `heuristic_retry`) and `tool_outcome_confidence` (`high` / `medium`) mirror the R1.2 / R1.4 provenance contract so analytics can render explainable labels per-message.
- Add `work_outcome` module that derives a per-session label (`committed` / `branch_merged` / `no_commit` / `unknown`) from local git state only — no remote Git/PR API calls, no content capture. `budi session detail <id>` surfaces the label plus a one-line rationale; the list views intentionally skip the derivation to keep them from spawning `git` once per row.
- Update `SOUL.md` with the new tag keys, outcome contract, and privacy constraints.

## Risks / compatibility notes

- No schema changes. New signals are emitted as ordinary tags plus two optional fields on `SessionListEntry` that serialize with `skip_serializing_if = Option::is_none`, so existing API/CLI consumers see identical payloads when the derivation can't run.
- The proxy ingest path does not emit `tool_outcome` in 8.1 — tool names and IDs aren't captured there yet. Outcomes are import-only for now; the proxy-side extension is a natural 8.2 follow-up.
- Work outcome derivation relies on `git` being on PATH and the repo root being resolvable from the session's stored cwd. Missing either falls open to `unknown`.

## Validation

- `cargo fmt --all`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked` — 414 tests pass, including 4 new pipeline cases for `tool_outcome` emission + retry heuristic, 5 new JSONL classifier cases, and 6 integration tests that exercise `derive_work_outcome` against scratch git repos (skipped when `git` is unavailable).
- Manual smoke: ran `budi session detail <id>` against a session on this branch; the `Outcome` row renders `committed` with a "1 commit(s) unique to …" rationale.

Closes #293

Made with [Cursor](https://cursor.com)