### PR TITLE
[8.2][R2.8] Complete Round 2 docs review pass

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,16 +111,16 @@ If a review issue leads to "no code changes needed", still include a small artif
 
 ## Adding support for a new agent
 
-New agents are supported via **proxy traffic classification** — no new `Provider` implementation needed for live data (see [ADR-0081](docs/adr/0081-product-contract-and-deprecation-policy.md)).
+New agents are supported via the shared transcript/provider ingest path (see [ADR-0089](docs/adr/0089-reverse-proxy-first-jsonl-tailing-as-sole-live-path.md)).
 
-1. Update the agent compatibility matrix in [ADR-0082](docs/adr/0082-proxy-compatibility-matrix-and-gateway-contract.md)
-2. If the agent uses an existing protocol family (OpenAI Chat Completions or Anthropic Messages), add the agent's env var / config key to the `budi launch` CLI wrapper in `crates/budi-cli/src/commands/launch.rs`
-3. If the agent uses a new protocol family (e.g., Gemini), implement a new protocol handler in the proxy (`crates/budi-daemon/src/routes/proxy.rs`)
+1. Implement or extend a `Provider` in `crates/budi-core/src/provider.rs` / `crates/budi-core/src/providers/`
+2. Add `watch_roots()`, `discover_files()`, and `parse_file()` support for the agent's local artifacts
+3. If the agent has a trustworthy direct usage API, wire any optional reconciliation path alongside the provider (Cursor-style) without introducing a second live path
 4. Add pricing data for the agent's models in `crates/budi-core/src/cost.rs`
-5. Add onboarding instructions to README.md and update the supported agents table
+5. Update README / SOUL / ADR references that describe supported agents
 6. Add tests
 
-The existing `Provider` trait is retained only for historical import via `budi import`. Do not create new `Provider` implementations for live data ingestion.
+The same `Provider` implementation powers both live tailing and `budi import`; do not introduce shell wrappers or proxy-based live ingestion for new agents.
 
 ## Adding a new enricher
 

--- a/README.md
+++ b/README.md
@@ -40,11 +40,11 @@ Everything stays on your machine by default. Optional cloud sync pushes aggregat
 ## What it does
 
 - Tracks tokens, costs, and usage per message across AI coding agents
-- **Local proxy** (port 9878) sits between your agent and the LLM provider, capturing every request in real time — streaming responses pass through with no visible lag
+- **Local transcript tailer** watches the JSONL/session files agents already write on disk and ingests them live
 - Attributes cost to repos, branches, tickets, and custom tags
 - **Session health** — detects context bloat, cache degradation, cost acceleration, and retry loops with actionable, provider-aware tips
 - **Cloud dashboard** at [`app.getbudi.dev`](https://app.getbudi.dev) — team-wide cost visibility across users, repos, models, branches, and tickets (daily granularity, opt-in via `~/.config/budi/cloud.toml`)
-- Provider-scoped live cost status line in Claude Code and Cursor (quiet rolling `1d` / `7d` / `30d`)
+- Provider-scoped cost status line in Claude Code and Cursor (quiet rolling `1d` / `7d` / `30d`)
 - **One-time import** of historical transcripts via `budi import` (Claude Code JSONL, Codex Desktop/CLI sessions, Copilot CLI sessions, Cursor Usage API)
 - ~6 MB Rust binary, minimal footprint
 
@@ -56,13 +56,13 @@ budi targets **macOS**, **Linux** (glibc), and **Windows 10+**. Prebuilt release
 
 | Agent | Tier | Status | How |
 |-------|------|--------|-----|
-| **Claude Code** | Tier 1 | Supported | Auto-configured by `budi init` (shell profile env block) |
-| **Codex CLI** | Tier 1 | Supported | Auto-configured by `budi init` (shell profile env block + Codex Desktop config patch) |
-| **Cursor** | Tier 2 | Supported | Auto-configured by `budi init` (Cursor settings.json patch) |
-| **Copilot CLI** | Tier 2 | Supported | Auto-configured by `budi init` (shell profile env block) |
-| **Gemini CLI** | Tier 3 | Deferred | Different API format; not supported in v1 proxy |
+| **Claude Code** | Tier 1 | Supported | Live transcript tailing from local JSONL files |
+| **Codex CLI** | Tier 1 | Supported | Live transcript tailing from local session files |
+| **Cursor** | Tier 2 | Supported | Live transcript tailing plus Usage API cost reconciliation |
+| **Copilot CLI** | Tier 2 | Supported | Live transcript tailing from local session files |
+| **Gemini CLI** | Tier 3 | Deferred | Not part of the 8.2 scope |
 
-Tier 1 agents use simple env vars with high confidence. Tier 2 agents work but have onboarding caveats (GUI settings, proprietary env vars). See [ADR-0082](docs/adr/0082-proxy-compatibility-matrix-and-gateway-contract.md) for the full compatibility matrix.
+Supported means Budi can observe the agent's normal local transcript/session artifacts. `budi init` does not wrap the agent, patch shell profiles, or rewrite editor settings in 8.2.
 
 All agents also support one-time historical import via `budi import` (Claude Code JSONL transcripts, Codex Desktop/CLI sessions, Copilot CLI sessions, Cursor Usage API).
 
@@ -142,16 +142,11 @@ If you install with Homebrew, run `budi init` right after `brew install`.
 
 **One install on PATH.** Do not mix Homebrew with `~/.local/bin` (macOS/Linux) or with `%LOCALAPPDATA%\budi\bin` (Windows): you can end up with different `budi` and `budi-daemon` versions and confusing restarts. Keep a single install directory ahead of others on `PATH` (or remove duplicates). `budi init` warns if it detects multiple binaries.
 
-`budi init` starts the daemon (port 7878) and proxy (port 9878), and **prompts you to choose which agents to track** (Claude Code, Cursor, Codex CLI, Copilot CLI) and **which integrations to install** (statusline, extension). Agent choices are stored in `~/.config/budi/agents.toml`. In non-interactive mode it uses safe defaults (all agents enabled). You can also choose integrations explicitly with flags like `--with`, `--without`, and `--integrations all|none|auto`.
+`budi init` is intentionally small in 8.2: it creates the data directory, validates schema/binary state, starts the daemon on port 7878, installs the platform-native autostart service, prints any detected agents based on local transcript roots, and exits.
 
-During init, budi automatically applies proxy routing for selected agents:
-- CLI agents (Claude/Codex/Copilot): injects a managed env-var block into your shell profile (`~/.zshrc`, `~/.bashrc`, or `~/.bash_profile`)
-- Cursor: patches Cursor settings.json with the proxy base URL
-- Codex Desktop: patches `~/.codex/config.toml` with `openai_base_url`
+It does **not** patch shell profiles, Cursor settings, or Codex config files. Run your agent normally (`claude`, `codex`, `cursor`, `gh copilot`) and Budi will tail the transcripts those tools already write locally.
 
-`budi launch <agent>` still works as an explicit fallback. For a one-off bypass, run `BUDI_BYPASS=1 budi launch <agent>`.
-
-**Important:** After `budi init` or `budi enable`, restart your terminal so the shell-profile proxy env vars take effect for CLI agents (Claude Code, Codex, Copilot). Already-running sessions are NOT going through the proxy until the shell is restarted. For immediate proxy routing without restart, use `budi launch <agent>`. `budi doctor` detects when proxy env vars are configured but not active in the current shell. Customize ports in the **repo-local** `config.toml` under `<budi-home>/repos/<repo-id>/config.toml` (run `budi doctor` inside the repo to see the exact path).
+If you are upgrading from 8.0/8.1 and `budi doctor` reports leftover proxy-era config, run `budi init --cleanup` to review and remove managed Budi blocks with explicit consent.
 
 To install a specific version, set the `VERSION` environment variable: `VERSION=v7.1.0 curl -fsSL ... | bash` (or `$env:VERSION="v7.1.0"` on PowerShell).
 
@@ -164,20 +159,19 @@ Use this sequence if you want the fastest "did setup really work?" path:
 1. **Install and initialize**
    - Homebrew: `brew install siropkin/budi/budi` then `budi init`
    - Standalone installers and `./scripts/install.sh` already run `budi init` for you
-   - `budi init` prompts for agents and integrations (defaults are safe), starts the daemon + proxy, and installs a platform-native autostart service (launchd on macOS, systemd on Linux, Task Scheduler on Windows)
-2. **Restart your terminal** (CLI agents only: Claude Code, Codex, Copilot CLI)
-   - Proxy env vars are written into your shell profile; already-running shells won't route through the proxy until they are reloaded
-   - For immediate routing without a restart, use `budi launch <agent>`
-3. **Send your first prompt**
-   - Open your agent as usual (`claude`, `codex`, `cursor`, `gh copilot`) and send a prompt — proxy is auto-configured
-   - One-off bypass if needed: `BUDI_BYPASS=1 budi launch <agent>`
-4. **Verify end-to-end** with `budi doctor`
-   - Checks daemon, proxy, autostart, agent configuration, database, and attribution (sessions / branches / activities)
+   - `budi init` starts the daemon, installs autostart, shows detected agents, and exits
+2. **Send your first prompt**
+   - Open your agent as usual (`claude`, `codex`, `cursor`, `gh copilot`) and send a prompt
+   - Budi tails the local transcript/session files the agent already writes
+3. **Verify end-to-end** with `budi doctor`
+   - Checks daemon, tailer readiness, schema, transcript visibility, and any leftover 8.0/8.1 proxy residue
    - The top of the report says "All checks passed." when first-run setup is healthy — and adds a friendly nudge if no activity has been recorded yet
-5. **See today's cost** with `budi status`
-   - Quick snapshot: daemon/proxy state, today's cost, and active agents
-6. **Import historical data** (optional)
+4. **See today's cost** with `budi status`
+   - Quick snapshot: daemon health, today's cost, and first-run hints when the DB is still quiet
+5. **Import historical data** (optional)
    - Run `budi import` to backfill from Claude Code JSONL transcripts, Codex Desktop/CLI sessions, Copilot CLI sessions, and Cursor Usage API
+6. **Upgraded from 8.0/8.1?** (only if `budi doctor` warns)
+   - Run `budi init --cleanup` to preview and remove managed proxy-era shell/editor config residue
 
 ### PATH and duplicate binary checks
 
@@ -285,18 +279,15 @@ Environment variable overrides: `BUDI_CLOUD_ENABLED=true`, `BUDI_CLOUD_API_KEY=b
 **Launch and onboarding:**
 
 ```bash
-budi init                          # start daemon, configure integrations
-budi launch claude                 # launch Claude Code through the proxy (zero config)
-budi launch codex                  # launch Codex CLI through the proxy
-budi launch copilot                # launch Copilot CLI through the proxy
-budi launch cursor                 # print Cursor proxy setup instructions (GUI only)
+budi init                          # start daemon + install autostart + show detected agents
+budi init --cleanup                # review/remove managed 8.0/8.1 proxy residue
 budi import                        # one-time import of historical transcripts
 ```
 
 **Monitoring and analytics:**
 
 ```bash
-budi status                        # quick overview: daemon, proxy, today's cost
+budi status                        # quick overview: daemon and today's cost
 budi stats                         # usage summary with cost breakdown
 budi stats --models                # model usage breakdown
 budi stats --projects              # repos ranked by cost
@@ -322,7 +313,7 @@ budi health --session <id>         # health vitals for a specific session
 **Diagnostics and maintenance:**
 
 ```bash
-budi doctor                        # check health: daemon, proxy, database, config
+budi doctor                        # check health: daemon, tailer, schema, transcript visibility
 budi doctor --deep                 # run full SQLite integrity_check (slower)
 budi cloud status                  # cloud sync readiness + last-synced-at + queued records
 budi cloud sync                    # push queued local rollups/sessions to the cloud now
@@ -398,7 +389,7 @@ Health state appears in the statusline's opt-in `coach` / `full` presets (see ab
 
 ## Privacy
 
-Budi is local-first. All data stays on your machine by default (`~/.local/share/budi/` on Unix, `%LOCALAPPDATA%\budi` on Windows). The proxy forwards your requests to the upstream LLM provider and back, but budi only **stores** metadata locally: timestamps, token counts, model names, and costs. Prompts, code, and AI responses pass through the proxy and are never written to disk or retained by budi.
+Budi is local-first. All data stays on your machine by default (`~/.local/share/budi/` on Unix, `%LOCALAPPDATA%\budi` on Windows). In 8.2, Budi reads the local transcripts/session files the agent already wrote to disk and stores derived analytics metadata locally: timestamps, token counts, model names, costs, and attribution tags. Prompts, code, and responses never leave the machine; cloud sync sends only aggregated rollups and session summaries.
 
 **Cloud sync** (optional, disabled by default) pushes pre-aggregated daily rollups and session summaries to a team dashboard at `app.getbudi.dev`. Only numeric metrics cross the wire: token counts, costs, model names, hashed repo IDs, branch names, and ticket IDs. Prompts, code, responses, file paths, email addresses, raw payloads, and tag values are structurally excluded from the sync payload — there is no "full upload" mode.
 
@@ -414,7 +405,7 @@ See [ADR-0083](docs/adr/0083-cloud-ingest-identity-and-privacy-contract.md) for 
 
 ## How it works
 
-A lightweight Rust daemon (port 7878) manages a single SQLite database. The daemon runs a **proxy server** on port 9878 that transparently forwards agent traffic to upstream providers (Anthropic, OpenAI) while capturing metadata. Streaming (SSE) responses pass through chunk-by-chunk with no buffering; token metadata is extracted from the byte stream without modifying it. Proxy traffic is attributed to repos, branches, and tickets via `X-Budi-Repo`/`X-Budi-Branch`/`X-Budi-Cwd` headers or automatic git resolution, with cost computed from provider pricing tables. Historical data from Claude Code JSONL transcripts and Cursor Usage API can be backfilled via `budi import`. The CLI is a thin HTTP client — all queries go through the daemon.
+A lightweight Rust daemon (port 7878) manages a single SQLite database. The daemon watches each supported provider's local transcript/session roots, tails incremental appends through the shared pipeline, and writes canonical `messages` + tag rows. Cursor cost/token reconciliation still comes from the Usage API on a pull cadence; the CLI is a thin HTTP client and all queries go through the daemon.
 
 ## Details
 
@@ -424,7 +415,7 @@ A lightweight Rust daemon (port 7878) manages a single SQLite database. The daem
 | | budi | ccusage | Claude `/cost` |
 |---|---|---|---|
 | Multi-agent support | **Yes** (Claude Code, Codex CLI, Cursor, Copilot CLI) | Claude Code only | Claude Code only |
-| Real-time cost via proxy | **Yes** | No | No |
+| Live local transcript tailing | **Yes** | No | No |
 | Cost history | **Per-message + daily** | Per-session | Current session |
 | Cloud dashboard | **Yes** ([app.getbudi.dev](https://app.getbudi.dev)) | No | No |
 | Status line + session health | **Yes** (with actionable tips) | No | No |
@@ -445,25 +436,17 @@ A lightweight Rust daemon (port 7878) manages a single SQLite database. The daem
 └──────────┘             │  (port 7878) │              └──────────┘
                          │              │                    ▲
                          │  - analytics │    Pipeline       │
-                         │  - import    │ ──────────────────┘
-                         │  (on demand) │    Extract → Normalize
+                         │  - tailer    │ ──────────────────┘
+                         │  - import    │    Extract → Normalize
                          └──────────────┘      → Enrich → Load
+                                ▲
                                 │
-                         ┌──────────────┐
-┌──────────┐    proxy    │ budi proxy   │    upstream
-│ AI Agent │ ──────────▶ │  (port 9878) │ ──────────▶ Anthropic / OpenAI
-│ (CC/CX)  │  localhost  │  transparent │  API calls
-└──────────┘             │  pass-thru   │
-                         └──────────────┘
-
-Historical import (budi import):
-  JSONL transcripts (Claude Code) ──┐
-  JSONL sessions (Codex) ───────────┤
-  JSONL sessions (Copilot CLI) ─────┼──▶ Pipeline → SQLite
-  Usage API (Cursor) ───────────────┘
+       Claude/Codex/Copilot JSONL/session files  ─┐
+       Cursor transcripts + Usage API pull        ├──▶ shared ingest path
+       Historical import (`budi import`)          ┘
 ```
 
-The daemon is the single source of truth — the CLI never opens the database directly. The **proxy** is the sole live data source: every LLM request flows through it, capturing tokens, cost, and attribution in real time. Historical data from Claude Code JSONL transcripts, Codex Desktop/CLI sessions, Copilot CLI sessions, and Cursor Usage API can be imported via `budi import` for one-time backfill.
+The daemon is the single source of truth — the CLI never opens the database directly. The transcript tailer is the sole live data path in 8.2. Historical data from Claude Code JSONL transcripts, Codex Desktop/CLI sessions, Copilot CLI sessions, and Cursor Usage API can be imported via `budi import` for one-time backfill.
 
 **Data model** — nine tables, seven data entities + two supporting:
 
@@ -471,7 +454,6 @@ The daemon is the single source of truth — the CLI never opens the database di
 |-------|------|
 | **messages** | Single cost entity — all token/cost data lives here (one row per API call) |
 | **sessions** | Lifecycle context (start/end, duration, mode) without mixing cost concerns |
-| **proxy_events** | Append-only log of proxied LLM API requests (provider, model, tokens, duration, status, repo, branch, ticket, cost) |
 | **tags** | Flexible key-value pairs per message (repo, ticket, activity, user, etc.) |
 | **sync_state** | Tracks incremental ingestion progress per file for progressive sync, plus cloud sync watermarks |
 | **message_rollups_hourly** | Derived hourly aggregates (provider/model/repo/branch/role) for low-latency analytics reads |
@@ -517,7 +499,7 @@ Retention cleanup runs automatically after sync and queued realtime ingestion pr
 <details>
 <summary>Hooks (removed in 8.0)</summary>
 
-Hook-based ingestion (`budi hook`) and the `hook_events` table have been removed. The proxy (port 9878) is now the sole live data source.
+Hook-based ingestion (`budi hook`) and the `hook_events` table have been removed. In 8.2, the transcript tailer is the sole live data source.
 
 </details>
 
@@ -528,7 +510,7 @@ Every message carries a `cost_confidence` tag that indicates how the cost was de
 
 | Level | Source | Accuracy |
 |-------|--------|----------|
-| `proxy_estimated` | Proxy real-time capture | Estimated from response body / SSE stream |
+| `proxy_estimated` | Retained 8.1 proxy-era rows (historical only) | Estimated from response body / SSE stream |
 | `exact` | Cursor Usage API / Claude Code JSONL tokens | Exact tokens, calculated cost |
 | `estimated` | JSONL tokens x model pricing | ~92-96% accurate (missing thinking tokens) |
 
@@ -608,9 +590,9 @@ Most endpoints accept `?since=<ISO>&until=<ISO>` for date filtering.
 ## Troubleshooting
 
 **No data after setup:**
-1. Run `budi status` to check daemon, proxy, and today's cost
-2. Verify auto-proxy config with `budi doctor` (shell profile + Cursor/Codex settings)
-3. If `budi doctor` reports proxy env vars not set in current shell, restart your terminal or use `budi launch <agent>` for immediate routing
+1. Run `budi status` to check daemon health and today's cost
+2. Run `budi doctor` to verify transcript visibility and any leftover 8.0/8.1 proxy residue
+3. If `budi doctor` warns about legacy proxy residue, run `budi init --cleanup` and follow the consent flow
 4. Send a prompt and check `budi stats` for non-zero usage
 5. For historical data: `budi import` (one-time backfill from Claude Code JSONL, Codex sessions, Copilot CLI sessions, Cursor Usage API)
 
@@ -627,20 +609,20 @@ Windows equivalent:
 **Daemon doesn't survive reboots:**
 Run `budi autostart status` — if it shows "not installed", run `budi autostart install` to install the platform-native service (launchd on macOS, systemd on Linux, Task Scheduler on Windows). `budi init` also installs the autostart service.
 
-**Proxy not reachable (agent gets connection refused on port 9878):**
-1. Run `budi doctor` to check proxy health
-2. Check if port 9878 is in use by another process: `lsof -i :9878`
-3. Restart with `budi init`
+**Legacy proxy residue warning after upgrade:**
+1. Run `budi doctor` to see which shell/editor files still contain managed 8.0/8.1 proxy blocks
+2. Run `budi init --cleanup` to preview and remove those managed blocks with explicit consent
+3. Open a fresh terminal after cleanup if the current shell still has old proxy env vars loaded
 
 **Status line not showing:**
 1. Restart Claude Code after `budi init`
 2. Check: `budi statusline` should output cost data
 
 **Cursor extension status bar shows offline (red dot) or stays quiet (yellow):**
-1. Run `budi doctor` to verify daemon + proxy health.
+1. Run `budi doctor` to verify daemon health and Cursor transcript visibility.
 2. In Cursor, run **Budi: Refresh Status**.
 3. If needed, reload Cursor window (`Developer: Reload Window`) after `budi init` or daemon URL changes.
-4. Confirm `Override OpenAI Base URL` is set to `http://localhost:9878` (Cursor Settings → Models) so Cursor traffic routes through the budi proxy.
+4. Open a Cursor chat/composer once so Cursor creates its local session artifacts, then send a prompt and recheck `budi status`.
 
 ## Uninstall
 

--- a/SOUL.md
+++ b/SOUL.md
@@ -29,7 +29,7 @@ After upgrading: the first CLI command now verifies daemon version and auto-rest
 
 ### Local end-to-end tests
 
-Shell-driven end-to-end tests live under `scripts/e2e/`. They exercise the full stack — real release binaries (`budi` + `budi-daemon`), a mock upstream over loopback, the HTTP proxy path, and the CLI — against an isolated `$HOME` so they never touch real user data.
+Shell-driven end-to-end tests live under `scripts/e2e/`. They exercise the full stack — real release binaries (`budi` + `budi-daemon`), the transcript tailer, the CLI, and upgrade/compatibility edges — against an isolated `$HOME` so they never touch real user data.
 
 ```bash
 cargo build --release                                 # once per change
@@ -45,7 +45,7 @@ Each script is a single self-contained bash file that:
 
 1. Builds a throwaway `HOME` in `mktemp` and exports it for the whole run.
 2. Boots a tiny Python mock upstream on loopback.
-3. Starts `budi-daemon serve --port … --proxy-port …` with `BUDI_ANTHROPIC_UPSTREAM` / `BUDI_OPENAI_UPSTREAM` pointed at the mock (these env vars override the hard-coded upstreams — see `ProxyConfig::effective_anthropic_upstream` / `effective_openai_upstream`).
+3. Starts `budi-daemon serve ...` inside that throwaway home; some upgrade-compatibility scripts also point `BUDI_ANTHROPIC_UPSTREAM` / `BUDI_OPENAI_UPSTREAM` at a mock so legacy proxy-era state can be exercised without touching real upstreams.
 4. Drives real CLI/HTTP commands and asserts DB rows, API responses, and CLI output.
 5. Tears down the temp HOME and child processes via a `trap`.
 
@@ -89,8 +89,8 @@ Three independent repos (extraction completed per [ADR-0086](docs/adr/0086-extra
 ### Crates
 
 - **budi-core** - Business logic: analytics (SQLite queries), providers (Claude Code, Codex, Copilot CLI, Cursor) including each provider's `watch_roots()` for live tailing, pipeline (enrichment), cost calculation, config, migrations, autostart (platform-native daemon service management). The 8.1-era proxy runtime is deleted in R2.1 (#322); R2.5 (#326) keeps proxy-sourced `messages` rows read-only for historical analytics while dropping the obsolete `proxy_events` table on upgrade. Historical hook/OTEL data is read-only (tables kept for schema compat, ingestion removed).
-- **budi-cli** - Thin HTTP client to the daemon. Commands: init, launch, stats, sessions, status, sync, import, statusline, doctor, health, update, integrations, autostart, uninstall, migrate, repair (the launch / enable / disable / proxy-install commands are deleted in 8.2 R2.1 #322 — R2.3 #324 also reduces `budi init` to daemon-+-autostart only)
-- **budi-daemon** - axum HTTP server (port 7878). Owns SQLite exclusively. Serves analytics API and runs the daemon-side filesystem tailer that watches each `Provider::watch_roots()` directory, parses incremental JSONL appends through `Pipeline::default_pipeline()`, and writes to the canonical `messages` / tag tables. JSONL tailing is the sole live ingestion path per [ADR-0089](docs/adr/0089-reverse-proxy-first-jsonl-tailing-as-sole-live-path.md); the legacy proxy server on port 9878 still runs in 8.1.x for the transition window and is removed in 8.2 R2.1 (#322). One-shot historical backfill remains user-initiated via `budi import`.
+- **budi-cli** - Thin HTTP client to the daemon. Commands include `init`, `stats`, `sessions`, `status`, `sync`, `import`, `statusline`, `doctor`, `health`, `update`, `integrations`, `autostart`, `uninstall`, `migrate`, `repair`, and `cloud`. `budi init` is the daemon + autostart entry point; legacy launch / enable / disable / proxy-install commands are removed in 8.2.
+- **budi-daemon** - axum HTTP server (port 7878). Owns SQLite exclusively. Serves analytics API and runs the daemon-side filesystem tailer that watches each `Provider::watch_roots()` directory, parses incremental JSONL appends through `Pipeline::default_pipeline()`, and writes to the canonical `messages` / tag tables. JSONL tailing is the sole live ingestion path per [ADR-0089](docs/adr/0089-reverse-proxy-first-jsonl-tailing-as-sole-live-path.md). One-shot historical backfill remains user-initiated via `budi import`.
 
 ### Data flow
 
@@ -382,8 +382,8 @@ status contract. It is consumed by the CLI statusline, the Cursor
 extension ([#232](https://github.com/siropkin/budi/issues/232)), and the
 cloud dashboard ([#235](https://github.com/siropkin/budi/issues/235)).
 Provider is an explicit filter rather than a family of per-surface
-shapes — new agents added in 8.2 under
-[#294](https://github.com/siropkin/budi/issues/294) slot into the same
+shapes — future agent coverage under
+[#294](https://github.com/siropkin/budi/issues/294) slots into the same
 shape. See [`docs/statusline-contract.md`](docs/statusline-contract.md)
 for the full schema.
 
@@ -440,7 +440,7 @@ Key points:
 - **Session context propagation**: git_branch/repo_id flow from user -> assistant messages within a session
 - **Progressive sync**: files processed newest-first so dashboard shows recent data quickly
 - **Historical import**: `budi import` = full history backfill, `budi import --force` = clear all data and re-ingest from scratch
-- **Proxy mode**: Daemon runs a second HTTP server on port 9878 that acts as a transparent proxy between AI agents and upstream providers (Anthropic, OpenAI). `budi init` auto-installs proxy routing for selected agents: shell-profile env block for Claude Code/Codex/Copilot, Cursor settings patch (`openai.baseUrl`), and Codex Desktop config patch (`openai_base_url` in `~/.codex/config.toml`). `budi enable <agent>` / `budi disable <agent>` toggle this configuration. `budi launch <agent>` remains an explicit fallback launcher, and `BUDI_BYPASS=1 budi launch <agent>` skips proxy injection for one run. Gemini CLI is deferred (Tier 3, different API format). Path-based routing: `/v1/messages` → Anthropic, `/v1/chat/completions` → OpenAI. SSE streaming responses are passed through chunk-by-chunk with no buffering; a tee/tap on the byte stream extracts token metadata (input/output tokens) from SSE events without modifying the data. Non-streaming responses are buffered and parsed for usage data. Duration is measured from request start to stream end (not to first headers). Mid-stream failures and client disconnects are handled gracefully — partial metadata is recorded via Drop. No read timeout on streaming; non-streaming uses 300s. Config: `[proxy]` section in `config.toml`, `BUDI_PROXY_PORT` / `BUDI_PROXY_ENABLED` env vars, `--proxy-port` / `--no-proxy` CLI flags. See [ADR-0082](docs/adr/0082-proxy-compatibility-matrix-and-gateway-contract.md) for the full contract.
+- **Legacy proxy residue (upgrade only)**: 8.2 does not route live traffic through a proxy. The only remaining proxy-related code scans for 8.0/8.1 residue in shell profiles and agent configs, reports retained `proxy_estimated` history honestly, and lets users remove managed blocks via `budi init --cleanup` (consent-first) or `budi uninstall` (managed cleanup parity).
 
 ## Key files
 
@@ -461,19 +461,20 @@ Key points:
 - `crates/budi-core/src/migration.rs` - Schema v1, all migration paths
 - `crates/budi-core/src/cloud_sync.rs` - Cloud sync worker: envelope builder, watermark tracking, HTTPS-only HTTP client with retry/backoff, privacy-safe rollup extraction
 - `crates/budi-core/src/autostart.rs` - Platform-native daemon autostart: launchd (macOS), systemd (Linux), Task Scheduler (Windows). Install/uninstall/status.
-- `crates/budi-core/src/config.rs` - BudiConfig, ProxyConfig, AgentsConfig, StatuslineConfig, TagsConfig, CloudConfig
+- `crates/budi-core/src/config.rs` - BudiConfig, ProxyConfig (legacy test/compat knobs), AgentsConfig, StatuslineConfig, TagsConfig, CloudConfig
 - `crates/budi-cli/build.rs` - Build script: creates empty vsix placeholder if not pre-built
-- `crates/budi-daemon/src/main.rs` - HTTP server (port 7878) + cloud sync worker + (in 8.1.x only) the legacy proxy server on port 9878, ~40 routes. The proxy server, its routes, and the port-9878 listener are removed in 8.2 R2.1 (#322); the daemon-side filesystem tailer worker added in 8.2 R1.3 (#319) replaces the proxy as the live ingestion source.
+- `crates/budi-daemon/src/main.rs` - HTTP server (port 7878) + cloud sync worker + startup hooks for tailer / migration / legacy-residue notices.
 - `crates/budi-daemon/src/workers/cloud_sync.rs` - Background cloud sync loop: configurable interval, backoff, auth/schema error handling
 - `crates/budi-daemon/src/routes/hooks.rs` - /sync, /sync/all, /sync/reset, /sync/status, /health, /health/integrations, /health/check-update, /admin/integrations/install endpoints (hook ingestion removed)
 - `crates/budi-daemon/src/routes/cloud.rs` - /cloud/sync (loopback-only manual cloud flush) and /cloud/status (cloud readiness + watermarks); added in R2.1 (#225)
 - `crates/budi-cli/src/commands/cloud.rs` - `budi cloud sync` / `budi cloud status` (R2.1 #225): text + JSON output, exit code 2 on non-ok sync
 - `crates/budi-daemon/src/routes/analytics.rs` - All analytics + admin endpoints (summary, messages, projects, cost, models, activity, branches, tags, providers, statusline, cache-efficiency, session-cost-curve, cost-confidence, subagent-cost, sessions, session-health, session-audit, admin/providers, admin/schema, admin/migrate, admin/repair)
-- `crates/budi-daemon/src/routes/proxy.rs` - Legacy 8.1 proxy handlers for Anthropic Messages and OpenAI Chat Completions. **Slated for deletion in 8.2 R2.1 (#322)** along with `crates/budi-core/src/proxy.rs` and the launch / enable / disable CLI commands.
-- `crates/budi-cli/src/commands/proxy_install.rs` - Legacy 8.1 auto-proxy installer and verifier: shell profile block + Cursor/Codex config patching + `budi enable/disable`. **Slated for deletion in 8.2 R2.1 (#322)**; existing user state is cleaned up via the consent-first `budi init --cleanup` path added in R2.6 (#357).
-- `crates/budi-cli/src/commands/launch.rs` - Legacy 8.1 `budi launch <agent>` explicit launcher (fallback path, supports `BUDI_BYPASS=1`). **Slated for deletion in 8.2 R2.1 (#322)** — agents are launched directly in 8.2+ (no Budi wrapper); the tailer sees activity via the transcript files the agent already writes.
+- `crates/budi-core/src/legacy_proxy.rs` - Upgrade-only detection/cleanup for managed 8.0/8.1 proxy residue in shell profiles and agent configs.
+- `crates/budi-cli/src/commands/init.rs` - `budi init` (daemon + autostart + detected-agent output) plus consent-first `--cleanup`.
+- `crates/budi-cli/src/commands/doctor.rs` - `budi doctor` checks daemon health, schema, transcript visibility, leftover legacy proxy residue, and retained proxy-era history.
+- `crates/budi-cli/src/commands/uninstall.rs` - `budi uninstall` removes autostart, Claude/Cursor integrations, and managed legacy proxy residue.
 - `crates/budi-cli/src/commands/sessions.rs` - `budi sessions` list and detail view (Rich CLI)
-- `crates/budi-cli/src/commands/status.rs` - `budi status` quick overview (daemon, proxy, today's cost). When the daemon is healthy but no messages are recorded for today, the command prints a first-run hint pointing the user at their agents and at `budi doctor` (R2.2, #228)
+- `crates/budi-cli/src/commands/status.rs` - `budi status` quick overview (daemon, tailer contract hints, today's cost). When the daemon is healthy but no messages are recorded for today, the command prints a first-run hint pointing the user at their agents and at `budi doctor` (R2.2, #228)
 - `crates/budi-cli/src/commands/statusline.rs` - Statusline rendering (default: quiet rolling `1d` / `7d` / `30d`, provider-scoped per ADR-0088 §4 / [docs/statusline-contract.md](docs/statusline-contract.md); `coach` / `full` presets remain as opt-in advanced variants) + installation
 <!-- budi-cursor and budi-cloud live in their own repos: siropkin/budi-cursor, siropkin/budi-cloud -->
 
@@ -481,8 +482,7 @@ Key points:
 
 - CLI never touches SQLite directly - all queries go through the daemon HTTP API
 - CostEnricher is the single source of truth for cost - sets cost_cents during pipeline. Skips if cost already set (API data)
-- `budi init` prompts for per-agent enablement (Claude Code, Codex CLI, Cursor, Copilot CLI), persists choices to `~/.config/budi/agents.toml`, and auto-configures proxy routing for enabled agents (shell profile + Cursor/Codex settings). `budi enable/disable <agent>` updates this config later. Legacy installs (no `agents.toml`) treat all available agents as enabled for backward compatibility. After configuring CLI agents (Claude, Codex, Copilot), both `budi init` and `budi enable` warn that a shell restart is required for proxy env vars to take effect and suggest `budi launch <agent>` for immediate routing. `budi doctor` detects when proxy env vars are configured in the shell profile but not set in the current process. R2.2 (#228) reshaped the `budi init` "Next steps" output so the restart-terminal prompt is step 1 (previously buried in a trailing warning), `budi doctor` is framed as the canonical end-to-end verifier, and `budi status` is framed as a today-only snapshot. `budi status` adds a friendly "no activity recorded today yet — open your agent and send a prompt" hint when the daemon is healthy but today has zero messages; `budi doctor` prints a matching first-run nudge when the DB has no assistant activity yet, so day-zero users don't misread empty attribution as a setup failure. Install scripts (`scripts/install.sh`, `scripts/install-standalone.sh`, `scripts/install-standalone.ps1`) close with the same `budi doctor` recommendation.
-- `budi init` configures integrations (statusline, extension) for enabled agents
+- `budi init` creates the data dir, validates schema/binary state, starts the daemon, installs autostart, prints detected agents from `Provider::watch_roots()`, and exits. It does not mutate shell profiles or editor configs on the live path. `budi init --cleanup` is the explicit upgrade-only path for reviewing/removing managed 8.0/8.1 proxy residue. `budi doctor` is the canonical end-to-end verifier and prints the matching first-run nudge when the DB has no assistant activity yet, so day-zero users do not misread empty attribution as a setup failure. Install scripts close with the same `budi doctor` recommendation.
 - Tags are auto-detected (`provider`, `model`, `tool`, `tool_use_id`, `ticket_id`, `ticket_source`, `activity`, `activity_source`, `activity_confidence`, `file_path`, `file_path_source`, `file_path_confidence`, `tool_outcome`, `tool_outcome_source`, `tool_outcome_confidence`, and conditional tags like `cost_confidence` / `speed`) + custom rules via `~/.config/budi/tags.toml`
 - git_branch is a column on messages (not a tag) for fast queries
 - **Session health**: Four vitals computed per session - context growth (context-size growth), cache reuse (cache hit rate), cost acceleration (per-reply cost growth), retry loops (currently disabled — hook ingestion removed in 8.0; `hook_events` table no longer exists in schema v1). Each vital has green/yellow/red state. New sessions start green - the default is always positive; vitals only degrade to yellow/red when there is clear evidence of a problem. Tips are provider-aware via `ProviderKind` enum (Claude Code -> `/compact`/`/clear`, Cursor -> "new composer session", Other -> neutral). When no session ID is provided, health auto-select prefers the latest session with assistant activity, then falls back to session timestamps. Statusline "coach" mode shows health icon + session cost + tip. Dashboard session detail page has a health panel with vitals grid and tips section.

--- a/crates/budi-core/src/analytics/queries.rs
+++ b/crates/budi-core/src/analytics/queries.rs
@@ -1757,9 +1757,9 @@ const TICKET_SOURCE_TAG_KEY: &str = "ticket_source";
 
 /// Canonical fallback source for legacy rows (pre-R1.3) that carry a
 /// `ticket_id` tag but no sibling `ticket_source` tag. The alphanumeric
-/// extractor was the only producer before R1.3 — everything else was
-/// proxy-only — so this default keeps analytics consistent without a
-/// reindex.
+/// extractor was the only producer before R1.3; the numeric fallback
+/// shipped later with the unified extractor. This default keeps older
+/// analytics readable without a reindex.
 pub const TICKET_SOURCE_BRANCH: &str = crate::pipeline::TICKET_SOURCE_BRANCH;
 
 /// Query cost grouped by ticket, sorted by cost descending. Includes an

--- a/crates/budi-core/src/analytics/tests.rs
+++ b/crates/budi-core/src/analytics/tests.rs
@@ -2088,8 +2088,8 @@ fn session_visibility_flags_mismatch_when_all_rows_missing_session_id() {
     assert!(today.has_mismatch());
 }
 
-/// Regression for #303 — `budi doctor` must see when live proxy traffic
-/// lands in the last 7 days without `git_branch`, which is exactly what
+/// Regression for #303 — `budi doctor` must see when recent assistant rows
+/// land in the last 7 days without `git_branch`, which is exactly what
 /// makes `budi stats --branches` collapse into `(untagged)`.
 #[test]
 fn branch_attribution_stats_reports_missing_branch_within_7d() {

--- a/crates/budi-core/src/jsonl.rs
+++ b/crates/budi-core/src/jsonl.rs
@@ -332,7 +332,7 @@ fn truncate_utf8_at_char_boundary(s: &mut String, max: usize) {
 }
 
 /// Bounded label constants for `tool_outcome` tag values. Pinned here so
-/// analytics, tests, and proxy/import ingest all agree.
+/// analytics, tests, live tailing, and `budi import` all agree.
 pub const TOOL_OUTCOME_SUCCESS: &str = "success";
 pub const TOOL_OUTCOME_ERROR: &str = "error";
 pub const TOOL_OUTCOME_DENIED: &str = "denied";
@@ -367,8 +367,8 @@ const USER_DENIAL_SENTINELS: &[&str] = &[
 ];
 
 /// Classify a single `tool_result` block given its `is_error` flag and
-/// flattened content text. Exposed for tests and for the proxy path (if
-/// we ever grow one that inspects follow-up request bodies).
+/// flattened content text. Exposed for tests and any parser/pipeline code
+/// that needs the shared bounded outcome labels.
 pub fn classify_tool_outcome(is_error: bool, text: Option<&str>) -> &'static str {
     if let Some(t) = text {
         let lower = t.to_ascii_lowercase();

--- a/crates/budi-core/src/pipeline/enrichers.rs
+++ b/crates/budi-core/src/pipeline/enrichers.rs
@@ -51,11 +51,10 @@ impl Enricher for GitEnricher {
         }
 
         // Extract ticket_id from git_branch (branch itself is stored as a
-        // column, not a tag). R1.3 (#221) unifies the extractor with the
-        // proxy ingest path so imported Claude Code / Cursor data agrees
-        // with live proxy rows — in particular, pure-numeric tickets from
-        // branches like `fix/1234-typo` (ADR-0082 §9) now tag consistently
-        // on both paths.
+        // column, not a tag). R1.3 (#221) unified the extractor so live
+        // tailing and `budi import` tag pure-numeric branches like
+        // `fix/1234-typo` consistently, while staying readable against
+        // retained 8.1 legacy history.
         if let Some(ref branch) = msg.git_branch
             && let Some((ticket, source)) = extract_ticket_from_branch(branch)
         {
@@ -643,10 +642,10 @@ mod tests {
         assert!(!tags.iter().any(|t| t.key == "branch"));
     }
 
-    /// R1.3 (#221): the import path must also honour the ADR-0082 §9
-    /// numeric-only ticket fallback, matching the proxy ingest path.
-    /// Before R1.3, `fix/1234-typo` produced a ticket tag on the proxy
-    /// path but not on `budi import`, so analytics disagreed.
+    /// R1.3 (#221): `budi import` must also honour the ADR-0082 §9
+    /// numeric-only ticket fallback so it matches the live tailer.
+    /// Before R1.3, `fix/1234-typo` produced a ticket tag in legacy
+    /// proxy-era rows but not on `budi import`, so analytics disagreed.
     #[test]
     fn git_enricher_extracts_numeric_only_ticket() {
         let mut enricher = GitEnricher {

--- a/crates/budi-core/src/pipeline/mod.rs
+++ b/crates/budi-core/src/pipeline/mod.rs
@@ -430,8 +430,8 @@ pub const TICKET_SOURCE_BRANCH: &str = "branch";
 pub const TICKET_SOURCE_BRANCH_NUMERIC: &str = "branch_numeric";
 
 /// Branch names that are never tickets — integration branches and the
-/// literal detached-HEAD sentinel. Kept in one place so proxy ingest and
-/// the import pipeline agree.
+/// literal detached-HEAD sentinel. Kept in one place so live tailing,
+/// `budi import`, and legacy-history handling stay aligned.
 const INTEGRATION_BRANCHES: &[&str] = &["main", "master", "develop", "HEAD"];
 
 /// Extract a ticket ID (e.g. `PAVA-2057`) from a branch name.
@@ -447,8 +447,8 @@ pub fn extract_ticket_id(branch: &str) -> Option<String> {
     extract_ticket_alpha(branch)
 }
 
-/// Unified ticket extractor used by both the proxy ingest path and the
-/// batch import pipeline. Returns `(ticket_id, source)` where `source` is
+/// Unified ticket extractor used by both the live tailer and `budi import`.
+/// Returns `(ticket_id, source)` where `source` is
 /// one of `TICKET_SOURCE_BRANCH` or `TICKET_SOURCE_BRANCH_NUMERIC`.
 ///
 /// Behavior (R1.3, #221):
@@ -461,8 +461,8 @@ pub fn extract_ticket_id(branch: &str) -> Option<String> {
 /// 3. Falls back to the pure-numeric pattern from ADR-0082 §9 — a
 ///    leading numeric segment in the last `/`-separated path component,
 ///    followed by `-` or end-of-string. This handles `fix/1234-typo`
-///    conventions that many GitHub-flow teams rely on and keeps proxy
-///    behaviour consistent with batch ingest.
+///    conventions that many GitHub-flow teams rely on and keeps
+///    transcript-derived rows consistent with retained legacy data.
 pub fn extract_ticket_from_branch(branch: &str) -> Option<(String, &'static str)> {
     if branch.is_empty() || INTEGRATION_BRANCHES.contains(&branch) {
         return None;

--- a/docs/adr/0081-product-contract-and-deprecation-policy.md
+++ b/docs/adr/0081-product-contract-and-deprecation-policy.md
@@ -83,12 +83,12 @@ The proxy solves data ingestion generically — no dedicated provider needed. Bu
 
 ### Provider System
 
-The existing provider trait (`Provider` in `crates/budi-core/src/provider.rs`) and its two implementations (Claude Code, Cursor) are **removed from the ongoing sync pipeline** when the proxy ships in R2. However, they may be retained as a **one-time historical import** mechanism.
+The existing provider trait (`Provider` in `crates/budi-core/src/provider.rs`) remains the core ingestion extension point after the ADR-0089 pivot.
 
-- **R0–R1**: Providers still exist as the primary ingestion path (the proxy hasn't shipped yet).
-- **R2**: Proxy ships and becomes the primary ingestion path. Providers are removed from the continuous sync loop.
-- **Historical import**: Providers may be kept (or re-scoped) behind a `budi import` command for one-time backfill of pre-proxy data (Claude Code transcripts on disk, Cursor usage history). This lets new users load their existing data when they first set up budi. The decision on whether to keep or rebuild this is made during R2 implementation based on actual complexity.
-- **New agents**: Supported via proxy traffic classification only. No new `Provider` implementations for ongoing sync.
+- **R0–R1 historical context**: Providers were the original file-import path before 8.0's proxy-first contract.
+- **8.2+ live contract**: Providers power both the live tailer and `budi import`. `watch_roots()` declares the transcript directories the daemon watches live; `discover_files()` remains the one-shot backfill enumerator; `parse_file()` stays shared between both modes.
+- **Historical import**: `budi import` continues to use the same providers for one-time backfill of transcript/API history (Claude Code, Codex, Copilot CLI, Cursor Usage API).
+- **New agents**: Added by implementing `Provider` for that agent's local transcript/API surface, not by introducing a proxy adapter or env-var wrapper.
 
 ### Downstream Impact on R2.4
 
@@ -102,7 +102,7 @@ Issue #92 ([R2.4] "Keep hooks, OTEL, and historical importers as transition fall
 ### Expected
 
 - Clear scope lock for R1–R5 implementation.
-- Simpler codebase — one ingestion path (proxy), one local UX (Rich CLI), one web UX (cloud dashboard).
+- Simpler codebase — one ingestion path (tailer/import pipeline), one local UX (Rich CLI), one web UX (cloud dashboard).
 - Less code to maintain, test, and reason about.
 - Faster iteration — no energy spent on backward compatibility with paths that are being replaced.
 

--- a/docs/adr/0088-8x-local-developer-first-product-contract.md
+++ b/docs/adr/0088-8x-local-developer-first-product-contract.md
@@ -45,10 +45,10 @@ Budi 8.x is organized around one **local product** with optional **cloud visibil
 | Surface | Owner repo | Role in 8.x |
 |---------|------------|-------------|
 | CLI (`budi`) | `siropkin/budi` | Primary developer surface. Daily-use commands (`stats`, `sessions`, `status`, `doctor`, `statusline`). |
-| Daemon (`budi-daemon`) | `siropkin/budi` | Owns SQLite, serves analytics APIs, runs proxy, runs cloud sync worker. |
-| Proxy | `siropkin/budi` | Sole live ingestion path (ADR-0082). |
+| Daemon (`budi-daemon`) | `siropkin/budi` | Owns SQLite, serves analytics APIs, runs the transcript tailer, and runs the cloud sync worker. |
+| Tailer | `siropkin/budi` | Sole live ingestion path in 8.2+ (ADR-0089). Watches agent transcript roots; no proxy. |
 | Statusline | `siropkin/budi` | Quiet, provider-scoped ambient signal (see §4). |
-| Classification | `siropkin/budi` | Rule-based activity/ticket/branch/file/outcome signals inside the proxy + pipeline (see §5). |
+| Classification | `siropkin/budi` | Rule-based activity/ticket/branch/file/outcome signals inside the pipeline over tailed/imported transcripts (see §5). |
 | Cursor extension | `siropkin/budi-cursor` | Provider-scoped Cursor surface. Consumes the shared status contract from §4. |
 | Cloud dashboard | `siropkin/budi-cloud` | Shared visibility + manager-facing view. Uses the **same** windows (`1d`/`7d`/`30d`) and classification vocabulary as local. Owns local→cloud linking UX. |
 
@@ -111,14 +111,14 @@ Classification should improve through **simple, explainable, local-first methods
 **R1.4 — file-level attribution (#292):**
 
 - Stays inside ADR-0083 privacy limits: **repo-relative paths only**, no absolute paths, no outside-of-repo paths, no file contents, no diffs.
-- Signal is derived from tool-call arguments already visible to the proxy and pipeline.
+- Signal is derived from tool-call arguments already present in parsed transcript messages and the pipeline.
 - Writes are small, bounded, and deduplicated — file attribution must not inflate row size or row count unboundedly.
 - A file attribution row without a valid repo-relative path is dropped, not stored with a placeholder.
 
 **R1.5 — tool outcome and session→work outcome signals (#293):**
 
 - Rule-based and debuggable. No remote git or PR API calls in 8.1. No content capture.
-- Tool outcomes are derived from proxy-observable signals (denials, retries, follow-up success) and optional local git state the daemon can already see, not from external systems.
+- Tool outcomes are derived from transcript-observable signals (denials, retries, follow-up success) and optional local git state the daemon can already see, not from external systems.
 - Session→work outcome ("did this session produce a merged change, a reverted change, or no change?") is inferred from local git transitions only.
 - Every outcome signal is labeled with an explicit `source` / `confidence` so surfaces can honestly say "this is a heuristic".
 

--- a/docs/adr/0089-reverse-proxy-first-jsonl-tailing-as-sole-live-path.md
+++ b/docs/adr/0089-reverse-proxy-first-jsonl-tailing-as-sole-live-path.md
@@ -1,7 +1,8 @@
 # ADR-0089: Reverse Proxy-First Architecture — JSONL Tailing as Sole Live Path
 
 - **Date**: 2026-04-17
-- **Status**: Accepted (2026-04-18 — promotion criteria below all satisfied; recorded in [#356](https://github.com/siropkin/budi/issues/356) R1.7 docs review pass)
+- **Status**: Accepted
+- **Accepted on**: 2026-04-18 (promotion criteria below all satisfied; recorded in [#356](https://github.com/siropkin/budi/issues/356) R1.7 docs review pass)
 - **Issue**: [#317](https://github.com/siropkin/budi/issues/317)
 - **Milestone**: 8.2.0 (epic: [#316](https://github.com/siropkin/budi/issues/316))
 - **Supersedes**: [ADR-0082](./0082-proxy-compatibility-matrix-and-gateway-contract.md)
@@ -99,7 +100,7 @@ Caveats are spelled out in the verdict comment: N = 12 is small (so `p99` ≈ `m
 
 ### 8. Plugin model is preserved
 
-The `Provider` trait is the only extension point. Adding a new agent in 8.3 (#294) is one new `Provider` impl plus its registration — no proxy adapter, no base URL matrix, no env-var injection, no shell profile work. The plugin model survives intact; what changes is that it is also the live model, not just the import model.
+The `Provider` trait is the only extension point. Adding a new agent under the future coverage epic ([#294](https://github.com/siropkin/budi/issues/294)) is one new `Provider` impl plus its registration — no proxy adapter, no base URL matrix, no env-var injection, no shell profile work. The plugin model survives intact; what changes is that it is also the live model, not just the import model.
 
 ## Consequences
 
@@ -171,7 +172,7 @@ Rewritten in full in [#317](https://github.com/siropkin/budi/issues/317) as "JSO
 
 ### `SOUL.md`
 
-Any section that still describes the proxy as the live path is updated in the R1.1 PR.
+Any section that still describes the proxy as the live path is updated during the 8.2 docs passes; `#359` is the Round 2 scrub that removes the remaining misleading live-path language.
 
 ## Promotion Criteria
 
@@ -194,4 +195,4 @@ The 8.2 R2 proxy-removal work is unblocked once the R1 exit gate ([#362](https:/
 - [#316](https://github.com/siropkin/budi/issues/316) — 8.2.0 Invisible Budi epic
 - [#317](https://github.com/siropkin/budi/issues/317) — this ADR's tracking issue
 - [#201](https://github.com/siropkin/budi/issues/201) — 8.1.0 epic (must ship before 8.2 work starts)
-- [#294](https://github.com/siropkin/budi/issues/294) — 8.3.0 AI coding tool coverage epic (built on the tailer)
+- [#294](https://github.com/siropkin/budi/issues/294) — future AI coding tool coverage epic (built on the tailer)

--- a/docs/research/agent-local-files-2026-04.md
+++ b/docs/research/agent-local-files-2026-04.md
@@ -4,6 +4,8 @@
 - **Purpose**: Catalogue what local session/log files each AI coding agent produces, to inform the proxy-vs-file-watching design decision
 - **Last updated**: 2026-04-13
 
+> **Decision note after 2026-04-17 (ADR-0089).** This inventory was gathered for the proxy-vs-file-watching decision and is preserved as historical research. The open design question is closed: transcript tailing is the sole live path in 8.2+ per [ADR-0089](../adr/0089-reverse-proxy-first-jsonl-tailing-as-sole-live-path.md).
+
 ---
 
 ## Summary Table

--- a/docs/research/competitive-landscape-2026-04.md
+++ b/docs/research/competitive-landscape-2026-04.md
@@ -4,6 +4,8 @@
 - **Purpose**: Inform roadmap planning for Budi 9.0+ by mapping the competitive landscape
 - **Last updated**: 2026-04-12
 
+> **Stale after 2026-04-17 (ADR-0089).** This note captures pre-8.2 proxy-first assumptions and is preserved as historical research only. Current live-path/product-direction decisions are governed by [ADR-0089](../adr/0089-reverse-proxy-first-jsonl-tailing-as-sole-live-path.md).
+
 ## Market Summary
 
 The AI coding cost analytics space has exploded from ~5 tools in early 2025 to **50+ tools** by April 2026. Most are small open-source projects by individual developers targeting Claude Code. The team/manager tier remains underserved.

--- a/docs/research/ideas-alerts.md
+++ b/docs/research/ideas-alerts.md
@@ -4,6 +4,8 @@
 - **Status**: Proposed (partially planned in R5 #106, #107)
 - **Related issues**: #106 (budget engine warn-only), #107 (hard budget blocking)
 
+> **Stale after 2026-04-17 (ADR-0089).** This design note assumes a proxy-enforced live path and is preserved as historical research only. Any future alerts/budget design should start from the transcript-tailer contract in [ADR-0089](../adr/0089-reverse-proxy-first-jsonl-tailing-as-sole-live-path.md), not from proxy blocking.
+
 ## Concept
 
 Alerts are a separate entity from tags. Tags are for attribution/grouping. Alerts are for thresholds and notifications.

--- a/docs/research/ideas-repo-identity.md
+++ b/docs/research/ideas-repo-identity.md
@@ -4,6 +4,8 @@
 - **Status**: Implemented (repo_id column exists, hash-based)
 - **See**: `crates/budi-core/src/repo_id.rs`
 
+> **Stale after 2026-04-17 (ADR-0089).** This note is preserved for historical context, but any mention of proxy/header-based attribution is obsolete in 8.2+. Current live-path attribution comes from tailed transcripts per [ADR-0089](../adr/0089-reverse-proxy-first-jsonl-tailing-as-sole-live-path.md).
+
 ## Problem
 
 Same git repo in different worktrees or clones counts as separate projects in stats/dashboard. User expects them merged.

--- a/docs/research/yc-landscape-2026-04.md
+++ b/docs/research/yc-landscape-2026-04.md
@@ -3,6 +3,8 @@
 - **Date**: 2026-04-12
 - **Purpose**: Understand which competitors and adjacent companies are YC-backed, funding levels, and market signals
 
+> **Stale after 2026-04-17 (ADR-0089).** This note preserves pre-pivot proxy/gateway market framing as historical research only. Current live-path decisions are governed by [ADR-0089](../adr/0089-reverse-proxy-first-jsonl-tailing-as-sole-live-path.md).
+
 ## Summary
 
 YC W23 was the defining batch for LLM observability — Helicone, Langfuse, LiteLLM, Traceloop, and Athina AI all came from it. The shakeout since then is telling:

--- a/docs/statusline-contract.md
+++ b/docs/statusline-contract.md
@@ -9,7 +9,7 @@ This document pins the shared provider-scoped status contract emitted by Budi's 
 - the Cursor extension ([#232](https://github.com/siropkin/budi/issues/232), surfaced as a single Cursor status bar item — no sidebar, no side panel)
 - the cloud dashboard's provider-scoped views ([#235](https://github.com/siropkin/budi/issues/235))
 
-Provider is an explicit filter rather than a family of per-surface shapes. New agents added in 8.2 under [#294](https://github.com/siropkin/budi/issues/294) slot into the same shape — they do not each invent their own statusline schema.
+Provider is an explicit filter rather than a family of per-surface shapes. Future agents added under [#294](https://github.com/siropkin/budi/issues/294) slot into the same shape — they do not each invent their own statusline schema.
 
 ## Endpoint
 

--- a/scripts/install-standalone.ps1
+++ b/scripts/install-standalone.ps1
@@ -141,7 +141,7 @@ try {
         if ($initExit -eq 2) {
             Log "Setup complete with warnings. Run 'budi doctor' to see what needs fixing."
         } else {
-            Log "Setup complete! Restart your terminal so CLI agents pick up proxy env vars, then run 'budi doctor' to verify end-to-end."
+            Log "Setup complete! Run 'budi doctor' to verify end-to-end, then open your agent and send a prompt."
         }
     } else {
         Fail "budi init failed (exit code $initExit). Run 'budi doctor' to diagnose."

--- a/scripts/install-standalone.sh
+++ b/scripts/install-standalone.sh
@@ -234,7 +234,7 @@ main() {
     "$BIN_DIR/budi" init || init_rc=$?
     if [ "$init_rc" -eq 0 ]; then
       log ""
-      log "Setup complete! Restart your terminal so CLI agents pick up proxy env vars, then run 'budi doctor' to verify end-to-end."
+      log "Setup complete! Run 'budi doctor' to verify end-to-end, then open your agent and send a prompt."
     elif [ "$init_rc" -eq 2 ]; then
       log ""
       log "Setup complete with warnings. Run 'budi doctor' to see what needs fixing."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -343,7 +343,7 @@ main() {
   "$BIN_DIR/budi" init || init_rc=$?
   if [[ "$init_rc" -eq 0 ]]; then
     log ""
-    log "Setup complete! Restart your terminal so CLI agents pick up proxy env vars, then run 'budi doctor' to verify end-to-end."
+    log "Setup complete! Run 'budi doctor' to verify end-to-end, then open your agent and send a prompt."
   elif [[ "$init_rc" -eq 2 ]]; then
     log ""
     log "Setup complete with warnings. Run 'budi doctor' to see what needs fixing."


### PR DESCRIPTION
## Summary
- align `README.md`, `SOUL.md`, installer success text, and contributor guidance with the 8.2 transcript-tailer-only live path
- update ADR-0081, ADR-0088, ADR-0089, and the shared statusline contract so the authoritative docs no longer describe removed proxy-first setup/live-ingestion behavior
- mark stale research notes as historical and trim stale inline Rust comments so only deliberate legacy proxy references remain

## Risks / compatibility notes
- this PR intentionally updates top-level repo guidance beyond the files explicitly listed in `#359` because `README.md` was still describing removed proxy flows and would otherwise remain the most misleading setup surface
- legacy proxy references are kept only where they document upgrade cleanup, retained `proxy_estimated` history, or superseded ADR history
- the issue acceptance text references `v8.1.latest`, but that ref is not present in git locally; the no-new-files audit was run against the shipped `v8.1.0` tag instead

## Validation
- [x] `cargo fmt --all`
- [x] `cargo test --doc --workspace`
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `git log v8.1.0..HEAD --name-only --diff-filter=A -- docs/research docs/releases`

Closes #359

Made with [Cursor](https://cursor.com)