### PR TITLE
[8.2.1] pipeline: centralize sibling-tag emission helpers (#335)

### DIFF
--- a/crates/budi-core/src/pipeline/emit.rs
+++ b/crates/budi-core/src/pipeline/emit.rs
@@ -1,0 +1,251 @@
+//! Defensive tag-emission helpers for first-class analytics dimensions.
+//!
+//! ## Contract (#335)
+//!
+//! Every first-class dimension tag (`activity`, `ticket_id`, `file_path`,
+//! `tool_outcome`) carries a **sibling source tag** (`*_source`) and — for
+//! `activity` / `file_path` / `tool_outcome` — a sibling confidence tag
+//! (`*_confidence`). Analytics surfaces such as `budi stats --activities`
+//! rely on the pair being present to render explainable per-group labels;
+//! a headline tag without its siblings silently degrades those surfaces
+//! to `src=?` / `confidence=?`.
+//!
+//! Historically this invariant was maintained "by construction" at each
+//! emission site using `if let Some(...)` around the sibling pushes, and
+//! kept honest by `propagate_session_context` filling defaults upstream.
+//! That worked but the invariant lived entirely in reviewer discipline —
+//! a future contributor extending the pipeline could quietly emit a
+//! headline tag alone.
+//!
+//! The helpers below make that impossible at the type level: the
+//! sibling values are non-`Option` parameters, so the compiler rejects
+//! any call site that tries to emit the headline without also providing
+//! source and (where applicable) confidence.
+
+use crate::analytics::Tag;
+use crate::tag_keys as tk;
+
+/// Emit the `ticket_id` + `ticket_prefix` + `ticket_source` triplet.
+///
+/// The prefix is derived from `ticket` so callers cannot accidentally
+/// ship a mismatched pair. Numeric-only tickets (ADR-0082 §9) do not
+/// carry a `-` separator and therefore skip the `ticket_prefix` tag,
+/// matching the R1.3 contract recorded in the numeric-fallback test.
+pub(crate) fn ticket(tags: &mut Vec<Tag>, ticket: &str, source: &str) {
+    tags.push(Tag {
+        key: tk::TICKET_ID.to_string(),
+        value: ticket.to_string(),
+    });
+    if let Some(dash) = ticket.find('-') {
+        tags.push(Tag {
+            key: tk::TICKET_PREFIX.to_string(),
+            value: ticket[..dash].to_string(),
+        });
+    }
+    tags.push(Tag {
+        key: tk::TICKET_SOURCE.to_string(),
+        value: source.to_string(),
+    });
+}
+
+/// Emit the `activity` + `activity_source` + `activity_confidence`
+/// triplet. Callers must supply defaults (`hooks::SOURCE_RULE` /
+/// `hooks::CONF_MEDIUM`) when upstream enrichers left them unset.
+pub(crate) fn activity(tags: &mut Vec<Tag>, activity: &str, source: &str, confidence: &str) {
+    tags.push(Tag {
+        key: tk::ACTIVITY.to_string(),
+        value: activity.to_string(),
+    });
+    tags.push(Tag {
+        key: tk::ACTIVITY_SOURCE.to_string(),
+        value: source.to_string(),
+    });
+    tags.push(Tag {
+        key: tk::ACTIVITY_CONFIDENCE.to_string(),
+        value: confidence.to_string(),
+    });
+}
+
+/// Emit a batch of `file_path` tags plus the shared
+/// `file_path_source` / `file_path_confidence` siblings.
+///
+/// `paths` must be non-empty — the caller is responsible for
+/// short-circuiting when attribution produced nothing. This keeps the
+/// helper aligned with the ADR-0083 invariant that file siblings are
+/// only meaningful when at least one path was accepted.
+pub(crate) fn file_paths(tags: &mut Vec<Tag>, paths: Vec<String>, source: &str, confidence: &str) {
+    debug_assert!(
+        !paths.is_empty(),
+        "emit::file_paths called with empty paths — siblings would be meaningless"
+    );
+    tags.reserve(paths.len() + 2);
+    for path in paths {
+        tags.push(Tag {
+            key: tk::FILE_PATH.to_string(),
+            value: path,
+        });
+    }
+    tags.push(Tag {
+        key: tk::FILE_PATH_SOURCE.to_string(),
+        value: source.to_string(),
+    });
+    tags.push(Tag {
+        key: tk::FILE_PATH_CONFIDENCE.to_string(),
+        value: confidence.to_string(),
+    });
+}
+
+/// Emit one `tool_outcome` tag per distinct outcome plus the shared
+/// `tool_outcome_source` / `tool_outcome_confidence` siblings.
+///
+/// `outcomes` must be non-empty. Callers already guard on that — the
+/// assertion here exists to keep the sibling-always-present invariant
+/// true even if a future refactor forgets.
+pub(crate) fn tool_outcomes<I>(tags: &mut Vec<Tag>, outcomes: I, source: &str, confidence: &str)
+where
+    I: IntoIterator,
+    I::Item: AsRef<str>,
+{
+    let before = tags.len();
+    for outcome in outcomes {
+        tags.push(Tag {
+            key: tk::TOOL_OUTCOME.to_string(),
+            value: outcome.as_ref().to_string(),
+        });
+    }
+    debug_assert!(
+        tags.len() > before,
+        "emit::tool_outcomes called with empty outcomes — siblings would be meaningless"
+    );
+    tags.push(Tag {
+        key: tk::TOOL_OUTCOME_SOURCE.to_string(),
+        value: source.to_string(),
+    });
+    tags.push(Tag {
+        key: tk::TOOL_OUTCOME_CONFIDENCE.to_string(),
+        value: confidence.to_string(),
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ticket_emits_triplet_for_alphanumeric() {
+        let mut tags = Vec::new();
+        ticket(&mut tags, "PAVA-2057", "branch");
+        let kv: Vec<(&str, &str)> = tags
+            .iter()
+            .map(|t| (t.key.as_str(), t.value.as_str()))
+            .collect();
+        assert_eq!(
+            kv,
+            vec![
+                ("ticket_id", "PAVA-2057"),
+                ("ticket_prefix", "PAVA"),
+                ("ticket_source", "branch"),
+            ]
+        );
+    }
+
+    #[test]
+    fn ticket_skips_prefix_for_numeric_only() {
+        let mut tags = Vec::new();
+        ticket(&mut tags, "1234", "branch_numeric");
+        let kv: Vec<(&str, &str)> = tags
+            .iter()
+            .map(|t| (t.key.as_str(), t.value.as_str()))
+            .collect();
+        assert_eq!(
+            kv,
+            vec![("ticket_id", "1234"), ("ticket_source", "branch_numeric"),]
+        );
+    }
+
+    #[test]
+    fn activity_emits_full_triplet() {
+        let mut tags = Vec::new();
+        activity(&mut tags, "coding", "rule", "medium");
+        let kv: Vec<(&str, &str)> = tags
+            .iter()
+            .map(|t| (t.key.as_str(), t.value.as_str()))
+            .collect();
+        assert_eq!(
+            kv,
+            vec![
+                ("activity", "coding"),
+                ("activity_source", "rule"),
+                ("activity_confidence", "medium"),
+            ]
+        );
+    }
+
+    #[test]
+    fn file_paths_emits_paths_then_siblings() {
+        let mut tags = Vec::new();
+        file_paths(
+            &mut tags,
+            vec!["src/a.rs".into(), "src/b.rs".into()],
+            "tool_arg",
+            "high",
+        );
+        let kv: Vec<(&str, &str)> = tags
+            .iter()
+            .map(|t| (t.key.as_str(), t.value.as_str()))
+            .collect();
+        assert_eq!(
+            kv,
+            vec![
+                ("file_path", "src/a.rs"),
+                ("file_path", "src/b.rs"),
+                ("file_path_source", "tool_arg"),
+                ("file_path_confidence", "high"),
+            ]
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "emit::file_paths called with empty paths")]
+    fn file_paths_rejects_empty_input_in_debug() {
+        let mut tags = Vec::new();
+        file_paths(&mut tags, Vec::new(), "tool_arg", "high");
+    }
+
+    #[test]
+    fn tool_outcomes_emits_each_outcome_then_siblings() {
+        let mut tags = Vec::new();
+        tool_outcomes(
+            &mut tags,
+            ["success", "error"].iter().copied(),
+            "jsonl_tool_result",
+            "high",
+        );
+        let kv: Vec<(&str, &str)> = tags
+            .iter()
+            .map(|t| (t.key.as_str(), t.value.as_str()))
+            .collect();
+        assert_eq!(
+            kv,
+            vec![
+                ("tool_outcome", "success"),
+                ("tool_outcome", "error"),
+                ("tool_outcome_source", "jsonl_tool_result"),
+                ("tool_outcome_confidence", "high"),
+            ]
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "emit::tool_outcomes called with empty outcomes")]
+    fn tool_outcomes_rejects_empty_input_in_debug() {
+        let mut tags = Vec::new();
+        let empty: [&str; 0] = [];
+        tool_outcomes(
+            &mut tags,
+            empty.iter().copied(),
+            "jsonl_tool_result",
+            "high",
+        );
+    }
+}

--- a/crates/budi-core/src/pipeline/enrichers.rs
+++ b/crates/budi-core/src/pipeline/enrichers.rs
@@ -6,7 +6,7 @@ use crate::analytics::Tag;
 use crate::config::TagsConfig;
 use crate::file_attribution;
 use crate::jsonl::ParsedMessage;
-use crate::pipeline::{Enricher, extract_ticket_from_branch, glob_match};
+use crate::pipeline::{Enricher, emit, extract_ticket_from_branch, glob_match};
 use crate::repo_id::{RepoIdCache, repo_root_for};
 use crate::tag_keys as tk;
 
@@ -54,24 +54,13 @@ impl Enricher for GitEnricher {
         // column, not a tag). R1.3 (#221) unified the extractor so live
         // tailing and `budi import` tag pure-numeric branches like
         // `fix/1234-typo` consistently, while staying readable against
-        // retained 8.1 legacy history.
+        // retained 8.1 legacy history. #335: emit the triplet through the
+        // shared helper so a future caller cannot land a `ticket_id`
+        // without its sibling `ticket_source` tag.
         if let Some(ref branch) = msg.git_branch
             && let Some((ticket, source)) = extract_ticket_from_branch(branch)
         {
-            tags.push(Tag {
-                key: tk::TICKET_ID.to_string(),
-                value: ticket.to_string(),
-            });
-            if let Some(dash) = ticket.find('-') {
-                tags.push(Tag {
-                    key: tk::TICKET_PREFIX.to_string(),
-                    value: ticket[..dash].to_string(),
-                });
-            }
-            tags.push(Tag {
-                key: tk::TICKET_SOURCE.to_string(),
-                value: source.to_string(),
-            });
+            emit::ticket(&mut tags, &ticket, source);
         }
 
         tags
@@ -185,25 +174,19 @@ impl Enricher for FileEnricher {
         if attribution.paths.is_empty() {
             return Vec::new();
         }
-        let mut tags = Vec::with_capacity(attribution.paths.len() + 2);
-        for path in attribution.paths {
-            tags.push(Tag {
-                key: tk::FILE_PATH.to_string(),
-                value: path,
-            });
-        }
-        if let Some(source) = attribution.source {
-            tags.push(Tag {
-                key: tk::FILE_PATH_SOURCE.to_string(),
-                value: source.to_string(),
-            });
-        }
-        if let Some(confidence) = attribution.confidence {
-            tags.push(Tag {
-                key: tk::FILE_PATH_CONFIDENCE.to_string(),
-                value: confidence.to_string(),
-            });
-        }
+        // `attribute_files` guarantees that `source` / `confidence` are
+        // `Some` whenever `paths` is non-empty; the `expect` calls pin
+        // that invariant so the shared helper (#335) can take
+        // non-optional siblings without smuggling in a silent-fallback
+        // path.
+        let source = attribution
+            .source
+            .expect("attribute_files sets source when paths is non-empty");
+        let confidence = attribution
+            .confidence
+            .expect("attribute_files sets confidence when paths is non-empty");
+        let mut tags = Vec::new();
+        emit::file_paths(&mut tags, attribution.paths, source, confidence);
         tags
     }
 }

--- a/crates/budi-core/src/pipeline/mod.rs
+++ b/crates/budi-core/src/pipeline/mod.rs
@@ -3,6 +3,7 @@
 //! Provides a pluggable enrichment pipeline that transforms raw `ParsedMessage`s
 //! before they are ingested into the database.
 
+pub(crate) mod emit;
 pub mod enrichers;
 
 use crate::analytics::Tag;
@@ -136,23 +137,21 @@ impl Pipeline {
                 // R1.2 (#222) also emits source/confidence as sibling tags so
                 // aggregates in `activity_cost*` can render explainable
                 // labels per-activity instead of a global fallback.
+                // #335: emission goes through `emit::activity` so the
+                // headline can never ship without its siblings. If upstream
+                // left the source/confidence unset (e.g. a legacy code path
+                // that bypassed `propagate_session_context`) we fall back to
+                // the same `rule` / `medium` defaults the propagator uses.
                 if let Some(ref cat) = msg.prompt_category {
-                    msg_tags.push(Tag {
-                        key: tk::ACTIVITY.to_string(),
-                        value: cat.clone(),
-                    });
-                    if let Some(ref src) = msg.prompt_category_source {
-                        msg_tags.push(Tag {
-                            key: tk::ACTIVITY_SOURCE.to_string(),
-                            value: src.clone(),
-                        });
-                    }
-                    if let Some(ref conf) = msg.prompt_category_confidence {
-                        msg_tags.push(Tag {
-                            key: tk::ACTIVITY_CONFIDENCE.to_string(),
-                            value: conf.clone(),
-                        });
-                    }
+                    let src = msg
+                        .prompt_category_source
+                        .as_deref()
+                        .unwrap_or(crate::hooks::SOURCE_RULE);
+                    let conf = msg
+                        .prompt_category_confidence
+                        .as_deref()
+                        .unwrap_or(crate::hooks::CONF_MEDIUM);
+                    emit::activity(&mut msg_tags, cat, src, conf);
                 }
 
                 // R1.5 (#293): tool_outcome tags. For each tool_use on
@@ -267,12 +266,7 @@ fn emit_tool_outcome_tags(
             last_tool_outcome.insert((sid.clone(), name.clone()), raw);
         }
 
-        if seen.insert(outcome.clone()) {
-            msg_tags.push(Tag {
-                key: tk::TOOL_OUTCOME.to_string(),
-                value: outcome,
-            });
-        }
+        seen.insert(outcome);
     }
 
     if seen.is_empty() {
@@ -293,14 +287,10 @@ fn emit_tool_outcome_tags(
     } else {
         j::TOOL_OUTCOME_CONFIDENCE_MEDIUM
     };
-    msg_tags.push(Tag {
-        key: tk::TOOL_OUTCOME_SOURCE.to_string(),
-        value: source.to_string(),
-    });
-    msg_tags.push(Tag {
-        key: tk::TOOL_OUTCOME_CONFIDENCE.to_string(),
-        value: confidence.to_string(),
-    });
+    // #335: emit the full triplet through the shared helper so headline
+    // `tool_outcome` tags can never ship without their sibling
+    // source/confidence pair.
+    emit::tool_outcomes(msg_tags, seen.iter(), source, confidence);
 }
 
 /// Propagate git_branch, repo_id, cwd, prompt_category, and the R1.2


### PR DESCRIPTION
## Summary

Eliminates the `if let Some(...)` pattern around sibling-tag pushes in the enrichment pipeline by routing all first-class dimension emissions through a new `crates/budi-core/src/pipeline/emit.rs` helper module. Each helper accepts sibling values as non-optional parameters, so a caller cannot emit `ticket_id`, `activity`, `file_path`, or `tool_outcome` without also supplying the matching `*_source` / `*_confidence` tags. Before this change the invariant lived entirely in reviewer discipline — a future pipeline contributor could silently ship a headline tag alone and degrade `budi stats --activities` (and equivalent CLI/cloud surfaces) to `src=?` / `confidence=?`.

Call-site updates:

- `GitEnricher::enrich` now calls `emit::ticket(..., source)` with prefix derivation moved inside the helper.
- `FileEnricher::enrich` now calls `emit::file_paths(...)` after pinning the `attribute_files` "paths non-empty ⇒ source & confidence are Some" invariant with explicit `expect`s.
- The activity block in `Pipeline::process` now calls `emit::activity(...)`, falling back to `hooks::SOURCE_RULE` / `hooks::CONF_MEDIUM` when upstream left them unset (same defaults `propagate_session_context` already applies — just promoted to the emission site so the contract is visible locally).
- `emit_tool_outcome_tags` now calls `emit::tool_outcomes(...)` for the headline + siblings.

## Risks / compatibility notes

- **No new dependencies.**
- **Tag shape unchanged.** Keys and values are identical to what the pipeline emitted before. The only observable behaviour change is that an assistant message whose `prompt_category` was set but whose source/confidence were left unset (a path that should not arise in practice because `propagate_session_context` fills the defaults first) now always ships `activity_source=rule` / `activity_confidence=medium` instead of dropping siblings. This matches the upstream defaults and strengthens the R1.2 contract; no existing test asserts the old "drop siblings silently" behaviour.
- **`tool_outcome` multi-value ordering** shifts from "first-seen tool_use order" to "BTreeSet lexicographic order" because `seen` is now iterated directly by the helper instead of pushing during dedup. Nothing in the codebase relies on the old ordering (existing tests use `contains` / `any` / single-outcome `vec!` asserts); the new order is deterministic and stable across runs.
- Helper-level `debug_assert!`s pin the "siblings are only meaningful when you emit at least one headline value" invariant. Release builds stay silent; debug builds panic if a future caller violates it.

## Validation

- `cargo fmt --all`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked` (all 422 `budi-core` tests plus 25 daemon tests pass; one daemon tailer shutdown test flaked on the first run — `run_blocking_exits_when_shutdown_flag_is_set`, unrelated to this PR — and passed cleanly on re-run)
- New unit tests in `pipeline::emit::tests`: exact-tag-shape coverage for `ticket` (alphanumeric + numeric-only), `activity`, `file_paths`, and `tool_outcomes`; plus `#[should_panic]` coverage for the empty-input debug-assert paths.

Closes #335
