### PR TITLE
[8.2][R1.2] Add Provider::watch_roots() for live tailing (#318)

### DIFF
--- a/crates/budi-core/src/provider.rs
+++ b/crates/budi-core/src/provider.rs
@@ -97,6 +97,46 @@ pub trait Provider: Send + Sync {
     ) -> Option<Result<(usize, usize, Vec<String>)>> {
         None
     }
+
+    /// Directories the daemon's filesystem tailer should watch for new and
+    /// grown transcript files (see [ADR-0089] §1 and #318).
+    ///
+    /// The tailer registers a recursive `notify` watcher on each returned
+    /// path; on each event it calls [`Provider::parse_file`] with the stored
+    /// per-file offset and feeds the resulting messages through
+    /// `Pipeline::default_pipeline()`. This is the single live ingestion
+    /// path in 8.2+ — there is no proxy fallback.
+    ///
+    /// Returned paths must:
+    /// - be absolute,
+    /// - point at directories that currently exist on disk (the tailer skips
+    ///   non-existent roots rather than blocking startup), and
+    /// - cover the parent of every file [`Provider::discover_files`] would
+    ///   return on the same machine.
+    ///
+    /// The default implementation derives roots by deduplicating the parent
+    /// directories of [`Provider::discover_files`]. This keeps existing
+    /// providers compiling, but every shipped provider should override with
+    /// its well-known root(s) so the watcher can attach even before any
+    /// transcripts have been written (e.g. on a freshly installed agent).
+    ///
+    /// Cursor's Usage API is **not** a watch root. It is a pull-mode
+    /// reconciliation handled by [`Provider::sync_direct`] and scheduled
+    /// independently of the tailer (see #321).
+    ///
+    /// [ADR-0089]: https://github.com/siropkin/budi/blob/main/docs/adr/0089-reverse-proxy-first-jsonl-tailing-as-sole-live-path.md
+    fn watch_roots(&self) -> Vec<PathBuf> {
+        let Ok(files) = self.discover_files() else {
+            return Vec::new();
+        };
+        let mut roots: Vec<PathBuf> = files
+            .into_iter()
+            .filter_map(|f| f.path.parent().map(Path::to_path_buf))
+            .collect();
+        roots.sort();
+        roots.dedup();
+        roots
+    }
 }
 
 /// Returns all registered providers (whether or not their data is present).
@@ -129,5 +169,69 @@ pub fn enabled_providers() -> Vec<Box<dyn Provider>> {
             .filter(|p| p.is_available() && config.is_agent_enabled(p.name()))
             .collect(),
         None => available_providers(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A minimal Provider that only implements the required surface so we can
+    /// exercise the default `watch_roots()` implementation.
+    struct StubProvider {
+        files: Vec<PathBuf>,
+    }
+
+    impl Provider for StubProvider {
+        fn name(&self) -> &'static str {
+            "stub"
+        }
+        fn display_name(&self) -> &'static str {
+            "Stub"
+        }
+        fn is_available(&self) -> bool {
+            true
+        }
+        fn discover_files(&self) -> Result<Vec<DiscoveredFile>> {
+            Ok(self
+                .files
+                .iter()
+                .cloned()
+                .map(|path| DiscoveredFile { path })
+                .collect())
+        }
+        fn parse_file(
+            &self,
+            _path: &Path,
+            _content: &str,
+            _offset: usize,
+        ) -> Result<(Vec<crate::jsonl::ParsedMessage>, usize)> {
+            Ok((Vec::new(), 0))
+        }
+    }
+
+    #[test]
+    fn default_watch_roots_dedups_parent_dirs() {
+        let provider = StubProvider {
+            files: vec![
+                PathBuf::from("/tmp/budi-stub/a/one.jsonl"),
+                PathBuf::from("/tmp/budi-stub/a/two.jsonl"),
+                PathBuf::from("/tmp/budi-stub/b/three.jsonl"),
+            ],
+        };
+        let roots = provider.watch_roots();
+        assert_eq!(
+            roots,
+            vec![
+                PathBuf::from("/tmp/budi-stub/a"),
+                PathBuf::from("/tmp/budi-stub/b"),
+            ]
+        );
+    }
+
+    #[test]
+    fn default_watch_roots_empty_when_no_files() {
+        let provider = StubProvider { files: Vec::new() };
+        assert!(provider.watch_roots().is_empty());
     }
 }

--- a/crates/budi-core/src/providers/claude_code.rs
+++ b/crates/budi-core/src/providers/claude_code.rs
@@ -40,6 +40,29 @@ impl Provider for ClaudeCodeProvider {
     ) -> Result<(Vec<ParsedMessage>, usize)> {
         Ok(jsonl::parse_transcript(content, offset))
     }
+
+    fn watch_roots(&self) -> Vec<PathBuf> {
+        let Ok(home) = crate::config::home_dir() else {
+            return Vec::new();
+        };
+        watch_roots_for_home(&home)
+    }
+}
+
+/// Compute Claude Code's tailer watch roots relative to the given home dir.
+///
+/// Claude Code writes JSONL transcripts under `~/.claude/projects/<encoded-cwd>/*.jsonl`.
+/// The daemon's tailer attaches a recursive watcher to `~/.claude/projects`,
+/// so this function returns that single root when it exists. Returning an
+/// empty vector when the directory is absent lets the daemon skip the
+/// watcher rather than failing to start.
+fn watch_roots_for_home(home: &Path) -> Vec<PathBuf> {
+    let projects = home.join(".claude").join("projects");
+    if projects.is_dir() {
+        vec![projects]
+    } else {
+        Vec::new()
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -341,6 +364,30 @@ mod tests {
                 p.cache_read
             );
         }
+    }
+
+    #[test]
+    fn watch_roots_returns_projects_dir_when_present() {
+        let tmp = std::env::temp_dir().join("budi-claude-watch-roots-present");
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(tmp.join(".claude/projects")).unwrap();
+
+        let roots = watch_roots_for_home(&tmp);
+        assert_eq!(roots, vec![tmp.join(".claude/projects")]);
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn watch_roots_empty_when_projects_dir_absent() {
+        let tmp = std::env::temp_dir().join("budi-claude-watch-roots-absent");
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(&tmp).unwrap();
+
+        let roots = watch_roots_for_home(&tmp);
+        assert!(roots.is_empty(), "expected empty roots, got {roots:?}");
+
+        let _ = std::fs::remove_dir_all(&tmp);
     }
 
     /// Verify that a realistic message produces the expected cost.

--- a/crates/budi-core/src/providers/codex.rs
+++ b/crates/budi-core/src/providers/codex.rs
@@ -67,6 +67,32 @@ impl Provider for CodexProvider {
     ) -> Result<(Vec<ParsedMessage>, usize)> {
         Ok(parse_codex_transcript(content, offset))
     }
+
+    fn watch_roots(&self) -> Vec<PathBuf> {
+        let Ok(home) = crate::config::home_dir() else {
+            return Vec::new();
+        };
+        watch_roots_for_home(&home)
+    }
+}
+
+/// Compute Codex's tailer watch roots relative to the given home dir.
+///
+/// Codex writes session JSONL to two parallel locations:
+/// - `~/.codex/sessions/YYYY/MM/DD/*.jsonl` — active sessions, currently
+///   growing, written to live by `codex` runs.
+/// - `~/.codex/archived_sessions/*.jsonl` — sessions the CLI rotates out
+///   of `sessions/`. Tail-watching keeps offsets honest if a session is
+///   rotated mid-tail.
+///
+/// Both are returned when present; missing roots are filtered so the daemon
+/// can attach a watcher to whichever subset exists.
+fn watch_roots_for_home(home: &Path) -> Vec<PathBuf> {
+    let codex = home.join(".codex");
+    [codex.join("sessions"), codex.join("archived_sessions")]
+        .into_iter()
+        .filter(|p| p.is_dir())
+        .collect()
 }
 
 // ---------------------------------------------------------------------------
@@ -613,5 +639,48 @@ mod tests {
         let p = codex_pricing_for_model("some-future-model");
         assert_eq!(p.input, 1.75);
         assert_eq!(p.output, 14.0);
+    }
+
+    #[test]
+    fn watch_roots_returns_both_session_dirs_when_present() {
+        let tmp = std::env::temp_dir().join("budi-codex-watch-roots-both");
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(tmp.join(".codex/sessions")).unwrap();
+        std::fs::create_dir_all(tmp.join(".codex/archived_sessions")).unwrap();
+
+        let roots = watch_roots_for_home(&tmp);
+        assert_eq!(
+            roots,
+            vec![
+                tmp.join(".codex/sessions"),
+                tmp.join(".codex/archived_sessions"),
+            ]
+        );
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn watch_roots_skips_missing_archived_dir() {
+        let tmp = std::env::temp_dir().join("budi-codex-watch-roots-active-only");
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(tmp.join(".codex/sessions")).unwrap();
+
+        let roots = watch_roots_for_home(&tmp);
+        assert_eq!(roots, vec![tmp.join(".codex/sessions")]);
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn watch_roots_empty_when_codex_home_absent() {
+        let tmp = std::env::temp_dir().join("budi-codex-watch-roots-empty");
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(&tmp).unwrap();
+
+        let roots = watch_roots_for_home(&tmp);
+        assert!(roots.is_empty(), "expected empty roots, got {roots:?}");
+
+        let _ = std::fs::remove_dir_all(&tmp);
     }
 }

--- a/crates/budi-core/src/providers/copilot.rs
+++ b/crates/budi-core/src/providers/copilot.rs
@@ -90,6 +90,29 @@ impl Provider for CopilotProvider {
             content, offset, session_id, workspace,
         ))
     }
+
+    fn watch_roots(&self) -> Vec<PathBuf> {
+        let Ok(home) = copilot_home() else {
+            return Vec::new();
+        };
+        watch_roots_under(&home)
+    }
+}
+
+/// Compute Copilot CLI's tailer watch root relative to the given Copilot home.
+///
+/// Copilot writes session events to `<COPILOT_HOME>/session-state/<session-id>/events.jsonl`.
+/// New sessions create new subdirectories, so the daemon attaches a recursive
+/// watcher to `session-state/` rather than to each individual session directory.
+/// Returns an empty vector when the directory is absent so the daemon can
+/// skip the watcher rather than failing to start.
+fn watch_roots_under(copilot_home: &Path) -> Vec<PathBuf> {
+    let session_state = copilot_home.join("session-state");
+    if session_state.is_dir() {
+        vec![session_state]
+    } else {
+        Vec::new()
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -535,5 +558,29 @@ mod tests {
         let codex_p = crate::providers::codex::codex_pricing_for_model("gpt-5.3");
         assert_eq!(p.input, codex_p.input);
         assert_eq!(p.output, codex_p.output);
+    }
+
+    #[test]
+    fn watch_roots_returns_session_state_when_present() {
+        let tmp = std::env::temp_dir().join("budi-copilot-watch-roots-present");
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(tmp.join("session-state/sess-1")).unwrap();
+
+        let roots = watch_roots_under(&tmp);
+        assert_eq!(roots, vec![tmp.join("session-state")]);
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn watch_roots_empty_when_session_state_absent() {
+        let tmp = std::env::temp_dir().join("budi-copilot-watch-roots-absent");
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(&tmp).unwrap();
+
+        let roots = watch_roots_under(&tmp);
+        assert!(roots.is_empty(), "expected empty roots, got {roots:?}");
+
+        let _ = std::fs::remove_dir_all(&tmp);
     }
 }

--- a/crates/budi-core/src/providers/cursor.rs
+++ b/crates/budi-core/src/providers/cursor.rs
@@ -84,6 +84,37 @@ impl Provider for CursorProvider {
         // Sync from Cursor Usage API (exact per-request tokens and cost)
         sync_from_usage_api(conn, pipeline, max_age_days)
     }
+
+    fn watch_roots(&self) -> Vec<PathBuf> {
+        let Ok(home) = crate::config::home_dir() else {
+            return Vec::new();
+        };
+        watch_roots_for_home(&home)
+    }
+}
+
+/// Compute Cursor's tailer watch roots relative to the given home dir.
+///
+/// Cursor writes JSONL transcripts under
+/// `~/.cursor/projects/<encoded-cwd>/agent-transcripts/**/*.jsonl`. The
+/// tailer attaches a recursive watcher to `~/.cursor/projects` so that new
+/// per-project subdirs are picked up automatically.
+///
+/// The Cursor Usage API is intentionally **not** a watch root. Per ADR-0089
+/// §7 it remains a pull-mode reconciliation handled by
+/// [`Provider::sync_direct`] and is scheduled independently of the live
+/// tailer; its lag profile is the subject of #321.
+///
+/// `state.vscdb` is also not a watch root — the JSONL transcripts already
+/// carry the messages the pipeline needs, and `state.vscdb` is a SQLite
+/// database whose write semantics are not tail-friendly.
+fn watch_roots_for_home(home: &Path) -> Vec<PathBuf> {
+    let projects = home.join(".cursor").join("projects");
+    if projects.is_dir() {
+        vec![projects]
+    } else {
+        Vec::new()
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -2235,5 +2266,46 @@ mod tests {
                 .count(),
             1
         );
+    }
+
+    #[test]
+    fn watch_roots_returns_projects_dir_when_present() {
+        let tmp = std::env::temp_dir().join("budi-cursor-watch-roots-present");
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(tmp.join(".cursor/projects")).unwrap();
+
+        let roots = watch_roots_for_home(&tmp);
+        assert_eq!(roots, vec![tmp.join(".cursor/projects")]);
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn watch_roots_empty_when_projects_dir_absent() {
+        let tmp = std::env::temp_dir().join("budi-cursor-watch-roots-absent");
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(&tmp).unwrap();
+
+        let roots = watch_roots_for_home(&tmp);
+        assert!(roots.is_empty(), "expected empty roots, got {roots:?}");
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn watch_roots_excludes_state_vscdb_and_usage_api() {
+        // ADR-0089 §7: Usage API stays in sync_direct; state.vscdb is not a
+        // watch root. Even when both exist, the only watch root is the JSONL
+        // projects dir.
+        let tmp = std::env::temp_dir().join("budi-cursor-watch-roots-jsonl-only");
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(tmp.join(".cursor/projects")).unwrap();
+        std::fs::create_dir_all(tmp.join("Library/Application Support/Cursor/User/globalStorage"))
+            .unwrap();
+
+        let roots = watch_roots_for_home(&tmp);
+        assert_eq!(roots, vec![tmp.join(".cursor/projects")]);
+
+        let _ = std::fs::remove_dir_all(&tmp);
     }
 }


### PR DESCRIPTION
## Summary

Adds `fn watch_roots(&self) -> Vec<PathBuf>` to the `Provider` trait so the daemon's upcoming notify-based tailer (`#319`) can ask each provider where to attach its filesystem watcher, without hard-coding per-agent paths in the daemon. This is the trait-surface contract that R1.3 will implement against.

Per [ADR-0089](https://github.com/siropkin/budi/blob/main/docs/adr/0089-reverse-proxy-first-jsonl-tailing-as-sole-live-path.md) §1, JSONL tailing is the sole live ingestion path in 8.2+. The trait surface is the contract; this PR ships only the surface so R1.3 can implement against a stable contract (rule 6 of `#316`).

### Trait surface

- Default impl returns deduplicated `discover_files()` parent dirs so existing third-party providers keep compiling.
- Method-level rustdoc cites ADR-0089 §1 (single live path) and §7 (Cursor Usage API stays a pull, not a watch root).
- Tailer plumbing, `tail_offsets` table, and the `BUDI_LIVE_TAIL` flag are intentionally out of scope here — they land in `#319`.

### Per-provider overrides

| Provider     | Watch roots                                                  |
| ------------ | ------------------------------------------------------------ |
| Claude Code  | `~/.claude/projects` (recursive)                             |
| Codex        | `~/.codex/sessions`, `~/.codex/archived_sessions`            |
| Copilot CLI  | `<COPILOT_HOME>/session-state` (recursive across sessions)   |
| Cursor       | `~/.cursor/projects` only — Usage API stays in `sync_direct` |

Each override filters to directories that currently exist so the daemon can skip missing roots rather than failing to start.

For Cursor, `state.vscdb` is intentionally **not** a watch root (SQLite write semantics are not tail-friendly, and the JSONL transcripts already carry the messages the pipeline needs); the Cursor Usage API is also intentionally not a watch root per ADR-0089 §7 — it remains a pull-mode reconciliation handled by `Provider::sync_direct` and is scheduled separately by `#321`.

## Risks / compatibility notes

- **Trait change is additive with a default impl**, so out-of-tree `Provider` impls (none today) keep compiling.
- **No new dependencies** — uses `std::path` and the existing `crate::config::home_dir()`.
- **No new env vars**, no shell profile writes, no `~/.codex/config.toml` mutation, no Cursor `settings.json` patching (rule 9 of `#316`, ADR-0089 §3).
- **No behaviour change at runtime** — nothing yet calls `watch_roots()`. The `analytics/sync.rs` `proxy_cutoff` dedup rule is unchanged and stays in place until R2 starts deleting code (ADR-0089 promotion criteria, rule 6 of `#316`).
- ADR-0089 still `Proposed`; promotion is gated on `#321` (Cursor Usage API lag), `#319`, and `#320` per the ADR's promotion criteria. This PR satisfies one of the four bullets ("`Provider::watch_roots()` is merged").
- **Privacy envelope unchanged** (ADR-0083) — `watch_roots()` only computes paths; no I/O on user content.

## Validation

```
cargo fmt --all
cargo clippy --workspace --all-targets --locked -- -D warnings   # clean
cargo test --workspace --locked                                   # 431 budi-core + 32 budi-daemon, all green
cargo test --workspace --locked watch_roots                       # 12/12 new tests pass
```

New unit tests (12 total):

- `provider::tests::default_watch_roots_dedups_parent_dirs`
- `provider::tests::default_watch_roots_empty_when_no_files`
- `providers::claude_code::tests::watch_roots_returns_projects_dir_when_present`
- `providers::claude_code::tests::watch_roots_empty_when_projects_dir_absent`
- `providers::codex::tests::watch_roots_returns_both_session_dirs_when_present`
- `providers::codex::tests::watch_roots_skips_missing_archived_dir`
- `providers::codex::tests::watch_roots_empty_when_codex_home_absent`
- `providers::copilot::tests::watch_roots_returns_session_state_when_present`
- `providers::copilot::tests::watch_roots_empty_when_session_state_absent`
- `providers::cursor::tests::watch_roots_returns_projects_dir_when_present`
- `providers::cursor::tests::watch_roots_empty_when_projects_dir_absent`
- `providers::cursor::tests::watch_roots_excludes_state_vscdb_and_usage_api`

Each per-provider helper takes an explicit home path so tests use `env::temp_dir()` fixtures and never bake absolute home paths into assertions.

Closes #318

Made with [Cursor](https://cursor.com)