### PR TITLE
[8.2] Hard prompt for proxy cleanup and dummy proxy listener

### DIFF
--- a/crates/budi-cli/src/commands/init.rs
+++ b/crates/budi-cli/src/commands/init.rs
@@ -13,6 +13,14 @@ use crate::daemon::ensure_daemon_running;
 pub fn cmd_init(cleanup: bool, yes: bool, no_daemon: bool) -> Result<()> {
     if cleanup {
         run_cleanup_flow(yes)?;
+    } else if let Ok(scan) = legacy_proxy::scan()
+        && scan.has_managed_blocks()
+    {
+        let yellow = super::ansi("\x1b[33m");
+        let reset = super::ansi("\x1b[0m");
+        println!("\n{yellow}Critical:{reset} Detected legacy 8.0/8.1 proxy configuration.");
+        println!("This configuration will break Claude Code in 8.2.0 and must be removed.");
+        run_cleanup_flow(yes)?;
     }
 
     clean_duplicate_binaries();

--- a/crates/budi-daemon/src/main.rs
+++ b/crates/budi-daemon/src/main.rs
@@ -229,6 +229,27 @@ async fn main() -> Result<()> {
         }
     }
 
+    // --- Start dummy proxy listener if legacy proxy residue exists ---
+    if let Ok(scan) = budi_core::legacy_proxy::scan()
+        && scan.has_managed_blocks()
+    {
+        tracing::info!(
+            target: "budi_daemon::dummy_proxy",
+            "legacy proxy residue detected; starting dummy proxy on 9878 to return actionable 400s to agents"
+        );
+        tokio::spawn(async move {
+            let dummy_app = axum::Router::new().fallback(axum::routing::any(|| async {
+                (
+                    axum::http::StatusCode::BAD_REQUEST,
+                    "Budi proxy is removed in 8.2.0. Please run `budi init --cleanup` to fix your shell profile."
+                )
+            }));
+            if let Ok(listener) = tokio::net::TcpListener::bind("127.0.0.1:9878").await {
+                let _ = axum::serve(listener, dummy_app).await;
+            }
+        });
+    }
+
     let addr: SocketAddr = format!("{}:{}", host, port).parse()?;
     let listener = tokio::net::TcpListener::bind(addr).await?;
     tracing::info!("budi-daemon listening on {}", addr);


### PR DESCRIPTION
## Summary
- Closes #400.
- `budi init` now explicitly checks for legacy proxy configuration and forces a hard prompt for cleanup if it exists.
- `budi-daemon` now starts a dummy proxy listener on port 9878 if legacy proxy configuration exists. This dummy listener returns an actionable 400 Bad Request with instructions to run `budi init --cleanup`, ensuring `claude` fails fast and informs the user instead of hanging indefinitely.

## Risks / compatibility notes
- The dummy proxy listener runs in the background until the user cleans up their shell profile. It uses port 9878, which was previously used by the actual proxy, so it shouldn't conflict with anything else.

## Validation
- Tested `budi init` without `--cleanup` when proxy config exists; it now fails non-interactively and prompts interactively.
- Tested `claude` with `ANTHROPIC_BASE_URL=http://localhost:9878` exported; it now fails fast with `API Error: 400 Budi proxy is removed in 8.2.0. Please run budi init --cleanup to fix your shell profile.` instead of hanging indefinitely.

Made with [Cursor](https://cursor.com)