### PR TITLE
[8.2][R2.7] Code review pass for Round 2

### DIFF
--- a/crates/budi-core/src/analytics/sync.rs
+++ b/crates/budi-core/src/analytics/sync.rs
@@ -38,14 +38,14 @@ fn sync_with_max_age(
     let mut pipeline = crate::pipeline::Pipeline::default_pipeline(tags_config);
     let mut total_files = 0;
     let mut total_messages = 0;
-    let mut total_messages_skipped_after_proxy_cutoff = 0usize;
+    let mut total_messages_skipped_after_legacy_overlap = 0usize;
     let mut cursor_file_messages_ingested = 0usize;
     let mut warnings: Vec<String> = Vec::new();
-    let proxy_cutoff = first_proxy_message_timestamp(conn);
+    let legacy_overlap_cutoff = first_legacy_proxy_message_timestamp(conn);
 
-    if let Some(cutoff) = proxy_cutoff {
+    if let Some(cutoff) = legacy_overlap_cutoff {
         warnings.push(format!(
-            "Proxy data detected; importing transcript history only before {} to avoid double-counting.",
+            "Retained 8.1 proxy history detected; importing transcript history only before {} to avoid double-counting against legacy proxy-estimated rows.",
             cutoff.to_rfc3339()
         ));
     }
@@ -106,10 +106,14 @@ fn sync_with_max_age(
             // this slice, so we add the original file offset back afterward.
             let (mut messages, relative_offset) = provider.parse_file(file_path, &content, 0)?;
             let new_offset = parse_start_offset.saturating_add(relative_offset);
-            if let Some(cutoff) = proxy_cutoff {
+            // 8.2 keeps legacy `proxy_estimated` messages queryable after upgrade.
+            // Historical transcript imports must avoid re-ingesting the same time
+            // window on top of those retained rows.
+            if let Some(cutoff) = legacy_overlap_cutoff {
                 let before = messages.len();
                 messages.retain(|msg| msg.timestamp < cutoff);
-                total_messages_skipped_after_proxy_cutoff += before.saturating_sub(messages.len());
+                total_messages_skipped_after_legacy_overlap +=
+                    before.saturating_sub(messages.len());
             }
             if messages.is_empty() {
                 set_sync_offset(conn, &path_str, new_offset)?;
@@ -133,10 +137,10 @@ fn sync_with_max_age(
         crate::providers::cursor::run_cursor_repairs(conn);
     }
 
-    if total_messages_skipped_after_proxy_cutoff > 0 {
+    if total_messages_skipped_after_legacy_overlap > 0 {
         warnings.push(format!(
-            "Skipped {} transcript messages at/after the first proxy event to prevent duplicate accounting.",
-            total_messages_skipped_after_proxy_cutoff
+            "Skipped {} transcript messages at/after the retained legacy overlap boundary to prevent duplicate accounting.",
+            total_messages_skipped_after_legacy_overlap
         ));
     }
 
@@ -216,7 +220,7 @@ fn sync_with_max_age(
     Ok((total_files, total_messages, warnings))
 }
 
-fn first_proxy_message_timestamp(conn: &Connection) -> Option<DateTime<Utc>> {
+fn first_legacy_proxy_message_timestamp(conn: &Connection) -> Option<DateTime<Utc>> {
     let ts: Option<String> = conn
         .query_row(
             "SELECT MIN(timestamp) FROM messages WHERE role = 'assistant' AND cost_confidence = 'proxy_estimated'",
@@ -606,7 +610,7 @@ fn truncate_title(text: &str, max_len: usize) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{first_proxy_message_timestamp, read_transcript_tail};
+    use super::{first_legacy_proxy_message_timestamp, read_transcript_tail};
 
     fn temp_file_path(test_name: &str) -> std::path::PathBuf {
         let nanos = std::time::SystemTime::now()
@@ -646,14 +650,14 @@ mod tests {
     }
 
     #[test]
-    fn first_proxy_message_timestamp_returns_none_without_proxy_rows() {
+    fn first_legacy_proxy_message_timestamp_returns_none_without_proxy_rows() {
         let conn = rusqlite::Connection::open_in_memory().expect("open in-memory db");
         crate::migration::migrate(&conn).expect("migrate schema");
-        assert!(first_proxy_message_timestamp(&conn).is_none());
+        assert!(first_legacy_proxy_message_timestamp(&conn).is_none());
     }
 
     #[test]
-    fn first_proxy_message_timestamp_returns_earliest_proxy_row() {
+    fn first_legacy_proxy_message_timestamp_returns_earliest_proxy_row() {
         let conn = rusqlite::Connection::open_in_memory().expect("open in-memory db");
         crate::migration::migrate(&conn).expect("migrate schema");
         conn.execute(
@@ -667,7 +671,7 @@ mod tests {
         )
         .expect("insert messages");
 
-        let ts = first_proxy_message_timestamp(&conn).expect("timestamp exists");
+        let ts = first_legacy_proxy_message_timestamp(&conn).expect("timestamp exists");
         assert_eq!(ts.to_rfc3339(), "2026-04-10T09:00:00+00:00");
     }
 }

--- a/crates/budi-core/src/hooks.rs
+++ b/crates/budi-core/src/hooks.rs
@@ -1,4 +1,4 @@
-//! Prompt classification heuristics for JSONL and proxy ingestion.
+//! Prompt classification heuristics for JSONL-derived ingestion.
 //!
 //! The activity classifier is intentionally rule-based and explainable — every
 //! label can be traced back to a keyword match in this file. See ADR-0088 §5:
@@ -14,9 +14,9 @@
 //!
 //! ## Contract (R1.2 / #222)
 //!
-//! - `source` is a stable string label for the producer. The primary 8.1 path
-//!   is always [`SOURCE_RULE`]; the proxy layer tags explicit caller intent
-//!   (via `X-Budi-Activity`) as [`SOURCE_HEADER`] in 9.0+.
+//! - `source` is a stable string label for the producer. The primary path is
+//!   always [`SOURCE_RULE`]; [`SOURCE_HEADER`] is reserved for a future
+//!   explicit caller hint if one is ever reintroduced.
 //! - `confidence` is one of [`CONF_HIGH`], [`CONF_MEDIUM`], [`CONF_LOW`].
 //!   It is derived from how many distinct keyword signals a prompt produced
 //!   within the chosen category and whether the prompt is short enough that
@@ -31,10 +31,9 @@
 /// Every label emitted by [`classify_prompt_detailed`] reports this source.
 pub const SOURCE_RULE: &str = "rule";
 
-/// Reserved classifier source for explicit caller intent (e.g. a proxy
-/// `X-Budi-Activity` header). Not emitted by this function today but kept
-/// as part of the stable label set so surfaces can render it without
-/// special-casing.
+/// Reserved classifier source for explicit caller intent. Not emitted by this
+/// function today, but kept as part of the stable label set so surfaces can
+/// render it without special-casing.
 pub const SOURCE_HEADER: &str = "header";
 
 /// Classifier is confident: multiple independent keyword signals matched in

--- a/crates/budi-daemon/src/workers/tailer.rs
+++ b/crates/budi-daemon/src/workers/tailer.rs
@@ -43,11 +43,10 @@
 //!   `sessions`, and `tail_offsets` only.
 //! - No changes to `Pipeline` signature or the enricher list — the tailer
 //!   uses `Pipeline::default_pipeline` exactly as `budi import` does.
-//! - No edits to `analytics/sync.rs` `proxy_cutoff`. Cross-path dedup stays
-//!   on until R2.5 (#326) decides the fate of pre-existing
-//!   `cost_confidence='proxy_estimated'` rows from 8.1.x users; while those
-//!   rows live in the DB, `budi import` still needs the cutoff to avoid
-//!   double-counting JSONL backfill against historical proxy ingest.
+//! - No writes that mutate or reinterpret retained legacy proxy history.
+//!   After #326, 8.1-era `cost_confidence='proxy_estimated'` rows remain
+//!   queryable read-only; `budi import` carries its own overlap guard so a
+//!   later historical backfill does not double-count that retained window.
 //!
 //! [ADR-0089]: https://github.com/siropkin/budi/blob/main/docs/adr/0089-reverse-proxy-first-jsonl-tailing-as-sole-live-path.md
 


### PR DESCRIPTION
## Summary
- keep the retained 8.1 overlap guard in `analytics/sync.rs`, but remove the stale `proxy_cutoff` / live-proxy framing now that only read-only legacy `proxy_estimated` rows remain
- remove the remaining live Rust/code-comment references to the deleted `X-Budi-*` and `budi launch` / `enable` / `disable` contract under `crates/`
- align the tailer and classifier commentary with the 8.2 tailer-only runtime, while leaving historical docs/ADR cleanup to `#359`

## Risks / compatibility notes
- import behavior remains intentionally conservative for upgraded 8.1 users: transcript backfill still stops at the first retained legacy overlap boundary so historical proxy-estimated rows are not double-counted
- historical references outside live code still exist in docs/ADR material and are deferred to the Round 2 docs review pass

## Validation
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `rg -i 'x-budi|proxy_cutoff|ProxyAttribution|budi launch|budi enable |budi disable ' crates`

Closes #358

Made with [Cursor](https://cursor.com)