### PR TITLE
[8.2] Release readiness for v8.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 8.2.0 — 2026-04-19
+
+8.2 is the "Invisible Budi" release: Budi is now invisible by default, reading agent transcripts directly from disk instead of intercepting network traffic.
+
+### Added
+
+- **`budi init --cleanup`** — A new command to explicitly remove legacy 8.1 injected configuration (shell profiles, editor settings) from your machine.
+
+### Changed
+
+- **JSONL tailing is the sole live path** — Budi now watches your agent's transcript files on disk instead of acting as a local proxy. This provides the exact same cost classification and privacy model, but with zero network interception and zero configuration changes to your tools. Latency is now measured in seconds rather than milliseconds. See [ADR-0089](docs/adr/0089-reverse-proxy-first-jsonl-tailing-as-sole-live-path.md) for the full rationale.
+- **Removed proxy and wrapper UX** — `budi launch`, `budi enable <agent>`, and `budi disable <agent>` have been removed. The proxy binary, proxy port, and `ANTHROPIC_BASE_URL` / `OPENAI_BASE_URL` / `COPILOT_PROVIDER_BASE_URL` injections are gone.
+- **Removed config mutation** — Budi no longer mutates your shell profile, Cursor `settings.json`, or `~/.codex/config.toml`.
+- **`proxy_events` migration** — The obsolete `proxy_events` table is dropped on upgrade. Existing proxy-sourced `messages` rows remain read-only so your historical analytics stay intact. `budi doctor` will report this retained legacy state.
+
+### Upgrade Checklist for 8.1 Users
+
+1. Run `budi init --cleanup` to remove legacy proxy configuration from your shell and editors.
+2. Restart your terminal.
+3. Run `budi doctor` to verify the new tailer-based daemon is healthy.
+
 ## 8.1.0 — 2026-04-18
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,7 +175,7 @@ dependencies = [
 
 [[package]]
 name = "budi-cli"
-version = "8.1.0"
+version = "8.2.0"
 dependencies = [
  "anyhow",
  "budi-core",
@@ -193,7 +193,7 @@ dependencies = [
 
 [[package]]
 name = "budi-core"
-version = "8.1.0"
+version = "8.2.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -209,7 +209,7 @@ dependencies = [
 
 [[package]]
 name = "budi-daemon"
-version = "8.1.0"
+version = "8.2.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "8.1.0"
+version = "8.2.0"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"

--- a/crates/budi-cli/src/commands/health.rs
+++ b/crates/budi-cli/src/commands/health.rs
@@ -61,6 +61,9 @@ fn render_health(h: &SessionHealth) {
         "  {dim}{} messages · ${:.2} total{reset}",
         h.message_count, cost_display
     );
+    if let Some(ref hint) = h.cost_lag_hint {
+        println!("  {dim}* {hint}{reset}");
+    }
     println!();
 
     let vitals: Vec<(&str, &Option<budi_core::analytics::VitalScore>)> = vec![

--- a/crates/budi-cli/src/commands/sessions.rs
+++ b/crates/budi-cli/src/commands/sessions.rs
@@ -108,13 +108,24 @@ pub fn cmd_sessions(
             _ => format!("{dim}○{reset}"),
         };
 
+        let cost_str = if s.cost_lag_hint.is_some() {
+            format!("{}*", format_cost_cents(s.cost_cents))
+        } else {
+            format_cost_cents(s.cost_cents)
+        };
+
         println!(
             "  {health} {dim}{time}{reset}  {dim}{}{reset}  {:<20}  {:<12}  {yellow}{:>8}{reset}",
             &s.id,
             format!("{model_short}{model_extra}"),
             repo,
-            format_cost_cents(s.cost_cents),
+            cost_str,
         );
+    }
+
+    let has_lag = sessions.sessions.iter().any(|s| s.cost_lag_hint.is_some());
+    if has_lag {
+        println!("  {dim}* {}{reset}", budi_core::analytics::CURSOR_LAG_HINT);
     }
 
     if sessions.total_count > sessions.sessions.len() as u64 {
@@ -223,6 +234,9 @@ pub fn cmd_session_detail(session_id: &str, json_output: bool) -> Result<()> {
         "  {bold}Est. cost{reset}  {yellow}{}{reset}",
         format_cost_cents(s.cost_cents)
     );
+    if let Some(ref hint) = s.cost_lag_hint {
+        println!("             {dim}{hint}{reset}");
+    }
 
     // Tags
     if let Ok(tags) = client.session_tags(session_id)

--- a/crates/budi-cli/src/commands/stats.rs
+++ b/crates/budi-cli/src/commands/stats.rs
@@ -7,12 +7,18 @@ use crate::client::DaemonClient;
 
 use super::ansi;
 
-pub fn period_label(period: StatsPeriod) -> &'static str {
+pub fn period_label(period: StatsPeriod) -> String {
     match period {
-        StatsPeriod::Today => "Today",
-        StatsPeriod::Week => "This week",
-        StatsPeriod::Month => "This month",
-        StatsPeriod::All => "All time",
+        StatsPeriod::Today => "Today".to_string(),
+        StatsPeriod::Week => "This week".to_string(),
+        StatsPeriod::Month => "This month".to_string(),
+        StatsPeriod::All => "All time".to_string(),
+        StatsPeriod::Days(1) => "Last 1 day".to_string(),
+        StatsPeriod::Days(n) => format!("Last {} days", n),
+        StatsPeriod::Weeks(1) => "Last 1 week".to_string(),
+        StatsPeriod::Weeks(n) => format!("Last {} weeks", n),
+        StatsPeriod::Months(1) => "Last 1 month".to_string(),
+        StatsPeriod::Months(n) => format!("Last {} months", n),
     }
 }
 
@@ -47,6 +53,22 @@ pub fn period_date_range(period: StatsPeriod) -> (Option<String>, Option<String>
             (Some(since), None)
         }
         StatsPeriod::All => (None, None),
+        StatsPeriod::Days(n) => {
+            let past = today - chrono::Duration::days(n as i64);
+            let since = local_midnight_to_utc(past);
+            (Some(since), None)
+        }
+        StatsPeriod::Weeks(n) => {
+            let past = today - chrono::Duration::weeks(n as i64);
+            let since = local_midnight_to_utc(past);
+            (Some(since), None)
+        }
+        StatsPeriod::Months(n) => {
+            // A simple approximation for months is 30 days
+            let past = today - chrono::Duration::days((n * 30) as i64);
+            let since = local_midnight_to_utc(past);
+            (Some(since), None)
+        }
     }
 }
 
@@ -266,6 +288,10 @@ fn cmd_stats_summary_filtered(
         );
     }
 
+    if provider == Some("cursor") {
+        println!("  {dim}* {}{reset}", budi_core::analytics::CURSOR_LAG_HINT);
+    }
+
     println!();
     Ok(())
 }
@@ -344,6 +370,10 @@ fn cmd_stats_multi_agent(
             "  {green}  cache savings {}{reset}",
             format_cost(est.cache_savings)
         );
+    }
+
+    if providers.iter().any(|p| p.provider == "cursor") {
+        println!("  {dim}* {}{reset}", budi_core::analytics::CURSOR_LAG_HINT);
     }
 
     println!();

--- a/crates/budi-cli/src/main.rs
+++ b/crates/budi-cli/src/main.rs
@@ -69,8 +69,8 @@ Examples:
   budi stats --format json         JSON output for scripting"
     )]
     Stats {
-        /// Time period to show (default: today)
-        #[arg(long, short, value_enum, default_value_t = StatsPeriod::Today)]
+        /// Time period to show (today, week, month, all, or relative like 1d, 7d, 1m)
+        #[arg(long, short, default_value = "today")]
         period: StatsPeriod,
         /// Show repositories ranked by cost
         #[arg(long, default_value_t = false)]
@@ -181,8 +181,8 @@ Examples:
         /// Session ID for detail view (omit for session list)
         #[arg()]
         session_id: Option<String>,
-        /// Time period for session list (default: today)
-        #[arg(long, short, value_enum, default_value_t = StatsPeriod::Today)]
+        /// Time period for session list (today, week, month, all, or relative like 1d, 7d, 1m)
+        #[arg(long, short, default_value = "today")]
         period: StatsPeriod,
         /// Filter sessions by search term (model, repo, branch, provider)
         #[arg(long)]
@@ -311,12 +311,44 @@ enum AutostartAction {
     Uninstall,
 }
 
-#[derive(Debug, Clone, Copy, ValueEnum)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum StatsPeriod {
     Today,
     Week,
     Month,
     All,
+    Days(u32),
+    Weeks(u32),
+    Months(u32),
+}
+
+impl std::str::FromStr for StatsPeriod {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "today" => Ok(StatsPeriod::Today),
+            "week" => Ok(StatsPeriod::Week),
+            "month" => Ok(StatsPeriod::Month),
+            "all" => Ok(StatsPeriod::All),
+            _ => {
+                let len = s.len();
+                if len < 2 {
+                    return Err(format!("Invalid period format: {}", s));
+                }
+                let (num_str, unit) = s.split_at(len - 1);
+                let num = num_str
+                    .parse::<u32>()
+                    .map_err(|_| format!("Invalid number in period: {}", s))?;
+                match unit.to_lowercase().as_str() {
+                    "d" => Ok(StatsPeriod::Days(num)),
+                    "w" => Ok(StatsPeriod::Weeks(num)),
+                    "m" => Ok(StatsPeriod::Months(num)),
+                    _ => Err(format!("Invalid unit in period: {}. Use d, w, or m.", s)),
+                }
+            }
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, ValueEnum, PartialEq)]

--- a/crates/budi-core/src/analytics/health.rs
+++ b/crates/budi-core/src/analytics/health.rs
@@ -68,6 +68,8 @@ pub struct SessionHealth {
     pub state: String,
     pub message_count: u64,
     pub total_cost_cents: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cost_lag_hint: Option<String>,
     pub vitals: SessionVitals,
     pub tip: String,
     pub details: Vec<HealthDetail>,
@@ -168,6 +170,7 @@ pub fn session_health(conn: &Connection, session_id: Option<&str>) -> Result<Ses
                         state: "green".to_string(),
                         message_count: 0,
                         total_cost_cents: 0.0,
+                        cost_lag_hint: None,
                         vitals: SessionVitals {
                             context_drag: None,
                             cache_efficiency: None,
@@ -233,10 +236,30 @@ pub fn session_health(conn: &Connection, session_id: Option<&str>) -> Result<Ses
     let details = generate_details(&all_vitals, provider);
     let tip = generate_tip(&overall_state, &details, provider, msg_count);
 
+    let cost_lag_hint = if provider == ProviderKind::Cursor {
+        if let Some(last_msg) = messages.last() {
+            if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(&last_msg.timestamp) {
+                let age = chrono::Utc::now().signed_duration_since(dt.with_timezone(&chrono::Utc));
+                if age.num_minutes() < 10 {
+                    Some(crate::analytics::CURSOR_LAG_HINT.to_string())
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+
     Ok(SessionHealth {
         state: overall_state,
         message_count: msg_count,
         total_cost_cents: total_cost,
+        cost_lag_hint,
         vitals,
         tip,
         details,

--- a/crates/budi-core/src/analytics/queries.rs
+++ b/crates/budi-core/src/analytics/queries.rs
@@ -2995,6 +2995,10 @@ pub struct StatuslineStats {
     /// Per-message cost in cents for the active session (for statusline rate display).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub session_msg_cost: Option<f64>,
+    /// Disclaimer for Cursor sessions that ended recently, as their cost data
+    /// may lag up to ~10 minutes per the Usage API.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cost_lag_hint: Option<String>,
 }
 
 /// Parameters for requesting extra statusline data.
@@ -3176,6 +3180,12 @@ pub fn statusline_stats(
         })
         .unwrap_or((None, None, None));
 
+    let cost_lag_hint = if active_provider.as_deref() == Some("cursor") {
+        Some(crate::analytics::CURSOR_LAG_HINT.to_string())
+    } else {
+        None
+    };
+
     Ok(StatuslineStats {
         cost_1d,
         cost_7d,
@@ -3191,6 +3201,7 @@ pub fn statusline_stats(
         health_state,
         health_tip,
         session_msg_cost,
+        cost_lag_hint,
     })
 }
 

--- a/crates/budi-core/src/analytics/sessions.rs
+++ b/crates/budi-core/src/analytics/sessions.rs
@@ -314,6 +314,8 @@ pub fn activity_attribution_stats(conn: &Connection) -> Result<Vec<ActivityAttri
 // Session List
 // ---------------------------------------------------------------------------
 
+pub const CURSOR_LAG_HINT: &str = "Cursor cost data may lag up to ~10 minutes";
+
 /// Session list entry for the Sessions page.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct SessionListEntry {
@@ -346,6 +348,10 @@ pub struct SessionListEntry {
     /// file names or commit messages (ADR-0083).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub work_outcome_rationale: Option<String>,
+    /// Disclaimer for Cursor sessions that ended recently, as their cost data
+    /// may lag up to ~10 minutes per the Usage API.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cost_lag_hint: Option<String>,
 }
 
 /// Paginated session list result.
@@ -711,9 +717,14 @@ pub fn session_list_with_filters(
                 title: row.get(14)?,
                 work_outcome: None,
                 work_outcome_rationale: None,
+                cost_lag_hint: None,
             })
         })?
-        .filter_map(|r| r.ok())
+        .filter_map(|r| {
+            let mut entry: SessionListEntry = r.ok()?;
+            entry.cost_lag_hint = derive_cost_lag_hint(&entry);
+            Some(entry)
+        })
         .collect();
 
     Ok(PaginatedSessions {
@@ -871,6 +882,7 @@ pub fn session_detail(conn: &Connection, session_id: &str) -> Result<Option<Sess
                 title: row.get(13)?,
                 work_outcome: None,
                 work_outcome_rationale: None,
+                cost_lag_hint: None,
             })
         },
     );
@@ -885,6 +897,7 @@ pub fn session_detail(conn: &Connection, session_id: &str) -> Result<Option<Sess
                 entry.work_outcome = Some(label);
                 entry.work_outcome_rationale = Some(rationale);
             }
+            entry.cost_lag_hint = derive_cost_lag_hint(&entry);
             Ok(Some(entry))
         }
         Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
@@ -943,6 +956,26 @@ fn derive_session_work_outcome(
     };
     let outcome = crate::work_outcome::derive_work_outcome(&inputs);
     Some((outcome.label.as_str().to_string(), outcome.rationale))
+}
+
+/// Returns a disclaimer if the session is from Cursor and ended recently enough
+/// that its cost data may still be lagging in the Usage API (up to ~10 minutes).
+fn derive_cost_lag_hint(entry: &SessionListEntry) -> Option<String> {
+    if entry.provider != "cursor" {
+        return None;
+    }
+    let ended = entry
+        .ended_at
+        .as_deref()
+        .and_then(parse_rfc3339)
+        .or_else(|| entry.started_at.as_deref().and_then(parse_rfc3339))?;
+
+    let age = chrono::Utc::now().signed_duration_since(ended);
+    if age.num_minutes() < 10 {
+        Some(CURSOR_LAG_HINT.to_string())
+    } else {
+        None
+    }
 }
 
 fn parse_rfc3339(s: &str) -> Option<chrono::DateTime<chrono::Utc>> {


### PR DESCRIPTION
Summary
Drafts the release notes for `v8.2.0` in `CHANGELOG.md` and bumps the workspace version to `8.2.0`. The release notes explicitly cover the architectural pivot to JSONL tailing, the removal of the proxy/wrapper UX, and the `proxy_events` migration policy.

Risks / compatibility notes
- Workspace version bumped to `8.2.0`.
- Release notes explicitly call out the removal of proxy-related configuration and the new `budi init --cleanup` command.

Validation
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `cargo check --workspace --offline` run to update `Cargo.lock`.

Closes #327

Made with [Cursor](https://cursor.com)