### PR TITLE
[8.1][R1.6] Code review pass for classification round (#217)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 - **`BUDI_ANTHROPIC_UPSTREAM` / `BUDI_OPENAI_UPSTREAM` env overrides** on the proxy (mirroring the existing `BUDI_PROXY_PORT` / `BUDI_PROXY_ENABLED` pattern) so local end-to-end tests and air-gapped deployments can redirect proxy traffic without editing on-disk config.
 - **Local end-to-end test harness** in `scripts/e2e/` — the first script, `test_302_sessions_visibility.sh`, boots a real `budi-daemon` + mock upstream + CLI against an isolated `$HOME` and pins the #302 fix. See `scripts/e2e/README.md` for conventions and the new "Local end-to-end tests" section in `SOUL.md`.
 
+### Process
+
+- **R1.6 code review pass for the 8.1 classification round** completed (#217). Audited the merged work from R1.0.1 (#302) through R1.5 (#293) for correctness, privacy, and explainability against ADR-0088 §5. No blocking defects; the round meets the 8.1 classification contract. Four non-blocking follow-ups filed for 8.2: cloud-sync ticket extractor should share the pipeline helper (#333), `proxy_events` schema missing first-class dimension columns (#334), defensive sibling-tag pairing at emission sites (#335), and R1.5 edge cases in `work_outcome` integration-branch detection and `tool_result` variant coverage (#336). Docs-drift items handed off to R1.7 (#220) in an issue comment.
+
 ## 8.0.0 — 2026-04-16
 
 Budi 8.0 is a ground-up rearchitecture: proxy-first live cost tracking replaces the old hook/OTEL/file-sync ingestion model, the Cursor extension and cloud dashboard are extracted into independent repos, and a new optional cloud layer gives managers team-wide AI cost visibility — all while keeping prompts, code, and responses strictly local.


### PR DESCRIPTION
## Summary

R1.6 code review pass for the 8.1 classification round, per the control issue #201. Audited every PR that landed R1.0–R1.5:

| Round | Issue | PR |
|-------|-------|----|
| R1.0.1 — sessions visibility | #302 | #306 |
| R1.0.2 — branch attribution | #303 | #307 |
| R1.0.3 — ticket first-class CLI | #304 | #308 |
| R1.0.4 — activity first-class CLI | #305 | #310 |
| R1.1 — ADR-0088 local-developer-first contract | #216 | #311 |
| R1.2 — activity classification source/confidence | #222 | #312 |
| R1.3 — ticket attribution hardening | #221 | #313 |
| R1.4 — file-level attribution | #292 | #315 |
| R1.5 — tool outcome + session work outcome | #293 | #332 |

The audit covered: ADR-0083 privacy limits (repo-relative paths only, no contents, no diffs, no remote git/PR API calls), ADR-0088 §5 classification principles (explainability, simplest trustworthy path, source+confidence on every classification, no new local LLM dependencies), and the `SOUL.md` §149–340 attribution contract.

### Findings

**Blocking:** none.

- `work_outcome.rs` is local-git only — no `reqwest` or remote Git/PR API calls.
- `file_attribution::attribute_files` drops absolute paths and traversals, caps fan-out at 16 per message, and never persists file contents, mtimes, or sizes.
- The proxy `classify_request_body` path extracts a classification and records only the `(activity, source, confidence)` triple as tags — no prompt text is persisted, consistent with ADR-0083.
- `extract_ticket_from_branch` consistently filters `main` / `master` / `develop` / `HEAD` via the shared `INTEGRATION_BRANCHES` list.
- SQL uses bound parameters everywhere; the `/analytics/files/{*path}` route validates repo-relative paths before hitting SQLite.
- All insert sites normalize empty-string `session_id` to `NULL`.
- `ticket_source`, `activity_source` + `activity_confidence`, `file_path_source` + `file_path_confidence`, and `tool_outcome_source` + `tool_outcome_confidence` are paired with their headline tag at both emitter sites (batch pipeline + live proxy).
- All 414 `budi-core` + 26 `budi-daemon` tests pass locally on this branch.

**Non-blocking (filed as follow-ups, milestone `8.2.0`):**

- #333 — `cloud_sync` ships its own `extract_ticket_from_branch` that diverges from `pipeline::extract_ticket_from_branch` (no shared integration-branch list, no numeric fallback, no `ticket_source`).
- #334 — `proxy_events` table does not persist the new first-class dimension columns (`ticket_source`, `activity`, `activity_source`, `activity_confidence`) that `ProxyEvent` already carries.
- #335 — Emission sites for activity / ticket / file / tool_outcome tags gate siblings behind `Option`; centralize through per-dimension helpers so it becomes impossible to emit the headline without the sibling contract.
- #336 — `work_outcome` only short-circuits on `main` / `master` / `develop` (missing `HEAD`); `tool_result` extraction only handles `UserContent::Blocks`.

**Docs drift (handed off to R1.7 #220 via issue comment):**

- `SOUL.md:355-357` reads \"red when **100%** missing\"; `doctor.rs:411` uses `pct >= 99.9` (float tolerance).
- `SOUL.md:374` says \"All 5 enricher implementations\" in `enrichers.rs`; R1.4 added `FileEnricher` and R1.5 wired tool/work outcomes — verify the narrative and count.

### What this PR changes

Per the review-pass discipline (rule 11), this PR fixes **only** blocking defects — and none were found. The only code change is a `CHANGELOG.md` `### Process` entry under `Unreleased (8.1.0)` recording the review pass outcome and linking to the four follow-up issues.

## Risks / compatibility notes

None. CHANGELOG-only change.

## Validation

- `cargo fmt --all -- --check` — clean.
- `cargo clippy --workspace --all-targets --locked -- -D warnings` — clean.
- `cargo test --workspace --locked` — 414 + 26 passed, 0 failed.

Closes #217

Made with [Cursor](https://cursor.com)