### PR TITLE
[8.2][R1.7] Promote ADR-0089 to Accepted; refresh stale 'before promotes' SOUL.md reference

### DIFF
--- a/SOUL.md
+++ b/SOUL.md
@@ -149,7 +149,7 @@ Nine tables, seven data entities + two supporting:
 | Source | Confidence | What it provides |
 |--------|-----------|-----------------|
 | **JSONL tailer** (Claude Code, Codex, Copilot CLI) | `estimated` | Per-message tokens parsed from the agent's local transcript as it grows. Same parser as `budi import`; same enricher chain. Live in 8.2+ via [ADR-0089](docs/adr/0089-reverse-proxy-first-jsonl-tailing-as-sole-live-path.md). |
-| **Cursor Usage API** | `exact` | Per-request tokens + totalCents pulled from Cursor's API. Reconciles cost/token data the JSONL doesn't carry; lag profile measured in #321 before ADR-0089 promotes from Proposed to Accepted. |
+| **Cursor Usage API** | `exact` | Per-request tokens + totalCents pulled from Cursor's API. Reconciles cost/token data the JSONL doesn't carry; lag profile was measured in #321 (p50 ≈ 70 s, p99 ≈ 6 min, N = 12) and embedded in [ADR-0089](docs/adr/0089-reverse-proxy-first-jsonl-tailing-as-sole-live-path.md) §7 — the Usage API stays a scheduled pull (not a live path) and a "Cursor cost may lag up to ~10 min" UX disclaimer follow-up is tracked in #381. |
 | **JSONL backfill** (`budi import`) | `estimated` (Claude Code / Codex / Copilot CLI) / `exact` (Cursor) | Same providers, one-shot mode for historical backfill. Used after install or after `budi import --force`. |
 | **Legacy proxy** (8.1.x only, transition window) | `proxy_estimated` | Pre-8.2 real-time per-request tokens captured by the proxy on port 9878. New writes stop in 8.2 R1.4 (#320); the proxy is deleted in R2.1 (#322). Existing `proxy_estimated` rows remain queryable. |
 

--- a/docs/adr/0089-reverse-proxy-first-jsonl-tailing-as-sole-live-path.md
+++ b/docs/adr/0089-reverse-proxy-first-jsonl-tailing-as-sole-live-path.md
@@ -1,7 +1,7 @@
 # ADR-0089: Reverse Proxy-First Architecture — JSONL Tailing as Sole Live Path
 
 - **Date**: 2026-04-17
-- **Status**: Proposed
+- **Status**: Accepted (2026-04-18 — promotion criteria below all satisfied; recorded in [#356](https://github.com/siropkin/budi/issues/356) R1.7 docs review pass)
 - **Issue**: [#317](https://github.com/siropkin/budi/issues/317)
 - **Milestone**: 8.2.0 (epic: [#316](https://github.com/siropkin/budi/issues/316))
 - **Supersedes**: [ADR-0082](./0082-proxy-compatibility-matrix-and-gateway-contract.md)
@@ -175,14 +175,14 @@ Any section that still describes the proxy as the live path is updated in the R1
 
 ## Promotion Criteria
 
-This ADR is promoted from `Proposed` to `Accepted` only when all of the following are true:
+This ADR is promoted from `Proposed` to `Accepted` only when all of the following are true. As of 2026-04-18 every entry below is satisfied and the status banner at the top of this document reads `Accepted`.
 
 - [#321](https://github.com/siropkin/budi/issues/321) Cursor Usage API lag verdict is published — **satisfied**: instrument shipped (`scripts/research/cursor_usage_api_lag.sh`), real-machine run completed, numeric verdict and §C.c recommendation posted as a [comment on #321](https://github.com/siropkin/budi/issues/321#issuecomment-4275063605), §7 above embeds those findings, and the recommendation is consistent with this ADR's §7
-- [#318](https://github.com/siropkin/budi/issues/318) `Provider::watch_roots()` is merged
-- [#319](https://github.com/siropkin/budi/issues/319) daemon tailer is merged behind `BUDI_LIVE_TAIL=1`
-- [#320](https://github.com/siropkin/budi/issues/320) tailer is promoted to default and proxy ingestion is short-circuited
+- [#318](https://github.com/siropkin/budi/issues/318) `Provider::watch_roots()` is merged — **satisfied** (PR #369)
+- [#319](https://github.com/siropkin/budi/issues/319) daemon tailer is merged behind `BUDI_LIVE_TAIL=1` — **satisfied** (PR #370)
+- [#320](https://github.com/siropkin/budi/issues/320) tailer is promoted to default and proxy ingestion is short-circuited — **satisfied** (PR #372)
 
-Until those gates close, this ADR remains `Proposed` and the 8.2 R2 proxy-removal work is explicitly blocked. That gating is intentional: removing the proxy before the tailer is trusted is the one failure mode this ADR is trying to avoid.
+The 8.2 R2 proxy-removal work is unblocked once the R1 exit gate ([#362](https://github.com/siropkin/budi/issues/362), R1.8 smoke + E2E) closes with a full PASS — proxy + tailer must demonstrate analytics parity through at least one RC before the proxy module is deleted in [#322](https://github.com/siropkin/budi/issues/322). That gating is intentional: removing the proxy before the tailer is trusted is the one failure mode this ADR is trying to avoid.
 
 ## References
 


### PR DESCRIPTION
## Summary

R1.7 (#356) docs review pass for Round 1 of the 8.2 architectural pivot.

The audit covered ADR-0089, the four amended ADRs (0081, 0082, 0088, design-principles.md, SOUL.md), the Provider trait additions from #318, and the tailer worker rustdoc from #319. The review summary is posted as a comment on `#356`. Two contract-vs-reality drifts needed an in-tree fix:

1. **`docs/adr/0089-reverse-proxy-first-jsonl-tailing-as-sole-live-path.md`**: status banner promoted from `Proposed` to `Accepted` (2026-04-18). All four entries in the ADR's own `Promotion Criteria` section are satisfied — #321 verdict landed via #380, #318 via #369, #319 via #370, #320 via #372 — and the criteria section is now annotated to record which PRs satisfied each entry. The "Until those gates close, this ADR remains `Proposed`" sentence is replaced with the accurate forward-looking constraint that R2 proxy-removal still depends on the R1.8 (`#362`) smoke + E2E exit gate.
2. **`SOUL.md`** (Cost sources table): the conditional "lag profile measured in #321 before ADR-0089 promotes from Proposed to Accepted" line is replaced with the actual numeric verdict (p50 ≈ 70 s, p99 ≈ 6 min, N = 12), the design conclusion (Usage API stays a scheduled pull, not a live path), and a forward link to the UX disclaimer follow-up tracked in `#381`.

Everything else in scope was either already consistent (ADR-0082 supersession banner, ADR-0088 §2/§5 amendment banner, ADR-0081 §Provider System amendment banner, design-principles.md §4 rewrite, Provider::watch_roots rustdoc, tailer module rustdoc) or is intentionally deferred to later rounds (README.md proxy-first install walkthrough → R2.2/R2.3/R3.1; SOUL.md "Proxy mode" key concept and `budi init` description → rewritten in R2.2/R2.3 when the underlying behaviour actually goes away).

## Risks / compatibility notes

- **No code changes.** Documentation only.
- **No new files** under `docs/research/` or `docs/releases/` — rule 12 of `#316` respected.
- **ADR status promotion is a process step, not a behaviour change.** The runtime is already on the tailer-by-default path that the Accepted status reflects (R1.4 / #320 shipped via #372).
- **Cross-references** in ADR-0089 already pointed at the ADRs they amend / supersede; no link rot introduced.
- The acknowledged gate-ordering slip from `#355` (R1.6) — the original R1.7 acceptance bullet read "Closed before #320 (R1.4) is merged" but #320 merged first — is preserved as-is in `#356` so the historical record remains accurate; this PR closes the substantive remediation by promoting the ADR now.

## Validation

Per `#316` rule 16:

- `cargo fmt --all -- --check` — clean (no diffs).
- `cargo clippy --workspace --all-targets --locked -- -D warnings` — clean.
- `cargo test --workspace --locked` — 38/38 pass; doctests 0/0 (no rustdoc examples land or fail).
- `cargo test --doc --workspace` — 0/0 (per `#356` acceptance bullet).
- Manual: confirmed no new files added under `docs/research/` or `docs/releases/` since 2026-04-17 (`git log --since=2026-04-17 --name-only` shows only 8.1.0 release docs that pre-date the 8.2 ban).
- Manual: re-rendered ADR-0089 cross-references on GitHub and verified the supersession / amendment banners on ADR-0082 / ADR-0088 / ADR-0081 still link back correctly.

Closes #356

Made with [Cursor](https://cursor.com)