### PR TITLE
[8.2][R2.6] Add consent-first cleanup for legacy proxy residue

### DIFF
--- a/crates/budi-cli/src/commands/doctor.rs
+++ b/crates/budi-cli/src/commands/doctor.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 
 use anyhow::{Context, Result};
 use budi_core::config;
+use budi_core::legacy_proxy;
 use budi_core::provider::Provider;
 use chrono::{DateTime, Local, Utc};
 use rusqlite::{Connection, OptionalExtension, params};
@@ -44,7 +45,7 @@ pub fn cmd_doctor(repo_root: Option<PathBuf>, deep: bool) -> Result<()> {
     schema.result.print();
     report.record(&schema.result);
 
-    let proxy_residue = check_legacy_proxy_env();
+    let proxy_residue = check_legacy_proxy_residue();
     proxy_residue.print();
     report.record(&proxy_residue);
 
@@ -384,53 +385,70 @@ fn integrity_check_mode_label(deep: bool) -> &'static str {
     }
 }
 
-fn check_legacy_proxy_env() -> CheckResult {
-    let residue = legacy_proxy_env_vars();
-    if residue.is_empty() {
+fn check_legacy_proxy_residue() -> CheckResult {
+    let scan = match legacy_proxy::scan() {
+        Ok(scan) => scan,
+        Err(e) => {
+            return CheckResult::warn(
+                "leftover proxy config",
+                format!("could not inspect legacy proxy residue ({e})"),
+                Some("Run `budi init --cleanup` once the affected files are readable.".to_string()),
+            );
+        }
+    };
+
+    if !scan.has_any_residue() {
         return CheckResult::pass(
             "leftover proxy config",
-            "no legacy proxy-routing env vars are exported",
+            "no legacy proxy-routing residue detected in known config files or the current shell",
         );
     }
 
-    let rendered = residue
+    let mut details = Vec::new();
+    let managed_paths = scan
+        .files
         .iter()
-        .map(|(key, value)| format!("{key}={value}"))
-        .collect::<Vec<_>>()
-        .join(", ");
+        .filter(|file| file.has_managed_blocks())
+        .map(|file| file.path.display().to_string())
+        .collect::<Vec<_>>();
+    if !managed_paths.is_empty() {
+        details.push(format!(
+            "managed Budi proxy block(s) remain in {}",
+            managed_paths.join(", ")
+        ));
+    }
+
+    if scan.total_fuzzy_findings() > 0 {
+        let fuzzy_paths = scan
+            .files
+            .iter()
+            .filter(|file| file.has_fuzzy_findings())
+            .map(|file| file.path.display().to_string())
+            .collect::<Vec<_>>();
+        details.push(format!(
+            "manual edits still reference the old proxy in {}",
+            fuzzy_paths.join(", ")
+        ));
+    }
+
+    if !scan.exported_env_vars.is_empty() {
+        let rendered = scan
+            .exported_env_vars
+            .iter()
+            .map(|entry| format!("{}={}", entry.key, entry.value))
+            .collect::<Vec<_>>()
+            .join(", ");
+        details.push(format!("current shell still exports {rendered}"));
+    }
 
     CheckResult::warn(
         "leftover proxy config",
-        format!("legacy proxy env vars are still exported ({rendered})"),
+        details.join("; "),
         Some(
             "Run `budi init --cleanup` to review and remove old 8.0/8.1 proxy residue with explicit consent."
                 .to_string(),
         ),
     )
-}
-
-fn legacy_proxy_env_vars() -> Vec<(String, String)> {
-    [
-        "ANTHROPIC_BASE_URL",
-        "OPENAI_BASE_URL",
-        "COPILOT_PROVIDER_BASE_URL",
-    ]
-    .into_iter()
-    .filter_map(|key| {
-        let value = std::env::var(key).ok()?;
-        looks_like_legacy_proxy_value(&value).then_some((key.to_string(), value))
-    })
-    .collect()
-}
-
-fn looks_like_legacy_proxy_value(value: &str) -> bool {
-    let lower = value.trim().to_ascii_lowercase();
-    if lower.is_empty() {
-        return false;
-    }
-    lower.contains("localhost:9878")
-        || lower.contains("127.0.0.1:9878")
-        || lower.contains("[::1]:9878")
 }
 
 #[derive(Debug, Clone, Default)]
@@ -892,14 +910,6 @@ mod tests {
     fn integrity_check_uses_full_check_in_deep_mode() {
         assert_eq!(integrity_check_pragma(true), "PRAGMA integrity_check");
         assert_eq!(integrity_check_mode_label(true), "integrity_check");
-    }
-
-    #[test]
-    fn detects_legacy_proxy_env_values() {
-        assert!(looks_like_legacy_proxy_value("http://127.0.0.1:9878"));
-        assert!(looks_like_legacy_proxy_value("http://localhost:9878/v1"));
-        assert!(looks_like_legacy_proxy_value("http://[::1]:9878"));
-        assert!(!looks_like_legacy_proxy_value("https://api.anthropic.com"));
     }
 
     #[test]

--- a/crates/budi-cli/src/commands/init.rs
+++ b/crates/budi-cli/src/commands/init.rs
@@ -1,18 +1,18 @@
 use std::fs;
+use std::io::IsTerminal;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 
 use anyhow::{Context, Result};
 use budi_core::config;
+use budi_core::legacy_proxy::{self, LegacyProxyFile, LegacyProxyScan};
 use budi_core::provider::Provider;
 
 use crate::daemon::ensure_daemon_running;
 
-pub fn cmd_init(cleanup: bool, no_daemon: bool) -> Result<()> {
+pub fn cmd_init(cleanup: bool, yes: bool, no_daemon: bool) -> Result<()> {
     if cleanup {
-        anyhow::bail!(
-            "`budi init --cleanup` is reserved for the consent-first upgrade cleanup tracked by #357 and is not implemented yet."
-        );
+        run_cleanup_flow(yes)?;
     }
 
     clean_duplicate_binaries();
@@ -54,6 +54,139 @@ pub fn cmd_init(cleanup: bool, no_daemon: bool) -> Result<()> {
     );
 
     Ok(())
+}
+
+fn run_cleanup_flow(yes: bool) -> Result<()> {
+    let scan = legacy_proxy::scan()?;
+    let managed_files = scan
+        .files
+        .iter()
+        .filter(|file| file.has_managed_blocks())
+        .collect::<Vec<_>>();
+
+    if managed_files.is_empty() {
+        println!("No managed 8.0/8.1 Budi proxy blocks found. Nothing to clean.");
+        print_manual_review_findings(&scan);
+        print_current_shell_warning(&scan);
+        println!();
+        return Ok(());
+    }
+
+    if !yes && !std::io::stdin().is_terminal() {
+        anyhow::bail!(
+            "Non-interactive terminal. Use `budi init --cleanup --yes` to skip per-file confirmation."
+        );
+    }
+
+    println!("Reviewing legacy 8.0/8.1 proxy residue...");
+
+    let mut removed = 0usize;
+    let mut skipped = 0usize;
+
+    for file in managed_files {
+        println!();
+        print_cleanup_preview(file);
+
+        let should_apply = yes || prompt_for_cleanup(file)?;
+        if should_apply {
+            file.apply_cleanup()?;
+            removed += 1;
+            println!(
+                "  Removed managed Budi proxy block(s) from {}",
+                file.path.display()
+            );
+        } else {
+            skipped += 1;
+            println!("  Skipped {}", file.path.display());
+        }
+
+        if file.has_fuzzy_findings() {
+            print_file_manual_review(file);
+        }
+    }
+
+    print_manual_review_findings(&scan);
+    print_current_shell_warning(&scan);
+    println!();
+    println!("Cleanup summary: removed {removed} file(s), skipped {skipped}.");
+    Ok(())
+}
+
+fn print_cleanup_preview(file: &LegacyProxyFile) {
+    println!(
+        "  {} ({})",
+        file.path.display(),
+        file.surface.display_name()
+    );
+    println!("    diff preview:");
+    for block in &file.managed_blocks {
+        let range = match block.end_line {
+            Some(end_line) => format!("lines {}-{}", block.start_line, end_line),
+            None => format!("line {} to EOF (unterminated block)", block.start_line),
+        };
+        println!("      - remove managed block at {range}");
+        for line in &block.lines {
+            println!("      - {}", line);
+        }
+    }
+    if file.surface == budi_core::legacy_proxy::LegacyProxySurface::CursorSettings {
+        println!("      - clean up any dangling JSON comma left behind by the removed block");
+    }
+}
+
+fn prompt_for_cleanup(file: &LegacyProxyFile) -> Result<bool> {
+    eprint!(
+        "Remove the managed Budi proxy block(s) from {}? [y/N] ",
+        file.path.display()
+    );
+    let mut answer = String::new();
+    std::io::stdin()
+        .read_line(&mut answer)
+        .context("Failed to read stdin")?;
+    Ok(matches!(answer.trim(), "y" | "Y"))
+}
+
+fn print_manual_review_findings(scan: &LegacyProxyScan) {
+    let fuzzy_only = scan
+        .files
+        .iter()
+        .filter(|file| !file.has_managed_blocks() && file.has_fuzzy_findings())
+        .collect::<Vec<_>>();
+    if fuzzy_only.is_empty() {
+        return;
+    }
+    println!();
+    println!("Manual review only (not auto-removed):");
+    for file in fuzzy_only {
+        print_file_manual_review(file);
+    }
+}
+
+fn print_file_manual_review(file: &LegacyProxyFile) {
+    println!("  {}:", file.path.display());
+    for finding in &file.fuzzy_findings {
+        println!(
+            "    ! line {} ({}) {}",
+            finding.line_number, finding.label, finding.snippet
+        );
+    }
+}
+
+fn print_current_shell_warning(scan: &LegacyProxyScan) {
+    if scan.exported_env_vars.is_empty() {
+        return;
+    }
+    let rendered = scan
+        .exported_env_vars
+        .iter()
+        .map(|entry| format!("{}={}", entry.key, entry.value))
+        .collect::<Vec<_>>()
+        .join(", ");
+    println!();
+    println!("Current shell still has legacy proxy env vars loaded: {rendered}");
+    println!(
+        "Open a fresh terminal after cleanup so those stale exports disappear from the live session."
+    );
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/budi-cli/src/commands/uninstall.rs
+++ b/crates/budi-cli/src/commands/uninstall.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 use std::process::Command;
 
 use anyhow::{Context, Result};
+use budi_core::legacy_proxy;
 use serde_json::Value;
 
 use super::statusline::CLAUDE_USER_SETTINGS;
@@ -30,6 +31,8 @@ pub fn cmd_uninstall(keep_data: bool, yes: bool) -> Result<()> {
             "{yellow}warning: could not determine home directory — skipping hook/config cleanup{reset}"
         );
     } else {
+        cleanup_legacy_proxy_residue(green, yellow, reset);
+
         // 2-6. Remove Claude Code integrations (single file pass)
         match remove_all_from_claude_code(&home) {
             Ok((hooks, otel, mcp, statusline)) => {
@@ -123,6 +126,63 @@ pub fn cmd_uninstall(keep_data: bool, yes: bool) -> Result<()> {
     print_binary_removal_hint();
 
     Ok(())
+}
+
+fn cleanup_legacy_proxy_residue(green: &str, yellow: &str, reset: &str) {
+    print!("Removing legacy 8.0/8.1 proxy residue... ");
+    let scan = match legacy_proxy::scan() {
+        Ok(scan) => scan,
+        Err(e) => {
+            println!("{yellow}warning: {e}{reset}");
+            return;
+        }
+    };
+
+    let mut removed_paths = Vec::new();
+    for file in scan.files.iter().filter(|file| file.has_managed_blocks()) {
+        match file.apply_cleanup() {
+            Ok(true) => removed_paths.push(file.path.display().to_string()),
+            Ok(false) => {}
+            Err(e) => {
+                println!("{yellow}warning: {e}{reset}");
+                return;
+            }
+        }
+    }
+
+    if removed_paths.is_empty() {
+        println!("none found");
+    } else {
+        println!("{green}✓{reset} removed from {}", removed_paths.join(", "));
+    }
+
+    if scan.total_fuzzy_findings() > 0 {
+        println!(
+            "  {yellow}warning:{reset} manual edits still reference the old proxy and were not auto-removed:"
+        );
+        for file in scan.files.iter().filter(|file| file.has_fuzzy_findings()) {
+            println!("    {}:", file.path.display());
+            for finding in &file.fuzzy_findings {
+                println!(
+                    "      line {} ({}) {}",
+                    finding.line_number, finding.label, finding.snippet
+                );
+            }
+        }
+    }
+
+    if !scan.exported_env_vars.is_empty() {
+        let rendered = scan
+            .exported_env_vars
+            .iter()
+            .map(|entry| format!("{}={}", entry.key, entry.value))
+            .collect::<Vec<_>>()
+            .join(", ");
+        println!("  Current shell still exports legacy proxy env vars: {rendered}");
+        println!(
+            "  Open a fresh terminal if you want the current session to drop those values too."
+        );
+    }
 }
 
 fn stop_daemon() -> Result<bool> {

--- a/crates/budi-cli/src/main.rs
+++ b/crates/budi-cli/src/main.rs
@@ -31,6 +31,9 @@ enum Commands {
         /// Remove legacy 8.0/8.1 proxy residue after showing a consent-first cleanup flow
         #[arg(long, default_value_t = false)]
         cleanup: bool,
+        /// Skip cleanup confirmation prompts
+        #[arg(long, default_value_t = false)]
+        yes: bool,
         #[arg(long, hide = true)]
         no_daemon: bool,
     },
@@ -344,7 +347,11 @@ fn main() -> Result<()> {
         .init();
 
     match cli.command {
-        Commands::Init { cleanup, no_daemon } => commands::init::cmd_init(cleanup, no_daemon),
+        Commands::Init {
+            cleanup,
+            yes,
+            no_daemon,
+        } => commands::init::cmd_init(cleanup, yes, no_daemon),
         Commands::Doctor { deep, repo_root } => commands::doctor::cmd_doctor(repo_root, deep),
         Commands::Stats {
             period,

--- a/crates/budi-core/src/legacy_proxy.rs
+++ b/crates/budi-core/src/legacy_proxy.rs
@@ -1,0 +1,748 @@
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+
+use crate::config;
+
+pub const SHELL_BLOCK_START: &str = "# >>> budi >>>";
+pub const SHELL_BLOCK_END: &str = "# <<< budi <<<";
+pub const CURSOR_BLOCK_START: &str = "// >>> budi >>>";
+pub const CURSOR_BLOCK_END: &str = "// <<< budi <<<";
+
+const CURSOR_OPENAI_BASE_URL_KEY: &str = "openai.baseUrl";
+const UPGRADE_NOTICE_DIR: &str = "upgrade-flags";
+const UPGRADE_NOTICE_FILE: &str = "legacy-proxy-cleanup-v8.2.flag";
+const PROXY_ENV_VARS: [&str; 5] = [
+    "ANTHROPIC_BASE_URL",
+    "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC",
+    "OPENAI_BASE_URL",
+    "COPILOT_PROVIDER_BASE_URL",
+    "COPILOT_PROVIDER_TYPE",
+];
+const EXPORTED_PROXY_URL_ENV_VARS: [&str; 3] = [
+    "ANTHROPIC_BASE_URL",
+    "OPENAI_BASE_URL",
+    "COPILOT_PROVIDER_BASE_URL",
+];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LegacyProxySurface {
+    ShellProfile,
+    CursorSettings,
+    CodexConfig,
+}
+
+impl LegacyProxySurface {
+    pub fn display_name(self) -> &'static str {
+        match self {
+            Self::ShellProfile => "shell profile",
+            Self::CursorSettings => "Cursor settings",
+            Self::CodexConfig => "Codex config",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ManagedBlock {
+    pub start_line: usize,
+    pub end_line: Option<usize>,
+    pub lines: Vec<String>,
+}
+
+impl ManagedBlock {
+    pub fn is_corrupted(&self) -> bool {
+        self.end_line.is_none()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FuzzyFinding {
+    pub line_number: usize,
+    pub label: String,
+    pub snippet: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExportedEnvVar {
+    pub key: String,
+    pub value: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LegacyProxyFile {
+    pub surface: LegacyProxySurface,
+    pub path: PathBuf,
+    pub original_text: String,
+    pub cleaned_text: String,
+    pub managed_blocks: Vec<ManagedBlock>,
+    pub fuzzy_findings: Vec<FuzzyFinding>,
+}
+
+impl LegacyProxyFile {
+    pub fn has_managed_blocks(&self) -> bool {
+        !self.managed_blocks.is_empty()
+    }
+
+    pub fn has_fuzzy_findings(&self) -> bool {
+        !self.fuzzy_findings.is_empty()
+    }
+
+    pub fn apply_cleanup(&self) -> Result<bool> {
+        if !self.has_managed_blocks() || self.cleaned_text == self.original_text {
+            return Ok(false);
+        }
+        if let Some(parent) = self.path.parent() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("Failed to create {}", parent.display()))?;
+        }
+        fs::write(&self.path, &self.cleaned_text)
+            .with_context(|| format!("Failed writing {}", self.path.display()))?;
+        Ok(true)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LegacyProxyScan {
+    pub files: Vec<LegacyProxyFile>,
+    pub exported_env_vars: Vec<ExportedEnvVar>,
+}
+
+impl LegacyProxyScan {
+    pub fn has_any_residue(&self) -> bool {
+        !self.files.is_empty() || !self.exported_env_vars.is_empty()
+    }
+
+    pub fn has_managed_blocks(&self) -> bool {
+        self.files.iter().any(LegacyProxyFile::has_managed_blocks)
+    }
+
+    pub fn managed_file_count(&self) -> usize {
+        self.files
+            .iter()
+            .filter(|file| file.has_managed_blocks())
+            .count()
+    }
+
+    pub fn fuzzy_file_count(&self) -> usize {
+        self.files
+            .iter()
+            .filter(|file| file.has_fuzzy_findings())
+            .count()
+    }
+
+    pub fn total_fuzzy_findings(&self) -> usize {
+        self.files
+            .iter()
+            .map(|file| file.fuzzy_findings.len())
+            .sum()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UpgradeNoticeOutcome {
+    NotNeeded,
+    AlreadyLogged,
+    LoggedNow,
+}
+
+#[derive(Debug, Clone)]
+struct EnvContext {
+    shell: Option<String>,
+    appdata: Option<String>,
+    codex_home: Option<String>,
+    exported_env_vars: Vec<ExportedEnvVar>,
+}
+
+impl EnvContext {
+    fn capture() -> Self {
+        Self {
+            shell: std::env::var("SHELL").ok(),
+            appdata: std::env::var("APPDATA").ok(),
+            codex_home: std::env::var("CODEX_HOME").ok(),
+            exported_env_vars: current_process_proxy_url_env_vars(),
+        }
+    }
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PlatformFamily {
+    Macos,
+    Linux,
+    Windows,
+}
+
+#[derive(Debug, Clone)]
+struct StripResult {
+    cleaned_text: String,
+    managed_blocks: Vec<ManagedBlock>,
+}
+
+pub fn scan() -> Result<LegacyProxyScan> {
+    let home = config::home_dir()?;
+    scan_with_env(&home, current_platform(), &EnvContext::capture())
+}
+
+pub fn emit_upgrade_notice_once() -> Result<UpgradeNoticeOutcome> {
+    let home = config::home_dir()?;
+    let scan = scan_with_env(&home, current_platform(), &EnvContext::capture())?;
+    let flag_path = upgrade_notice_flag_path()?;
+    emit_upgrade_notice_once_for_scan(&scan, &flag_path)
+}
+
+fn emit_upgrade_notice_once_for_scan(
+    scan: &LegacyProxyScan,
+    flag_path: &Path,
+) -> Result<UpgradeNoticeOutcome> {
+    if !scan.has_managed_blocks() {
+        return Ok(UpgradeNoticeOutcome::NotNeeded);
+    }
+    if flag_path.exists() {
+        return Ok(UpgradeNoticeOutcome::AlreadyLogged);
+    }
+    if let Some(parent) = flag_path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("Failed to create {}", parent.display()))?;
+    }
+
+    let managed_paths = scan
+        .files
+        .iter()
+        .filter(|file| file.has_managed_blocks())
+        .map(|file| file.path.display().to_string())
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    tracing::warn!(
+        managed_files = scan.managed_file_count(),
+        paths = %managed_paths,
+        "Detected legacy 8.0/8.1 proxy config residue managed by Budi. Run `budi init --cleanup` to review and remove it before those stale localhost routes break your agents on 8.2."
+    );
+
+    fs::write(flag_path, "logged\n")
+        .with_context(|| format!("Failed writing {}", flag_path.display()))?;
+    Ok(UpgradeNoticeOutcome::LoggedNow)
+}
+
+fn scan_with_env(
+    home: &Path,
+    platform: PlatformFamily,
+    env: &EnvContext,
+) -> Result<LegacyProxyScan> {
+    let mut files = Vec::new();
+
+    for path in shell_profile_candidates(home, platform, env.shell.as_deref()) {
+        if let Some(file) = scan_shell_profile(&path)? {
+            files.push(file);
+        }
+    }
+
+    for path in cursor_settings_candidates(home, platform, env.appdata.as_deref()) {
+        if let Some(file) = scan_cursor_settings(&path)? {
+            files.push(file);
+        }
+    }
+
+    for path in codex_config_candidates(home, env.codex_home.as_deref()) {
+        if let Some(file) = scan_codex_config(&path)? {
+            files.push(file);
+        }
+    }
+
+    Ok(LegacyProxyScan {
+        files,
+        exported_env_vars: env.exported_env_vars.clone(),
+    })
+}
+
+fn scan_shell_profile(path: &Path) -> Result<Option<LegacyProxyFile>> {
+    scan_text_file(
+        path,
+        LegacyProxySurface::ShellProfile,
+        shell_marker_variants(),
+        scan_shell_env_findings,
+    )
+}
+
+fn scan_cursor_settings(path: &Path) -> Result<Option<LegacyProxyFile>> {
+    scan_text_file(
+        path,
+        LegacyProxySurface::CursorSettings,
+        cursor_marker_variants(),
+        scan_cursor_settings_findings,
+    )
+}
+
+fn scan_codex_config(path: &Path) -> Result<Option<LegacyProxyFile>> {
+    scan_text_file(
+        path,
+        LegacyProxySurface::CodexConfig,
+        shell_marker_variants(),
+        |_| Vec::new(),
+    )
+}
+
+fn scan_text_file<F>(
+    path: &Path,
+    surface: LegacyProxySurface,
+    marker_variants: &[(&str, &str)],
+    fuzzy_scan: F,
+) -> Result<Option<LegacyProxyFile>>
+where
+    F: Fn(&str) -> Vec<FuzzyFinding>,
+{
+    if !path.exists() {
+        return Ok(None);
+    }
+    let original_text =
+        fs::read_to_string(path).with_context(|| format!("Failed to read {}", path.display()))?;
+
+    let stripped = strip_managed_blocks(&original_text, marker_variants);
+    let cleaned_text = if surface == LegacyProxySurface::CursorSettings {
+        trim_trailing_comma_before_closing_brace(&stripped.cleaned_text)
+    } else {
+        stripped.cleaned_text
+    };
+    let fuzzy_findings = fuzzy_scan(&cleaned_text);
+
+    if stripped.managed_blocks.is_empty() && fuzzy_findings.is_empty() {
+        return Ok(None);
+    }
+
+    Ok(Some(LegacyProxyFile {
+        surface,
+        path: path.to_path_buf(),
+        original_text,
+        cleaned_text,
+        managed_blocks: stripped.managed_blocks,
+        fuzzy_findings,
+    }))
+}
+
+fn shell_marker_variants() -> &'static [(&'static str, &'static str)] {
+    &[(SHELL_BLOCK_START, SHELL_BLOCK_END)]
+}
+
+fn cursor_marker_variants() -> &'static [(&'static str, &'static str)] {
+    &[(CURSOR_BLOCK_START, CURSOR_BLOCK_END)]
+}
+
+fn strip_managed_blocks(raw: &str, marker_variants: &[(&str, &str)]) -> StripResult {
+    let mut kept_lines = Vec::new();
+    let mut managed_blocks = Vec::new();
+    let mut in_block = false;
+    let mut current_end = "";
+    let mut current_start_line = 0usize;
+    let mut current_lines: Vec<String> = Vec::new();
+
+    for (index, line) in raw.lines().enumerate() {
+        let line_number = index + 1;
+        let trimmed = line.trim();
+
+        if !in_block {
+            if let Some((_, end)) = marker_variants.iter().find(|(start, _)| trimmed == *start) {
+                in_block = true;
+                current_end = end;
+                current_start_line = line_number;
+                current_lines.push(line.to_string());
+                continue;
+            }
+
+            kept_lines.push(line.to_string());
+            continue;
+        }
+
+        current_lines.push(line.to_string());
+        if trimmed == current_end {
+            managed_blocks.push(ManagedBlock {
+                start_line: current_start_line,
+                end_line: Some(line_number),
+                lines: std::mem::take(&mut current_lines),
+            });
+            in_block = false;
+            current_end = "";
+            current_start_line = 0;
+        }
+    }
+
+    if in_block {
+        managed_blocks.push(ManagedBlock {
+            start_line: current_start_line,
+            end_line: None,
+            lines: current_lines,
+        });
+    }
+
+    StripResult {
+        cleaned_text: rebuild_text(&kept_lines, raw),
+        managed_blocks,
+    }
+}
+
+fn rebuild_text(lines: &[String], original: &str) -> String {
+    if lines.is_empty() {
+        return String::new();
+    }
+    let newline = newline_style(original);
+    let mut rebuilt = lines.join(newline);
+    if original.ends_with("\r\n") {
+        rebuilt.push_str("\r\n");
+    } else if original.ends_with('\n') {
+        rebuilt.push('\n');
+    }
+    rebuilt
+}
+
+fn newline_style(raw: &str) -> &'static str {
+    if raw.contains("\r\n") { "\r\n" } else { "\n" }
+}
+
+fn trim_trailing_comma_before_closing_brace(raw: &str) -> String {
+    let Some(close_idx) = raw.rfind('}') else {
+        return raw.to_string();
+    };
+
+    let mut idx = close_idx;
+    let bytes = raw.as_bytes();
+    while idx > 0 && bytes[idx - 1].is_ascii_whitespace() {
+        idx -= 1;
+    }
+
+    if idx > 0 && bytes[idx - 1] == b',' {
+        let mut out = String::new();
+        out.push_str(&raw[..idx - 1]);
+        out.push_str(&raw[idx..]);
+        out
+    } else {
+        raw.to_string()
+    }
+}
+
+fn scan_shell_env_findings(raw: &str) -> Vec<FuzzyFinding> {
+    let mut findings = Vec::new();
+    for (index, line) in raw.lines().enumerate() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with('#') || trimmed.starts_with("//") {
+            continue;
+        }
+        for key in PROXY_ENV_VARS {
+            if looks_like_env_assignment(trimmed, key) {
+                findings.push(FuzzyFinding {
+                    line_number: index + 1,
+                    label: key.to_string(),
+                    snippet: line.trim().to_string(),
+                });
+            }
+        }
+    }
+    findings
+}
+
+fn scan_cursor_settings_findings(raw: &str) -> Vec<FuzzyFinding> {
+    let mut findings = Vec::new();
+    for (index, line) in raw.lines().enumerate() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("//") {
+            continue;
+        }
+        let lower = line.to_ascii_lowercase();
+        if lower.contains(CURSOR_OPENAI_BASE_URL_KEY.to_ascii_lowercase().as_str())
+            && looks_like_legacy_proxy_url(&lower)
+        {
+            findings.push(FuzzyFinding {
+                line_number: index + 1,
+                label: CURSOR_OPENAI_BASE_URL_KEY.to_string(),
+                snippet: line.trim().to_string(),
+            });
+        }
+    }
+    findings
+}
+
+fn looks_like_env_assignment(line: &str, key: &str) -> bool {
+    let without_export = line.strip_prefix("export ").unwrap_or(line).trim_start();
+    let Some(rest) = without_export.strip_prefix(key) else {
+        return false;
+    };
+    rest.trim_start().starts_with('=')
+}
+
+fn current_process_proxy_url_env_vars() -> Vec<ExportedEnvVar> {
+    EXPORTED_PROXY_URL_ENV_VARS
+        .into_iter()
+        .filter_map(|key| {
+            let value = std::env::var(key).ok()?;
+            if looks_like_legacy_proxy_url(&value) {
+                Some(ExportedEnvVar {
+                    key: key.to_string(),
+                    value,
+                })
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+fn looks_like_legacy_proxy_url(value: &str) -> bool {
+    let lower = value.trim().to_ascii_lowercase();
+    if lower.is_empty() {
+        return false;
+    }
+    lower.contains("localhost:9878")
+        || lower.contains("127.0.0.1:9878")
+        || lower.contains("[::1]:9878")
+}
+
+fn current_platform() -> PlatformFamily {
+    #[cfg(target_os = "macos")]
+    {
+        PlatformFamily::Macos
+    }
+    #[cfg(target_os = "windows")]
+    {
+        return PlatformFamily::Windows;
+    }
+    #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
+    {
+        PlatformFamily::Linux
+    }
+}
+
+fn shell_profile_candidates(
+    home: &Path,
+    platform: PlatformFamily,
+    shell: Option<&str>,
+) -> Vec<PathBuf> {
+    if platform == PlatformFamily::Windows {
+        return Vec::new();
+    }
+
+    let zsh = home.join(".zshrc");
+    let bashrc = home.join(".bashrc");
+    let bash_profile = home.join(".bash_profile");
+
+    let mut candidates = Vec::new();
+    if let Some(shell) = shell {
+        let lower = shell.to_ascii_lowercase();
+        if lower.contains("zsh") {
+            candidates.push(zsh.clone());
+        }
+        if lower.contains("bash") {
+            candidates.push(bashrc.clone());
+            candidates.push(bash_profile.clone());
+        }
+    }
+    candidates.push(zsh);
+    candidates.push(bashrc);
+    candidates.push(bash_profile);
+    dedup_paths(candidates)
+}
+
+fn cursor_settings_candidates(
+    home: &Path,
+    platform: PlatformFamily,
+    appdata: Option<&str>,
+) -> Vec<PathBuf> {
+    let candidates = match platform {
+        PlatformFamily::Macos => vec![
+            home.join("Library/Application Support/Cursor/User/settings.json"),
+            home.join(".cursor/settings.json"),
+        ],
+        PlatformFamily::Linux => vec![
+            home.join(".config/Cursor/User/settings.json"),
+            home.join(".cursor/settings.json"),
+        ],
+        PlatformFamily::Windows => {
+            let mut candidates = Vec::new();
+            if let Some(appdata) = appdata {
+                let trimmed = appdata.trim();
+                if !trimmed.is_empty() {
+                    candidates.push(PathBuf::from(trimmed).join("Cursor/User/settings.json"));
+                }
+            }
+            candidates.push(home.join("AppData/Roaming/Cursor/User/settings.json"));
+            candidates.push(home.join(".cursor/settings.json"));
+            candidates
+        }
+    };
+    dedup_paths(candidates)
+}
+
+fn codex_config_candidates(home: &Path, codex_home: Option<&str>) -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
+    if let Some(raw) = codex_home {
+        let trimmed = raw.trim();
+        if !trimmed.is_empty() {
+            candidates.push(PathBuf::from(trimmed).join("config.toml"));
+        }
+    }
+    candidates.push(home.join(".codex/config.toml"));
+    dedup_paths(candidates)
+}
+
+fn dedup_paths(paths: Vec<PathBuf>) -> Vec<PathBuf> {
+    let mut seen = HashSet::new();
+    let mut deduped = Vec::new();
+    for path in paths {
+        if seen.insert(path.clone()) {
+            deduped.push(path);
+        }
+    }
+    deduped
+}
+
+fn upgrade_notice_flag_path() -> Result<PathBuf> {
+    Ok(config::budi_home_dir()?
+        .join(UPGRADE_NOTICE_DIR)
+        .join(UPGRADE_NOTICE_FILE))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn unique_temp_dir(name: &str) -> PathBuf {
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "budi-legacy-proxy-{name}-{}-{stamp}",
+            std::process::id()
+        ))
+    }
+
+    #[test]
+    fn strip_managed_blocks_removes_complete_block() {
+        let raw = "alpha\n# >>> budi >>>\nexport X=1\n# <<< budi <<<\nomega\n";
+        let stripped = strip_managed_blocks(raw, shell_marker_variants());
+        assert_eq!(stripped.cleaned_text, "alpha\nomega\n");
+        assert_eq!(stripped.managed_blocks.len(), 1);
+        assert_eq!(stripped.managed_blocks[0].start_line, 2);
+        assert_eq!(stripped.managed_blocks[0].end_line, Some(4));
+    }
+
+    #[test]
+    fn strip_managed_blocks_marks_unterminated_block_as_corrupted() {
+        let raw = "alpha\n# >>> budi >>>\nexport OPENAI_BASE_URL=http://localhost:9878\n";
+        let stripped = strip_managed_blocks(raw, shell_marker_variants());
+        assert_eq!(stripped.cleaned_text, "alpha\n");
+        assert_eq!(stripped.managed_blocks.len(), 1);
+        assert!(stripped.managed_blocks[0].is_corrupted());
+    }
+
+    #[test]
+    fn scan_shell_env_findings_ignores_commented_lines() {
+        let findings = scan_shell_env_findings(
+            "# export OPENAI_BASE_URL=http://localhost:9878\nexport OPENAI_BASE_URL=http://localhost:9878\n",
+        );
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].label, "OPENAI_BASE_URL");
+    }
+
+    #[test]
+    fn scan_cursor_settings_findings_only_flags_localhost_values() {
+        let findings = scan_cursor_settings_findings(
+            "{\n  \"openai.baseUrl\": \"http://127.0.0.1:9878\"\n}\n",
+        );
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].label, "openai.baseUrl");
+
+        let clean = scan_cursor_settings_findings(
+            "{\n  \"openai.baseUrl\": \"https://api.openai.com\"\n}\n",
+        );
+        assert!(clean.is_empty());
+    }
+
+    #[test]
+    fn shell_profile_candidates_cover_mac_and_linux_shapes() {
+        let home = Path::new("/tmp/home");
+        assert_eq!(
+            shell_profile_candidates(home, PlatformFamily::Macos, Some("/bin/zsh")),
+            vec![
+                home.join(".zshrc"),
+                home.join(".bashrc"),
+                home.join(".bash_profile"),
+            ]
+        );
+        assert_eq!(
+            shell_profile_candidates(home, PlatformFamily::Linux, Some("/bin/bash")),
+            vec![
+                home.join(".bashrc"),
+                home.join(".bash_profile"),
+                home.join(".zshrc"),
+            ]
+        );
+    }
+
+    #[test]
+    fn cursor_settings_candidates_cover_windows_and_fallbacks() {
+        let home = Path::new("/tmp/home");
+        assert_eq!(
+            cursor_settings_candidates(home, PlatformFamily::Macos, None),
+            vec![
+                home.join("Library/Application Support/Cursor/User/settings.json"),
+                home.join(".cursor/settings.json"),
+            ]
+        );
+        assert_eq!(
+            cursor_settings_candidates(
+                home,
+                PlatformFamily::Windows,
+                Some("C:/Users/test/AppData/Roaming"),
+            ),
+            vec![
+                PathBuf::from("C:/Users/test/AppData/Roaming/Cursor/User/settings.json"),
+                home.join("AppData/Roaming/Cursor/User/settings.json"),
+                home.join(".cursor/settings.json"),
+            ]
+        );
+    }
+
+    #[test]
+    fn codex_config_candidates_include_codex_home_override() {
+        let home = Path::new("/tmp/home");
+        assert_eq!(
+            codex_config_candidates(home, Some("/tmp/codex-home")),
+            vec![
+                PathBuf::from("/tmp/codex-home/config.toml"),
+                home.join(".codex/config.toml"),
+            ]
+        );
+    }
+
+    #[test]
+    fn upgrade_notice_outcome_only_logs_once_when_managed_block_exists() {
+        let home = unique_temp_dir("notice");
+        let flag_path = unique_temp_dir("notice-flag").join("legacy.flag");
+        fs::create_dir_all(&home).unwrap();
+        fs::write(
+            home.join(".zshrc"),
+            "# >>> budi >>>\nexport OPENAI_BASE_URL=http://localhost:9878\n# <<< budi <<<\n",
+        )
+        .unwrap();
+
+        let env = EnvContext {
+            shell: Some("/bin/zsh".to_string()),
+            appdata: None,
+            codex_home: None,
+            exported_env_vars: Vec::new(),
+        };
+        let scan = scan_with_env(&home, PlatformFamily::Macos, &env).unwrap();
+
+        let first = emit_upgrade_notice_once_for_scan(&scan, &flag_path).unwrap();
+        let second = emit_upgrade_notice_once_for_scan(&scan, &flag_path).unwrap();
+
+        assert_eq!(first, UpgradeNoticeOutcome::LoggedNow);
+        assert_eq!(second, UpgradeNoticeOutcome::AlreadyLogged);
+
+        let _ = fs::remove_dir_all(&home);
+        if let Some(parent) = flag_path.parent() {
+            let _ = fs::remove_dir_all(parent);
+        }
+    }
+}

--- a/crates/budi-core/src/lib.rs
+++ b/crates/budi-core/src/lib.rs
@@ -8,6 +8,7 @@ pub mod hooks;
 pub mod identity;
 pub mod integrations;
 pub mod jsonl;
+pub mod legacy_proxy;
 pub mod migration;
 pub mod pipeline;
 pub mod privacy;

--- a/crates/budi-daemon/src/main.rs
+++ b/crates/budi-daemon/src/main.rs
@@ -181,6 +181,9 @@ async fn main() -> Result<()> {
     {
         tracing::warn!("Failed to initialize database: {e}");
     }
+    if let Err(e) = budi_core::legacy_proxy::emit_upgrade_notice_once() {
+        tracing::warn!("Failed to scan legacy proxy residue on startup: {e}");
+    }
 
     // --- Start filesystem tailer (ADR-0089 §1 / R1.4 #320) ---
     //

--- a/scripts/e2e/test_357_upgrade_cleanup.sh
+++ b/scripts/e2e/test_357_upgrade_cleanup.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# End-to-end regression for issue #357: verify 8.2 can detect and remove
+# legacy 8.0/8.1 proxy config residue with explicit cleanup, and that
+# `budi uninstall` applies the same managed-block removal on upgraded machines.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BUDI="$ROOT/target/release/budi"
+
+if [[ ! -x "$BUDI" ]]; then
+  echo "error: release binary not built. run \`cargo build --release\` first." >&2
+  exit 2
+fi
+
+TMPDIR_ROOT="$(mktemp -d -t budi-e2e-357-XXXXXX)"
+export HOME="$TMPDIR_ROOT"
+export BUDI_HOME="$HOME/.local/share/budi"
+export CODEX_HOME="$HOME/custom-codex"
+
+SHELL_FILE="$HOME/.zshrc"
+CURSOR_FILE="$HOME/Library/Application Support/Cursor/User/settings.json"
+CODEX_FILE="$CODEX_HOME/config.toml"
+MANUAL_FILE="$HOME/.bash_profile"
+
+cleanup() {
+  local status=$?
+  if [[ "${KEEP_TMP:-0}" == "1" ]]; then
+    echo "[e2e] leaving tmp: $TMPDIR_ROOT"
+  else
+    rm -rf "$TMPDIR_ROOT"
+  fi
+  exit $status
+}
+trap cleanup EXIT INT TERM
+
+assert_contains() {
+  local file="$1"
+  local needle="$2"
+  if ! grep -Fq "$needle" "$file"; then
+    echo "[e2e] FAIL: expected '$needle' in $file" >&2
+    cat "$file" >&2 || true
+    exit 1
+  fi
+}
+
+assert_not_contains() {
+  local file="$1"
+  local needle="$2"
+  if grep -Fq "$needle" "$file"; then
+    echo "[e2e] FAIL: did not expect '$needle' in $file" >&2
+    cat "$file" >&2 || true
+    exit 1
+  fi
+}
+
+seed_managed_blocks() {
+  mkdir -p "$(dirname "$CURSOR_FILE")" "$CODEX_HOME"
+
+  cat >"$SHELL_FILE" <<'EOF'
+export PATH="/usr/local/bin:$PATH"
+
+# >>> budi >>>
+export ANTHROPIC_BASE_URL="http://localhost:9878"
+export CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1
+export OPENAI_BASE_URL="http://localhost:9878"
+export COPILOT_PROVIDER_BASE_URL="http://localhost:9878"
+export COPILOT_PROVIDER_TYPE="openai"
+# <<< budi <<<
+EOF
+
+  cat >"$CURSOR_FILE" <<'EOF'
+{
+  "editor.fontSize": 13,
+  // >>> budi >>>
+  "openai.baseUrl": "http://localhost:9878"
+  // <<< budi <<<
+}
+EOF
+
+  cat >"$CODEX_FILE" <<'EOF'
+# >>> budi >>>
+openai_base_url = "http://localhost:9878"
+# <<< budi <<<
+EOF
+}
+
+assert_managed_blocks_removed() {
+  assert_not_contains "$SHELL_FILE" "# >>> budi >>>"
+  assert_not_contains "$SHELL_FILE" "ANTHROPIC_BASE_URL"
+  assert_not_contains "$CURSOR_FILE" "// >>> budi >>>"
+  assert_not_contains "$CURSOR_FILE" "openai.baseUrl"
+  assert_not_contains "$CODEX_FILE" "# >>> budi >>>"
+  assert_not_contains "$CODEX_FILE" "openai_base_url"
+
+  python3 - "$CURSOR_FILE" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], "r", encoding="utf-8") as f:
+    data = json.load(f)
+
+assert data["editor.fontSize"] == 13, data
+assert "openai.baseUrl" not in data, data
+PY
+}
+
+echo "[e2e] seed 8.1-style managed blocks"
+seed_managed_blocks
+
+echo "[e2e] explicit cleanup removes managed blocks"
+INIT_LOG="$TMPDIR_ROOT/init-cleanup.log"
+"$BUDI" init --cleanup --yes --no-daemon >"$INIT_LOG" 2>&1 || {
+  cat "$INIT_LOG" >&2 || true
+  echo "[e2e] FAIL: init --cleanup failed" >&2
+  exit 1
+}
+assert_contains "$INIT_LOG" "Cleanup summary: removed 3 file(s), skipped 0."
+assert_managed_blocks_removed
+
+echo "[e2e] second cleanup is idempotent"
+INIT_LOG_2="$TMPDIR_ROOT/init-cleanup-2.log"
+"$BUDI" init --cleanup --yes --no-daemon >"$INIT_LOG_2" 2>&1 || {
+  cat "$INIT_LOG_2" >&2 || true
+  echo "[e2e] FAIL: second init --cleanup failed" >&2
+  exit 1
+}
+assert_contains "$INIT_LOG_2" "Nothing to clean."
+
+echo "[e2e] reseed managed blocks and add manual shell residue"
+seed_managed_blocks
+cat >"$MANUAL_FILE" <<'EOF'
+export OPENAI_BASE_URL="http://localhost:9878"
+EOF
+
+echo "[e2e] uninstall removes managed blocks but leaves manual edits alone"
+UNINSTALL_LOG="$TMPDIR_ROOT/uninstall.log"
+"$BUDI" uninstall --yes --keep-data >"$UNINSTALL_LOG" 2>&1 || {
+  cat "$UNINSTALL_LOG" >&2 || true
+  echo "[e2e] FAIL: uninstall failed" >&2
+  exit 1
+}
+assert_contains "$UNINSTALL_LOG" "Removing legacy 8.0/8.1 proxy residue..."
+assert_contains "$UNINSTALL_LOG" "manual edits still reference the old proxy"
+assert_managed_blocks_removed
+assert_contains "$MANUAL_FILE" "OPENAI_BASE_URL"
+
+echo "[e2e] PASS"


### PR DESCRIPTION
## Summary
- add a shared legacy-proxy detector that scans shell profile, Cursor, and Codex config residue from 8.0/8.1 and records a one-time daemon startup notice for managed leftovers
- implement `budi init --cleanup` as the consent-first upgrade path with per-file preview, optional `--yes`, managed-block removal, idempotent reruns, and fuzzy manual-residue warnings
- reuse the same cleanup logic from `budi doctor` and `budi uninstall`, and pin the upgrade contract with a focused end-to-end regression

## Risks / compatibility notes
- cleanup only auto-removes managed Budi blocks; fuzzy matches outside those blocks are reported for manual review and intentionally left untouched
- the startup notice is one-time and only fires when managed legacy residue is still present, so upgraded 8.2 users are nudged without repeated log spam
- Cursor cleanup also trims the dangling comma left by removing the managed JSONC block so existing settings stay parseable after cleanup

## Validation
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `cargo build --release`
- `bash scripts/e2e/test_357_upgrade_cleanup.sh`

Closes #357

Made with [Cursor](https://cursor.com)