### PR TITLE
[8.2][R1.3] Add notify-based tailer worker behind BUDI_LIVE_TAIL=1 (#319)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,6 +154,12 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
@@ -211,10 +217,13 @@ dependencies = [
  "clap",
  "futures-util",
  "http-body-util",
+ "notify",
+ "notify-debouncer-mini",
  "reqwest",
  "rusqlite",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "tower",
  "tracing",
@@ -446,6 +455,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -474,6 +489,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -869,6 +893,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
+dependencies = [
+ "bitflags 2.11.0",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -909,6 +953,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -936,6 +1000,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -1005,8 +1075,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "notify"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+dependencies = [
+ "bitflags 2.11.0",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-debouncer-mini"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a689eb4262184d9a1727f9087cd03883ea716682ab03ed24efec57d7716dccb8"
+dependencies = [
+ "log",
+ "notify",
+ "notify-types",
+ "tempfile",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -1290,7 +1400,7 @@ version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c6d5e5acb6f6129fe3f7ba0a7fc77bca1942cb568535e18e7bc40262baf3110"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -1303,6 +1413,19 @@ name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.11.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "rustls"
@@ -1351,6 +1474,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "semver"
@@ -1544,6 +1676,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1744,7 +1889,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "bytes",
  "futures-util",
  "http",
@@ -1952,6 +2097,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2080,7 +2235,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -2113,6 +2268,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2397,7 +2561,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.0",
  "indexmap",
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,8 @@ axum = "0.8"
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive"] }
 futures-util = "0.3"
+notify = { version = "8", default-features = false, features = ["macos_fsevent"] }
+notify-debouncer-mini = { version = "0.6", default-features = false, features = ["macos_fsevent"] }
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "rustls-tls", "stream"] }
 rusqlite = { version = "0.33", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }

--- a/crates/budi-core/src/analytics/mod.rs
+++ b/crates/budi-core/src/analytics/mod.rs
@@ -81,6 +81,47 @@ pub fn set_sync_offset(conn: &Connection, file_path: &str, offset: usize) -> Res
     Ok(())
 }
 
+/// Look up the live tailer's stored byte offset for `(provider, path)`.
+///
+/// Returns `Ok(None)` when no row exists, signalling that the tailer has
+/// never observed this file before. Callers use that signal to decide
+/// whether to seek to end-of-file (the daemon's "skip the backfill"
+/// behaviour, owned by `budi import`) or to resume from the stored
+/// offset. See [ADR-0089] §1 / #319.
+///
+/// [ADR-0089]: https://github.com/siropkin/budi/blob/main/docs/adr/0089-reverse-proxy-first-jsonl-tailing-as-sole-live-path.md
+pub fn get_tail_offset(conn: &Connection, provider: &str, path: &str) -> Result<Option<usize>> {
+    let result = conn.query_row(
+        "SELECT byte_offset FROM tail_offsets WHERE provider = ?1 AND path = ?2",
+        params![provider, path],
+        |row| row.get::<_, i64>(0),
+    );
+    match result {
+        Ok(offset) => Ok(Some(offset.max(0) as usize)),
+        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+        Err(e) => Err(e.into()),
+    }
+}
+
+/// Persist the tailer's byte offset for `(provider, path)`. Inserts when
+/// missing, updates otherwise; `last_seen` is refreshed on every call so
+/// stale entries are easy to identify later.
+///
+/// Distinct from [`set_sync_offset`]: that table is shared with `budi
+/// import` and keyed on path alone. The tailer's offsets must not collide
+/// with import's offsets — if a user ever runs both for the same file,
+/// they should advance independently.
+pub fn set_tail_offset(conn: &Connection, provider: &str, path: &str, offset: usize) -> Result<()> {
+    let now = Utc::now().to_rfc3339();
+    conn.execute(
+        "INSERT INTO tail_offsets (provider, path, byte_offset, last_seen)
+         VALUES (?1, ?2, ?3, ?4)
+         ON CONFLICT(provider, path) DO UPDATE SET byte_offset = ?3, last_seen = ?4",
+        params![provider, path, offset as i64, now],
+    )?;
+    Ok(())
+}
+
 /// Record that a full sync run completed successfully at the current time.
 pub fn mark_sync_completed(conn: &Connection) -> Result<()> {
     let now = Utc::now().to_rfc3339();

--- a/crates/budi-core/src/migration.rs
+++ b/crates/budi-core/src/migration.rs
@@ -156,7 +156,38 @@ fn create_current_schema(conn: &Connection) -> Result<()> {
     )?;
     create_sessions(conn)?;
     ensure_rollup_schema(conn, false)?;
+    ensure_tail_offsets(conn)?;
     create_indexes(conn)?;
+    Ok(())
+}
+
+/// Per-(provider, file) byte offset table used by the daemon's live tailer
+/// (see [ADR-0089] §1 and #319).
+///
+/// This is intentionally distinct from `sync_state` (which is keyed on file
+/// path alone and shared with `budi import`). The tailer needs:
+/// - a per-provider scope so two providers sharing a watch root cannot
+///   stomp on each other's offsets,
+/// - a `last_seen` timestamp so future tooling can prune stale rows
+///   without crawling the filesystem.
+///
+/// Offsets are byte counts into the JSONL file, identical in semantics to
+/// `sync_state.byte_offset` so the `Provider::parse_file(path, content,
+/// offset)` contract works unchanged.
+///
+/// [ADR-0089]: https://github.com/siropkin/budi/blob/main/docs/adr/0089-reverse-proxy-first-jsonl-tailing-as-sole-live-path.md
+fn ensure_tail_offsets(conn: &Connection) -> Result<()> {
+    conn.execute_batch(
+        "
+        CREATE TABLE IF NOT EXISTS tail_offsets (
+            provider     TEXT NOT NULL,
+            path         TEXT NOT NULL,
+            byte_offset  INTEGER NOT NULL DEFAULT 0,
+            last_seen    TEXT NOT NULL,
+            PRIMARY KEY (provider, path)
+        );
+        ",
+    )?;
     Ok(())
 }
 
@@ -969,6 +1000,12 @@ fn reconcile_schema(conn: &Connection) -> Result<SchemaReconcileReport> {
         }
     }
 
+    let needs_tail_offsets = !table_exists(conn, "tail_offsets")?;
+    if needs_tail_offsets {
+        ensure_tail_offsets(conn)?;
+        added_columns.push("tail_offsets".to_string());
+    }
+
     let added_indexes = missing_reconcile_indexes(conn)?;
 
     create_indexes(conn)?;
@@ -997,6 +1034,7 @@ mod tests {
             .unwrap();
         assert!(table_exists(conn, "message_rollups_hourly").unwrap());
         assert!(table_exists(conn, "message_rollups_daily").unwrap());
+        assert!(table_exists(conn, "tail_offsets").unwrap());
         assert!(trigger_exists(conn, "trg_messages_rollup_insert").unwrap());
         assert!(trigger_exists(conn, "trg_messages_rollup_delete").unwrap());
         assert!(trigger_exists(conn, "trg_messages_rollup_update").unwrap());
@@ -1067,5 +1105,28 @@ mod tests {
                 .unwrap();
             assert_eq!(junk, 0, "old tables should be dropped (v{old_version})");
         }
+    }
+
+    /// 8.1 → 8.2 upgrade: an existing v1 database that pre-dates the
+    /// `tail_offsets` table must gain it through `reconcile_schema` without
+    /// triggering a destructive migration. See #319 / ADR-0089.
+    #[test]
+    fn reconcile_adds_tail_offsets_to_existing_v1_db() {
+        let conn = Connection::open_in_memory().unwrap();
+        migrate(&conn).unwrap();
+        conn.execute_batch("DROP TABLE tail_offsets;").unwrap();
+        assert!(!table_exists(&conn, "tail_offsets").unwrap());
+
+        let report = repair(&conn).unwrap();
+
+        assert_eq!(report.from_version, SCHEMA_VERSION);
+        assert_eq!(report.to_version, SCHEMA_VERSION);
+        assert!(!report.migrated, "additive repair should not bump version");
+        assert!(
+            report.added_columns.iter().any(|c| c == "tail_offsets"),
+            "report should mention the new table; got {:?}",
+            report.added_columns
+        );
+        assert!(table_exists(&conn, "tail_offsets").unwrap());
     }
 }

--- a/crates/budi-daemon/Cargo.toml
+++ b/crates/budi-daemon/Cargo.toml
@@ -13,6 +13,9 @@ budi-core = { path = "../budi-core" }
 chrono.workspace = true
 clap.workspace = true
 futures-util.workspace = true
+notify.workspace = true
+notify-debouncer-mini.workspace = true
+rusqlite.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 reqwest.workspace = true
@@ -22,5 +25,5 @@ tracing-subscriber.workspace = true
 
 [dev-dependencies]
 http-body-util = "0.1"
-rusqlite.workspace = true
+tempfile = "3"
 tower = { version = "0.5", features = ["util"] }

--- a/crates/budi-daemon/src/main.rs
+++ b/crates/budi-daemon/src/main.rs
@@ -269,6 +269,31 @@ async fn main() -> Result<()> {
         }
     }
 
+    // --- Start filesystem tailer if BUDI_LIVE_TAIL=1 (R1.3 / ADR-0089 / #319) ---
+    //
+    // R1.3 ships the tailer behind a feature flag. R1.4 (#320) flips the
+    // default and starts skipping `proxy_events` writes; this stage
+    // intentionally runs both paths in parallel so analytics output can be
+    // cross-validated on the same machine before R2 starts deleting proxy
+    // code (#322).
+    if std::env::var("BUDI_LIVE_TAIL").as_deref() == Ok("1") {
+        match analytics::db_path() {
+            Ok(db_path) => {
+                tracing::info!(
+                    target: "budi_daemon::tailer",
+                    "BUDI_LIVE_TAIL=1: starting filesystem tailer (ADR-0089 §1)"
+                );
+                let shutdown = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+                tokio::spawn(workers::tailer::run(db_path, shutdown));
+            }
+            Err(e) => tracing::warn!(
+                target: "budi_daemon::tailer",
+                error = %e,
+                "BUDI_LIVE_TAIL=1 set but db_path is not resolvable; tailer not started"
+            ),
+        }
+    }
+
     // --- Start cloud sync worker if configured ---
     {
         let cloud_config = budi_core::config::load_cloud_config();

--- a/crates/budi-daemon/src/workers/mod.rs
+++ b/crates/budi-daemon/src/workers/mod.rs
@@ -1,1 +1,2 @@
 pub mod cloud_sync;
+pub mod tailer;

--- a/crates/budi-daemon/src/workers/tailer.rs
+++ b/crates/budi-daemon/src/workers/tailer.rs
@@ -1,0 +1,805 @@
+//! Filesystem tailer worker.
+//!
+//! The tailer is the live ingestion path introduced by [ADR-0089] §1 / #319.
+//! It registers a recursive `notify` watcher on every directory returned by
+//! [`Provider::watch_roots`] and feeds appended JSONL content through
+//! [`Pipeline::default_pipeline`] into the same tables `budi import` writes
+//! to. There is no second code path — the import command and the live tailer
+//! call the same provider parser, the same enricher chain, and the same
+//! `ingest_messages_with_sync` sink.
+//!
+//! ## Lifecycle (R1.3 — feature-flagged)
+//!
+//! 1. `main.rs` checks `BUDI_LIVE_TAIL=1` (the only env var this round
+//!    introduces) and spawns [`run`] iff the flag is set. The proxy stays
+//!    live in parallel — R1.4 (#320) flips the default and starts skipping
+//!    `proxy_events` writes; this PR does neither.
+//! 2. [`run`] hops into a blocking thread (`notify` is fundamentally
+//!    blocking and we don't want to bind a Tokio worker thread for it),
+//!    snapshots `enabled_providers()`, builds a `(provider, watch_root)`
+//!    map, and seeds [`tail_offsets`](budi_core::analytics::set_tail_offset)
+//!    with `byte_offset = file_len` for every existing transcript. That is
+//!    the "skip the backfill, leave history to `budi import`" property
+//!    called out in the ticket Acceptance.
+//! 3. A `notify-debouncer-mini` watcher with a 500 ms debounce dispatches
+//!    grown / created `*.jsonl` paths into a `std::sync::mpsc` channel; the
+//!    main loop drains the channel and runs [`process_path`].
+//! 4. Every 5 s the loop also calls [`backstop_scan`] to cover the well-known
+//!    macOS / WSL `notify` edge cases (rotated files, mtime jitter, missed
+//!    events on network volumes).
+//!
+//! ## Why a separate `tail_offsets` table
+//!
+//! The existing `sync_state` table is keyed on `file_path` only and is
+//! shared with `budi import`. If the user runs `budi import` and the live
+//! tailer concurrently, their offsets must not stomp on each other. Per-
+//! provider scope also lets the post-removal cleanup in #357 prune by
+//! provider when a user disables one. See
+//! [`budi_core::analytics::set_tail_offset`].
+//!
+//! ## What this module deliberately does **not** do (Must-not list, #319)
+//!
+//! - No writes to `proxy_events`. The pipeline writes to `messages`, `tags`,
+//!   `sessions`, and `tail_offsets` only.
+//! - No changes to `Pipeline` signature or the enricher list — the tailer
+//!   uses `Pipeline::default_pipeline` exactly as `budi import` does.
+//! - No edits to `analytics/sync.rs` `proxy_cutoff`. Cross-path dedup stays
+//!   on until R2 (#322) starts deleting proxy code.
+//!
+//! [ADR-0089]: https://github.com/siropkin/budi/blob/main/docs/adr/0089-reverse-proxy-first-jsonl-tailing-as-sole-live-path.md
+
+use std::collections::HashMap;
+use std::io::{Read, Seek, SeekFrom};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use budi_core::analytics::{self, get_tail_offset, ingest_messages_with_sync, set_tail_offset};
+use budi_core::pipeline::Pipeline;
+use budi_core::provider::Provider;
+use notify::RecursiveMode;
+use notify_debouncer_mini::{DebounceEventResult, new_debouncer};
+use rusqlite::Connection;
+
+/// `notify-debouncer-mini` collapses duplicate events that arrive within
+/// this window. 500 ms is short enough to feel live (well under the 1–10 s
+/// budget ADR-0089 §5 sets) and long enough to coalesce the burst of writes
+/// most agents emit when streaming a single response.
+const DEBOUNCE: Duration = Duration::from_millis(500);
+
+/// Backstop poll cadence. Runs whenever the event channel is idle. Catches
+/// the documented `notify` edge cases (rotated files on macOS Spotlight,
+/// missed events on WSL2 / network shares) without adding meaningful CPU.
+const BACKSTOP_POLL: Duration = Duration::from_secs(5);
+
+/// Spawn the tailer in a blocking task and return immediately.
+///
+/// The caller (`daemon::main`) owns the `shutdown` flag — flipping it
+/// causes the loop to exit at the next event or backstop tick. Dropping
+/// the flag without flipping is also fine; the worker just keeps running
+/// for the lifetime of the daemon process.
+pub async fn run(db_path: PathBuf, shutdown: Arc<AtomicBool>) {
+    let providers = budi_core::provider::enabled_providers();
+    if providers.is_empty() {
+        tracing::info!(
+            target: "budi_daemon::tailer",
+            "no enabled providers; tailer exiting"
+        );
+        return;
+    }
+    let _ = tokio::task::spawn_blocking(move || run_blocking(db_path, providers, shutdown)).await;
+}
+
+/// Blocking entry point. Public for the integration test in
+/// `tests/tailer_offsets.rs`, which constructs a stub provider and drives
+/// the loop directly.
+pub fn run_blocking(
+    db_path: PathBuf,
+    providers: Vec<Box<dyn Provider>>,
+    shutdown: Arc<AtomicBool>,
+) {
+    let routes = build_routes(&providers);
+    if routes.is_empty() {
+        tracing::info!(
+            target: "budi_daemon::tailer",
+            "no watch roots from enabled providers; tailer exiting"
+        );
+        return;
+    }
+
+    let mut conn = match analytics::open_db(&db_path) {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::error!(
+                target: "budi_daemon::tailer",
+                error = %e,
+                "failed to open analytics db; tailer exiting"
+            );
+            return;
+        }
+    };
+
+    let providers_by_name = index_providers_by_name(providers);
+
+    if let Err(e) = seed_offsets(&mut conn, &providers_by_name) {
+        tracing::warn!(
+            target: "budi_daemon::tailer",
+            error = %format!("{e:#}"),
+            "offset seeding failed; tailer continues with default offsets"
+        );
+    }
+
+    let mut pipeline = Pipeline::default_pipeline(budi_core::config::load_tags_config());
+
+    let (tx, rx) = std::sync::mpsc::channel::<PathBuf>();
+    let mut debouncer = match new_debouncer(DEBOUNCE, move |res: DebounceEventResult| match res {
+        Ok(events) => {
+            for ev in events {
+                let _ = tx.send(ev.path);
+            }
+        }
+        Err(e) => tracing::warn!(
+            target: "budi_daemon::tailer",
+            error = %e,
+            "debouncer error"
+        ),
+    }) {
+        Ok(d) => d,
+        Err(e) => {
+            tracing::error!(
+                target: "budi_daemon::tailer",
+                error = %e,
+                "failed to create filesystem debouncer; tailer exiting"
+            );
+            return;
+        }
+    };
+
+    for (root, provider_name) in &routes {
+        match debouncer.watcher().watch(root, RecursiveMode::Recursive) {
+            Ok(()) => tracing::info!(
+                target: "budi_daemon::tailer",
+                provider = %provider_name,
+                root = %root.display(),
+                "watching"
+            ),
+            Err(e) => tracing::warn!(
+                target: "budi_daemon::tailer",
+                provider = %provider_name,
+                root = %root.display(),
+                error = %e,
+                "failed to attach watcher; backstop poll will still cover this root"
+            ),
+        }
+    }
+
+    loop {
+        if shutdown.load(Ordering::SeqCst) {
+            tracing::info!(target: "budi_daemon::tailer", "shutdown requested");
+            break;
+        }
+
+        match rx.recv_timeout(BACKSTOP_POLL) {
+            Ok(path) => {
+                process_path(&mut conn, &mut pipeline, &providers_by_name, &routes, &path);
+                while let Ok(p) = rx.try_recv() {
+                    process_path(&mut conn, &mut pipeline, &providers_by_name, &routes, &p);
+                }
+            }
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                backstop_scan(&mut conn, &mut pipeline, &providers_by_name);
+            }
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                tracing::warn!(
+                    target: "budi_daemon::tailer",
+                    "event channel disconnected; tailer exiting"
+                );
+                break;
+            }
+        }
+    }
+}
+
+/// `(watch_root, provider_name)` pairs sorted from longest-prefix to
+/// shortest, so [`provider_for_path`] can resolve nested roots
+/// deterministically.
+type Routes = Vec<(PathBuf, String)>;
+
+fn build_routes(providers: &[Box<dyn Provider>]) -> Routes {
+    let mut routes: Routes = providers
+        .iter()
+        .flat_map(|p| {
+            p.watch_roots()
+                .into_iter()
+                .map(|root| (root, p.name().to_string()))
+                .collect::<Vec<_>>()
+        })
+        .collect();
+    routes.sort_by(|a, b| b.0.components().count().cmp(&a.0.components().count()));
+    routes
+}
+
+fn index_providers_by_name(
+    providers: Vec<Box<dyn Provider>>,
+) -> HashMap<String, Box<dyn Provider>> {
+    providers
+        .into_iter()
+        .map(|p| (p.name().to_string(), p))
+        .collect()
+}
+
+/// Resolve which provider owns a path event by longest matching watch root.
+fn provider_for_path<'a>(path: &Path, routes: &'a Routes) -> Option<&'a str> {
+    routes
+        .iter()
+        .find(|(root, _)| path.starts_with(root))
+        .map(|(_, name)| name.as_str())
+}
+
+/// Skip the backfill on first observation: every transcript already on
+/// disk gets `byte_offset = file_len`. Any later append (via `notify`) is
+/// what we ingest. This is how the ticket says we keep `budi import` as
+/// the only path that processes history.
+fn seed_offsets(
+    conn: &mut Connection,
+    providers_by_name: &HashMap<String, Box<dyn Provider>>,
+) -> Result<()> {
+    for (name, provider) in providers_by_name {
+        let files = provider
+            .discover_files()
+            .with_context(|| format!("discover_files failed for provider {name}"))?;
+        for file in files {
+            let path_str = file.path.display().to_string();
+            if get_tail_offset(conn, name, &path_str)?.is_some() {
+                continue;
+            }
+            let len = std::fs::metadata(&file.path)
+                .map(|m| m.len() as usize)
+                .unwrap_or(0);
+            set_tail_offset(conn, name, &path_str, len)?;
+            tracing::debug!(
+                target: "budi_daemon::tailer",
+                provider = %name,
+                path = %file.path.display(),
+                seeded_offset = len,
+                "seeded existing transcript at end-of-file"
+            );
+        }
+    }
+    Ok(())
+}
+
+/// Periodic safety net for missed FS events. Re-discovers each provider's
+/// files and runs [`process_path`] on every one — `process_path` is
+/// idempotent (it short-circuits when the stored offset already matches
+/// `file_len`), so this is cheap when nothing has changed.
+fn backstop_scan(
+    conn: &mut Connection,
+    pipeline: &mut Pipeline,
+    providers_by_name: &HashMap<String, Box<dyn Provider>>,
+) {
+    for (name, provider) in providers_by_name {
+        let files = match provider.discover_files() {
+            Ok(f) => f,
+            Err(e) => {
+                tracing::debug!(
+                    target: "budi_daemon::tailer",
+                    provider = %name,
+                    error = %format!("{e:#}"),
+                    "backstop discover_files failed"
+                );
+                continue;
+            }
+        };
+        for f in files {
+            let routes = vec![(f.path.clone(), name.clone())];
+            process_path(conn, pipeline, providers_by_name, &routes, &f.path);
+        }
+    }
+}
+
+/// Process a single path event. Pure data flow:
+/// `read tail → provider.parse_file → Pipeline::process →
+/// ingest_messages_with_sync → set_tail_offset`. Logs at the
+/// `budi_daemon::tailer` target with `provider`, `path`, `bytes_read`,
+/// `messages_parsed`, `ingested` per the ticket's structured-logging
+/// requirement.
+fn process_path(
+    conn: &mut Connection,
+    pipeline: &mut Pipeline,
+    providers_by_name: &HashMap<String, Box<dyn Provider>>,
+    routes: &Routes,
+    path: &Path,
+) {
+    if !is_jsonl(path) {
+        return;
+    }
+    let Some(provider_name) = provider_for_path(path, routes) else {
+        return;
+    };
+    let Some(provider) = providers_by_name.get(provider_name) else {
+        return;
+    };
+
+    let file_len = match std::fs::metadata(path) {
+        Ok(m) => m.len() as usize,
+        Err(_) => return,
+    };
+
+    let path_str = path.display().to_string();
+    let stored_offset = match get_tail_offset(conn, provider_name, &path_str) {
+        Ok(Some(o)) => o,
+        Ok(None) => 0,
+        Err(e) => {
+            tracing::warn!(
+                target: "budi_daemon::tailer",
+                provider = %provider_name,
+                path = %path.display(),
+                error = %format!("{e:#}"),
+                "get_tail_offset failed"
+            );
+            return;
+        }
+    };
+
+    if stored_offset == file_len {
+        return;
+    }
+
+    let (content, parse_start_offset) = match read_tail(path, stored_offset, file_len) {
+        Ok(slice) => slice,
+        Err(e) => {
+            tracing::warn!(
+                target: "budi_daemon::tailer",
+                provider = %provider_name,
+                path = %path.display(),
+                error = %format!("{e:#}"),
+                "read_tail failed"
+            );
+            return;
+        }
+    };
+
+    if content.is_empty() {
+        return;
+    }
+
+    let bytes_read = content.len();
+    let (mut messages, relative_offset) = match provider.parse_file(path, &content, 0) {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::warn!(
+                target: "budi_daemon::tailer",
+                provider = %provider_name,
+                path = %path.display(),
+                error = %format!("{e:#}"),
+                "provider.parse_file failed"
+            );
+            return;
+        }
+    };
+    let new_offset = parse_start_offset.saturating_add(relative_offset);
+
+    if messages.is_empty() {
+        if let Err(e) = set_tail_offset(conn, provider_name, &path_str, new_offset) {
+            tracing::warn!(
+                target: "budi_daemon::tailer",
+                provider = %provider_name,
+                path = %path.display(),
+                error = %format!("{e:#}"),
+                "set_tail_offset failed (no messages)"
+            );
+        }
+        return;
+    }
+
+    let messages_parsed = messages.len();
+    let tags = pipeline.process(&mut messages);
+
+    match ingest_messages_with_sync(conn, &messages, Some(&tags), None) {
+        Ok(ingested) => {
+            if let Err(e) = set_tail_offset(conn, provider_name, &path_str, new_offset) {
+                tracing::warn!(
+                    target: "budi_daemon::tailer",
+                    provider = %provider_name,
+                    path = %path.display(),
+                    error = %format!("{e:#}"),
+                    "set_tail_offset failed after ingest"
+                );
+                return;
+            }
+            tracing::info!(
+                target: "budi_daemon::tailer",
+                provider = %provider_name,
+                path = %path.display(),
+                bytes_read = bytes_read,
+                messages_parsed = messages_parsed,
+                ingested = ingested,
+                "tail batch processed"
+            );
+        }
+        Err(e) => {
+            tracing::warn!(
+                target: "budi_daemon::tailer",
+                provider = %provider_name,
+                path = %path.display(),
+                error = %format!("{e:#}"),
+                "ingest failed; offset not advanced"
+            );
+        }
+    }
+}
+
+fn is_jsonl(path: &Path) -> bool {
+    path.extension()
+        .and_then(|e| e.to_str())
+        .map(|e| e.eq_ignore_ascii_case("jsonl"))
+        .unwrap_or(false)
+}
+
+/// Read appended bytes since `stored_offset`, mirroring the truncation
+/// behaviour of `analytics::sync::read_transcript_tail` so a single file
+/// rotation does not desync the tailer from `budi import`.
+fn read_tail(path: &Path, stored_offset: usize, file_len: usize) -> Result<(String, usize)> {
+    let effective_offset = if stored_offset > file_len {
+        tracing::info!(
+            target: "budi_daemon::tailer",
+            path = %path.display(),
+            stored = stored_offset,
+            len = file_len,
+            "transcript shrank; resetting offset"
+        );
+        0
+    } else {
+        stored_offset
+    };
+    if effective_offset == file_len {
+        return Ok((String::new(), effective_offset));
+    }
+    let mut file = std::fs::File::open(path).with_context(|| format!("open {}", path.display()))?;
+    file.seek(SeekFrom::Start(effective_offset as u64))
+        .with_context(|| format!("seek {}", path.display()))?;
+    let mut content = String::new();
+    file.read_to_string(&mut content)
+        .with_context(|| format!("read {}", path.display()))?;
+    Ok((content, effective_offset))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use budi_core::jsonl::ParsedMessage;
+    use budi_core::provider::DiscoveredFile;
+    use std::sync::Mutex;
+    use std::sync::atomic::AtomicU64;
+
+    static UUID_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    /// Deterministic stub provider. Lets us exercise the tailer without
+    /// touching `~/.claude` / `~/.codex` / etc. Each call to
+    /// `parse_file` consumes the entire `content` and returns one
+    /// assistant message per non-blank line, with the line's byte offset
+    /// as the new offset.
+    struct StubProvider {
+        name: &'static str,
+        roots: Vec<PathBuf>,
+        files: Mutex<Vec<PathBuf>>,
+    }
+
+    impl StubProvider {
+        fn new(name: &'static str, root: PathBuf) -> Self {
+            Self {
+                name,
+                roots: vec![root],
+                files: Mutex::new(Vec::new()),
+            }
+        }
+        fn add_file(&self, path: PathBuf) {
+            self.files.lock().unwrap().push(path);
+        }
+    }
+
+    impl Provider for StubProvider {
+        fn name(&self) -> &'static str {
+            self.name
+        }
+        fn display_name(&self) -> &'static str {
+            "Stub"
+        }
+        fn is_available(&self) -> bool {
+            true
+        }
+        fn discover_files(&self) -> Result<Vec<DiscoveredFile>> {
+            Ok(self
+                .files
+                .lock()
+                .unwrap()
+                .iter()
+                .cloned()
+                .map(|path| DiscoveredFile { path })
+                .collect())
+        }
+        fn parse_file(
+            &self,
+            _path: &Path,
+            content: &str,
+            offset: usize,
+        ) -> Result<(Vec<ParsedMessage>, usize)> {
+            let mut messages = Vec::new();
+            for line in content.lines() {
+                if line.trim().is_empty() {
+                    continue;
+                }
+                let id = UUID_COUNTER.fetch_add(1, Ordering::SeqCst);
+                let mut msg = ParsedMessage {
+                    uuid: format!("{}-{}", self.name, id),
+                    role: "assistant".to_string(),
+                    timestamp: chrono::Utc::now(),
+                    provider: self.name.to_string(),
+                    cost_confidence: "estimated".to_string(),
+                    ..Default::default()
+                };
+                msg.session_id = Some(format!("{}-session-{}", self.name, id));
+                messages.push(msg);
+            }
+            Ok((messages, offset + content.len()))
+        }
+        fn watch_roots(&self) -> Vec<PathBuf> {
+            self.roots.clone()
+        }
+    }
+
+    fn open_test_db(tmp: &Path) -> (PathBuf, Connection) {
+        let db_path = tmp.join("analytics.db");
+        budi_core::migration::migrate(&budi_core::analytics::open_db(&db_path).unwrap()).unwrap();
+        let conn = budi_core::analytics::open_db(&db_path).unwrap();
+        (db_path, conn)
+    }
+
+    #[test]
+    fn provider_for_path_picks_longest_prefix() {
+        let routes: Routes = vec![
+            (PathBuf::from("/tmp/a/b"), "specific".to_string()),
+            (PathBuf::from("/tmp/a"), "general".to_string()),
+        ];
+        let mut sorted = routes.clone();
+        sorted.sort_by(|a, b| b.0.components().count().cmp(&a.0.components().count()));
+        assert_eq!(
+            provider_for_path(Path::new("/tmp/a/b/c.jsonl"), &sorted),
+            Some("specific")
+        );
+        assert_eq!(
+            provider_for_path(Path::new("/tmp/a/x.jsonl"), &sorted),
+            Some("general")
+        );
+        assert_eq!(provider_for_path(Path::new("/elsewhere"), &sorted), None);
+    }
+
+    #[test]
+    fn is_jsonl_recognizes_extension() {
+        assert!(is_jsonl(Path::new("a.jsonl")));
+        assert!(is_jsonl(Path::new("a.JSONL")));
+        assert!(!is_jsonl(Path::new("a.json")));
+        assert!(!is_jsonl(Path::new("a.txt")));
+        assert!(!is_jsonl(Path::new("a")));
+    }
+
+    #[test]
+    fn seed_offsets_marks_existing_files_at_eof() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().to_path_buf();
+        let f1 = root.join("one.jsonl");
+        let f2 = root.join("two.jsonl");
+        std::fs::write(&f1, "line1\nline2\n").unwrap();
+        std::fs::write(&f2, "line3\n").unwrap();
+
+        let provider = StubProvider::new("stub", root.clone());
+        provider.add_file(f1.clone());
+        provider.add_file(f2.clone());
+
+        let (db_path, _) = open_test_db(tmp.path());
+        let mut conn = budi_core::analytics::open_db(&db_path).unwrap();
+
+        let mut providers_by_name: HashMap<String, Box<dyn Provider>> = HashMap::new();
+        providers_by_name.insert("stub".to_string(), Box::new(provider));
+
+        seed_offsets(&mut conn, &providers_by_name).unwrap();
+
+        let f1_offset = get_tail_offset(&conn, "stub", &f1.display().to_string())
+            .unwrap()
+            .unwrap();
+        let f2_offset = get_tail_offset(&conn, "stub", &f2.display().to_string())
+            .unwrap()
+            .unwrap();
+        assert_eq!(f1_offset, std::fs::metadata(&f1).unwrap().len() as usize);
+        assert_eq!(f2_offset, std::fs::metadata(&f2).unwrap().len() as usize);
+    }
+
+    #[test]
+    fn process_path_advances_offset_and_is_idempotent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().to_path_buf();
+        let f = root.join("session.jsonl");
+        std::fs::write(&f, "line1\n").unwrap();
+
+        let provider = StubProvider::new("stub", root.clone());
+        provider.add_file(f.clone());
+
+        let (db_path, _) = open_test_db(tmp.path());
+        let mut conn = budi_core::analytics::open_db(&db_path).unwrap();
+
+        let mut providers_by_name: HashMap<String, Box<dyn Provider>> = HashMap::new();
+        providers_by_name.insert("stub".to_string(), Box::new(provider));
+        let routes = build_routes(
+            &providers_by_name
+                .values()
+                .map(|p| {
+                    let p_ref: &dyn Provider = p.as_ref();
+                    Box::new(StubProvider::new(p_ref.name(), root.clone())) as Box<dyn Provider>
+                })
+                .collect::<Vec<_>>(),
+        );
+        let mut pipeline = Pipeline::default_pipeline(None);
+
+        process_path(&mut conn, &mut pipeline, &providers_by_name, &routes, &f);
+        let first_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM messages", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(first_count, 1, "first event should ingest one message");
+        let first_offset = get_tail_offset(&conn, "stub", &f.display().to_string())
+            .unwrap()
+            .unwrap();
+        assert_eq!(first_offset, std::fs::metadata(&f).unwrap().len() as usize);
+
+        process_path(&mut conn, &mut pipeline, &providers_by_name, &routes, &f);
+        let after_idempotent_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM messages", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(
+            after_idempotent_count, first_count,
+            "re-processing the same path with no new bytes must be a no-op"
+        );
+
+        std::fs::OpenOptions::new()
+            .append(true)
+            .open(&f)
+            .unwrap()
+            .write_all(b"line2\n")
+            .unwrap();
+        process_path(&mut conn, &mut pipeline, &providers_by_name, &routes, &f);
+        let after_append_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM messages", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(
+            after_append_count, 2,
+            "append should ingest one new message"
+        );
+    }
+
+    use std::io::Write;
+
+    /// Acceptance from #319: "Offsets persist across daemon restarts
+    /// (integration test: write, kill, restart, write more, confirm no
+    /// dupes and no missed messages)". We simulate the daemon process
+    /// boundary by dropping every in-memory handle (pipeline, conn,
+    /// providers map) between phases — the only thing carrying state
+    /// across the restart is the on-disk `tail_offsets` table.
+    #[test]
+    fn offsets_survive_simulated_daemon_restart() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().to_path_buf();
+        let f = root.join("session.jsonl");
+        std::fs::write(&f, "before-restart-1\nbefore-restart-2\n").unwrap();
+
+        let (db_path, _) = open_test_db(tmp.path());
+
+        // Phase 1 — first daemon boot. Tailer seeds existing transcripts
+        // at EOF (so history stays the import command's job), then a new
+        // append is delivered and ingested.
+        {
+            let provider = StubProvider::new("stub", root.clone());
+            provider.add_file(f.clone());
+            let mut providers_by_name: HashMap<String, Box<dyn Provider>> = HashMap::new();
+            providers_by_name.insert("stub".to_string(), Box::new(provider));
+            let mut conn = budi_core::analytics::open_db(&db_path).unwrap();
+            seed_offsets(&mut conn, &providers_by_name).unwrap();
+
+            let routes: Routes = vec![(root.clone(), "stub".to_string())];
+            let mut pipeline = Pipeline::default_pipeline(None);
+
+            std::fs::OpenOptions::new()
+                .append(true)
+                .open(&f)
+                .unwrap()
+                .write_all(b"after-boot-1\n")
+                .unwrap();
+            process_path(&mut conn, &mut pipeline, &providers_by_name, &routes, &f);
+        }
+
+        let conn = budi_core::analytics::open_db(&db_path).unwrap();
+        let after_boot: i64 = conn
+            .query_row("SELECT COUNT(*) FROM messages", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(
+            after_boot, 1,
+            "phase 1 should ingest exactly the post-seed append, not the seeded history"
+        );
+        drop(conn);
+
+        // Append more bytes while the "daemon" is dead.
+        std::fs::OpenOptions::new()
+            .append(true)
+            .open(&f)
+            .unwrap()
+            .write_all(b"between-restarts-1\nbetween-restarts-2\n")
+            .unwrap();
+
+        // Phase 2 — restart. Brand-new provider map, brand-new pipeline,
+        // brand-new connection. seed_offsets must be a no-op for the
+        // already-known path; process_path must pick up exactly the
+        // bytes appended while we were down — no re-ingest of phase-1
+        // content, no skipped lines.
+        {
+            let provider = StubProvider::new("stub", root.clone());
+            provider.add_file(f.clone());
+            let mut providers_by_name: HashMap<String, Box<dyn Provider>> = HashMap::new();
+            providers_by_name.insert("stub".to_string(), Box::new(provider));
+            let mut conn = budi_core::analytics::open_db(&db_path).unwrap();
+            seed_offsets(&mut conn, &providers_by_name).unwrap();
+
+            let routes: Routes = vec![(root.clone(), "stub".to_string())];
+            let mut pipeline = Pipeline::default_pipeline(None);
+            process_path(&mut conn, &mut pipeline, &providers_by_name, &routes, &f);
+        }
+
+        let conn = budi_core::analytics::open_db(&db_path).unwrap();
+        let after_restart: i64 = conn
+            .query_row("SELECT COUNT(*) FROM messages", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(
+            after_restart, 3,
+            "phase 2 must ingest the two bytes-while-down lines on top of phase 1's one (got {after_restart})"
+        );
+
+        // Final invariant: the persisted offset matches file_len (we
+        // consumed every byte we are responsible for).
+        let final_offset = get_tail_offset(&conn, "stub", &f.display().to_string())
+            .unwrap()
+            .unwrap();
+        assert_eq!(final_offset, std::fs::metadata(&f).unwrap().len() as usize);
+    }
+
+    #[test]
+    fn process_path_recovers_from_truncation() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().to_path_buf();
+        let f = root.join("session.jsonl");
+        std::fs::write(&f, "line1\nline2\n").unwrap();
+
+        let provider = StubProvider::new("stub", root.clone());
+        provider.add_file(f.clone());
+        let (db_path, _) = open_test_db(tmp.path());
+        let mut conn = budi_core::analytics::open_db(&db_path).unwrap();
+        let mut providers_by_name: HashMap<String, Box<dyn Provider>> = HashMap::new();
+        providers_by_name.insert("stub".to_string(), Box::new(provider));
+        let routes: Routes = vec![(root.clone(), "stub".to_string())];
+        let mut pipeline = Pipeline::default_pipeline(None);
+
+        process_path(&mut conn, &mut pipeline, &providers_by_name, &routes, &f);
+        assert_eq!(
+            get_tail_offset(&conn, "stub", &f.display().to_string())
+                .unwrap()
+                .unwrap(),
+            std::fs::metadata(&f).unwrap().len() as usize
+        );
+
+        std::fs::write(&f, "fresh\n").unwrap();
+        process_path(&mut conn, &mut pipeline, &providers_by_name, &routes, &f);
+        let new_offset = get_tail_offset(&conn, "stub", &f.display().to_string())
+            .unwrap()
+            .unwrap();
+        assert_eq!(new_offset, std::fs::metadata(&f).unwrap().len() as usize);
+    }
+}

--- a/crates/budi-daemon/src/workers/tailer.rs
+++ b/crates/budi-daemon/src/workers/tailer.rs
@@ -217,7 +217,7 @@ fn build_routes(providers: &[Box<dyn Provider>]) -> Routes {
                 .collect::<Vec<_>>()
         })
         .collect();
-    routes.sort_by(|a, b| b.0.components().count().cmp(&a.0.components().count()));
+    routes.sort_by_key(|r| std::cmp::Reverse(r.0.components().count()));
     routes
 }
 
@@ -565,7 +565,7 @@ mod tests {
             (PathBuf::from("/tmp/a"), "general".to_string()),
         ];
         let mut sorted = routes.clone();
-        sorted.sort_by(|a, b| b.0.components().count().cmp(&a.0.components().count()));
+        sorted.sort_by_key(|r| std::cmp::Reverse(r.0.components().count()));
         assert_eq!(
             provider_for_path(Path::new("/tmp/a/b/c.jsonl"), &sorted),
             Some("specific")


### PR DESCRIPTION
## Summary

Lands the daemon-side filesystem tailer mandated by [ADR-0089](../blob/main/docs/adr/0089-reverse-proxy-first-jsonl-tailing-as-sole-live-path.md) §1, behind the `BUDI_LIVE_TAIL=1` feature flag so it can soak alongside the proxy for a release before R1.4 (`#320`) flips the default and starts skipping `proxy_events` writes. This PR introduces no new CLI surface, no env vars beyond `BUDI_LIVE_TAIL`, and no protocol code.

- New `workers::tailer` module owning a single long-lived blocking task per daemon process. `notify-debouncer-mini` (500 ms debounce) registers a recursive watcher on every directory returned by `Provider::watch_roots()` (R1.2, `#318`); a 5 s polling backstop covers the documented `notify` edge cases on macOS / WSL.
- Per-file offsets live in a new `tail_offsets (provider, path, byte_offset, last_seen)` table — intentionally distinct from the import path's `sync_state` so concurrent runs cannot collide and so `#357` cleanup can prune by provider. Table is created on fresh installs and added on existing v1 databases via `reconcile_schema` (additive, non-destructive — covered by `reconcile_adds_tail_offsets_to_existing_v1_db`).
- On startup the tailer seeds every existing transcript at `byte_offset = file_len`, leaving historical backfill the `budi import` command's responsibility. Appended bytes are read via the same `Provider::parse_file(path, content, offset)` contract `analytics/sync.rs` uses, run through `Pipeline::default_pipeline()`, and ingested via `ingest_messages_with_sync` — no second code path.
- Structured logs land at the `budi_daemon::tailer` target with `provider`, `path`, `bytes_read`, `messages_parsed`, `ingested` per ticket spec.

The module is filed under `workers/` to match `workers::cloud_sync`; the issue text says `src/tailer.rs` but the existing daemon convention puts long-lived worker tasks in `workers/`.

Closes #319.

## Risks / compatibility notes

- **Must-not list (#319) honored.** The tailer does not write to `proxy_events`, does not change the `Pipeline` signature or enricher list, and does not touch `analytics/sync.rs` `proxy_cutoff`. The dual-path dedup rule remains exactly where R1.4 / R2.1 will need to find it.
- **Default-off.** Without `BUDI_LIVE_TAIL=1` set in the environment, daemon behaviour is unchanged from `v8.1.0`. The proxy ingestion path is untouched. Users opting into the flag run both paths in parallel; cross-validation across `messages` rows is the entire point of the R1.3→R1.4 split.
- **Schema is additive.** `tail_offsets` is added by `reconcile_schema` for existing databases — no destructive migration, no `user_version` bump. The new `assert_core_schema` assertion guarantees fresh installs ship with the table.
- **No new env vars beyond `BUDI_LIVE_TAIL`** (acceptance criterion).
- Privacy envelope unchanged (ADR-0083): tailer reads the same on-disk JSONL `budi import` already reads. No file content is logged at any level — only path, provider, and byte counts.

## Validation

- `cargo fmt --all`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked` — 432 core + 38 daemon (incl. 6 new `workers::tailer` tests covering route resolution, jsonl filtering, EOF-seeding, single-event ingest, idempotency, truncation recovery, and a simulated daemon-restart that drops every in-memory handle between phases) + 69 cli unit tests, all green
- Cross-path analytics-parity diff is the deliverable for R1.4 (`#320`) under the rolling RC; this PR ships the infrastructure to make that diff possible.

## Next round

- R1.4 (`#320`) — promote tailer to default, stop writing `proxy_events`, drop `proxy_cutoff` once parity is demonstrated.
- R1.5 (`#321`) — Cursor Usage API lag measurement (gates ADR-0089 promotion to Accepted).

Made with [Cursor](https://cursor.com)