### PR TITLE
[8.2][R2.5] Drop proxy_events on upgrade

### DIFF
--- a/SOUL.md
+++ b/SOUL.md
@@ -88,7 +88,7 @@ Three independent repos (extraction completed per [ADR-0086](docs/adr/0086-extra
 
 ### Crates
 
-- **budi-core** - Business logic: analytics (SQLite queries), providers (Claude Code, Codex, Copilot CLI, Cursor) including each provider's `watch_roots()` for live tailing, pipeline (enrichment), cost calculation, config, migrations, autostart (platform-native daemon service management). The 8.1-era `proxy_events` table and `proxy.rs` storage helpers remain for the 8.1 → 8.2 transition window (read-only after R1.4 #320; deleted in R2.1 #322). Historical hook/OTEL data is read-only (tables kept for schema compat, ingestion removed).
+- **budi-core** - Business logic: analytics (SQLite queries), providers (Claude Code, Codex, Copilot CLI, Cursor) including each provider's `watch_roots()` for live tailing, pipeline (enrichment), cost calculation, config, migrations, autostart (platform-native daemon service management). The 8.1-era proxy runtime is deleted in R2.1 (#322); R2.5 (#326) keeps proxy-sourced `messages` rows read-only for historical analytics while dropping the obsolete `proxy_events` table on upgrade. Historical hook/OTEL data is read-only (tables kept for schema compat, ingestion removed).
 - **budi-cli** - Thin HTTP client to the daemon. Commands: init, launch, stats, sessions, status, sync, import, statusline, doctor, health, update, integrations, autostart, uninstall, migrate, repair (the launch / enable / disable / proxy-install commands are deleted in 8.2 R2.1 #322 — R2.3 #324 also reduces `budi init` to daemon-+-autostart only)
 - **budi-daemon** - axum HTTP server (port 7878). Owns SQLite exclusively. Serves analytics API and runs the daemon-side filesystem tailer that watches each `Provider::watch_roots()` directory, parses incremental JSONL appends through `Pipeline::default_pipeline()`, and writes to the canonical `messages` / tag tables. JSONL tailing is the sole live ingestion path per [ADR-0089](docs/adr/0089-reverse-proxy-first-jsonl-tailing-as-sole-live-path.md); the legacy proxy server on port 9878 still runs in 8.1.x for the transition window and is removed in 8.2 R2.1 (#322). One-shot historical backfill remains user-initiated via `budi import`.
 
@@ -112,7 +112,7 @@ Sources (Claude Code JSONL, Codex sessions, Copilot CLI sessions, Cursor Usage A
 
 Enricher order is critical — each depends on prior enrichers. Do not reorder. The live tailer and `budi import` run the **same** pipeline against the **same** transcript files, so every classification feature (ticket extraction, file-level attribution, activity classification, tool outcomes) lands for both paths automatically.
 
-> **Transition window (8.1.x → 8.2)**: in 8.1.x the daemon also runs an HTTP proxy on port 9878 that captures live LLM traffic into a separate `proxy_events` table and a parallel `insert_proxy_message` write path. That path is shipped behind `BUDI_LIVE_TAIL=1` cross-validation in 8.2 R1.3 (#319), made the default in R1.4 (#320 — proxy stops writing `proxy_events`), and the proxy code itself is deleted in 8.2 R2.1 (#322). The dedup rule in `analytics/sync.rs` (`proxy_cutoff`) exists only to keep these two paths from double-counting during the transition.
+> **Transition window (8.1.x → 8.2)**: in 8.1.x the daemon also runs an HTTP proxy on port 9878 that captures live LLM traffic into a separate `proxy_events` table and a parallel `insert_proxy_message` write path. That path is shipped behind `BUDI_LIVE_TAIL=1` cross-validation in 8.2 R1.3 (#319), made the default in R1.4 (#320 — proxy stops writing `proxy_events`), and the proxy code itself is deleted in 8.2 R2.1 (#322). R2.5 (#326) removes the now-unused `proxy_events` table on upgrade while keeping proxy-sourced `messages` rows read-only; the dedup rule in `analytics/sync.rs` (`proxy_cutoff`) remains only to keep those historical rows from double-counting during the transition.
 
 ```
 Cloud sync (optional, disabled by default):
@@ -136,10 +136,9 @@ AppState.cloud_syncing AtomicBool guards worker and manual path from double-post
 
 ### Database (SQLite, WAL mode, schema v1)
 
-Nine tables, seven data entities + two supporting:
+Core tables:
 - **messages** - Single cost entity. One row per API call. All token/cost data lives here. Fields: id, session_id, role, model, provider, timestamp, input/output/cache tokens, cost_cents, cost_confidence, git_branch, repo_id, cwd, request_id
 - **sessions** - Lifecycle context (start/end, duration, mode, title) without mixing cost concerns. One row per conversation. Primary key field: id
-- **proxy_events** - Legacy 8.1 append-only log of proxied LLM API requests (timestamp, provider, model, input/output_tokens, duration_ms, status_code, is_streaming, repo_id, git_branch, ticket_id, cost_cents). Retained read-only during the 8.1 → 8.2 transition window per R2.5 (#326). New writes stop in R1.4 (#320 — tailer becomes the default and the proxy stops emitting `proxy_events`). The proxy code path itself is deleted in R2.1 (#322); existing rows remain queryable so 8.1-era analytics queries still resolve. The `proxy_cutoff` dedup in `analytics/sync.rs` exists solely to keep the legacy proxy rows from racing the new tailer rows during the cross-validation window.
 - **tags** - Flexible key-value pairs per message (repo, ticket_id, activity, user, etc.) using message_id FK to messages(id)
 - **sync_state** - Tracks incremental ingestion progress per file for progressive sync. Also stores cloud sync watermarks (`__budi_cloud_sync__` keys) for idempotent cloud uploads
 - **message_rollups_hourly** - Derived hourly aggregates (provider/model/repo/branch/role dimensions) for low-latency analytics reads
@@ -460,7 +459,6 @@ Key points:
 - `crates/budi-core/src/providers/copilot.rs` - Copilot CLI provider (transcript import from `~/.copilot/session-state/`, delegates pricing to Claude/OpenAI based on model)
 - `crates/budi-core/src/providers/cursor.rs` - Cursor provider (Usage API primary, transcript fallback; auth/session context from state.vscdb across macOS/Linux/Windows layouts)
 - `crates/budi-core/src/migration.rs` - Schema v1, all migration paths
-- `crates/budi-core/src/proxy.rs` - Legacy 8.1 proxy module: ProxyEvent types with attribution (repo, branch, ticket, cost), `proxy_events` and `messages` table storage, ProxyAttribution resolution from headers/git. **Slated for deletion in 8.2 R2.1 (#322)** — listed here for the audit trail; new live ingestion goes through the daemon-side tailer (per-provider `Provider::watch_roots()`) instead.
 - `crates/budi-core/src/cloud_sync.rs` - Cloud sync worker: envelope builder, watermark tracking, HTTPS-only HTTP client with retry/backoff, privacy-safe rollup extraction
 - `crates/budi-core/src/autostart.rs` - Platform-native daemon autostart: launchd (macOS), systemd (Linux), Task Scheduler (Windows). Install/uninstall/status.
 - `crates/budi-core/src/config.rs` - BudiConfig, ProxyConfig, AgentsConfig, StatuslineConfig, TagsConfig, CloudConfig

--- a/crates/budi-cli/src/commands/doctor.rs
+++ b/crates/budi-cli/src/commands/doctor.rs
@@ -48,6 +48,12 @@ pub fn cmd_doctor(repo_root: Option<PathBuf>, deep: bool) -> Result<()> {
     proxy_residue.print();
     report.record(&proxy_residue);
 
+    if let Some(conn) = schema.conn.as_ref() {
+        let legacy_proxy_history = check_legacy_proxy_history(conn);
+        legacy_proxy_history.print();
+        report.record(&legacy_proxy_history);
+    }
+
     let providers = doctor_providers();
     if providers.is_empty() {
         let no_providers = CheckResult::warn(
@@ -427,6 +433,98 @@ fn looks_like_legacy_proxy_value(value: &str) -> bool {
         || lower.contains("[::1]:9878")
 }
 
+#[derive(Debug, Clone, Default)]
+struct LegacyProxyHistoryData {
+    retained_assistant_messages: usize,
+    oldest_message: Option<DateTime<Utc>>,
+    newest_message: Option<DateTime<Utc>>,
+    proxy_events_table_present: bool,
+}
+
+fn check_legacy_proxy_history(conn: &Connection) -> CheckResult {
+    match load_legacy_proxy_history(conn) {
+        Ok(data) => summarize_legacy_proxy_history(&data),
+        Err(e) => CheckResult::fail(
+            "legacy proxy history",
+            format!("could not inspect retained 8.1 proxy-era data ({e})"),
+            Some("Run `budi repair`, then rerun `budi doctor`.".to_string()),
+        ),
+    }
+}
+
+fn load_legacy_proxy_history(conn: &Connection) -> Result<LegacyProxyHistoryData> {
+    let proxy_events_table_present = sqlite_table_exists(conn, "proxy_events")?;
+    let (retained_assistant_messages, oldest_message, newest_message) = conn
+        .query_row(
+            "SELECT
+                COUNT(*),
+                MIN(timestamp),
+                MAX(timestamp)
+             FROM messages
+             WHERE role = 'assistant'
+               AND cost_confidence = 'proxy_estimated'",
+            [],
+            |row| {
+                Ok((
+                    row.get::<_, i64>(0)?,
+                    row.get::<_, Option<String>>(1)?,
+                    row.get::<_, Option<String>>(2)?,
+                ))
+            },
+        )
+        .context("failed to read proxy_estimated assistant rows")?;
+
+    Ok(LegacyProxyHistoryData {
+        retained_assistant_messages: retained_assistant_messages.max(0) as usize,
+        oldest_message: oldest_message.and_then(|value| parse_rfc3339_utc(&value)),
+        newest_message: newest_message.and_then(|value| parse_rfc3339_utc(&value)),
+        proxy_events_table_present,
+    })
+}
+
+fn sqlite_table_exists(conn: &Connection, table: &str) -> Result<bool> {
+    let count = conn.query_row(
+        "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name = ?1",
+        params![table],
+        |row| row.get::<_, i64>(0),
+    )?;
+    Ok(count > 0)
+}
+
+fn summarize_legacy_proxy_history(data: &LegacyProxyHistoryData) -> CheckResult {
+    let label = "legacy proxy history";
+    let row_word = if data.retained_assistant_messages == 1 {
+        "row"
+    } else {
+        "rows"
+    };
+
+    let retained_detail = if data.retained_assistant_messages == 0 {
+        "no retained 8.1 proxy-sourced assistant history remains".to_string()
+    } else {
+        format!(
+            "retaining {} proxy-sourced assistant {} read-only (oldest {}, newest {}); newer live data comes from transcript tailing and legacy attribution may be weaker",
+            data.retained_assistant_messages,
+            row_word,
+            format_timestamp_local(data.oldest_message),
+            format_timestamp_local(data.newest_message)
+        )
+    };
+
+    if data.proxy_events_table_present {
+        return CheckResult::warn(
+            label,
+            format!("{retained_detail}; obsolete `proxy_events` table is still present"),
+            Some(
+                "Run `budi init` or `budi repair` with the current 8.2 build to remove the old `proxy_events` table."
+                    .to_string(),
+            ),
+        );
+    }
+
+    CheckResult::pass(label, retained_detail)
+}
+
 fn doctor_providers() -> Vec<Box<dyn Provider>> {
     match budi_core::config::load_agents_config() {
         Some(cfg) => budi_core::provider::all_providers()
@@ -802,6 +900,77 @@ mod tests {
         assert!(looks_like_legacy_proxy_value("http://localhost:9878/v1"));
         assert!(looks_like_legacy_proxy_value("http://[::1]:9878"));
         assert!(!looks_like_legacy_proxy_value("https://api.anthropic.com"));
+    }
+
+    #[test]
+    fn legacy_proxy_history_passes_when_only_retained_messages_remain() {
+        let result = summarize_legacy_proxy_history(&LegacyProxyHistoryData {
+            retained_assistant_messages: 2,
+            oldest_message: Some(Utc::now() - chrono::Duration::days(1)),
+            newest_message: Some(Utc::now()),
+            proxy_events_table_present: false,
+        });
+
+        assert_eq!(result.state, CheckState::Pass);
+        assert!(
+            result
+                .detail
+                .contains("retaining 2 proxy-sourced assistant rows")
+        );
+        assert!(result.detail.contains("transcript tailing"));
+    }
+
+    #[test]
+    fn legacy_proxy_history_warns_when_proxy_events_table_is_still_present() {
+        let result = summarize_legacy_proxy_history(&LegacyProxyHistoryData {
+            retained_assistant_messages: 1,
+            oldest_message: Some(Utc::now()),
+            newest_message: Some(Utc::now()),
+            proxy_events_table_present: true,
+        });
+
+        assert_eq!(result.state, CheckState::Warn);
+        assert!(result.detail.contains("obsolete `proxy_events` table"));
+        assert!(
+            result
+                .fix
+                .as_deref()
+                .unwrap_or_default()
+                .contains("budi repair")
+        );
+    }
+
+    #[test]
+    fn legacy_proxy_history_loader_reads_proxy_rows_and_table_presence() {
+        let conn = Connection::open_in_memory().unwrap();
+        budi_core::migration::migrate(&conn).unwrap();
+        conn.execute_batch(
+            "
+            CREATE TABLE proxy_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                timestamp TEXT NOT NULL
+            );
+            INSERT INTO messages (
+                id, role, timestamp, model, provider, input_tokens, output_tokens,
+                cache_creation_tokens, cache_read_tokens, cost_cents, cost_confidence
+            ) VALUES (
+                'legacy-proxy-row', 'assistant', '2026-04-19T17:00:00Z', 'gpt-4o',
+                'openai', 1, 1, 0, 0, 0.5, 'proxy_estimated'
+            );
+            ",
+        )
+        .unwrap();
+
+        let data = load_legacy_proxy_history(&conn).unwrap();
+
+        assert_eq!(data.retained_assistant_messages, 1);
+        assert!(data.proxy_events_table_present);
+        assert_eq!(
+            data.newest_message
+                .expect("newest proxy timestamp should parse")
+                .to_rfc3339(),
+            "2026-04-19T17:00:00+00:00"
+        );
     }
 
     #[test]

--- a/crates/budi-cli/src/commands/repair.rs
+++ b/crates/budi-cli/src/commands/repair.rs
@@ -40,6 +40,15 @@ pub fn cmd_repair() -> Result<()> {
                 .collect()
         })
         .unwrap_or_default();
+    let removed_tables: Vec<String> = result
+        .get("removed_tables")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(ToOwned::to_owned))
+                .collect()
+        })
+        .unwrap_or_default();
 
     if migrated {
         println!("Migrated database v{from} -> v{to}.");
@@ -59,6 +68,12 @@ pub fn cmd_repair() -> Result<()> {
             println!("Recreated missing indexes:");
             for idx in &added_indexes {
                 println!("  - {idx}");
+            }
+        }
+        if !removed_tables.is_empty() {
+            println!("Removed obsolete tables:");
+            for table in &removed_tables {
+                println!("  - {table}");
             }
         }
     } else {

--- a/crates/budi-core/src/migration.rs
+++ b/crates/budi-core/src/migration.rs
@@ -18,6 +18,7 @@ pub struct RepairReport {
     pub migrated: bool,
     pub added_columns: Vec<String>,
     pub added_indexes: Vec<String>,
+    pub removed_tables: Vec<String>,
 }
 
 /// Report from [`reconcile_schema`] (additive repairs and rollup healing).
@@ -25,6 +26,7 @@ pub struct RepairReport {
 pub struct SchemaReconcileReport {
     pub added_columns: Vec<String>,
     pub added_indexes: Vec<String>,
+    pub removed_tables: Vec<String>,
 }
 
 /// Check the current schema version without migrating.
@@ -73,6 +75,7 @@ pub fn repair(conn: &Connection) -> Result<RepairReport> {
         migrated: from_version != to_version,
         added_columns: reconcile.added_columns,
         added_indexes: reconcile.added_indexes,
+        removed_tables: reconcile.removed_tables,
     })
 }
 
@@ -914,6 +917,16 @@ fn trigger_exists(conn: &Connection, name: &str) -> Result<bool> {
     Ok(exists)
 }
 
+fn drop_legacy_proxy_events_table(conn: &Connection) -> Result<bool> {
+    if !table_exists(conn, "proxy_events")? {
+        return Ok(false);
+    }
+
+    conn.execute_batch("DROP TABLE proxy_events;")?;
+    tracing::info!("Schema reconcile: dropped obsolete proxy_events table");
+    Ok(true)
+}
+
 fn expected_reconcile_indexes(conn: &Connection) -> Result<Vec<String>> {
     let mut indexes = vec![
         "idx_messages_session".to_string(),
@@ -970,6 +983,7 @@ fn missing_reconcile_indexes(conn: &Connection) -> Result<Vec<String>> {
 
 fn reconcile_schema(conn: &Connection) -> Result<SchemaReconcileReport> {
     let mut added_columns: Vec<String> = Vec::new();
+    let mut removed_tables: Vec<String> = Vec::new();
 
     let has_hourly_rollups = table_exists(conn, "message_rollups_hourly")?;
     let has_daily_rollups = table_exists(conn, "message_rollups_daily")?;
@@ -1006,16 +1020,21 @@ fn reconcile_schema(conn: &Connection) -> Result<SchemaReconcileReport> {
         added_columns.push("tail_offsets".to_string());
     }
 
+    if drop_legacy_proxy_events_table(conn)? {
+        removed_tables.push("proxy_events".to_string());
+    }
+
     let added_indexes = missing_reconcile_indexes(conn)?;
 
     create_indexes(conn)?;
 
-    if !added_columns.is_empty() || !added_indexes.is_empty() {
+    if !added_columns.is_empty() || !added_indexes.is_empty() || !removed_tables.is_empty() {
         tracing::info!("Schema reconcile completed");
     }
     Ok(SchemaReconcileReport {
         added_columns,
         added_indexes,
+        removed_tables,
     })
 }
 
@@ -1063,12 +1082,14 @@ mod tests {
         assert!(!first.migrated);
         assert!(first.added_columns.is_empty());
         assert!(first.added_indexes.is_empty());
+        assert!(first.removed_tables.is_empty());
 
         let second = repair(&conn).unwrap();
         assert_eq!(second.from_version, SCHEMA_VERSION);
         assert!(!second.migrated);
         assert!(second.added_columns.is_empty());
         assert!(second.added_indexes.is_empty());
+        assert!(second.removed_tables.is_empty());
     }
 
     #[test]
@@ -1128,5 +1149,36 @@ mod tests {
             report.added_columns
         );
         assert!(table_exists(&conn, "tail_offsets").unwrap());
+        assert!(report.removed_tables.is_empty());
+    }
+
+    /// 8.1 -> 8.2 upgrade: keep proxy-sourced `messages` rows but remove the
+    /// orphaned `proxy_events` table now that the proxy runtime is gone.
+    #[test]
+    fn reconcile_drops_legacy_proxy_events_table_from_existing_v1_db() {
+        let conn = Connection::open_in_memory().unwrap();
+        migrate(&conn).unwrap();
+        conn.execute_batch(
+            "
+            CREATE TABLE proxy_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                timestamp TEXT NOT NULL
+            );
+            ",
+        )
+        .unwrap();
+        assert!(table_exists(&conn, "proxy_events").unwrap());
+
+        let report = repair(&conn).unwrap();
+
+        assert_eq!(report.from_version, SCHEMA_VERSION);
+        assert_eq!(report.to_version, SCHEMA_VERSION);
+        assert!(!report.migrated, "cleanup should not bump schema version");
+        assert!(
+            report.removed_tables.iter().any(|t| t == "proxy_events"),
+            "report should mention the removed table; got {:?}",
+            report.removed_tables
+        );
+        assert!(!table_exists(&conn, "proxy_events").unwrap());
     }
 }

--- a/crates/budi-daemon/src/routes/analytics.rs
+++ b/crates/budi-daemon/src/routes/analytics.rs
@@ -368,6 +368,7 @@ pub struct RepairResponse {
     pub repaired: bool,
     pub added_columns: Vec<String>,
     pub added_indexes: Vec<String>,
+    pub removed_tables: Vec<String>,
 }
 
 #[derive(serde::Serialize)]
@@ -1166,9 +1167,12 @@ pub async fn analytics_repair(
                 from_version: report.from_version,
                 to_version: report.to_version,
                 migrated: report.migrated,
-                repaired: !report.added_columns.is_empty() || !report.added_indexes.is_empty(),
+                repaired: !report.added_columns.is_empty()
+                    || !report.added_indexes.is_empty()
+                    || !report.removed_tables.is_empty(),
                 added_columns: report.added_columns,
                 added_indexes: report.added_indexes,
+                removed_tables: report.removed_tables,
             })
         })()
     })

--- a/docs/adr/0089-reverse-proxy-first-jsonl-tailing-as-sole-live-path.md
+++ b/docs/adr/0089-reverse-proxy-first-jsonl-tailing-as-sole-live-path.md
@@ -118,7 +118,7 @@ The `Provider` trait is the only extension point. Adding a new agent in 8.3 (#29
 - **Forces an 8.1 → 8.2 breaking upgrade.** Users with 8.1 exports in their shell profile need to run `budi init --cleanup`. Release notes must lead on this.
 - **Concedes that agents not writing transcripts cannot be supported.** Any future agent that only holds state in-memory is out of scope for the tailer path until that agent ships a transcript option. We treat this as a scoping decision per agent, not a whole-product fallback.
 - **Cursor cost/token accuracy depends on Usage API cadence.** This is an existing limitation, but it stops being mitigated by proxy pass-through. The [#321](https://github.com/siropkin/budi/issues/321) measurement is the gate on whether any compensating work is needed.
-- **`proxy_events` rows become historical artifacts.** Their fate on upgrade is decided in [#326](https://github.com/siropkin/budi/issues/326). At minimum they are read-only; at most they are reprocessed from JSONL.
+- **Proxy-era history stays in `messages`, not in `proxy_events`.** [#326](https://github.com/siropkin/budi/issues/326) settles the upgrade policy: 8.2 drops the obsolete `proxy_events` table on migration, keeps proxy-sourced `messages` rows read-only for historical analytics, and surfaces that retained legacy state in `budi doctor`.
 
 ### Neutral
 

--- a/scripts/e2e/test_326_proxy_events_upgrade.sh
+++ b/scripts/e2e/test_326_proxy_events_upgrade.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+# End-to-end regression for issue #326: verify an 8.1-shaped analytics DB
+# upgrades cleanly by dropping the obsolete `proxy_events` table while keeping
+# proxy-sourced `messages` rows queryable for stats and visible in `budi doctor`.
+#
+# Contract pinned:
+# - #316 R2.5 (`#326`) keeps legacy proxy-sourced history read-only in
+#   `messages` while removing the dead proxy-only table on upgrade
+# - `budi doctor` reports retained legacy proxy history honestly without
+#   pretending the old proxy runtime is still part of the live path
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BUDI="$ROOT/target/release/budi"
+BUDI_DAEMON="$ROOT/target/release/budi-daemon"
+
+if [[ ! -x "$BUDI" || ! -x "$BUDI_DAEMON" ]]; then
+  echo "error: release binaries not built. run \`cargo build --release\` first." >&2
+  exit 2
+fi
+
+TMPDIR_ROOT="$(mktemp -d -t budi-e2e-326-XXXXXX)"
+export HOME="$TMPDIR_ROOT"
+export BUDI_HOME="$HOME/.local/share/budi"
+
+DAEMON_PORT=17879
+DB="$BUDI_HOME/analytics.db"
+REPO_ROOT="$HOME/repo"
+
+cleanup() {
+  local status=$?
+  { kill "${DAEMON_PID:-}" 2>/dev/null || true; } >/dev/null 2>&1
+  pkill -f "budi-daemon serve --host 127.0.0.1 --port $DAEMON_PORT" >/dev/null 2>&1 || true
+  if [[ "${KEEP_TMP:-0}" == "1" ]]; then
+    echo "[e2e] leaving tmp: $TMPDIR_ROOT"
+  else
+    rm -rf "$TMPDIR_ROOT"
+  fi
+  exit $status
+}
+trap cleanup EXIT INT TERM
+
+assert_contains() {
+  local file="$1"
+  local needle="$2"
+  if ! grep -Fq "$needle" "$file"; then
+    echo "[e2e] FAIL: expected '$needle' in $file" >&2
+    cat "$file" >&2 || true
+    exit 1
+  fi
+}
+
+assert_not_contains() {
+  local file="$1"
+  local needle="$2"
+  if grep -Fq "$needle" "$file"; then
+    echo "[e2e] FAIL: did not expect '$needle' in $file" >&2
+    cat "$file" >&2 || true
+    exit 1
+  fi
+}
+
+mkdir -p "$REPO_ROOT/.budi"
+cat >"$REPO_ROOT/.budi/budi.toml" <<CFG
+daemon_host = "127.0.0.1"
+daemon_port = $DAEMON_PORT
+CFG
+
+(
+  cd "$REPO_ROOT"
+  git init -q 2>/dev/null || true
+)
+
+echo "[e2e] create fresh 8.2 database"
+"$BUDI" init --no-daemon >/dev/null
+
+echo "[e2e] inject 8.1-style proxy residue"
+python3 - <<'PY'
+import datetime
+import os
+import sqlite3
+
+db_path = os.path.join(os.environ["BUDI_HOME"], "analytics.db")
+conn = sqlite3.connect(db_path)
+conn.execute(
+    """
+    CREATE TABLE proxy_events (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        timestamp TEXT NOT NULL,
+        provider TEXT,
+        model TEXT,
+        input_tokens INTEGER NOT NULL DEFAULT 0,
+        output_tokens INTEGER NOT NULL DEFAULT 0,
+        cost_cents REAL
+    )
+    """
+)
+timestamp = datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0)
+raw_ts = timestamp.isoformat().replace("+00:00", "Z")
+conn.execute(
+    """
+    INSERT INTO proxy_events (timestamp, provider, model, input_tokens, output_tokens, cost_cents)
+    VALUES (?, 'openai', 'gpt-4o', 42, 7, 0.5)
+    """,
+    (raw_ts,),
+)
+conn.execute(
+    """
+    INSERT INTO messages (
+        id, role, timestamp, model, provider, input_tokens, output_tokens,
+        cache_creation_tokens, cache_read_tokens, cost_cents, cost_confidence
+    ) VALUES (
+        'legacy-proxy-message', 'assistant', ?, 'gpt-4o', 'openai', 42, 7, 0, 0, 0.5, 'proxy_estimated'
+    )
+    """,
+    (raw_ts,),
+)
+conn.commit()
+conn.close()
+PY
+
+if [[ "$(sqlite3 "$DB" "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='proxy_events';")" != "1" ]]; then
+  echo "[e2e] FAIL: expected proxy_events table before migration" >&2
+  exit 1
+fi
+
+echo "[e2e] rerun init to apply 8.2 cleanup migration"
+INIT_LOG="$TMPDIR_ROOT/init-upgrade.log"
+"$BUDI" init --no-daemon >"$INIT_LOG" 2>&1 || {
+  cat "$INIT_LOG" >&2 || true
+  echo "[e2e] FAIL: upgrade init failed" >&2
+  exit 1
+}
+
+if [[ "$(sqlite3 "$DB" "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='proxy_events';")" != "0" ]]; then
+  echo "[e2e] FAIL: proxy_events table should be removed after migration" >&2
+  sqlite3 "$DB" "SELECT name FROM sqlite_master WHERE type='table';" >&2 || true
+  exit 1
+fi
+if [[ "$(sqlite3 "$DB" "SELECT COUNT(*) FROM messages WHERE cost_confidence='proxy_estimated';")" != "1" ]]; then
+  echo "[e2e] FAIL: expected retained proxy_estimated message after migration" >&2
+  sqlite3 "$DB" "SELECT id, cost_confidence FROM messages;" >&2 || true
+  exit 1
+fi
+
+echo "[e2e] start daemon on :$DAEMON_PORT"
+RUST_LOG=info \
+  "$BUDI_DAEMON" serve \
+    --host 127.0.0.1 \
+    --port $DAEMON_PORT \
+    >"$TMPDIR_ROOT/daemon.log" 2>&1 &
+DAEMON_PID=$!
+
+DAEMON_UP=0
+for _ in {1..50}; do
+  if curl -s -o /dev/null -w "%{http_code}" --max-time 1 "http://127.0.0.1:$DAEMON_PORT/health" | grep -q "^200"; then
+    DAEMON_UP=1
+    break
+  fi
+  sleep 0.1
+done
+if [[ "$DAEMON_UP" != "1" ]]; then
+  echo "[e2e] FAIL: daemon did not come up on :$DAEMON_PORT" >&2
+  cat "$TMPDIR_ROOT/daemon.log" >&2 || true
+  exit 1
+fi
+
+echo "[e2e] analytics endpoints still see retained legacy proxy history"
+SUMMARY_JSON="$TMPDIR_ROOT/summary.json"
+COST_JSON="$TMPDIR_ROOT/cost.json"
+curl -fsS "http://127.0.0.1:$DAEMON_PORT/analytics/summary?since=$(date -u +%Y-%m-%dT00:00:00+00:00)" >"$SUMMARY_JSON"
+curl -fsS "http://127.0.0.1:$DAEMON_PORT/analytics/cost?since=$(date -u +%Y-%m-%dT00:00:00+00:00)" >"$COST_JSON"
+python3 - "$SUMMARY_JSON" "$COST_JSON" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], "r", encoding="utf-8") as f:
+    summary = json.load(f)
+with open(sys.argv[2], "r", encoding="utf-8") as f:
+    cost = json.load(f)
+
+assert summary["total_messages"] == 1, summary
+assert summary["total_assistant_messages"] == 1, summary
+assert cost["total_cost"] > 0, cost
+PY
+
+echo "[e2e] doctor reports retained legacy proxy history without stale-table residue"
+DOCTOR_LOG="$TMPDIR_ROOT/doctor.log"
+(
+  cd "$REPO_ROOT"
+  "$BUDI" doctor --repo-root "$REPO_ROOT" >"$DOCTOR_LOG" 2>&1 || true
+)
+assert_contains "$DOCTOR_LOG" "PASS legacy proxy history:"
+assert_contains "$DOCTOR_LOG" "retaining 1 proxy-sourced assistant row read-only"
+assert_not_contains "$DOCTOR_LOG" "obsolete \`proxy_events\` table is still present"
+
+echo "[e2e] PASS"


### PR DESCRIPTION
Summary
- drop the obsolete `proxy_events` table during schema reconcile while keeping proxy-sourced `messages` rows read-only for historical analytics
- surface retained legacy proxy history in `budi doctor` and repair responses so upgraded 8.1 databases are reported honestly
- add migration/unit/E2E coverage for the 8.1 -> 8.2 upgrade path and update authoritative docs to match the chosen policy

Risks / compatibility notes
- upgraded 8.1 databases lose the standalone `proxy_events` table; historical analytics continue through retained `messages` rows with `cost_confidence='proxy_estimated'`
- `budi doctor` now prints a legacy proxy-history check, which is informational when only retained rows remain and warning-level only if the obsolete table still exists

Validation
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `bash scripts/e2e/test_326_proxy_events_upgrade.sh`

Closes #326
