### PR TITLE
[8.2][R2.2] Add regression guards for init no-mutation contract

### DIFF
--- a/SOUL.md
+++ b/SOUL.md
@@ -35,6 +35,7 @@ Shell-driven end-to-end tests live under `scripts/e2e/`. They exercise the full 
 cargo build --release                                 # once per change
 bash scripts/e2e/test_302_sessions_visibility.sh      # regression guard for #302
 bash scripts/e2e/test_303_branch_attribution.sh       # regression guard for #303
+bash scripts/e2e/test_323_init_no_proxy_mutations.sh # regression guard for #323 (no legacy proxy config writes on init)
 bash scripts/e2e/test_221_ticket_first_class.sh       # regression guard for #221 / #304 (ticket dimension)
 bash scripts/e2e/test_222_activity_classification.sh  # regression guard for #222 / #305 (activity dimension)
 bash scripts/e2e/test_224_statusline_provider_scope.sh # regression guard for #224 (statusline provider scoping)

--- a/crates/budi-cli/src/main.rs
+++ b/crates/budi-cli/src/main.rs
@@ -567,6 +567,7 @@ mod tests {
         assert!(Cli::try_parse_from(["budi", "launch", "claude"]).is_err());
         assert!(Cli::try_parse_from(["budi", "enable", "claude"]).is_err());
         assert!(Cli::try_parse_from(["budi", "disable", "cursor"]).is_err());
+        assert!(Cli::try_parse_from(["budi", "proxy-install", "claude"]).is_err());
     }
 
     #[test]

--- a/scripts/e2e/README.md
+++ b/scripts/e2e/README.md
@@ -19,6 +19,7 @@ cargo build --release
 
 # Run one test:
 bash scripts/e2e/test_302_sessions_visibility.sh
+bash scripts/e2e/test_323_init_no_proxy_mutations.sh
 
 # Keep the temp HOME around for post-mortem inspection:
 KEEP_TMP=1 bash scripts/e2e/test_302_sessions_visibility.sh

--- a/scripts/e2e/test_323_init_no_proxy_mutations.sh
+++ b/scripts/e2e/test_323_init_no_proxy_mutations.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# End-to-end regression for issue #323: verify `budi init` no longer creates
+# legacy proxy-routing mutation files (shell profile, Cursor settings.json, or
+# Codex config.toml), and remains idempotent on a second run.
+#
+# Contract pinned:
+# - #316 R2.2 (stop new writes)
+# - #323 acceptance ("fresh init touches no legacy proxy mutation files")
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BUDI="$ROOT/target/release/budi"
+
+if [[ ! -x "$BUDI" ]]; then
+  echo "error: release binary not built. run \`cargo build --release\` first." >&2
+  exit 2
+fi
+
+TMPDIR_ROOT="$(mktemp -d -t budi-e2e-323-XXXXXX)"
+export HOME="$TMPDIR_ROOT"
+export BUDI_HOME="$HOME/.local/share/budi"
+
+cleanup() {
+  local status=$?
+  if [[ "${KEEP_TMP:-0}" == "1" ]]; then
+    echo "[e2e] leaving tmp: $TMPDIR_ROOT"
+  else
+    rm -rf "$TMPDIR_ROOT"
+  fi
+  exit $status
+}
+trap cleanup EXIT INT TERM
+
+echo "[e2e] HOME=$HOME"
+
+assert_absent() {
+  local path="$1"
+  if [[ -e "$path" ]]; then
+    echo "[e2e] FAIL: expected no file at $path" >&2
+    exit 1
+  fi
+}
+
+run_init_once() {
+  "$BUDI" init \
+    --yes \
+    --integrations none \
+    --no-daemon \
+    --no-open \
+    --no-sync
+}
+
+assert_no_legacy_proxy_mutations() {
+  assert_absent "$HOME/.zshrc"
+  assert_absent "$HOME/.bashrc"
+  assert_absent "$HOME/.bash_profile"
+  assert_absent "$HOME/.config/fish/config.fish"
+  assert_absent "$HOME/.cursor/settings.json"
+  assert_absent "$HOME/.codex/config.toml"
+}
+
+echo "[e2e] first init run"
+LOG1="$TMPDIR_ROOT/init-1.log"
+run_init_once >"$LOG1" 2>&1 || {
+  cat "$LOG1" >&2 || true
+  echo "[e2e] FAIL: first init run failed" >&2
+  exit 1
+}
+assert_no_legacy_proxy_mutations
+echo "[e2e] OK: first init created no legacy proxy mutation files"
+
+echo "[e2e] second init run (idempotence)"
+LOG2="$TMPDIR_ROOT/init-2.log"
+run_init_once >"$LOG2" 2>&1 || {
+  cat "$LOG2" >&2 || true
+  echo "[e2e] FAIL: second init run failed" >&2
+  exit 1
+}
+assert_no_legacy_proxy_mutations
+echo "[e2e] OK: second init remains free of legacy proxy mutation files"
+
+echo "[e2e] PASS"


### PR DESCRIPTION
## Summary

- adds `scripts/e2e/test_323_init_no_proxy_mutations.sh` to pin the R2.2 contract that `budi init` does not create legacy proxy mutation files (`~/.zshrc`, `~/.bashrc`, `~/.bash_profile`, `~/.config/fish/config.fish`, `~/.cursor/settings.json`, `~/.codex/config.toml`)
- verifies idempotence by running `budi init` twice in an isolated HOME and asserting those legacy files remain absent on both runs
- extends CLI regression coverage to reject the removed `proxy-install` command surface alongside existing `launch` / `enable` / `disable` checks
- documents the new E2E regression entry in `scripts/e2e/README.md` and `SOUL.md`

This PR stays scoped to R2.2 “stop new writes.” Cleanup of pre-existing 8.0/8.1 mutations remains tracked by `#357`.

## Risks / compatibility notes

- no runtime behavior change for transcript ingestion, analytics, daemon startup, or migrations
- no new env vars or new on-disk mutation surfaces
- this change adds test/guardrail coverage so legacy proxy config writes cannot silently re-enter
- repo reality note: R2.1 (`#322`) already removed `proxy_install.rs`; this PR therefore focuses on behavior verification and command-surface guardrails

## Validation

- `cargo fmt --all`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `bash scripts/e2e/test_323_init_no_proxy_mutations.sh`

Closes #323
