### PR TITLE
[8.2] Tailer: persist tail_offset in the same transaction as ingest

### DIFF
--- a/crates/budi-core/src/analytics/mod.rs
+++ b/crates/budi-core/src/analytics/mod.rs
@@ -304,15 +304,24 @@ pub fn ingest_messages(
     messages: &[ParsedMessage],
     tags: Option<&[Vec<Tag>]>,
 ) -> Result<usize> {
-    ingest_messages_with_sync(conn, messages, tags, None)
+    ingest_messages_with_sync(conn, messages, tags, None, None)
 }
 
-/// Ingest messages and optionally update sync offset atomically.
+/// Ingest messages and optionally update one or both offset tables atomically.
+///
+/// `sync_file` writes a `(file_path, byte_offset)` row into `sync_state` and is
+/// what `budi import` uses. `tail_file` writes a `(provider, path, byte_offset)`
+/// row into `tail_offsets` and is what the live tailer uses (#319, #382).
+///
+/// When both are `Some`, both writes happen inside the same transaction as the
+/// message inserts, so the daemon cannot crash between persisting messages and
+/// advancing its offset and end up reprocessing the same byte range on restart.
 pub fn ingest_messages_with_sync(
     conn: &mut Connection,
     messages: &[ParsedMessage],
     tags: Option<&[Vec<Tag>]>,
     sync_file: Option<(&str, usize)>,
+    tail_file: Option<(&str, &str, usize)>,
 ) -> Result<usize> {
     let tx = conn.transaction()?;
     let mut count = 0;
@@ -549,6 +558,19 @@ pub fn ingest_messages_with_sync(
              VALUES (?1, ?2, ?3)
              ON CONFLICT(file_path) DO UPDATE SET byte_offset = ?2, last_synced = ?3",
             params![file_path, offset as i64, now],
+        )?;
+    }
+
+    // Atomically update the live tailer's per-(provider, path) offset.
+    // Mirrors `set_tail_offset`'s upsert exactly so the in-tx and
+    // standalone code paths stay byte-for-byte equivalent (#382).
+    if let Some((provider, path, offset)) = tail_file {
+        let now = Utc::now().to_rfc3339();
+        tx.execute(
+            "INSERT INTO tail_offsets (provider, path, byte_offset, last_seen)
+             VALUES (?1, ?2, ?3, ?4)
+             ON CONFLICT(provider, path) DO UPDATE SET byte_offset = ?3, last_seen = ?4",
+            params![provider, path, offset as i64, now],
         )?;
     }
 

--- a/crates/budi-core/src/analytics/sync.rs
+++ b/crates/budi-core/src/analytics/sync.rs
@@ -259,6 +259,7 @@ fn ingest_in_batches(
             &messages[start..end],
             Some(&tags[start..end]),
             sync_file,
+            None,
         )?;
         start = end;
     }

--- a/crates/budi-core/src/analytics/tests.rs
+++ b/crates/budi-core/src/analytics/tests.rs
@@ -4653,3 +4653,105 @@ fn health_no_sessions_returns_green() {
     assert_eq!(h.tip, "No sessions yet");
     assert!(h.details.is_empty());
 }
+
+// --- #382: ingest_messages_with_sync `tail_file` atomic offset upsert ---
+
+fn tailer_assistant_msg(uuid: &str, session: &str, ts: &str) -> ParsedMessage {
+    ParsedMessage {
+        uuid: uuid.to_string(),
+        session_id: Some(session.to_string()),
+        timestamp: ts.parse().unwrap(),
+        role: "assistant".to_string(),
+        provider: "stub".to_string(),
+        cost_confidence: "estimated".to_string(),
+        ..Default::default()
+    }
+}
+
+#[test]
+fn ingest_with_tail_file_upserts_offset_in_same_transaction() {
+    let mut conn = test_db();
+    let path = "/tmp/stub/session-382.jsonl";
+    let provider = "stub";
+
+    // Pre-seed the row at 100 so we can prove the inline upsert advances
+    // it to the post-batch offset, not just inserts a new row.
+    set_tail_offset(&conn, provider, path, 100).unwrap();
+    assert_eq!(
+        get_tail_offset(&conn, provider, path).unwrap(),
+        Some(100),
+        "precondition: pre-seeded tail offset"
+    );
+
+    let msgs = vec![tailer_assistant_msg(
+        "382-a",
+        "session-382",
+        "2026-04-19T10:00:00Z",
+    )];
+    let ingested =
+        ingest_messages_with_sync(&mut conn, &msgs, None, None, Some((provider, path, 250)))
+            .unwrap();
+    assert_eq!(ingested, 1, "exactly one new message ingested");
+
+    let stored: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM messages WHERE id = ?1",
+            ["382-a"],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(stored, 1, "message row committed");
+
+    assert_eq!(
+        get_tail_offset(&conn, provider, path).unwrap(),
+        Some(250),
+        "tail_offsets row advanced to the post-batch offset inline with the ingest commit",
+    );
+}
+
+#[test]
+fn ingest_without_tail_file_leaves_tail_offsets_untouched() {
+    let mut conn = test_db();
+    let path = "/tmp/stub/session-382-noop.jsonl";
+    let provider = "stub";
+
+    // Sentinel offset proves we are observing a no-touch, not a coincident
+    // re-insert at the same value.
+    set_tail_offset(&conn, provider, path, 17).unwrap();
+
+    let msgs = vec![tailer_assistant_msg(
+        "382-b",
+        "session-382-b",
+        "2026-04-19T11:00:00Z",
+    )];
+    let ingested = ingest_messages_with_sync(&mut conn, &msgs, None, None, None).unwrap();
+    assert_eq!(ingested, 1);
+
+    assert_eq!(
+        get_tail_offset(&conn, provider, path).unwrap(),
+        Some(17),
+        "tail_offsets row must not be touched when tail_file is None",
+    );
+}
+
+#[test]
+fn ingest_with_tail_file_writes_offset_atomically_for_empty_message_batch() {
+    // Empty message batch + Some(tail_file) is the parser-skip case
+    // from process_path: no rows to ingest, but the tailer has still
+    // advanced past a parseable region and wants the offset persisted.
+    // The single-tx contract should still hold so the offset write
+    // rides on the same commit as the (empty) ingest pass.
+    let mut conn = test_db();
+    let path = "/tmp/stub/session-382-empty.jsonl";
+    let provider = "stub";
+
+    let ingested =
+        ingest_messages_with_sync(&mut conn, &[], None, None, Some((provider, path, 64))).unwrap();
+    assert_eq!(ingested, 0);
+
+    assert_eq!(
+        get_tail_offset(&conn, provider, path).unwrap(),
+        Some(64),
+        "empty-batch ingest with tail_file must still upsert the offset",
+    );
+}

--- a/crates/budi-daemon/src/workers/tailer.rs
+++ b/crates/budi-daemon/src/workers/tailer.rs
@@ -304,10 +304,19 @@ fn backstop_scan(
 
 /// Process a single path event. Pure data flow:
 /// `read tail → provider.parse_file → Pipeline::process →
-/// ingest_messages_with_sync → set_tail_offset`. Logs at the
+/// ingest_messages_with_sync (writes messages, tags, and the new
+/// tail_offsets row in a single transaction)`. Logs at the
 /// `budi_daemon::tailer` target with `provider`, `path`, `bytes_read`,
 /// `messages_parsed`, `ingested` per the ticket's structured-logging
 /// requirement.
+///
+/// Atomicity (#382): when there are messages to ingest, the offset
+/// advance is inlined into the ingest transaction so a daemon crash or
+/// power loss between persisting messages and persisting the offset
+/// cannot leave the tailer pointing at a pre-batch byte position. The
+/// no-message branch (line discipline only) still calls
+/// [`set_tail_offset`] directly because it has no other write to atomize
+/// with.
 fn process_path(
     conn: &mut Connection,
     pipeline: &mut Pipeline,
@@ -400,18 +409,14 @@ fn process_path(
     let messages_parsed = messages.len();
     let tags = pipeline.process(&mut messages);
 
-    match ingest_messages_with_sync(conn, &messages, Some(&tags), None) {
+    match ingest_messages_with_sync(
+        conn,
+        &messages,
+        Some(&tags),
+        None,
+        Some((provider_name, &path_str, new_offset)),
+    ) {
         Ok(ingested) => {
-            if let Err(e) = set_tail_offset(conn, provider_name, &path_str, new_offset) {
-                tracing::warn!(
-                    target: "budi_daemon::tailer",
-                    provider = %provider_name,
-                    path = %path.display(),
-                    error = %format!("{e:#}"),
-                    "set_tail_offset failed after ingest"
-                );
-                return;
-            }
             tracing::info!(
                 target: "budi_daemon::tailer",
                 provider = %provider_name,
@@ -419,6 +424,7 @@ fn process_path(
                 bytes_read = bytes_read,
                 messages_parsed = messages_parsed,
                 ingested = ingested,
+                new_offset = new_offset,
                 "tail batch processed"
             );
         }


### PR DESCRIPTION
## Summary

Atomicity follow-up from the R1 code review on #355 (live JSONL tailer).

`process_path` previously committed two SQLite writes per batch:

1. `ingest_messages_with_sync(...)` — inserts messages + tags inside one tx.
2. `set_tail_offset(...)` — separate write that advances `tail_offsets`.

If the daemon crashed (or the host lost power) between (1) and (2), the
on-disk message rows were correct (uuid dedup keeps them safe), but
`tail_offsets` still pointed at the pre-batch byte position. On the next
FS event the tailer re-read the same byte range, did the dedup dance
again, and the structured log overstated ingest volume.

This PR makes the offset bump atomic with the ingest commit:

- `analytics::ingest_messages_with_sync` now takes a second optional
  offset target, `tail_file: Option<(&str, &str, usize)>` (provider,
  path, new_offset). When `Some`, it upserts `tail_offsets` inside the
  same transaction as the message inserts, right before `tx.commit()`.
- The pre-existing `sync_file` parameter (used by `budi import` /
  `analytics::sync`) is unchanged. `sync.rs` passes `None` for
  `tail_file`, the tailer passes `None` for `sync_file`, so the two
  ingestion paths stay cleanly separated.
- `workers::tailer::process_path` now passes
  `Some((provider, &path_str, new_offset))` and drops its standalone
  `set_tail_offset` call after a successful batch. The empty-batch fast
  path keeps using `set_tail_offset` directly because there is no other
  write it needs to atomize with.

Three new unit tests in `crates/budi-core/src/analytics/tests.rs` pin
the new contract:

- `ingest_with_tail_file_upserts_offset_in_same_transaction` — verifies
  messages **and** the `tail_offsets` row advance together on a single
  commit.
- `ingest_without_tail_file_leaves_tail_offsets_untouched` — regression
  guard so the new branch never accidentally fires for sync.rs callers.
- `ingest_with_tail_file_writes_offset_atomically_for_empty_message_batch`
  — documents that even with zero messages, providing `tail_file` still
  upserts the offset on commit, so any future caller that bypasses the
  tailer's empty-batch shortcut still gets the invariant.

## Risks / compatibility notes

- Schema: no migration. `tail_offsets` already exists (created in 8.2
  schema bring-up); we only change *who* writes it and *when*.
- Wire / public API: none. `ingest_messages_with_sync` is internal to
  the workspace; both in-tree call sites are updated.
- Behavior on the happy path is identical — same offset values land in
  the same table. The only observable difference is on crash recovery,
  where we no longer re-tail the just-committed byte range.
- The empty-batch fast path in `process_path` still does an unwrapped
  `set_tail_offset` call. That is intentional: without an ingest tx to
  bundle into, an isolated upsert is the simplest correct behavior, and
  losing it on crash just means we re-scan an empty tail next boot.

## Validation

- \`cargo fmt --all\` — clean.
- \`cargo clippy --workspace --all-targets --locked -- -D warnings\` —
  clean.
- \`cargo test --workspace --locked\` — 412 (budi-core) + 60 (budi-cli)
  + 20 (budi-daemon) tests pass, including the three new analytics
  tests above and all four pre-existing tailer integration tests
  (\`process_path_advances_offset_and_is_idempotent\`,
  \`process_path_recovers_from_truncation\`,
  \`offsets_survive_simulated_daemon_restart\`,
  \`seed_offsets_marks_existing_files_at_eof\`).

Closes #382.

Made with [Cursor](https://cursor.com)