### PR TITLE
chore(release): prepare v8.1.0 tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased (8.1.0)
+## 8.1.0 — 2026-04-18
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,7 +169,7 @@ dependencies = [
 
 [[package]]
 name = "budi-cli"
-version = "8.0.0"
+version = "8.1.0"
 dependencies = [
  "anyhow",
  "budi-core",
@@ -186,7 +186,7 @@ dependencies = [
 
 [[package]]
 name = "budi-core"
-version = "8.0.0"
+version = "8.1.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -202,7 +202,7 @@ dependencies = [
 
 [[package]]
 name = "budi-daemon"
-version = "8.0.0"
+version = "8.1.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "8.0.0"
+version = "8.1.0"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"

--- a/docs/releases/8.1.0.md
+++ b/docs/releases/8.1.0.md
@@ -36,8 +36,8 @@ All items below must be **checked and evidenced** before [#202](https://github.c
 - [x] R2 review passes merged — #223 (code), #229 (docs)
 - [x] R3 surface alignment round merged — #235, #232
 - [x] R3 review passes merged — #231 (code), #236 (docs)
-- [ ] R4.2 smoke test plan (#297) closed with a full PASS record against [`docs/releases/8.1.0-smoke-tests.md`](./8.1.0-smoke-tests.md) minimum-viable set — **hard release gate** (ADR-0088 §3)
-- [ ] Public-site sync (#296) merged in `siropkin/getbudi.dev` — **hard release gate** (ADR-0088 §9)
+- [ ] R4.2 smoke test plan (#297) closed with a full PASS record against [`docs/releases/8.1.0-smoke-tests.md`](./8.1.0-smoke-tests.md) minimum-viable set — **hard release gate** (ADR-0088 §3) *(plan drafted and merged in #354; PASS record posted by the operator running the minimum-viable set is still outstanding at R4.3 prep time)*
+- [x] Public-site sync (#296) merged in `siropkin/getbudi.dev` — **hard release gate** (ADR-0088 §9) *(merged 2026-04-18 as `siropkin/getbudi.dev@03f5ed5` via [siropkin/getbudi.dev#26](https://github.com/siropkin/getbudi.dev/pull/26))*
 
 ### 2.2 Validation (local)
 
@@ -72,19 +72,19 @@ Run on a clean working tree of the tag candidate commit.
 
 ### 2.4 Repo hygiene
 
-- [ ] `CHANGELOG.md` has a promoted `## 8.1.0 — <date>` section (no `Unreleased (8.1.0)` entries left over)
-- [ ] `README.md`, `SOUL.md`, `docs/statusline-contract.md`, and `CONTRIBUTING.md` describe the shipped 8.1 behavior (verified by R3.4 docs review in #236; re-check before tag)
-- [ ] ADR index in `docs/adr/` is consistent with shipped 8.1 work — ADR-0088 is `Accepted (amended by ADR-0089)` and ADR-0089 reflects the 8.2 pivot
-- [ ] `Cargo.toml` workspace version bumped to `8.1.0`
-- [ ] All closed 8.1 PRs reference their issue via `Closes #` and every R1.0–R3 issue is closed via its merged PR
+- [x] `CHANGELOG.md` has a promoted `## 8.1.0 — <date>` section (no `Unreleased (8.1.0)` entries left over) *(promoted in this R4.3 prep PR, dated 2026-04-18)*
+- [x] `README.md`, `SOUL.md`, `docs/statusline-contract.md`, and `CONTRIBUTING.md` describe the shipped 8.1 behavior (verified by R3.4 docs review in #236; re-check before tag) *(re-verified at R4.3 prep time; R2.6 #229 and R3.4 #236 landed the last drift fixes)*
+- [x] ADR index in `docs/adr/` is consistent with shipped 8.1 work — ADR-0088 is `Accepted (amended by ADR-0089)` and ADR-0089 reflects the 8.2 pivot *(both files present in `docs/adr/` with the expected status lines)*
+- [x] `Cargo.toml` workspace version bumped to `8.1.0` *(bumped in this R4.3 prep PR)*
+- [x] All closed 8.1 PRs reference their issue via `Closes #` and every R1.0–R3 issue is closed via its merged PR *(verified via milestone view: only #201, #202 remain open in `8.1.0`)*
 
 ### 2.5 Open 8.1.0 milestone issues at tag time
 
 The milestone must contain **only** the R4 control tickets at tag time:
 
 - [ ] #201 (control) — stays open until 8.1 is tagged and promoted
-- [ ] #230 (R4.1) — closes with the PR landing this document
-- [ ] #297 (R4.2) — closes when the smoke test record is posted with full PASS
+- [x] #230 (R4.1) — closed by #353 (this document)
+- [x] #297 (R4.2) — plan drafted and closed by #354; PASS record still to be posted by the operator running the minimum-viable set before tag
 - [ ] #202 (R4.3) — closes when the tag is created and announced
 
 Any other open issue in the `8.1.0` milestone at tag time must be **explicitly triaged** into:
@@ -95,6 +95,8 @@ Any other open issue in the `8.1.0` milestone at tag time must be **explicitly t
 **Known open issue at R4.1 drafting time:**
 
 - **[#309](https://github.com/siropkin/budi/issues/309) — Daemon serves analytics endpoints on stale schema and returns opaque 500.** Adjacent to R2.2 (#228) first-run UX but tracked separately. Release readiness disposition: cover in the R4.2 smoke set (does `budi stats` on a stale DB produce an actionable error, or must we block?). If the smoke test reproduces the opaque 500 on a fresh upgrade, **this blocks the release** because it directly contradicts the R2.2 first-run-trust promise; otherwise move to 8.2. Do not tag v8.1.0 without a decision recorded on #309.
+
+**Disposition at R4.3 prep time (2026-04-18):** #309 has been closed. The R4.2 minimum-viable smoke set still covers the stale-schema path explicitly; a regression would show up there before tag.
 
 ### 2.6 Privacy re-check (ADR-0083)
 


### PR DESCRIPTION
## Summary

Release-prep PR for **R4.3 (#202)** that lands the agent-safe pre-tag steps on `main` so the release workflow (`.github/workflows/release.yml`) will accept the `v8.1.0` tag once the maintainer pushes it.

- Bumps `Cargo.toml` `[workspace.package]` version \`8.0.0\` → \`8.1.0\` so \`verify_tag_version\` accepts \`v8.1.0\`.
- Refreshes \`Cargo.lock\` against the new workspace version (three in-workspace crates re-pinned at 8.1.0).
- Promotes \`CHANGELOG.md\` \`## Unreleased (8.1.0)\` → \`## 8.1.0 — 2026-04-18\` with the existing body preserved — the release notes narrative for the GitHub release body lives in [\`docs/releases/8.1.0.md\`](../blob/v8/202-release-v8-1-0/docs/releases/8.1.0.md) §5 and will be pasted at tag time.
- Ticks the now-satisfied items in the release-readiness checklist in \`docs/releases/8.1.0.md\`:
  - §2.1 — public-site sync #296 merged (\`siropkin/getbudi.dev@03f5ed5\`, [siropkin/getbudi.dev#26](https://github.com/siropkin/getbudi.dev/pull/26))
  - §2.4 — CHANGELOG promoted, workspace version bumped, ADR index consistent (ADR-0088 \`Accepted (amended by ADR-0089)\`, ADR-0089 reflecting the 8.2 pivot), no non-R4 8.1.0 issues left open
  - §2.5 — #230 closed, #297 plan drafted/closed (PASS record still outstanding), #309 closed at prep time
- **Explicitly does not tick** §2.2 / §2.3 / §2.6 items that require fresh-OS smoke runs, live AI-agent API keys, tag-time signed assets, or the Homebrew tap bump. Those remain honestly unchecked so the doc reflects what still has to happen.

## Risks / compatibility notes

- Pure release-prep change: version string, lockfile, changelog header, and checklist text. No behavior changes, no API changes, no migrations, no new/removed files.
- \`Cargo.lock\` delta is exactly the three workspace crates re-pinning at 8.1.0; no transitive dep bumps.
- \`verify_tag_version\` in \`release.yml\` parses \`Cargo.toml\` with a regex that expects \`^version = \"X.Y.Z\"$\`; the new \`version = \"8.1.0\"\` matches byte-for-byte.
- Statusline / daemon / CLI consumers pin the \`api_version\` header, not the workspace version, so the Cursor extension (\`MIN_API_VERSION = 1\`) and cloud dashboard continue to work against 8.1.0 unchanged.
- \`today_cost\` / \`week_cost\` / \`month_cost\` deprecated aliases in the statusline contract are still populated by the 8.1 code (one release of backward compatibility, scheduled removal in 9.0). That is unchanged by this PR.

## What this PR deliberately does **not** do

These are real release operations that have to happen, but belong to the maintainer operator — not this PR and not an agent:

1. **Pushing the \`v8.1.0\` git tag.** The tag push triggers \`release.yml\` to build and publish signed cross-platform release assets (\`SHA256SUMS\`, per-OS archives). That is a real production artefact and must only land after the R4.2 smoke gate is PASS.
2. **Posting the #297 PASS record.** The minimum-viable pre-release set in [\`docs/releases/8.1.0-smoke-tests.md\`](../blob/v8/202-release-v8-1-0/docs/releases/8.1.0-smoke-tests.md) requires a real machine, real AI-agent API keys, fresh OS installs / upgrades, reboots, and a Cursor marketplace install. An agent cannot honestly PASS this and faking it would violate the ADR-0088 §3 hard release gate.
3. **Bumping the Homebrew tap.** \`siropkin/homebrew-budi\` gets its own PR after the release assets exist so the formula's \`url\` and \`sha256\` can point at the published v8.1.0 archive.
4. **Creating the GitHub release body on the tag.** That is pasted at tag time from \`docs/releases/8.1.0.md\` §5 with the final commit hash and current cross-repo version numbers.

## Validation

Run on this branch at the release-candidate commit:

- \`cargo fmt --all -- --check\` — clean
- \`cargo clippy --workspace --all-targets --locked -- -D warnings\` — clean
- \`cargo test --workspace --locked\` — **520 tests passed** (69 budi-core + 419 budi-cli + 32 budi-daemon + 0 doctests; 0 failed / 0 ignored)

## Proposed maintainer sequence after this PR merges

Per [\`docs/releases/8.1.0.md\`](../blob/v8/202-release-v8-1-0/docs/releases/8.1.0.md) §3:

1. Execute the minimum-viable set from \`docs/releases/8.1.0-smoke-tests.md\` on a real machine (real API keys, documented OS / provider matrix).
2. Post the full PASS record on #297 (as a comment; the ticket is already closed from the plan-drafting step — the PASS evidence threads in alongside it).
3. From the merge commit of this PR on \`main\`: \`git tag v8.1.0 && git push origin v8.1.0\`.
4. \`release.yml\` runs \`verify_tag_version\` (now matches), builds cross-platform artefacts, attaches \`SHA256SUMS\`, and publishes the GitHub release draft.
5. Edit the release, paste the body from \`docs/releases/8.1.0.md\` §5, fill in the final commit hash and cross-repo versions (\`siropkin/budi-cursor\` 1.2.x, \`siropkin/budi-cloud\` current R3.1 deploy, \`siropkin/getbudi.dev\` current main), and publish.
6. Open a bump PR on \`siropkin/homebrew-budi\` to \`8.1.0\`.
7. Close #202 with links to the tag, release, public-site merge, homebrew bump, and cross-repo versions. Then close #201.

Tracks #202; will **not** close on merge (intentional — #202 closes only after the tag is pushed and the cross-repo promotion sequence completes).

Made with [Cursor](https://cursor.com)