### PR TITLE
[8.1][R2.1] Add budi cloud sync / cloud status (#225)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Added
 
+- **`budi cloud sync` and `budi cloud status`** (R2.1, #225) — the pre-8.0 `budi sync` command was removed in #175 when transcript ingestion consolidated into `budi import`, leaving cloud sync running only as an async daemon worker (#101). The new `budi cloud` namespace restores a discoverable self-serve path: `budi cloud sync` pushes queued local rollups and session summaries to the cloud on demand and reports records upserted, watermark, and endpoint; `budi cloud status` reports whether sync is enabled, when it last succeeded, and how many records are queued locally. Both commands honor `--format text|json` in line with `budi stats` / `budi sessions`. Backed by new `POST /cloud/sync` (loopback-only) and `GET /cloud/status` daemon endpoints; a shared `cloud_syncing` `AtomicBool` prevents the manual command and the background worker from double-posting.
 - **`budi doctor` sessions-visibility check** — reports assistant-messages vs returned-session counts for the `today`, `7d`, and `30d` windows and flags a hard error if any window has activity but zero returned sessions (#302).
 - **`messages.timestamp` / `session_id` attribution contract** documented in `SOUL.md` so future providers cannot silently regress R1.0 (#302).
 - **`BUDI_ANTHROPIC_UPSTREAM` / `BUDI_OPENAI_UPSTREAM` env overrides** on the proxy (mirroring the existing `BUDI_PROXY_PORT` / `BUDI_PROXY_ENABLED` pattern) so local end-to-end tests and air-gapped deployments can redirect proxy traffic without editing on-disk config.

--- a/README.md
+++ b/README.md
@@ -310,6 +310,8 @@ budi health --session <id>         # health vitals for a specific session
 ```bash
 budi doctor                        # check health: daemon, proxy, database, config
 budi doctor --deep                 # run full SQLite integrity_check (slower)
+budi cloud status                  # cloud sync readiness + last-synced-at + queued records
+budi cloud sync                    # push queued local rollups/sessions to the cloud now
 budi autostart status              # check daemon autostart service
 budi autostart install             # install the autostart service
 budi autostart uninstall           # remove the autostart service

--- a/SOUL.md
+++ b/SOUL.md
@@ -121,6 +121,11 @@ Local SQLite daily rollups
   -> Manager dashboard at app.getbudi.dev
 Config: ~/.config/budi/cloud.toml ([cloud] section), env overrides BUDI_CLOUD_*
 Never uploaded: prompts, responses, code, file paths, email, raw payloads, tag values
+
+Manual cloud sync (since 8.1, R2.1, #225):
+`budi cloud sync`     -> POST /cloud/sync (loopback-only) -> same sync_tick as worker
+`budi cloud status`   -> GET /cloud/status -> readiness + watermarks, no network call
+AppState.cloud_syncing AtomicBool guards worker and manual path from double-posting.
 ```
 
 ### Database (SQLite, WAL mode, schema v1)
@@ -393,6 +398,8 @@ in [#302](https://github.com/siropkin/budi/issues/302) / #303 / #304 / #305):
 - `crates/budi-daemon/src/main.rs` - HTTP server (port 7878) + proxy server (port 9878) + cloud sync worker, ~40 routes
 - `crates/budi-daemon/src/workers/cloud_sync.rs` - Background cloud sync loop: configurable interval, backoff, auth/schema error handling
 - `crates/budi-daemon/src/routes/hooks.rs` - /sync, /sync/all, /sync/reset, /sync/status, /health, /health/integrations, /health/check-update, /admin/integrations/install endpoints (hook ingestion removed)
+- `crates/budi-daemon/src/routes/cloud.rs` - /cloud/sync (loopback-only manual cloud flush) and /cloud/status (cloud readiness + watermarks); added in R2.1 (#225)
+- `crates/budi-cli/src/commands/cloud.rs` - `budi cloud sync` / `budi cloud status` (R2.1 #225): text + JSON output, exit code 2 on non-ok sync
 - `crates/budi-daemon/src/routes/analytics.rs` - All analytics + admin endpoints (summary, messages, projects, cost, models, activity, branches, tags, providers, statusline, cache-efficiency, session-cost-curve, cost-confidence, subagent-cost, sessions, session-health, session-audit, admin/providers, admin/schema, admin/migrate, admin/repair)
 - `crates/budi-daemon/src/routes/proxy.rs` - Proxy handlers for Anthropic Messages and OpenAI Chat Completions
 - `crates/budi-cli/src/commands/proxy_install.rs` - Auto-proxy installer and verifier: shell profile block + Cursor/Codex config patching + `budi enable/disable`

--- a/crates/budi-cli/src/client.rs
+++ b/crates/budi-cli/src/client.rs
@@ -316,6 +316,37 @@ impl DaemonClient {
         Ok(resp.json()?)
     }
 
+    /// `POST /cloud/sync` — trigger an immediate cloud flush.
+    ///
+    /// The daemon runs the same code path as the background worker
+    /// (`cloud_sync::sync_tick_report`) and returns a structured JSON body
+    /// that the CLI renders via `commands::cloud`. Non-2xx responses are
+    /// surfaced as `anyhow` errors via [`check_response`]; a successful HTTP
+    /// status still encodes per-result outcomes (`auth_failure`,
+    /// `transient_error`, …) in `result`.
+    pub fn cloud_sync(&self) -> Result<Value> {
+        let resp = self
+            .client
+            .post(format!("{}/cloud/sync", self.base_url))
+            .timeout(std::time::Duration::from_secs(120))
+            .send()
+            .map_err(describe_send_error)?;
+        let resp = check_response(resp)?;
+        Ok(resp.json()?)
+    }
+
+    /// `GET /cloud/status` — read cloud sync readiness and watermarks.
+    /// Never blocks on the network; the daemon only reads local state.
+    pub fn cloud_status(&self) -> Result<Value> {
+        let resp = self
+            .client
+            .get(format!("{}/cloud/status", self.base_url))
+            .send()
+            .map_err(describe_send_error)?;
+        let resp = check_response(resp)?;
+        Ok(resp.json()?)
+    }
+
     // ─── Analytics ───────────────────────────────────────────────────
 
     pub fn summary(

--- a/crates/budi-cli/src/commands/cloud.rs
+++ b/crates/budi-cli/src/commands/cloud.rs
@@ -1,0 +1,194 @@
+//! `budi cloud` subcommands — manual cloud sync and freshness reporting.
+//!
+//! 8.1 R2.1 (issue #225) introduces `budi cloud sync` as the user-facing way
+//! to say "push my latest local data to cloud now" without waiting for the
+//! background worker interval (ADR-0083 §9). `budi cloud status` shows the
+//! same readiness snapshot the daemon exposes at `GET /cloud/status` so users
+//! can answer "is cloud sync healthy?" without reading logs.
+//!
+//! Both commands follow the normalized CLI output contract shared with
+//! `budi stats` / `budi sessions`:
+//! - `--format text` is the default, human-readable with ✓/✗ status lines.
+//! - `--format json` emits the daemon response body verbatim for scripting.
+
+use anyhow::Result;
+use serde_json::Value;
+
+use crate::StatsFormat;
+use crate::client::DaemonClient;
+
+use super::ansi;
+
+/// `budi cloud sync` — flush the pending cloud queue now.
+pub fn cmd_cloud_sync(format: StatsFormat) -> Result<()> {
+    let client = DaemonClient::connect()?;
+    let body = client.cloud_sync()?;
+
+    if matches!(format, StatsFormat::Json) {
+        println!("{}", serde_json::to_string_pretty(&body)?);
+        // Exit non-zero on non-ok result so scripts can branch on status.
+        if body.get("ok").and_then(Value::as_bool) != Some(true) {
+            std::process::exit(2);
+        }
+        return Ok(());
+    }
+
+    render_sync_text(&body);
+    if body.get("ok").and_then(Value::as_bool) != Some(true) {
+        std::process::exit(2);
+    }
+    Ok(())
+}
+
+/// `budi cloud status` — report cloud sync readiness and last-synced-at.
+pub fn cmd_cloud_status(format: StatsFormat) -> Result<()> {
+    let client = DaemonClient::connect()?;
+    let body = client.cloud_status()?;
+
+    if matches!(format, StatsFormat::Json) {
+        println!("{}", serde_json::to_string_pretty(&body)?);
+        return Ok(());
+    }
+
+    render_status_text(&body);
+    Ok(())
+}
+
+fn render_sync_text(body: &Value) {
+    let green = ansi("\x1b[32m");
+    let red = ansi("\x1b[31m");
+    let yellow = ansi("\x1b[33m");
+    let dim = ansi("\x1b[90m");
+    let bold = ansi("\x1b[1m");
+    let reset = ansi("\x1b[0m");
+
+    let ok = body.get("ok").and_then(Value::as_bool).unwrap_or(false);
+    let result = body
+        .get("result")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let message = body.get("message").and_then(Value::as_str).unwrap_or("");
+    let endpoint = body.get("endpoint").and_then(Value::as_str).unwrap_or("");
+    let records = body
+        .get("records_upserted")
+        .and_then(Value::as_i64)
+        .unwrap_or(0);
+    let rollups = body
+        .get("rollups_attempted")
+        .and_then(Value::as_i64)
+        .unwrap_or(0);
+    let sessions = body
+        .get("sessions_attempted")
+        .and_then(Value::as_i64)
+        .unwrap_or(0);
+    let watermark = body.get("watermark").and_then(Value::as_str);
+
+    println!();
+    let (icon, color, headline) = match (ok, result) {
+        (true, "success") => (
+            "✓",
+            green,
+            format!("Cloud sync complete ({records} records pushed)"),
+        ),
+        (true, "empty_payload") => ("✓", green, "Nothing new to sync".to_string()),
+        (_, "disabled") => ("-", dim, "Cloud sync is disabled".to_string()),
+        (_, "not_configured") => ("!", yellow, "Cloud sync is not configured".to_string()),
+        (_, "auth_failure") => ("✗", red, "Cloud sync failed: authentication".to_string()),
+        (_, "schema_mismatch") => ("✗", red, "Cloud sync failed: schema mismatch".to_string()),
+        (_, "transient_error") => ("✗", red, "Cloud sync failed: transient error".to_string()),
+        _ => ("✗", red, format!("Cloud sync result: {result}")),
+    };
+
+    println!("  {color}{icon}{reset} {bold}{headline}{reset}");
+    if !message.is_empty() {
+        println!("    {dim}{message}{reset}");
+    }
+    if !endpoint.is_empty() {
+        println!("    {dim}endpoint{reset}   {endpoint}");
+    }
+    if rollups > 0 || sessions > 0 {
+        println!("    {dim}attempted{reset}  {rollups} rollups, {sessions} sessions");
+    }
+    if let Some(wm) = watermark {
+        println!("    {dim}watermark{reset}  {wm}");
+    }
+    println!();
+}
+
+fn render_status_text(body: &Value) {
+    let green = ansi("\x1b[32m");
+    let red = ansi("\x1b[31m");
+    let yellow = ansi("\x1b[33m");
+    let dim = ansi("\x1b[90m");
+    let bold_cyan = ansi("\x1b[1;36m");
+    let bold = ansi("\x1b[1m");
+    let reset = ansi("\x1b[0m");
+
+    let enabled = body
+        .get("enabled")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let configured = body
+        .get("configured")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let ready = body.get("ready").and_then(Value::as_bool).unwrap_or(false);
+    let endpoint = body.get("endpoint").and_then(Value::as_str).unwrap_or("");
+    let last_synced_at = body.get("last_synced_at").and_then(Value::as_str);
+    let watermark = body.get("rollup_watermark").and_then(Value::as_str);
+    let pending_rollups = body
+        .get("pending_rollups")
+        .and_then(Value::as_i64)
+        .unwrap_or(0);
+    let pending_sessions = body
+        .get("pending_sessions")
+        .and_then(Value::as_i64)
+        .unwrap_or(0);
+
+    println!();
+    println!("  {bold_cyan} budi cloud status{reset}");
+    println!("  {dim}{}{reset}", "─".repeat(40));
+
+    let (state_icon, state_color, state_label) = if ready {
+        ("✓", green, "ready")
+    } else if enabled && !configured {
+        ("!", yellow, "enabled but missing api_key")
+    } else if enabled {
+        ("!", yellow, "enabled but not fully configured")
+    } else {
+        ("-", dim, "disabled")
+    };
+    println!(
+        "  {state_color}{state_icon}{reset} {bold}State{reset}      {state_color}{state_label}{reset}"
+    );
+
+    if !endpoint.is_empty() {
+        println!("    {dim}endpoint{reset}   {endpoint}");
+    }
+
+    match last_synced_at {
+        Some(ts) => println!("    {dim}last sync{reset}  {ts}"),
+        None => println!("    {dim}last sync{reset}  {red}never{reset}"),
+    }
+    if let Some(wm) = watermark {
+        println!("    {dim}watermark{reset}  {wm}");
+    }
+    if pending_rollups > 0 || pending_sessions > 0 {
+        println!(
+            "    {dim}pending{reset}    {yellow}{pending_rollups} rollups, {pending_sessions} sessions{reset}  (run `budi cloud sync`)"
+        );
+    }
+
+    if !enabled {
+        println!();
+        println!(
+            "  {dim}Cloud sync is off. Enable it by setting `enabled = true` in{reset} ~/.config/budi/cloud.toml"
+        );
+    } else if !configured {
+        println!();
+        println!(
+            "  {yellow}Cloud sync is enabled but missing credentials.{reset} See ~/.config/budi/cloud.toml"
+        );
+    }
+    println!();
+}

--- a/crates/budi-cli/src/commands/mod.rs
+++ b/crates/budi-cli/src/commands/mod.rs
@@ -6,6 +6,7 @@ use budi_core::config;
 use serde_json::Value;
 
 pub mod autostart;
+pub mod cloud;
 pub mod doctor;
 pub mod health;
 pub mod import;

--- a/crates/budi-cli/src/main.rs
+++ b/crates/budi-cli/src/main.rs
@@ -17,7 +17,7 @@ const HEALTH_TIMEOUT_SECS: u64 = 3;
 #[command(about = "budi — AI cost analytics. Know where your tokens and money go.")]
 #[command(version)]
 #[command(
-    after_help = "Get started:\n  budi init\n\nCommon commands:\n  budi enable claude      Enable proxy routing for Claude Code\n  budi disable cursor     Disable proxy routing for Cursor\n  budi launch claude      Explicitly launch Claude Code through the budi proxy\n  budi launch codex       Explicitly launch Codex CLI through the budi proxy\n  budi stats              Show today's cost summary\n  budi stats --models     Cost breakdown by model\n  budi stats --branches   Cost breakdown by branch\n  budi sessions           List recent sessions with cost and health\n  budi sessions <id>      Session detail: cost, models, health, tags\n  budi status             Quick check: daemon, proxy, today's spend\n  budi doctor             Full diagnostic: daemon, proxy, database, config\n  budi autostart status   Check daemon autostart service\n  budi import             Import historical transcripts from disk\n  budi import --force     Re-ingest all data from scratch (use after upgrades)\n  budi repair             Repair schema drift and run migration\n\nMore info: https://github.com/siropkin/budi"
+    after_help = "Get started:\n  budi init\n\nCommon commands:\n  budi enable claude      Enable proxy routing for Claude Code\n  budi disable cursor     Disable proxy routing for Cursor\n  budi launch claude      Explicitly launch Claude Code through the budi proxy\n  budi launch codex       Explicitly launch Codex CLI through the budi proxy\n  budi stats              Show today's cost summary\n  budi stats --models     Cost breakdown by model\n  budi stats --branches   Cost breakdown by branch\n  budi sessions           List recent sessions with cost and health\n  budi sessions <id>      Session detail: cost, models, health, tags\n  budi status             Quick check: daemon, proxy, today's spend\n  budi doctor             Full diagnostic: daemon, proxy, database, config\n  budi cloud status       Cloud sync readiness and last-synced-at\n  budi cloud sync         Push queued local data to the cloud now\n  budi autostart status   Check daemon autostart service\n  budi import             Import historical transcripts from disk\n  budi import --force     Re-ingest all data from scratch (use after upgrades)\n  budi repair             Repair schema drift and run migration\n\nMore info: https://github.com/siropkin/budi"
 )]
 struct Cli {
     #[command(subcommand)]
@@ -260,6 +260,22 @@ Examples:
         #[command(subcommand)]
         action: AutostartAction,
     },
+    /// Manual cloud sync and cloud freshness reporting
+    ///
+    /// `budi cloud sync` pushes queued local rollups and session summaries
+    /// to the cloud now (same work the background worker runs on an
+    /// interval — ADR-0083 §9, issue #225). `budi cloud status` reports
+    /// whether cloud sync is enabled, when it last succeeded, and how many
+    /// records are queued locally.
+    #[command(after_help = "\
+Examples:
+  budi cloud status              Show cloud sync readiness and last sync
+  budi cloud sync                Push queued local data to the cloud now
+  budi cloud sync --format json  JSON output (exit code 2 on failure)")]
+    Cloud {
+        #[command(subcommand)]
+        action: CloudAction,
+    },
     /// Launch an AI agent through the budi proxy (e.g. budi launch claude)
     #[command(after_help = "\
 Supported agents:
@@ -306,6 +322,22 @@ enum IntegrationAction {
         /// Skip prompts and use defaults
         #[arg(long, default_value_t = false)]
         yes: bool,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+enum CloudAction {
+    /// Show cloud sync readiness and last-synced-at
+    Status {
+        /// Output format: text (default) or json
+        #[arg(short, long, value_enum, default_value_t = StatsFormat::Text)]
+        format: StatsFormat,
+    },
+    /// Push queued local data (daily rollups, session summaries) to the cloud now
+    Sync {
+        /// Output format: text (default) or json
+        #[arg(short, long, value_enum, default_value_t = StatsFormat::Text)]
+        format: StatsFormat,
     },
 }
 
@@ -492,6 +524,10 @@ fn main() -> Result<()> {
             AutostartAction::Status => commands::autostart::cmd_autostart_status(),
             AutostartAction::Install => commands::autostart::cmd_autostart_install(),
             AutostartAction::Uninstall => commands::autostart::cmd_autostart_uninstall(),
+        },
+        Commands::Cloud { action } => match action {
+            CloudAction::Status { format } => commands::cloud::cmd_cloud_status(format),
+            CloudAction::Sync { format } => commands::cloud::cmd_cloud_sync(format),
         },
         Commands::Launch {
             agent,
@@ -774,6 +810,41 @@ mod tests {
             }
             _ => panic!("expected stats command"),
         }
+    }
+
+    #[test]
+    fn cli_parses_cloud_subcommands() {
+        let cli = Cli::try_parse_from(["budi", "cloud", "sync"]).expect("budi cloud sync parses");
+        match cli.command {
+            Commands::Cloud {
+                action: CloudAction::Sync { format },
+            } => assert!(matches!(format, StatsFormat::Text)),
+            _ => panic!("expected cloud sync command"),
+        }
+
+        let cli = Cli::try_parse_from(["budi", "cloud", "status", "--format", "json"])
+            .expect("budi cloud status --format json parses");
+        match cli.command {
+            Commands::Cloud {
+                action: CloudAction::Status { format },
+            } => assert!(matches!(format, StatsFormat::Json)),
+            _ => panic!("expected cloud status command"),
+        }
+    }
+
+    #[test]
+    fn help_lists_cloud_commands() {
+        let mut command = Cli::command();
+        let help = command.render_help().to_string();
+        let lower = help.to_ascii_lowercase();
+        assert!(
+            lower.contains("cloud"),
+            "top-level help should advertise cloud subcommand"
+        );
+        assert!(
+            lower.contains("budi cloud sync"),
+            "top-level help should mention `budi cloud sync`"
+        );
     }
 
     #[test]

--- a/crates/budi-core/src/cloud_sync.rs
+++ b/crates/budi-core/src/cloud_sync.rs
@@ -164,6 +164,63 @@ pub fn set_session_watermark(conn: &Connection, timestamp: &str) -> Result<()> {
     Ok(())
 }
 
+/// Snapshot of the cloud sync state for reporting via `budi cloud status`.
+///
+/// Captures configuration readiness, the last successful sync watermarks, and
+/// how many records are waiting to be pushed on the next tick. Counts are
+/// best-effort and can be reported without a live network call.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct CloudSyncStatus {
+    pub enabled: bool,
+    pub configured: bool,
+    pub ready: bool,
+    pub endpoint: String,
+    pub last_synced_at: Option<String>,
+    pub rollup_watermark: Option<String>,
+    pub pending_rollups: usize,
+    pub pending_sessions: usize,
+}
+
+/// Read the current cloud sync status from local config and SQLite.
+///
+/// Never makes a network call — this is used by `budi cloud status` and the
+/// daemon `/cloud/status` endpoint to report readiness and freshness at a
+/// glance. Pending counts are computed by running the envelope builder
+/// against the current watermarks; if envelope construction fails (e.g.
+/// device_id/org_id missing), pending counts fall back to 0 and the caller
+/// can still rely on `ready=false` to explain what is missing.
+pub fn current_cloud_status(db_path: &Path, config: &CloudConfig) -> CloudSyncStatus {
+    let endpoint = config.effective_endpoint();
+    let enabled = config.effective_enabled();
+    let ready = config.is_ready();
+    let configured = config.api_key.is_some() || config.effective_api_key().is_some();
+
+    let mut last_synced_at = None;
+    let mut rollup_watermark = None;
+    let mut pending_rollups = 0usize;
+    let mut pending_sessions = 0usize;
+
+    if let Ok(conn) = crate::analytics::open_db(db_path) {
+        last_synced_at = get_session_watermark(&conn).ok().flatten();
+        rollup_watermark = get_cloud_watermark_value(&conn).ok().flatten();
+        if ready && let Ok(envelope) = build_sync_envelope(&conn, config) {
+            pending_rollups = envelope.payload.daily_rollups.len();
+            pending_sessions = envelope.payload.session_summaries.len();
+        }
+    }
+
+    CloudSyncStatus {
+        enabled,
+        configured,
+        ready,
+        endpoint,
+        last_synced_at,
+        rollup_watermark,
+        pending_rollups,
+        pending_sessions,
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Data extraction from local SQLite (privacy-safe: rollups + session summaries)
 // ---------------------------------------------------------------------------
@@ -475,34 +532,103 @@ pub fn send_sync_envelope(endpoint: &str, api_key: &str, envelope: &SyncEnvelope
     }
 }
 
+/// Structured report of a single sync tick, suitable for rendering in the
+/// CLI (`budi cloud sync`) or returning as JSON from the daemon. Carries the
+/// underlying [`SyncResult`] plus the envelope counts that were attempted and
+/// any server-confirmed response fields.
+///
+/// Envelope counts are included so surfaces can say "pushed N records" even
+/// when the server omits `records_upserted`, and so `EmptyPayload` responses
+/// can still explain *why* nothing was pushed.
+#[derive(Debug)]
+pub struct SyncTickReport {
+    pub result: SyncResult,
+    pub endpoint: String,
+    pub envelope_rollups: usize,
+    pub envelope_sessions: usize,
+    pub server_records_upserted: Option<i64>,
+    pub server_watermark: Option<String>,
+}
+
 /// Execute a single sync tick: build envelope, send, update watermark.
 /// Blocking — call from `spawn_blocking`.
 pub fn sync_tick(db_path: &Path, config: &CloudConfig) -> SyncResult {
+    sync_tick_report(db_path, config).result
+}
+
+/// Execute a single sync tick and return a structured report.
+/// Used by the manual `budi cloud sync` path so the CLI can report how many
+/// records were attempted and confirmed, not just the coarse [`SyncResult`]
+/// variant. Shares all behavior with [`sync_tick`] so the manual and
+/// background paths stay in lockstep.
+pub fn sync_tick_report(db_path: &Path, config: &CloudConfig) -> SyncTickReport {
+    let endpoint = config.effective_endpoint();
+
     let conn = match crate::analytics::open_db(db_path) {
         Ok(c) => c,
-        Err(e) => return SyncResult::TransientError(format!("Failed to open DB: {e}")),
+        Err(e) => {
+            return SyncTickReport {
+                result: SyncResult::TransientError(format!("Failed to open DB: {e}")),
+                endpoint,
+                envelope_rollups: 0,
+                envelope_sessions: 0,
+                server_records_upserted: None,
+                server_watermark: None,
+            };
+        }
     };
 
     let envelope = match build_sync_envelope(&conn, config) {
         Ok(e) => e,
-        Err(e) => return SyncResult::TransientError(format!("Failed to build envelope: {e}")),
+        Err(e) => {
+            return SyncTickReport {
+                result: SyncResult::TransientError(format!("Failed to build envelope: {e}")),
+                endpoint,
+                envelope_rollups: 0,
+                envelope_sessions: 0,
+                server_records_upserted: None,
+                server_watermark: None,
+            };
+        }
     };
 
-    if envelope.payload.daily_rollups.is_empty() && envelope.payload.session_summaries.is_empty() {
-        return SyncResult::EmptyPayload;
+    let envelope_rollups = envelope.payload.daily_rollups.len();
+    let envelope_sessions = envelope.payload.session_summaries.len();
+
+    if envelope_rollups == 0 && envelope_sessions == 0 {
+        return SyncTickReport {
+            result: SyncResult::EmptyPayload,
+            endpoint,
+            envelope_rollups,
+            envelope_sessions,
+            server_records_upserted: None,
+            server_watermark: None,
+        };
     }
 
     let api_key = match config.effective_api_key() {
         Some(k) => k,
-        None => return SyncResult::AuthFailure,
+        None => {
+            return SyncTickReport {
+                result: SyncResult::AuthFailure,
+                endpoint,
+                envelope_rollups,
+                envelope_sessions,
+                server_records_upserted: None,
+                server_watermark: None,
+            };
+        }
     };
-
-    let endpoint = config.effective_endpoint();
 
     let result = send_sync_envelope(&endpoint, &api_key, &envelope);
 
+    let mut server_records_upserted = None;
+    let mut server_watermark = None;
+
     // On success, update watermarks (ADR-0083 §5)
     if let SyncResult::Success(ref resp) = result {
+        server_records_upserted = resp.records_upserted;
+        server_watermark = resp.watermark.clone();
         if let Some(ref wm) = resp.watermark
             && let Err(e) = set_cloud_watermark(&conn, wm)
         {
@@ -515,7 +641,14 @@ pub fn sync_tick(db_path: &Path, config: &CloudConfig) -> SyncResult {
         }
     }
 
-    result
+    SyncTickReport {
+        result,
+        endpoint,
+        envelope_rollups,
+        envelope_sessions,
+        server_records_upserted,
+        server_watermark,
+    }
 }
 
 /// Calculate exponential backoff delay.
@@ -722,6 +855,55 @@ mod tests {
         assert_eq!(envelope.org_id, "org_test");
         assert!(envelope.payload.daily_rollups.is_empty());
         assert!(envelope.payload.session_summaries.is_empty());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn current_cloud_status_reports_disabled_when_config_default() {
+        let dir = std::env::temp_dir().join("budi-cloud-status-disabled");
+        std::fs::create_dir_all(&dir).ok();
+        let db_path = dir.join("test.db");
+        let _ = std::fs::remove_file(&db_path);
+        let _ = crate::analytics::open_db_with_migration(&db_path).unwrap();
+
+        let status = current_cloud_status(&db_path, &CloudConfig::default());
+        assert!(!status.enabled);
+        assert!(!status.ready);
+        assert_eq!(status.pending_rollups, 0);
+        assert_eq!(status.pending_sessions, 0);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn current_cloud_status_reports_pending_counts_when_ready() {
+        let dir = std::env::temp_dir().join("budi-cloud-status-ready");
+        std::fs::create_dir_all(&dir).ok();
+        let db_path = dir.join("test.db");
+        let _ = std::fs::remove_file(&db_path);
+        let conn = crate::analytics::open_db_with_migration(&db_path).unwrap();
+
+        conn.execute(
+            "INSERT INTO messages (id, role, timestamp, model, provider, repo_id, git_branch,
+                                   input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens, cost_cents)
+             VALUES ('msg-status-1', 'assistant', '2026-04-10T14:30:00Z', 'claude-sonnet-4-6', 'anthropic',
+                     'sha256:abc', 'main', 100, 200, 10, 50, 1.5)",
+            [],
+        )
+        .unwrap();
+
+        let config = CloudConfig {
+            enabled: true,
+            api_key: Some("budi_test".into()),
+            device_id: Some("dev_test".into()),
+            org_id: Some("org_test".into()),
+            ..CloudConfig::default()
+        };
+        let status = current_cloud_status(&db_path, &config);
+        assert!(status.enabled);
+        assert!(status.ready);
+        assert!(status.pending_rollups >= 1);
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/crates/budi-daemon/src/main.rs
+++ b/crates/budi-daemon/src/main.rs
@@ -42,6 +42,10 @@ enum Commands {
 pub struct AppState {
     pub syncing: std::sync::Arc<std::sync::atomic::AtomicBool>,
     pub integrations_installing: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    /// Guards manual and background cloud sync runs so they cannot overlap.
+    /// Owned by the `/cloud/sync` route (see `routes::cloud`) and the
+    /// background worker in `workers::cloud_sync`.
+    pub cloud_syncing: std::sync::Arc<std::sync::atomic::AtomicBool>,
 }
 
 #[derive(Clone)]
@@ -69,12 +73,13 @@ fn build_proxy_router(proxy_state: ProxyState) -> Router {
 }
 
 fn build_router(app_state: AppState) -> Router {
-    use routes::{analytics as a, hooks as h, require_loopback};
+    use routes::{analytics as a, cloud as c, hooks as h, require_loopback};
 
     let protected_routes = Router::new()
         .route("/sync", post(h::analytics_sync))
         .route("/sync/all", post(h::analytics_history))
         .route("/sync/reset", post(h::analytics_sync_reset))
+        .route("/cloud/sync", post(c::cloud_sync))
         .route("/admin/providers", get(a::analytics_registered_providers))
         .route("/admin/schema", get(a::analytics_schema_version))
         .route("/admin/migrate", post(a::analytics_migrate))
@@ -91,6 +96,7 @@ fn build_router(app_state: AppState) -> Router {
         .route("/health/integrations", get(h::health_integrations))
         .route("/health/check-update", get(h::health_check_update))
         .route("/sync/status", get(h::sync_status))
+        .route("/cloud/status", get(routes::cloud::cloud_status))
         .route("/analytics/summary", get(a::analytics_summary))
         .route("/analytics/messages", get(a::analytics_messages))
         .route("/analytics/projects", get(a::analytics_projects))
@@ -195,9 +201,11 @@ async fn main() -> Result<()> {
     // take over without manual intervention (e.g. after `cargo build && cp`).
     kill_existing_daemon(port);
 
+    let cloud_syncing = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
     let app_state = AppState {
         syncing: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
         integrations_installing: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        cloud_syncing: cloud_syncing.clone(),
     };
 
     let app = build_router(app_state);
@@ -271,7 +279,11 @@ async fn main() -> Result<()> {
                     interval_s = cloud_config.sync.interval_seconds,
                     "Starting cloud sync worker"
                 );
-                tokio::spawn(workers::cloud_sync::run(db_path, cloud_config));
+                tokio::spawn(workers::cloud_sync::run(
+                    db_path,
+                    cloud_config,
+                    cloud_syncing.clone(),
+                ));
             }
         } else if cloud_config.effective_enabled() {
             tracing::warn!(
@@ -405,6 +417,7 @@ mod tests {
         build_router(AppState {
             syncing: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
             integrations_installing: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            cloud_syncing: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
         })
     }
 
@@ -496,6 +509,40 @@ mod tests {
             .insert(ConnectInfo(SocketAddr::from(([10, 0, 0, 4], 43434))));
         let resp = app.oneshot(req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn cloud_sync_route_blocks_non_loopback_client() {
+        let app = test_app();
+        let mut req = Request::post("/cloud/sync").body(Body::empty()).unwrap();
+        req.extensions_mut()
+            .insert(ConnectInfo(SocketAddr::from(([10, 0, 0, 4], 43434))));
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn cloud_status_route_public_and_reports_shape() {
+        let app = test_app();
+        let resp = app
+            .oneshot(Request::get("/cloud/status").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(
+            json.get("enabled").is_some(),
+            "cloud/status should include `enabled`"
+        );
+        assert!(
+            json.get("ready").is_some(),
+            "cloud/status should include `ready`"
+        );
+        assert!(
+            json.get("endpoint").is_some(),
+            "cloud/status should include `endpoint`"
+        );
     }
 
     #[tokio::test]

--- a/crates/budi-daemon/src/routes/cloud.rs
+++ b/crates/budi-daemon/src/routes/cloud.rs
@@ -1,0 +1,263 @@
+//! Cloud sync management endpoints.
+//!
+//! `GET /cloud/status` reports whether cloud sync is enabled and when it last
+//! ran, based on the local `cloud.toml` and the watermark rows in the
+//! `sync_state` table. It never makes a network call.
+//!
+//! `POST /cloud/sync` triggers an immediate cloud flush — the same work the
+//! background worker does on its interval (ADR-0083 §9), just user-driven.
+//! It is loopback-protected (see `build_router` in `main.rs`) and guarded
+//! against concurrent runs via `AppState::cloud_syncing`. See issue #225
+//! (R2.1) for the CLI contract this endpoint backs (`budi cloud sync` /
+//! `budi cloud status`).
+
+use axum::Json;
+use axum::extract::State;
+use axum::http::StatusCode;
+use budi_core::analytics;
+use budi_core::cloud_sync::{self, SyncResult, SyncTickReport};
+use budi_core::config::{self, CloudConfig};
+use serde_json::{Value, json};
+
+use crate::AppState;
+
+/// Variants are snake_case so CLI / dashboard consumers can switch on a
+/// stable string rather than parsing free-form error messages. Mirrors the
+/// [`SyncResult`] taxonomy plus the two "pre-network" states the manual
+/// path can observe before ever touching the wire.
+const RESULT_SUCCESS: &str = "success";
+const RESULT_EMPTY_PAYLOAD: &str = "empty_payload";
+const RESULT_AUTH_FAILURE: &str = "auth_failure";
+const RESULT_SCHEMA_MISMATCH: &str = "schema_mismatch";
+const RESULT_TRANSIENT_ERROR: &str = "transient_error";
+const RESULT_NOT_CONFIGURED: &str = "not_configured";
+const RESULT_DISABLED: &str = "disabled";
+
+/// `GET /cloud/status` — report cloud sync readiness and freshness.
+/// No network call; reads `cloud.toml` and the local watermarks.
+pub async fn cloud_status() -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+    let snapshot = tokio::task::spawn_blocking(read_status_snapshot)
+        .await
+        .map_err(|e| super::internal_error(anyhow::anyhow!("cloud status task panicked: {e}")))?;
+    Ok(Json(serde_json::to_value(snapshot).unwrap_or_else(
+        |_| json!({ "ok": false, "error": "failed to serialize cloud status" }),
+    )))
+}
+
+fn read_status_snapshot() -> budi_core::cloud_sync::CloudSyncStatus {
+    let db_path = analytics::db_path().unwrap_or_default();
+    let cfg = config::load_cloud_config();
+    cloud_sync::current_cloud_status(&db_path, &cfg)
+}
+
+/// `POST /cloud/sync` — flush the pending cloud queue now.
+///
+/// Returns 409 if another cloud sync is already running (either from the
+/// background worker or a prior CLI invocation).
+pub async fn cloud_sync(
+    State(state): State<AppState>,
+) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+    let cfg = config::load_cloud_config();
+
+    // Short-circuit without taking the busy flag so repeated `budi cloud
+    // sync` against a not-configured daemon is cheap and never blocks the
+    // background worker.
+    if !cfg.effective_enabled() {
+        return Ok(Json(not_ready_body(
+            RESULT_DISABLED,
+            &cfg,
+            "Cloud sync is not enabled. Set `enabled = true` in ~/.config/budi/cloud.toml to opt in.",
+        )));
+    }
+    if !cfg.is_ready() {
+        return Ok(Json(not_ready_body(
+            RESULT_NOT_CONFIGURED,
+            &cfg,
+            "Cloud sync is not fully configured. Ensure api_key, device_id, and org_id are set in ~/.config/budi/cloud.toml.",
+        )));
+    }
+
+    if state
+        .cloud_syncing
+        .compare_exchange(
+            false,
+            true,
+            std::sync::atomic::Ordering::SeqCst,
+            std::sync::atomic::Ordering::SeqCst,
+        )
+        .is_err()
+    {
+        return Err((
+            StatusCode::CONFLICT,
+            Json(json!({
+                "ok": false,
+                "error": "cloud sync already running",
+                "result": "busy"
+            })),
+        ));
+    }
+
+    let flag = state.cloud_syncing.clone();
+    let report = tokio::task::spawn_blocking(move || {
+        let _guard = CloudBusyFlagGuard::new(flag);
+        let db_path = analytics::db_path().unwrap_or_default();
+        cloud_sync::sync_tick_report(&db_path, &cfg)
+    })
+    .await
+    .map_err(|e| super::internal_error(anyhow::anyhow!("cloud sync task panicked: {e}")))?;
+
+    Ok(Json(report_to_json(report)))
+}
+
+fn not_ready_body(result: &str, cfg: &CloudConfig, message: &str) -> Value {
+    json!({
+        "ok": false,
+        "result": result,
+        "endpoint": cfg.effective_endpoint(),
+        "message": message,
+        "records_upserted": 0,
+        "rollups_attempted": 0,
+        "sessions_attempted": 0,
+    })
+}
+
+fn report_to_json(report: SyncTickReport) -> Value {
+    let SyncTickReport {
+        result,
+        endpoint,
+        envelope_rollups,
+        envelope_sessions,
+        server_records_upserted,
+        server_watermark,
+    } = report;
+
+    let (ok, result_tag, message) = match &result {
+        SyncResult::Success(_) => (
+            true,
+            RESULT_SUCCESS,
+            "Cloud sync completed successfully.".to_string(),
+        ),
+        SyncResult::EmptyPayload => (
+            true,
+            RESULT_EMPTY_PAYLOAD,
+            "Nothing new to sync — local and cloud are already in lockstep.".to_string(),
+        ),
+        SyncResult::AuthFailure => (
+            false,
+            RESULT_AUTH_FAILURE,
+            "Authentication failed (401). Check `api_key` in ~/.config/budi/cloud.toml."
+                .to_string(),
+        ),
+        SyncResult::SchemaMismatch(msg) => (
+            false,
+            RESULT_SCHEMA_MISMATCH,
+            format!(
+                "Server rejected the payload as schema-incompatible (422). Update budi to resume syncing. Detail: {msg}"
+            ),
+        ),
+        SyncResult::TransientError(msg) => (
+            false,
+            RESULT_TRANSIENT_ERROR,
+            format!("Cloud sync hit a transient error: {msg}"),
+        ),
+    };
+
+    json!({
+        "ok": ok,
+        "result": result_tag,
+        "endpoint": endpoint,
+        "message": message,
+        "records_upserted": server_records_upserted.unwrap_or(0),
+        "rollups_attempted": envelope_rollups,
+        "sessions_attempted": envelope_sessions,
+        "watermark": server_watermark,
+    })
+}
+
+/// RAII guard that clears the `cloud_syncing` flag on drop. Mirrors the
+/// existing `BusyFlagGuard` used by transcript ingest — kept local so the
+/// two busy flags stay independent.
+struct CloudBusyFlagGuard {
+    flag: std::sync::Arc<std::sync::atomic::AtomicBool>,
+}
+
+impl CloudBusyFlagGuard {
+    fn new(flag: std::sync::Arc<std::sync::atomic::AtomicBool>) -> Self {
+        Self { flag }
+    }
+}
+
+impl Drop for CloudBusyFlagGuard {
+    fn drop(&mut self) {
+        self.flag.store(false, std::sync::atomic::Ordering::SeqCst);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn not_ready_body_tags_result_and_endpoint() {
+        let cfg = CloudConfig::default();
+        let body = not_ready_body(RESULT_DISABLED, &cfg, "off");
+        assert_eq!(body["ok"], false);
+        assert_eq!(body["result"], RESULT_DISABLED);
+        assert_eq!(body["records_upserted"], 0);
+        assert_eq!(body["rollups_attempted"], 0);
+        assert_eq!(body["sessions_attempted"], 0);
+    }
+
+    #[test]
+    fn report_to_json_success_reports_upsert_count() {
+        let report = SyncTickReport {
+            result: SyncResult::Success(budi_core::cloud_sync::IngestResponse {
+                accepted: true,
+                watermark: Some("2026-04-17".into()),
+                records_upserted: Some(5),
+            }),
+            endpoint: "https://app.getbudi.dev".into(),
+            envelope_rollups: 5,
+            envelope_sessions: 0,
+            server_records_upserted: Some(5),
+            server_watermark: Some("2026-04-17".into()),
+        };
+        let body = report_to_json(report);
+        assert_eq!(body["ok"], true);
+        assert_eq!(body["result"], RESULT_SUCCESS);
+        assert_eq!(body["records_upserted"], 5);
+        assert_eq!(body["watermark"], "2026-04-17");
+    }
+
+    #[test]
+    fn report_to_json_empty_is_still_ok() {
+        let report = SyncTickReport {
+            result: SyncResult::EmptyPayload,
+            endpoint: "https://app.getbudi.dev".into(),
+            envelope_rollups: 0,
+            envelope_sessions: 0,
+            server_records_upserted: None,
+            server_watermark: None,
+        };
+        let body = report_to_json(report);
+        assert_eq!(body["ok"], true);
+        assert_eq!(body["result"], RESULT_EMPTY_PAYLOAD);
+    }
+
+    #[test]
+    fn report_to_json_auth_failure_is_not_ok() {
+        let report = SyncTickReport {
+            result: SyncResult::AuthFailure,
+            endpoint: "https://app.getbudi.dev".into(),
+            envelope_rollups: 3,
+            envelope_sessions: 4,
+            server_records_upserted: None,
+            server_watermark: None,
+        };
+        let body = report_to_json(report);
+        assert_eq!(body["ok"], false);
+        assert_eq!(body["result"], RESULT_AUTH_FAILURE);
+        assert_eq!(body["rollups_attempted"], 3);
+        assert_eq!(body["sessions_attempted"], 4);
+    }
+}

--- a/crates/budi-daemon/src/routes/mod.rs
+++ b/crates/budi-daemon/src/routes/mod.rs
@@ -1,4 +1,5 @@
 pub mod analytics;
+pub mod cloud;
 pub mod hooks;
 pub mod proxy;
 

--- a/crates/budi-daemon/src/workers/cloud_sync.rs
+++ b/crates/budi-daemon/src/workers/cloud_sync.rs
@@ -5,13 +5,21 @@
 //! Never blocks terminal execution.
 
 use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use budi_core::cloud_sync::{self, SyncResult};
 use budi_core::config::CloudConfig;
 
 /// Run the cloud sync worker loop. Designed to be spawned with `tokio::spawn`.
-pub async fn run(db_path: PathBuf, config: CloudConfig) {
+///
+/// The `cloud_syncing` flag is shared with the manual `POST /cloud/sync`
+/// route so a user-triggered flush and the interval-based worker never run
+/// concurrently. If the flag is already set when the interval fires, the
+/// worker skips that tick — the manual invocation will advance the
+/// watermarks.
+pub async fn run(db_path: PathBuf, config: CloudConfig, cloud_syncing: Arc<AtomicBool>) {
     let interval = Duration::from_secs(config.sync.interval_seconds);
     let retry_max = config.sync.retry_max_seconds;
     let mut consecutive_failures: u32 = 0;
@@ -47,10 +55,28 @@ pub async fn run(db_path: PathBuf, config: CloudConfig) {
             continue;
         }
 
+        // If a manual `budi cloud sync` (or a previous tick) is still
+        // running, skip this interval rather than contend — watermarks make
+        // this safe and avoid double-posting the same records.
+        if cloud_syncing
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .is_err()
+        {
+            tracing::debug!("Cloud sync skipped: another sync already in progress");
+            tokio::time::sleep(interval).await;
+            continue;
+        }
+
         // Normal sync tick
         let db = db_path.clone();
         let cfg = config.clone();
-        let result = tokio::task::spawn_blocking(move || cloud_sync::sync_tick(&db, &cfg)).await;
+        let flag = cloud_syncing.clone();
+        let result = tokio::task::spawn_blocking(move || {
+            let res = cloud_sync::sync_tick(&db, &cfg);
+            flag.store(false, Ordering::SeqCst);
+            res
+        })
+        .await;
 
         match result {
             Ok(SyncResult::Success(resp)) => {


### PR DESCRIPTION
## Summary

First R2.1 CLI normalization PR. Restores a discoverable self-serve path for cloud sync, which has been running only as an async daemon worker since pre-8.0's `budi sync` was repurposed for local transcript ingestion (#175).

**CLI**
- `budi cloud sync` — flushes queued local rollups + session summaries to the cloud on demand (same `sync_tick` the background worker runs on an interval, ADR-0083 §9). Reports records upserted, watermark, endpoint.
- `budi cloud status` — readiness snapshot (`enabled`/`configured`/`ready`), `last_synced_at`, rollup watermark, and pending rollup/session counts. No network call — reads `cloud.toml` + `sync_state` only.
- Both support `--format text` (default) and `--format json`, matching the normalized output contract shared with `budi stats` / `budi sessions`. JSON output exits `2` on non-ok result so scripts can branch on status.

**Daemon**
- New `POST /cloud/sync` (loopback-only) and `GET /cloud/status` routes in a new `routes::cloud` module.
- `AppState.cloud_syncing: Arc<AtomicBool>` guards the manual path from double-posting against the background worker. 409 Conflict when busy.
- `CloudBusyFlagGuard` mirrors the existing transcript-ingest RAII guard.
- Background worker respects the same busy flag.

**Core**
- `sync_tick_report` wraps the existing `sync_tick` and returns a `SyncTickReport` (envelope counts, server upsert count, watermark) so daemon handlers (and future callers) can report precisely.
- `current_cloud_status` builds a `CloudSyncStatus` snapshot from local config + sqlite with no network call.
- Stable snake_case result tags (`success`, `empty_payload`, `auth_failure`, `schema_mismatch`, `transient_error`, `disabled`, `not_configured`) so CLI / dashboard consumers don't parse prose.

**Docs**
- `SOUL.md`: new cloud commands section + key-files entries for the new daemon route module and CLI command module.
- `README.md`: `budi cloud sync` / `budi cloud status` added to the diagnostics command list.
- `CHANGELOG.md`: 8.1 Added entry explaining the gap (#175 removed the pre-8.0 `budi sync`) and the new surface.

Larger CLI rename work (e.g. `budi health` vs `budi doctor`, bare verbs vs namespaces) is deferred to 8.2 to keep this change small and reversible, per the audit posted on #225.

Closes #225

## Risks / compatibility notes

- No existing command names changed. Fully additive CLI surface.
- `POST /cloud/sync` is loopback-only, matching the admission contract of existing mutation routes (`/sync`, `/admin/*`).
- Manual and background sync share one `cloud_syncing` busy flag — they cannot accidentally double-post the same envelope.
- `cloud_status` is intentionally public (read-only, no secrets returned) so future integrations (Cursor extension, statusline) can display freshness without crossing the loopback gate.
- R2.1 governance is ADR-0088. No new local LLM dependencies. No network calls introduced on the classification path.

## Validation

- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings`
- [x] `cargo test --workspace --locked` — new tests:
  - `budi-core::cloud_sync::current_cloud_status_reports_disabled_when_config_default`
  - `budi-core::cloud_sync::current_cloud_status_reports_pending_counts_when_ready`
  - `budi-daemon::routes::cloud::tests::*` (not_ready body, report_to_json variants)
  - `budi-daemon::tests::cloud_sync_route_blocks_non_loopback_client`
  - `budi-daemon::tests::cloud_status_route_public_and_reports_shape`
  - `budi-cli::cli_parses_cloud_subcommands`, `budi-cli::help_lists_cloud_commands`
- [x] `budi cloud --help` renders the new examples block correctly
- [ ] Follow-up comment threaded into #296 (getbudi.dev public-site sync) — see comment below
- [ ] Covered by #297 smoke test plan: CLI-surface section to gain two new rows (`budi cloud status` — shape, `budi cloud sync` — text + JSON exit codes)


Made with [Cursor](https://cursor.com)