### PR TITLE
[8.2][R2.4] Rewrite budi doctor around the tailer contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,6 +182,7 @@ dependencies = [
  "chrono",
  "clap",
  "reqwest",
+ "rusqlite",
  "serde",
  "serde_json",
  "sha2",

--- a/crates/budi-cli/Cargo.toml
+++ b/crates/budi-cli/Cargo.toml
@@ -12,6 +12,7 @@ budi-core = { path = "../budi-core" }
 chrono.workspace = true
 clap.workspace = true
 reqwest.workspace = true
+rusqlite.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true

--- a/crates/budi-cli/src/client.rs
+++ b/crates/budi-cli/src/client.rs
@@ -306,16 +306,6 @@ impl DaemonClient {
         Ok(resp.json()?)
     }
 
-    pub fn schema_version(&self) -> Result<Value> {
-        let resp = self
-            .client
-            .get(format!("{}/admin/schema", self.base_url))
-            .send()
-            .map_err(describe_send_error)?;
-        let resp = check_response(resp)?;
-        Ok(resp.json()?)
-    }
-
     /// `POST /cloud/sync` — trigger an immediate cloud flush.
     ///
     /// The daemon runs the same code path as the background worker

--- a/crates/budi-cli/src/commands/doctor.rs
+++ b/crates/budi-cli/src/commands/doctor.rs
@@ -1,539 +1,364 @@
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use budi_core::config;
+use budi_core::provider::Provider;
+use chrono::{DateTime, Local, Utc};
+use rusqlite::{Connection, OptionalExtension, params};
 
 use crate::daemon::{daemon_health, ensure_daemon_running, resolve_daemon_binary};
 
 pub fn cmd_doctor(repo_root: Option<PathBuf>, deep: bool) -> Result<()> {
     let repo_root = super::try_resolve_repo_root(repo_root);
-
     let config = match &repo_root {
         Some(root) => config::load_or_default(root)?,
         None => config::BudiConfig::default(),
     };
-    let mut issues: Vec<String> = Vec::new();
-    // Track whether the local database shows any assistant activity yet so we
-    // can add a friendly first-run hint when everything is healthy but the
-    // user hasn't sent their first prompt. A single positive signal from any
-    // attribution check flips this off.
-    let mut has_any_assistant_activity = false;
 
-    let green = super::ansi("\x1b[32m");
-    let red = super::ansi("\x1b[31m");
     let dim = super::ansi("\x1b[90m");
     let reset = super::ansi("\x1b[0m");
 
     if let Some(ref root) = repo_root {
-        println!("budi doctor — {}", root.display());
+        println!("budi doctor - {}", root.display());
     } else {
-        println!("budi doctor — global mode");
+        println!("budi doctor - global mode");
     }
     println!();
 
-    if let Some(ref root) = repo_root {
-        let has_git = root.join(".git").exists();
-        doctor_check("git repo", has_git, None);
-        if !has_git {
-            issues.push("Not a git repository.".into());
-        }
+    let mut report = DoctorReport::default();
 
-        let paths = config::repo_paths(root)?;
-        let has_config = paths.config_file.exists();
-        if has_config {
-            doctor_check("config", true, Some(&paths.config_file));
-        } else {
-            println!("  {green}\u{2713}{reset} config: using defaults");
-        }
-    } else {
-        println!("  {dim}-{reset} git repo: not in a git repository (global mode)");
-        println!("  {green}\u{2713}{reset} config: using defaults");
+    let daemon = check_daemon_health(repo_root.as_deref(), &config);
+    daemon.result.print();
+    report.record(&daemon.result);
+
+    if daemon.started_this_run {
+        // The daemon seeds tail offsets on startup before the backstop loop
+        // begins. A short pause keeps `doctor` from racing that initial
+        // bookkeeping on a cold start.
+        std::thread::sleep(Duration::from_millis(750));
     }
 
-    // Check daemon binary resolution using the same strategy as runtime startup.
-    let cli_version = env!("CARGO_PKG_VERSION");
+    let db_path = budi_core::analytics::db_path()?;
+    let schema = check_schema(&db_path, deep);
+    schema.result.print();
+    report.record(&schema.result);
+
+    let proxy_residue = check_legacy_proxy_env();
+    proxy_residue.print();
+    report.record(&proxy_residue);
+
+    let providers = doctor_providers();
+    if providers.is_empty() {
+        let no_providers = CheckResult::warn(
+            "tailer providers",
+            "no enabled transcript providers are visible on disk yet",
+            Some(
+                "Open your agent once so it creates its local transcript directory, then rerun `budi doctor`."
+                    .to_string(),
+            ),
+        );
+        no_providers.print();
+        report.record(&no_providers);
+    } else {
+        let conn = schema.conn.as_ref();
+        for provider in &providers {
+            let diag = gather_provider_doctor_data(conn, provider.as_ref());
+
+            let tailer = summarize_tailer_health(&diag);
+            tailer.print();
+            report.record(&tailer);
+
+            let visibility = summarize_transcript_visibility(&diag);
+            visibility.print();
+            report.record(&visibility);
+        }
+    }
+
+    println!();
+    if report.fails == 0 && report.warns == 0 {
+        println!("All checks passed.");
+        return Ok(());
+    }
+
+    if report.fails == 0 {
+        println!("Doctor finished with {} warning(s).", report.warns);
+        println!(
+            "  {dim}Warnings are informational cleanup or readiness hints; Budi should still be able to collect live data where the PASS checks say it can.{reset}"
+        );
+        return Ok(());
+    }
+
+    anyhow::bail!(
+        "doctor found {} failing check(s) and {} warning(s)",
+        report.fail_count(),
+        report.warn_count()
+    );
+}
+
+#[derive(Debug, Default)]
+struct DoctorReport {
+    warns: usize,
+    fails: usize,
+}
+
+impl DoctorReport {
+    fn record(&mut self, result: &CheckResult) {
+        match result.state {
+            CheckState::Pass => {}
+            CheckState::Warn => self.warns += 1,
+            CheckState::Fail => self.fails += 1,
+        }
+    }
+
+    fn warn_count(&self) -> usize {
+        self.warns
+    }
+
+    fn fail_count(&self) -> usize {
+        self.fails
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CheckState {
+    Pass,
+    Warn,
+    Fail,
+}
+
+impl CheckState {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Pass => "PASS",
+            Self::Warn => "WARN",
+            Self::Fail => "FAIL",
+        }
+    }
+
+    fn color(self) -> &'static str {
+        match self {
+            Self::Pass => "\x1b[32m",
+            Self::Warn => "\x1b[33m",
+            Self::Fail => "\x1b[31m",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct CheckResult {
+    state: CheckState,
+    label: String,
+    detail: String,
+    fix: Option<String>,
+}
+
+impl CheckResult {
+    fn pass(label: impl Into<String>, detail: impl Into<String>) -> Self {
+        Self {
+            state: CheckState::Pass,
+            label: label.into(),
+            detail: detail.into(),
+            fix: None,
+        }
+    }
+
+    fn warn(label: impl Into<String>, detail: impl Into<String>, fix: Option<String>) -> Self {
+        Self {
+            state: CheckState::Warn,
+            label: label.into(),
+            detail: detail.into(),
+            fix,
+        }
+    }
+
+    fn fail(label: impl Into<String>, detail: impl Into<String>, fix: Option<String>) -> Self {
+        Self {
+            state: CheckState::Fail,
+            label: label.into(),
+            detail: detail.into(),
+            fix,
+        }
+    }
+
+    fn print(&self) {
+        let color = super::ansi(self.state.color());
+        let reset = super::ansi("\x1b[0m");
+        println!(
+            "  {color}{}{reset} {}: {}",
+            self.state.label(),
+            self.label,
+            self.detail
+        );
+        if let Some(ref fix) = self.fix {
+            println!("       fix: {fix}");
+        }
+    }
+}
+
+struct DaemonCheck {
+    result: CheckResult,
+    started_this_run: bool,
+}
+
+fn check_daemon_health(repo_root: Option<&Path>, config: &config::BudiConfig) -> DaemonCheck {
+    let base_url = config.daemon_base_url();
+    let daemon_bin_override = std::env::var_os("BUDI_DAEMON_BIN");
+    if daemon_health(config) {
+        return DaemonCheck {
+            result: CheckResult::pass("daemon health", format!("responding on {base_url}")),
+            started_this_run: false,
+        };
+    }
+
     let daemon_bin = match resolve_daemon_binary() {
         Ok(path) => path,
         Err(e) => {
-            issues.push(format!("Could not resolve daemon binary: {e}"));
-            PathBuf::from("budi-daemon")
+            return DaemonCheck {
+                result: CheckResult::fail(
+                    "daemon health",
+                    format!("daemon is not responding on {base_url} and the daemon binary could not be resolved ({e})"),
+                    Some(
+                        "Install `budi` and `budi-daemon` from the same build, or set `BUDI_DAEMON_BIN` to the daemon binary path."
+                            .to_string(),
+                    ),
+                ),
+                started_this_run: false,
+            };
         }
     };
-    let daemon_output = std::process::Command::new(&daemon_bin)
-        .arg("--version")
-        .output()
-        .ok()
-        .filter(|o| o.status.success());
-    let daemon_bin_found = daemon_output.is_some();
-    doctor_check("budi-daemon binary", daemon_bin_found, Some(&daemon_bin));
-    if !daemon_bin_found {
-        issues.push(format!(
-            "budi-daemon binary was not executable at '{}' — copy it alongside budi, set BUDI_DAEMON_BIN, or add it to PATH",
-            daemon_bin.display()
-        ));
-    }
 
-    let daemon_version = daemon_output.map(|o| {
-        let raw = String::from_utf8_lossy(&o.stdout);
-        let trimmed = raw.trim();
-        trimmed
-            .strip_prefix("budi-daemon ")
-            .unwrap_or(trimmed)
-            .to_string()
-    });
-    match daemon_version {
-        Some(ref dv) if dv == cli_version => {
-            println!(
-                "  {green}\u{2713}{reset} version: v{cli_version} (CLI and daemon match; checked via {})",
-                daemon_bin.display()
-            );
-        }
-        Some(ref dv) => {
-            let yellow = super::ansi("\x1b[33m");
-            println!(
-                "  {yellow}!{reset} version: CLI v{cli_version} != daemon v{dv} (checked via {})",
-                daemon_bin.display()
-            );
-            issues.push(format!(
-                "Version mismatch: CLI v{cli_version} but daemon v{dv}. Run `budi update` or reinstall."
-            ));
-        }
-        None if daemon_bin_found => {
-            println!(
-                "  {dim}-{reset} version: v{cli_version} (could not read daemon version via {})",
-                daemon_bin.display()
-            );
-        }
-        None => {} // Already reported as missing binary
-    }
-
-    let health = daemon_health(&config);
-    doctor_check("daemon", health, None);
-    if !health {
-        println!("  Attempting daemon start...");
-        match ensure_daemon_running(repo_root.as_deref(), &config) {
-            Ok(()) => {
-                let retry = daemon_health(&config);
-                doctor_check("daemon (retry)", retry, None);
-                if !retry {
-                    issues.push(
-                        "Daemon failed to start. Check logs with `RUST_LOG=debug budi doctor`."
-                            .to_string(),
-                    );
-                }
-            }
-            Err(e) => {
-                doctor_check("daemon start", false, None);
-                println!("    {e}");
-                issues.push(format!("Daemon start error: {e}"));
-            }
-        }
-    }
-
-    // Database file existence, readability, and integrity check
-    if let Ok(db_path) = budi_core::analytics::db_path() {
-        if db_path.exists() {
-            match std::fs::File::open(&db_path) {
-                Ok(_) => {
-                    println!(
-                        "  {green}\u{2713}{reset} database file: readable at {}",
-                        db_path.display()
-                    );
-                    // Integrity check: verify DB is not corrupted
-                    match budi_core::analytics::open_db(&db_path) {
-                        Ok(conn) => {
-                            let pragma = integrity_check_pragma(deep);
-                            let mode = integrity_check_mode_label(deep);
-                            match conn.query_row(pragma, [], |row| row.get::<_, String>(0)) {
-                                Ok(ref result) if result == "ok" => {
-                                    println!(
-                                        "  {green}\u{2713}{reset} database integrity ({mode}): ok"
-                                    );
-                                }
-                                Ok(result) => {
-                                    println!(
-                                        "  {red}\u{2717}{reset} database integrity ({mode}): {result}"
-                                    );
-                                    issues
-                                        .push(format!("Database integrity check failed: {result}"));
-                                }
-                                Err(e) => {
-                                    println!(
-                                        "  {red}\u{2717}{reset} database integrity ({mode}): could not check ({e})"
-                                    );
-                                    issues.push(format!("Database integrity check error: {e}"));
-                                }
-                            }
-                        }
-                        Err(e) => {
-                            println!(
-                                "  {red}\u{2717}{reset} database open: failed ({e}). Try `budi migrate`"
-                            );
-                            issues.push(format!("Database cannot be opened: {e}"));
-                        }
+    match ensure_daemon_running(repo_root, config) {
+        Ok(()) if daemon_health(config) => DaemonCheck {
+            result: CheckResult::pass(
+                "daemon health",
+                format!(
+                    "started successfully and is responding on {base_url} (binary: {})",
+                    daemon_bin.display()
+                ),
+            ),
+            started_this_run: true,
+        },
+        Ok(()) => DaemonCheck {
+            result: CheckResult::fail(
+                "daemon health",
+                format!(
+                    "attempted to start {base_url} via {}, but the daemon still did not answer",
+                    daemon_bin.display()
+                ),
+                Some(
+                    "Inspect the daemon log under `~/.local/share/budi/logs/daemon.log`, then rerun `budi init`."
+                        .to_string(),
+                ),
+            ),
+            started_this_run: true,
+        },
+        Err(e) => DaemonCheck {
+            result: CheckResult::fail(
+                "daemon health",
+                format!(
+                    "daemon is not responding on {base_url}; restart via {}{} failed ({e})",
+                    daemon_bin.display(),
+                    if daemon_bin_override.is_some() {
+                        " (from BUDI_DAEMON_BIN)"
+                    } else {
+                        ""
                     }
-                }
-                Err(e) => {
-                    println!(
-                        "  {red}\u{2717}{reset} database file: not readable at {} ({e})",
-                        db_path.display()
-                    );
-                    issues.push(format!("Database file is not readable: {e}"));
-                }
-            }
-        } else {
-            println!(
-                "  {dim}-{reset} database file: not yet created at {}",
-                db_path.display()
-            );
-        }
+                ),
+                Some(
+                    "Inspect the daemon log under `~/.local/share/budi/logs/daemon.log`, fix the startup error, then rerun `budi init`."
+                        .to_string(),
+                ),
+            ),
+            started_this_run: false,
+        },
     }
-
-    // Disk space check (warn if < 100MB available)
-    {
-        let check_path = budi_core::analytics::db_path()
-            .ok()
-            .and_then(|p| p.parent().map(|p| p.to_path_buf()))
-            .or_else(|| budi_core::config::budi_home_dir().ok());
-        if let Some(ref dir) = check_path {
-            match check_available_disk_mb(dir) {
-                Some(mb) if mb < 100 => {
-                    let yellow = super::ansi("\x1b[33m");
-                    println!("  {yellow}!{reset} disk space: {mb} MB available (< 100 MB)");
-                    issues.push(format!("Low disk space: only {mb} MB available"));
-                }
-                Some(mb) => {
-                    println!("  {green}\u{2713}{reset} disk space: {mb} MB available");
-                }
-                None => {
-                    println!("  {dim}-{reset} disk space: could not determine");
-                }
-            }
-        }
-    }
-
-    // Database schema check (via daemon if healthy, otherwise check file existence)
-    if daemon_health(&config) {
-        if let Ok(client) = crate::client::DaemonClient::connect()
-            && let Ok(sv) = client.schema_version()
-        {
-            let exists = sv.get("exists").and_then(|v| v.as_bool()).unwrap_or(false);
-            let current = sv.get("current").and_then(|v| v.as_u64()).unwrap_or(0);
-            let target = sv.get("target").and_then(|v| v.as_u64()).unwrap_or(0);
-            if !exists {
-                println!("  {red}\u{2717}{reset} database: not created yet");
-                issues.push("No database. Run `budi import` to create it.".into());
-            } else if current == target {
-                println!("  {green}\u{2713}{reset} database schema: v{}", current);
-            } else {
-                println!(
-                    "  {red}\u{2717}{reset} database schema: v{} (needs v{})",
-                    current, target
-                );
-                issues.push(format!(
-                    "Database needs migration (v{} → v{}). Run `budi init` or `budi update`.",
-                    current, target
-                ));
-            }
-        }
-    } else {
-        // Daemon is down — check if the database file at least exists
-        if let Ok(db_path) = budi_core::analytics::db_path() {
-            if db_path.exists() {
-                println!(
-                    "  {dim}-{reset} database: file exists at {} (daemon down, cannot check schema)",
-                    db_path.display()
-                );
-            } else {
-                println!(
-                    "  {red}\u{2717}{reset} database: not found at {}",
-                    db_path.display()
-                );
-                issues.push("Database not found. Run `budi import` to create it.".into());
-            }
-        }
-    }
-
-    // Per-agent enablement status
-    {
-        let agents = budi_core::config::load_agents_config();
-        match agents {
-            Some(ref cfg) => {
-                let enabled: Vec<&str> = [
-                    cfg.claude_code.enabled.then_some("Claude Code"),
-                    cfg.codex_cli.enabled.then_some("Codex CLI"),
-                    cfg.cursor.enabled.then_some("Cursor"),
-                    cfg.copilot_cli.enabled.then_some("Copilot CLI"),
-                ]
-                .into_iter()
-                .flatten()
-                .collect();
-                let disabled: Vec<&str> = [
-                    (!cfg.claude_code.enabled).then_some("Claude Code"),
-                    (!cfg.codex_cli.enabled).then_some("Codex CLI"),
-                    (!cfg.cursor.enabled).then_some("Cursor"),
-                    (!cfg.copilot_cli.enabled).then_some("Copilot CLI"),
-                ]
-                .into_iter()
-                .flatten()
-                .collect();
-                if !enabled.is_empty() {
-                    println!(
-                        "  {green}\u{2713}{reset} agents enabled: {}",
-                        enabled.join(", ")
-                    );
-                }
-                if !disabled.is_empty() {
-                    println!(
-                        "  {dim}-{reset} agents disabled: {} {dim}(data not collected){reset}",
-                        disabled.join(", ")
-                    );
-                }
-            }
-            None => {
-                println!(
-                    "  {dim}-{reset} agents: no agents.toml found — all available agents enabled (legacy mode)"
-                );
-            }
-        }
-    }
-
-    // Session visibility: catch a recurrence of R1.0.1 (#302) where assistant
-    // rows exist for a window but `budi sessions` returns empty because the
-    // session_id was dropped on write. Mismatch is a hard error for the
-    // developer-first story, so we add it to `issues`.
-    if let Ok(db_path) = budi_core::analytics::db_path()
-        && db_path.exists()
-        && let Ok(conn) = budi_core::analytics::open_db(&db_path)
-    {
-        match budi_core::analytics::session_visibility(&conn) {
-            Ok(windows) => {
-                let yellow = super::ansi("\x1b[33m");
-                let mut any_mismatch = false;
-                if windows.iter().any(|w| w.assistant_messages > 0) {
-                    has_any_assistant_activity = true;
-                }
-                for window in &windows {
-                    let mark = if window.has_mismatch() {
-                        any_mismatch = true;
-                        format!("{red}\u{2717}{reset}")
-                    } else if window.assistant_messages == 0 {
-                        format!("{dim}-{reset}")
-                    } else if window.assistant_messages_with_session < window.assistant_messages {
-                        format!("{yellow}!{reset}")
-                    } else {
-                        format!("{green}\u{2713}{reset}")
-                    };
-                    println!(
-                        "  {mark} sessions visibility ({}): assistant={} with_session={} distinct={} returned={}",
-                        window.label,
-                        window.assistant_messages,
-                        window.assistant_messages_with_session,
-                        window.distinct_sessions,
-                        window.returned_sessions,
-                    );
-                }
-                if any_mismatch {
-                    issues.push(
-                        "Sessions visibility mismatch: assistant messages exist in a window but `budi sessions` returns none. See #302.".into(),
-                    );
-                }
-            }
-            Err(e) => {
-                println!("  {dim}-{reset} sessions visibility: could not compute ({e})");
-            }
-        }
-    }
-
-    // Branch attribution: catch a recurrence of R1.0.2 (#303) where live
-    // proxy traffic lands in the database without `git_branch`, collapsing
-    // `budi stats --branches` into `(untagged)`. A single provider with a
-    // significant missing-branch ratio points at a broken attribution path
-    // for that provider even if totals are healthy overall.
-    if let Ok(db_path) = budi_core::analytics::db_path()
-        && db_path.exists()
-        && let Ok(conn) = budi_core::analytics::open_db(&db_path)
-    {
-        match budi_core::analytics::branch_attribution_stats(&conn) {
-            Ok(stats) if stats.is_empty() => {
-                println!("  {dim}-{reset} branch attribution (7d): no assistant activity yet");
-            }
-            Ok(stats) => {
-                let yellow = super::ansi("\x1b[33m");
-                let mut any_red = false;
-                for row in &stats {
-                    let pct = row.missing_branch_ratio() * 100.0;
-                    let mark = if pct > 50.0 {
-                        any_red = true;
-                        format!("{red}\u{2717}{reset}")
-                    } else if pct > 10.0 {
-                        format!("{yellow}!{reset}")
-                    } else {
-                        format!("{green}\u{2713}{reset}")
-                    };
-                    println!(
-                        "  {mark} branch attribution ({}, 7d): assistant={} missing_branch={} ({:.0}%) missing_repo={} missing_cwd={}",
-                        row.provider,
-                        row.total_assistant,
-                        row.missing_branch,
-                        pct,
-                        row.missing_repo,
-                        row.missing_cwd,
-                    );
-                }
-                if any_red {
-                    issues.push(
-                        "Branch attribution is broken for at least one provider (>50% of assistant rows have no git_branch). `budi stats --branches` will show `(untagged)`. See #303.".into(),
-                    );
-                }
-            }
-            Err(e) => {
-                println!("  {dim}-{reset} branch attribution: could not compute ({e})");
-            }
-        }
-    }
-
-    // Activity attribution: surface a recurrence of a silent classifier
-    // regression (#305 ships `activity` as a first-class dimension; if the
-    // classifier breaks, `budi stats --activities` collapses into
-    // `(untagged)` without anything else catching it). 100% missing for
-    // a provider with traffic is almost always a bug; a mid-range ratio
-    // is expected because short prompts and slash commands never carry
-    // an `activity` tag by design.
-    if let Ok(db_path) = budi_core::analytics::db_path()
-        && db_path.exists()
-        && let Ok(conn) = budi_core::analytics::open_db(&db_path)
-    {
-        match budi_core::analytics::activity_attribution_stats(&conn) {
-            Ok(stats) if stats.is_empty() => {
-                println!("  {dim}-{reset} activity attribution (7d): no assistant activity yet");
-            }
-            Ok(stats) => {
-                let yellow = super::ansi("\x1b[33m");
-                let mut any_red = false;
-                for row in &stats {
-                    let pct = row.missing_activity_ratio() * 100.0;
-                    // Only flag fully-silent providers with non-trivial
-                    // traffic — enough volume to rule out "everybody
-                    // typed a one-word prompt" coincidence.
-                    let fully_silent = pct >= 99.9 && row.total_assistant >= 5;
-                    let mark = if fully_silent {
-                        any_red = true;
-                        format!("{red}\u{2717}{reset}")
-                    } else if pct > 90.0 {
-                        format!("{yellow}!{reset}")
-                    } else {
-                        format!("{green}\u{2713}{reset}")
-                    };
-                    println!(
-                        "  {mark} activity attribution ({}, 7d): assistant={} missing_activity={} ({:.0}%)",
-                        row.provider, row.total_assistant, row.missing_activity, pct,
-                    );
-                }
-                if any_red {
-                    issues.push(
-                        "Activity classification is silent for at least one provider (100% of recent assistant rows have no `activity` tag). `budi stats --activities` will show only `(untagged)`. See #305.".into(),
-                    );
-                }
-            }
-            Err(e) => {
-                println!("  {dim}-{reset} activity attribution: could not compute ({e})");
-            }
-        }
-    }
-
-    // Cursor extension onboarding funnel (siropkin/budi#314).
-    //
-    // The Cursor extension writes local-only counters to
-    // `~/.local/share/budi/cursor-onboarding.json` when it is used as
-    // an onboarding entry point (the user discovered budi via the
-    // marketplace and clicked through the welcome view). Surfacing a
-    // one-line summary here gives us visibility into the acquisition
-    // funnel without any remote telemetry — if a new user got the
-    // welcome view but never landed a hand-off, we can see it on their
-    // machine when they run `budi doctor`.
-    {
-        match read_cursor_onboarding_counters() {
-            Some(counters) => {
-                let impressions = counters.welcome_view_impressions;
-                let terminal_clicks = counters.open_terminal_clicks;
-                let handoffs = counters.handoffs_completed;
-                let mark = if handoffs > 0 {
-                    format!("{green}\u{2713}{reset}")
-                } else if impressions > 0 {
-                    let yellow = super::ansi("\x1b[33m");
-                    format!("{yellow}!{reset}")
-                } else {
-                    format!("{dim}-{reset}")
-                };
-                println!(
-                    "  {mark} cursor extension onboarding: {impressions} welcome view(s), {terminal_clicks} open-terminal click(s), {handoffs} hand-off(s)"
-                );
-            }
-            None => {
-                // No counter file yet — treat as "no extension-first onboarding seen".
-                println!(
-                    "  {dim}-{reset} cursor extension onboarding: no local counters yet {dim}(not opened via extension-first flow){reset}"
-                );
-            }
-        }
-    }
-
-    println!("  {dim}-{reset} proxy: removed in 8.2 (tailer is the live path)");
-
-    // Autostart service check
-    {
-        let mechanism = budi_core::autostart::service_mechanism();
-        let status = budi_core::autostart::service_status();
-        match status {
-            budi_core::autostart::ServiceStatus::Running => {
-                println!("  {green}\u{2713}{reset} autostart: {status} ({mechanism})");
-            }
-            budi_core::autostart::ServiceStatus::Installed => {
-                let yellow = super::ansi("\x1b[33m");
-                println!("  {yellow}!{reset} autostart: {status} ({mechanism})");
-            }
-            budi_core::autostart::ServiceStatus::NotInstalled => {
-                println!("  {red}\u{2717}{reset} autostart: {status} ({mechanism})");
-                issues.push(
-                    "Autostart service not installed. Run `budi autostart install` to install it."
-                        .into(),
-                );
-            }
-        }
-    }
-
-    println!();
-    if issues.is_empty() {
-        println!("All checks passed.");
-        if !has_any_assistant_activity {
-            println!();
-            println!(
-                "  {dim}No assistant activity yet. Open your agent (`claude`, `codex`, `cursor`, `gh copilot`) and send a prompt — then re-run `budi doctor` to see attribution health.{reset}"
-            );
-        }
-    } else {
-        println!("Issues found:");
-        for issue in &issues {
-            println!("  - {issue}");
-        }
-        anyhow::bail!("{} issue(s) found", issues.len());
-    }
-    Ok(())
 }
 
-fn doctor_check(label: &str, ok: bool, path: Option<&Path>) {
-    let (mark, color) = if ok {
-        ("\u{2713}", "\x1b[32m")
-    } else {
-        ("\u{2717}", "\x1b[31m")
+struct SchemaCheck {
+    result: CheckResult,
+    conn: Option<Connection>,
+}
+
+fn check_schema(db_path: &Path, deep: bool) -> SchemaCheck {
+    if !db_path.exists() {
+        return SchemaCheck {
+            result: CheckResult::warn(
+                "schema drift",
+                format!(
+                    "analytics database does not exist yet at {}",
+                    db_path.display()
+                ),
+                Some(
+                    "Run `budi init` to create the schema before expecting live ingestion."
+                        .to_string(),
+                ),
+            ),
+            conn: None,
+        };
+    }
+
+    let conn = match budi_core::analytics::open_db(db_path) {
+        Ok(conn) => conn,
+        Err(e) => {
+            return SchemaCheck {
+                result: CheckResult::fail(
+                    "schema drift",
+                    format!(
+                        "analytics database exists at {} but could not be opened ({e})",
+                        db_path.display()
+                    ),
+                    Some(
+                        "Repair or remove the broken database, then rerun `budi init`.".to_string(),
+                    ),
+                ),
+                conn: None,
+            };
+        }
     };
-    let c = super::ansi(color);
-    let reset = super::ansi("\x1b[0m");
-    if let Some(p) = path {
-        println!("  {c}{mark}{reset} {label}: {}", p.display());
-    } else {
-        println!("  {c}{mark}{reset} {label}");
+
+    let current = budi_core::migration::current_version(&conn);
+    let target = budi_core::migration::SCHEMA_VERSION;
+    if current != target {
+        return SchemaCheck {
+            result: CheckResult::fail(
+                "schema drift",
+                format!("database schema is v{current}; this build expects v{target}"),
+                Some("Run `budi init` or `budi update` so the current binary can migrate the database.".to_string()),
+            ),
+            conn: Some(conn),
+        };
+    }
+
+    let pragma = integrity_check_pragma(deep);
+    let mode = integrity_check_mode_label(deep);
+    match conn.query_row(pragma, [], |row| row.get::<_, String>(0)) {
+        Ok(result) if result == "ok" => SchemaCheck {
+            result: CheckResult::pass(
+                "schema drift",
+                format!("schema v{target} at {} ({mode} ok)", db_path.display()),
+            ),
+            conn: Some(conn),
+        },
+        Ok(result) => SchemaCheck {
+            result: CheckResult::fail(
+                "schema drift",
+                format!("{mode} returned `{result}`"),
+                Some(
+                    "Run `budi repair` after backing up the database, then rerun `budi doctor`."
+                        .to_string(),
+                ),
+            ),
+            conn: Some(conn),
+        },
+        Err(e) => SchemaCheck {
+            result: CheckResult::fail(
+                "schema drift",
+                format!("could not run {mode} on {} ({e})", db_path.display()),
+                Some("Run `budi repair` or recreate the database with `budi init`.".to_string()),
+            ),
+            conn: Some(conn),
+        },
     }
 }
 
@@ -553,84 +378,411 @@ fn integrity_check_mode_label(deep: bool) -> &'static str {
     }
 }
 
-/// v1 contract for `~/.local/share/budi/cursor-onboarding.json`. This is
-/// the local-only onboarding counter file written by the Cursor
-/// extension (siropkin/budi-cursor, siropkin/budi#314). Only
-/// integer counts are surfaced here — no prompts, no code, no paths
-/// beyond the file's own path — so `budi doctor` can report the
-/// extension-first acquisition funnel without any remote telemetry.
-#[derive(Debug, Default, Clone)]
-struct CursorOnboardingCounters {
-    welcome_view_impressions: u64,
-    open_terminal_clicks: u64,
-    handoffs_completed: u64,
-}
+fn check_legacy_proxy_env() -> CheckResult {
+    let residue = legacy_proxy_env_vars();
+    if residue.is_empty() {
+        return CheckResult::pass(
+            "leftover proxy config",
+            "no legacy proxy-routing env vars are exported",
+        );
+    }
 
-fn cursor_onboarding_counters_path() -> Option<PathBuf> {
-    // Mirrors `onboardingCounters.ts` in siropkin/budi-cursor, which
-    // resolves relative to `os.homedir()`. `HOME` is consistent on
-    // the platforms budi ships on today (macOS / Linux). On Windows
-    // the extension writes to the same path under the user profile
-    // because `os.homedir()` already maps to `%USERPROFILE%`.
-    let home = std::env::var_os("HOME")
-        .or_else(|| std::env::var_os("USERPROFILE"))
-        .map(PathBuf::from)?;
-    Some(
-        home.join(".local")
-            .join("share")
-            .join("budi")
-            .join("cursor-onboarding.json"),
+    let rendered = residue
+        .iter()
+        .map(|(key, value)| format!("{key}={value}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    CheckResult::warn(
+        "leftover proxy config",
+        format!("legacy proxy env vars are still exported ({rendered})"),
+        Some(
+            "Run `budi init --cleanup` to review and remove old 8.0/8.1 proxy residue with explicit consent."
+                .to_string(),
+        ),
     )
 }
 
-fn read_cursor_onboarding_counters() -> Option<CursorOnboardingCounters> {
-    let path = cursor_onboarding_counters_path()?;
-    let bytes = std::fs::read(&path).ok()?;
-    parse_cursor_onboarding_counters(&bytes)
-}
-
-fn parse_cursor_onboarding_counters(bytes: &[u8]) -> Option<CursorOnboardingCounters> {
-    let value: serde_json::Value = serde_json::from_slice(bytes).ok()?;
-    let obj = value.as_object()?;
-    // Only version 1 is defined today; an unknown version still
-    // parses so `budi doctor` keeps working during a forward-compat
-    // upgrade, but we guard against reading garbage.
-    let version = obj.get("version").and_then(|v| v.as_u64()).unwrap_or(1);
-    if version == 0 {
-        return None;
-    }
-    let pick = |key: &str| -> u64 { obj.get(key).and_then(|v| v.as_u64()).unwrap_or(0) };
-    Some(CursorOnboardingCounters {
-        welcome_view_impressions: pick("welcome_view_impressions"),
-        open_terminal_clicks: pick("open_terminal_clicks"),
-        handoffs_completed: pick("handoffs_completed"),
+fn legacy_proxy_env_vars() -> Vec<(String, String)> {
+    [
+        "ANTHROPIC_BASE_URL",
+        "OPENAI_BASE_URL",
+        "COPILOT_PROVIDER_BASE_URL",
+    ]
+    .into_iter()
+    .filter_map(|key| {
+        let value = std::env::var(key).ok()?;
+        looks_like_legacy_proxy_value(&value).then_some((key.to_string(), value))
     })
+    .collect()
 }
 
-/// Check available disk space in MB. Uses `df -k` on Unix, skips on Windows.
-fn check_available_disk_mb(path: &Path) -> Option<u64> {
-    if cfg!(target_os = "windows") {
-        // df is not available on Windows; skip disk space check.
-        return None;
+fn looks_like_legacy_proxy_value(value: &str) -> bool {
+    let lower = value.trim().to_ascii_lowercase();
+    if lower.is_empty() {
+        return false;
     }
-    let output = std::process::Command::new("df")
-        .arg("-k")
-        .arg(path)
-        .output()
-        .ok()?;
-    if !output.status.success() {
-        return None;
+    lower.contains("localhost:9878")
+        || lower.contains("127.0.0.1:9878")
+        || lower.contains("[::1]:9878")
+}
+
+fn doctor_providers() -> Vec<Box<dyn Provider>> {
+    match budi_core::config::load_agents_config() {
+        Some(cfg) => budi_core::provider::all_providers()
+            .into_iter()
+            .filter(|provider| cfg.is_agent_enabled(provider.name()))
+            .collect(),
+        None => budi_core::provider::available_providers(),
     }
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    // df -k output: second line, fourth column is available KB
-    let line = stdout.lines().nth(1)?;
-    let available_kb: u64 = line.split_whitespace().nth(3)?.parse().ok()?;
-    Some(available_kb / 1024)
+}
+
+#[derive(Debug, Clone)]
+struct ProviderDoctorData {
+    display_name: &'static str,
+    watch_roots: Vec<PathBuf>,
+    discovered_files: usize,
+    latest_file: Option<PathBuf>,
+    latest_file_len: Option<u64>,
+    latest_file_mtime: Option<DateTime<Utc>>,
+    tracked_offsets: Option<usize>,
+    latest_tail_offset: Option<u64>,
+    latest_tail_seen: Option<DateTime<Utc>>,
+    discover_error: Option<String>,
+    db_error: Option<String>,
+}
+
+fn gather_provider_doctor_data(
+    conn: Option<&Connection>,
+    provider: &dyn Provider,
+) -> ProviderDoctorData {
+    let watch_roots = provider.watch_roots();
+    let mut data = ProviderDoctorData {
+        display_name: provider.display_name(),
+        watch_roots,
+        discovered_files: 0,
+        latest_file: None,
+        latest_file_len: None,
+        latest_file_mtime: None,
+        tracked_offsets: None,
+        latest_tail_offset: None,
+        latest_tail_seen: None,
+        discover_error: None,
+        db_error: None,
+    };
+
+    match provider.discover_files() {
+        Ok(files) => {
+            data.discovered_files = files.len();
+            if let Some(file) = files.first() {
+                data.latest_file = Some(file.path.clone());
+                data.latest_file_len = std::fs::metadata(&file.path).ok().map(|m| m.len());
+                data.latest_file_mtime = std::fs::metadata(&file.path)
+                    .ok()
+                    .and_then(|m| m.modified().ok())
+                    .map(DateTime::<Utc>::from);
+            }
+        }
+        Err(e) => {
+            data.discover_error = Some(e.to_string());
+        }
+    }
+
+    if let Some(conn) = conn {
+        match load_tail_offset_count(conn, provider.name()) {
+            Ok(count) => data.tracked_offsets = Some(count),
+            Err(e) => data.db_error = Some(e.to_string()),
+        }
+        match load_latest_tail_seen(conn, provider.name()) {
+            Ok(last_seen) => data.latest_tail_seen = last_seen,
+            Err(e) if data.db_error.is_none() => data.db_error = Some(e.to_string()),
+            Err(_) => {}
+        }
+        if let Some(ref latest_file) = data.latest_file {
+            match load_tail_offset_state(conn, provider.name(), latest_file) {
+                Ok(Some(state)) => {
+                    data.latest_tail_offset = Some(state.byte_offset);
+                    data.latest_tail_seen = data.latest_tail_seen.or(state.last_seen);
+                }
+                Ok(None) => {}
+                Err(e) if data.db_error.is_none() => data.db_error = Some(e.to_string()),
+                Err(_) => {}
+            }
+        }
+    }
+
+    data
+}
+
+#[derive(Debug, Clone)]
+struct TailOffsetState {
+    byte_offset: u64,
+    last_seen: Option<DateTime<Utc>>,
+}
+
+fn load_tail_offset_count(conn: &Connection, provider: &str) -> Result<usize> {
+    let count = conn
+        .query_row(
+            "SELECT COUNT(*) FROM tail_offsets WHERE provider = ?1",
+            params![provider],
+            |row| row.get::<_, i64>(0),
+        )
+        .context("failed to count tail_offsets rows")?;
+    Ok(count.max(0) as usize)
+}
+
+fn load_latest_tail_seen(conn: &Connection, provider: &str) -> Result<Option<DateTime<Utc>>> {
+    let last_seen: Option<String> = conn
+        .query_row(
+            "SELECT MAX(last_seen) FROM tail_offsets WHERE provider = ?1",
+            params![provider],
+            |row| row.get(0),
+        )
+        .context("failed to read last_seen from tail_offsets")?;
+    Ok(last_seen.and_then(|value| parse_rfc3339_utc(&value)))
+}
+
+fn load_tail_offset_state(
+    conn: &Connection,
+    provider: &str,
+    path: &Path,
+) -> Result<Option<TailOffsetState>> {
+    let path_str = path.display().to_string();
+    let row = conn
+        .query_row(
+            "SELECT byte_offset, last_seen
+             FROM tail_offsets
+             WHERE provider = ?1 AND path = ?2",
+            params![provider, path_str],
+            |row| Ok((row.get::<_, i64>(0)?, row.get::<_, Option<String>>(1)?)),
+        )
+        .optional()
+        .context("failed to read tail offset state")?;
+
+    Ok(row.map(|(offset, last_seen)| TailOffsetState {
+        byte_offset: offset.max(0) as u64,
+        last_seen: last_seen.and_then(|value| parse_rfc3339_utc(&value)),
+    }))
+}
+
+fn summarize_tailer_health(diag: &ProviderDoctorData) -> CheckResult {
+    let label = format!("tailer health / {}", diag.display_name);
+
+    if let Some(ref error) = diag.discover_error {
+        return CheckResult::fail(
+            label,
+            format!("could not discover transcript files ({error})"),
+            Some("Check the provider's local transcript directory permissions, then rerun `budi doctor`.".to_string()),
+        );
+    }
+
+    if diag.watch_roots.is_empty() {
+        return CheckResult::warn(
+            label,
+            "no transcript watch roots exist on disk yet".to_string(),
+            Some(format!(
+                "Open {} once so it creates its local transcript directory, then rerun `budi doctor`.",
+                diag.display_name
+            )),
+        );
+    }
+
+    if let Some(ref error) = diag.db_error {
+        return CheckResult::fail(
+            label,
+            format!("watch roots exist, but tailer state could not be inspected ({error})"),
+            Some("Fix the database or schema error above, then rerun `budi doctor`.".to_string()),
+        );
+    }
+
+    if diag.discovered_files == 0 {
+        return CheckResult::pass(
+            label,
+            format!(
+                "watching {} root(s); no transcript files discovered yet",
+                diag.watch_roots.len()
+            ),
+        );
+    }
+
+    match diag.tracked_offsets {
+        Some(0) => CheckResult::fail(
+            label,
+            format!(
+                "watching {} root(s) and found {} transcript file(s), but the tailer has not seeded any offsets",
+                diag.watch_roots.len(),
+                diag.discovered_files
+            ),
+            Some(
+                "Keep `budi-daemon` running for a moment so it can seed tail offsets, then rerun `budi doctor`."
+                    .to_string(),
+            ),
+        ),
+        Some(count) => {
+            let detail = if let Some(last_seen) = diag.latest_tail_seen {
+                format!(
+                    "watching {} root(s); tracking {count} transcript file(s); last tailer activity {} ago",
+                    diag.watch_roots.len(),
+                    format_relative_age(last_seen)
+                )
+            } else {
+                format!(
+                    "watching {} root(s); tracking {count} transcript file(s)",
+                    diag.watch_roots.len()
+                )
+            };
+            CheckResult::pass(label, detail)
+        }
+        None => CheckResult::fail(
+            label,
+            "watch roots exist, but no tailer offset summary is available".to_string(),
+            Some("Fix the database or schema error above, then rerun `budi doctor`.".to_string()),
+        ),
+    }
+}
+
+fn summarize_transcript_visibility(diag: &ProviderDoctorData) -> CheckResult {
+    let label = format!("transcript visibility / {}", diag.display_name);
+
+    if let Some(ref error) = diag.discover_error {
+        return CheckResult::fail(
+            label,
+            format!("could not discover transcript files ({error})"),
+            Some("Check the provider's local transcript directory permissions, then rerun `budi doctor`.".to_string()),
+        );
+    }
+
+    let Some(ref latest_file) = diag.latest_file else {
+        return CheckResult::pass(label, "no transcript files discovered yet");
+    };
+
+    if !latest_file_is_from_today(diag.latest_file_mtime) {
+        return CheckResult::pass(
+            label,
+            format!(
+                "latest transcript is {} (last modified {}; no transcript activity today)",
+                latest_file.display(),
+                format_timestamp_local(diag.latest_file_mtime)
+            ),
+        );
+    }
+
+    if let Some(ref error) = diag.db_error {
+        return CheckResult::fail(
+            label,
+            format!(
+                "latest transcript is {} but tailer state could not be inspected ({error})",
+                latest_file.display()
+            ),
+            Some("Fix the database or schema error above, then rerun `budi doctor`.".to_string()),
+        );
+    }
+
+    let Some(file_len) = diag.latest_file_len else {
+        return CheckResult::warn(
+            label,
+            format!(
+                "latest transcript is {} but its file size could not be read",
+                latest_file.display()
+            ),
+            Some(
+                "Check that the transcript still exists and is readable, then rerun `budi doctor`."
+                    .to_string(),
+            ),
+        );
+    };
+
+    let Some(offset) = diag.latest_tail_offset else {
+        return CheckResult::fail(
+            label,
+            format!("latest transcript is {} and is not tracked by the tailer yet", latest_file.display()),
+            Some(
+                "Make sure `budi-daemon` is running so the tailer can seed this file, then rerun `budi doctor`. Run `budi import` if you also need older history backfilled."
+                    .to_string(),
+            ),
+        );
+    };
+
+    let gap = file_len.saturating_sub(offset);
+    if gap > 0 {
+        return CheckResult::fail(
+            label,
+            format!(
+                "latest transcript is {} and the tailer is {} B behind",
+                latest_file.display(),
+                gap
+            ),
+            Some(
+                "Keep `budi-daemon` running and rerun `budi doctor`; if the gap persists, restart with `budi init`."
+                    .to_string(),
+            ),
+        );
+    }
+
+    CheckResult::pass(
+        label,
+        format!(
+            "latest transcript is {} and the tailer is caught up (0 B behind)",
+            latest_file.display()
+        ),
+    )
+}
+
+fn latest_file_is_from_today(ts: Option<DateTime<Utc>>) -> bool {
+    let Some(ts) = ts else {
+        return false;
+    };
+    ts.with_timezone(&Local).date_naive() == Local::now().date_naive()
+}
+
+fn format_timestamp_local(ts: Option<DateTime<Utc>>) -> String {
+    ts.map(|value| {
+        value
+            .with_timezone(&Local)
+            .format("%Y-%m-%d %H:%M")
+            .to_string()
+    })
+    .unwrap_or_else(|| "unknown".to_string())
+}
+
+fn format_relative_age(ts: DateTime<Utc>) -> String {
+    let delta = Utc::now().signed_duration_since(ts);
+    if delta.num_seconds() < 60 {
+        format!("{}s", delta.num_seconds().max(0))
+    } else if delta.num_minutes() < 60 {
+        format!("{}m", delta.num_minutes())
+    } else if delta.num_hours() < 48 {
+        format!("{}h", delta.num_hours())
+    } else {
+        format!("{}d", delta.num_days())
+    }
+}
+
+fn parse_rfc3339_utc(raw: &str) -> Option<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(raw)
+        .ok()
+        .map(|value| value.with_timezone(&Utc))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn diag(display_name: &'static str) -> ProviderDoctorData {
+        ProviderDoctorData {
+            display_name,
+            watch_roots: vec![PathBuf::from("/tmp/watch")],
+            discovered_files: 1,
+            latest_file: Some(PathBuf::from("/tmp/watch/session.jsonl")),
+            latest_file_len: Some(120),
+            latest_file_mtime: Some(Utc::now()),
+            tracked_offsets: Some(1),
+            latest_tail_offset: Some(120),
+            latest_tail_seen: Some(Utc::now()),
+            discover_error: None,
+            db_error: None,
+        }
+    }
 
     #[test]
     fn integrity_check_uses_quick_check_by_default() {
@@ -645,35 +797,72 @@ mod tests {
     }
 
     #[test]
-    fn parses_cursor_onboarding_counters_v1() {
-        let payload = br#"{
-            "version": 1,
-            "welcome_view_impressions": 3,
-            "open_terminal_clicks": 1,
-            "handoffs_completed": 1,
-            "first_impression_at": "2026-04-17T10:00:00.000Z",
-            "last_impression_at": "2026-04-17T10:05:00.000Z",
-            "last_handoff_at": "2026-04-17T10:05:30.000Z"
-        }"#;
-        let counters = parse_cursor_onboarding_counters(payload).expect("counters parse");
-        assert_eq!(counters.welcome_view_impressions, 3);
-        assert_eq!(counters.open_terminal_clicks, 1);
-        assert_eq!(counters.handoffs_completed, 1);
+    fn detects_legacy_proxy_env_values() {
+        assert!(looks_like_legacy_proxy_value("http://127.0.0.1:9878"));
+        assert!(looks_like_legacy_proxy_value("http://localhost:9878/v1"));
+        assert!(looks_like_legacy_proxy_value("http://[::1]:9878"));
+        assert!(!looks_like_legacy_proxy_value("https://api.anthropic.com"));
     }
 
     #[test]
-    fn cursor_onboarding_counters_default_missing_fields_to_zero() {
-        let payload = br#"{ "version": 1 }"#;
-        let counters = parse_cursor_onboarding_counters(payload).expect("counters parse");
-        assert_eq!(counters.welcome_view_impressions, 0);
-        assert_eq!(counters.open_terminal_clicks, 0);
-        assert_eq!(counters.handoffs_completed, 0);
+    fn transcript_visibility_fails_when_latest_file_is_untracked() {
+        let mut data = diag("Claude Code");
+        data.latest_tail_offset = None;
+
+        let result = summarize_transcript_visibility(&data);
+
+        assert_eq!(result.state, CheckState::Fail);
+        assert!(result.detail.contains("not tracked by the tailer"));
+        assert!(
+            result
+                .fix
+                .as_deref()
+                .unwrap_or_default()
+                .contains("budi-daemon")
+        );
     }
 
     #[test]
-    fn cursor_onboarding_counters_rejects_garbage_payload() {
-        // Should never panic — a broken file must not break `budi doctor`.
-        assert!(parse_cursor_onboarding_counters(b"not json").is_none());
-        assert!(parse_cursor_onboarding_counters(b"[1,2,3]").is_none());
+    fn transcript_visibility_reports_gap_bytes() {
+        let mut data = diag("Claude Code");
+        data.latest_tail_offset = Some(96);
+
+        let result = summarize_transcript_visibility(&data);
+
+        assert_eq!(result.state, CheckState::Fail);
+        assert!(result.detail.contains("24 B behind"));
+    }
+
+    #[test]
+    fn transcript_visibility_passes_when_no_activity_today() {
+        let mut data = diag("Claude Code");
+        data.latest_file_mtime = Some(Utc::now() - chrono::Duration::days(2));
+
+        let result = summarize_transcript_visibility(&data);
+
+        assert_eq!(result.state, CheckState::Pass);
+        assert!(result.detail.contains("no transcript activity today"));
+    }
+
+    #[test]
+    fn tailer_health_warns_when_watch_root_is_missing() {
+        let mut data = diag("Cursor");
+        data.watch_roots.clear();
+
+        let result = summarize_tailer_health(&data);
+
+        assert_eq!(result.state, CheckState::Warn);
+        assert!(result.detail.contains("no transcript watch roots"));
+    }
+
+    #[test]
+    fn tailer_health_fails_when_offsets_are_missing() {
+        let mut data = diag("Claude Code");
+        data.tracked_offsets = Some(0);
+
+        let result = summarize_tailer_health(&data);
+
+        assert_eq!(result.state, CheckState::Fail);
+        assert!(result.detail.contains("has not seeded any offsets"));
     }
 }

--- a/crates/budi-cli/src/commands/init.rs
+++ b/crates/budi-cli/src/commands/init.rs
@@ -50,7 +50,7 @@ pub fn cmd_init(cleanup: bool, no_daemon: bool) -> Result<()> {
         "  Start coding as usual {dim}(`claude`, `codex`, `cursor`, `gh copilot` — budi tails local transcripts automatically){reset}"
     );
     println!(
-        "  Run `budi doctor` for a full health check {dim}(daemon, tailer, attribution, autostart){reset}"
+        "  Run `budi doctor` for a full health check {dim}(daemon, tailer, schema, transcript visibility){reset}"
     );
 
     Ok(())

--- a/crates/budi-cli/src/main.rs
+++ b/crates/budi-cli/src/main.rs
@@ -17,7 +17,7 @@ const HEALTH_TIMEOUT_SECS: u64 = 3;
 #[command(about = "budi — AI cost analytics. Know where your tokens and money go.")]
 #[command(version)]
 #[command(
-    after_help = "Get started:\n  budi init\n\nCommon commands:\n  budi stats              Show today's cost summary\n  budi stats --models     Cost breakdown by model\n  budi stats --branches   Cost breakdown by branch\n  budi sessions           List recent sessions with cost and health\n  budi sessions <id>      Session detail: cost, models, health, tags\n  budi status             Quick check: daemon and today's spend\n  budi doctor             Full diagnostic: daemon, database, config\n  budi cloud status       Cloud sync readiness and last-synced-at\n  budi cloud sync         Push queued local data to the cloud now\n  budi autostart status   Check daemon autostart service\n  budi import             Import historical transcripts from disk\n  budi import --force     Re-ingest all data from scratch (use after upgrades)\n  budi repair             Repair schema drift and run migration\n\nMore info: https://github.com/siropkin/budi"
+    after_help = "Get started:\n  budi init\n\nCommon commands:\n  budi stats              Show today's cost summary\n  budi stats --models     Cost breakdown by model\n  budi stats --branches   Cost breakdown by branch\n  budi sessions           List recent sessions with cost and health\n  budi sessions <id>      Session detail: cost, models, health, tags\n  budi status             Quick check: daemon and today's spend\n  budi doctor             Full diagnostic: daemon, tailer, schema, transcript visibility\n  budi cloud status       Cloud sync readiness and last-synced-at\n  budi cloud sync         Push queued local data to the cloud now\n  budi autostart status   Check daemon autostart service\n  budi import             Import historical transcripts from disk\n  budi import --force     Re-ingest all data from scratch (use after upgrades)\n  budi repair             Repair schema drift and run migration\n\nMore info: https://github.com/siropkin/budi"
 )]
 struct Cli {
     #[command(subcommand)]
@@ -34,7 +34,7 @@ enum Commands {
         #[arg(long, hide = true)]
         no_daemon: bool,
     },
-    /// Check health: daemon, database, config
+    /// Check health: daemon, tailer, schema, transcript visibility
     Doctor {
         /// Run full SQLite integrity_check (slower). Default uses quick_check.
         #[arg(long, default_value_t = false)]

--- a/scripts/e2e/test_325_doctor_tailer_contract.sh
+++ b/scripts/e2e/test_325_doctor_tailer_contract.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# End-to-end regression for issue #325: verify `budi doctor` reports the
+# tailer-first 8.2 contract with actionable FAIL/WARN hints.
+#
+# Contract pinned:
+# - #316 R2.4 (`#325`) doctor is organized around daemon health, schema drift,
+#   transcript visibility, and leftover proxy residue
+# - Legacy proxy-reachability checks do not come back
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BUDI="$ROOT/target/release/budi"
+
+if [[ ! -x "$BUDI" ]]; then
+  echo "error: release binary not built. run \`cargo build --release\` first." >&2
+  exit 2
+fi
+
+TMPDIR_ROOT="$(mktemp -d -t budi-e2e-325-XXXXXX)"
+export HOME="$TMPDIR_ROOT"
+export BUDI_HOME="$HOME/.local/share/budi"
+
+cleanup() {
+  local status=$?
+  if [[ "${KEEP_TMP:-0}" == "1" ]]; then
+    echo "[e2e] leaving tmp: $TMPDIR_ROOT"
+  else
+    rm -rf "$TMPDIR_ROOT"
+  fi
+  exit $status
+}
+trap cleanup EXIT INT TERM
+
+assert_contains() {
+  local file="$1"
+  local needle="$2"
+  if ! grep -Fq "$needle" "$file"; then
+    echo "[e2e] FAIL: expected '$needle' in $file" >&2
+    cat "$file" >&2 || true
+    exit 1
+  fi
+}
+
+echo "[e2e] seed schema without starting daemon"
+"$BUDI" init --no-daemon >/dev/null
+
+mkdir -p "$HOME/.claude/projects/demo"
+printf '{"type":"assistant","message":{"content":[{"type":"text","text":"hi"}]}}\n' \
+  >"$HOME/.claude/projects/demo/session.jsonl"
+
+python3 - <<'PY'
+import os
+import sqlite3
+
+db_path = os.path.join(os.environ["BUDI_HOME"], "analytics.db")
+conn = sqlite3.connect(db_path)
+conn.execute("PRAGMA user_version = 0")
+conn.commit()
+conn.close()
+PY
+
+echo "[e2e] run doctor with fail modes injected"
+LOG="$TMPDIR_ROOT/doctor.log"
+set +e
+ANTHROPIC_BASE_URL="http://127.0.0.1:9878" \
+BUDI_DAEMON_BIN="/definitely/missing/budi-daemon" \
+"$BUDI" doctor >"$LOG" 2>&1
+STATUS=$?
+set -e
+
+if [[ $STATUS -eq 0 ]]; then
+  cat "$LOG" >&2 || true
+  echo "[e2e] FAIL: doctor was expected to fail" >&2
+  exit 1
+fi
+
+assert_contains "$LOG" "FAIL daemon health:"
+assert_contains "$LOG" "BUDI_DAEMON_BIN"
+assert_contains "$LOG" "FAIL schema drift:"
+assert_contains "$LOG" "Run \`budi init\` or \`budi update\`"
+assert_contains "$LOG" "WARN leftover proxy config:"
+assert_contains "$LOG" "budi init --cleanup"
+assert_contains "$LOG" "FAIL transcript visibility / Claude Code:"
+assert_contains "$LOG" "Run \`budi import\` if you also need older history backfilled."
+assert_contains "$LOG" "doctor found"
+
+echo "[e2e] PASS"


### PR DESCRIPTION
Summary
- Rewrite `budi doctor` around the 8.2 tailer contract with explicit PASS / WARN / FAIL checks for daemon health, schema drift, leftover proxy residue, and provider-specific tailer and transcript visibility.
- Remove proxy-era and unrelated doctor noise so the command answers the 8.2 question directly: will Budi actually see local AI activity?
- Add focused unit coverage plus `scripts/e2e/test_325_doctor_tailer_contract.sh` to pin the actionable fail-path output.

Risks / compatibility notes
- `budi doctor` output is intentionally different from the old proxy-era wording, so any external greps against the removed branch/activity/session checks will need to move to the new labels.
- Transcript visibility is evaluated at the transcript-file and tail-offset level; this change does not reinterpret expected Cursor Usage API lag inside the accepted disclaimer window tracked separately in `#381`.

Validation
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `bash scripts/e2e/test_325_doctor_tailer_contract.sh`
- Snapshot reviewed from the injected-failure regression run:

```text
FAIL daemon health: daemon is not responding on http://127.0.0.1:7878; restart via /definitely/missing/budi-daemon (from BUDI_DAEMON_BIN) failed (...)
FAIL schema drift: database schema is v0; this build expects v1
WARN leftover proxy config: legacy proxy env vars are still exported (...:9878)
FAIL transcript visibility / Claude Code: latest transcript is .../session.jsonl and is not tracked by the tailer yet
```

Closes #325
