### PR TITLE
[8.2.1] pipeline/work_outcome: share integration-branch predicate; document tool_result scope (#336)

### DIFF
--- a/SOUL.md
+++ b/SOUL.md
@@ -353,12 +353,20 @@ in [#302](https://github.com/siropkin/budi/issues/302) / #303 / #304 / #305):
   `tool_outcome_source` (`jsonl_tool_result` when direct,
   `heuristic_retry` when promoted) and `tool_outcome_confidence`
   (`high` / `medium`) mirror the `activity_source` / `file_path_source`
-  contract. Messages with no tool uses carry no outcome tag. In 8.1.x the
-  parallel proxy ingest path did not emit outcomes (tool names and IDs
-  weren't captured on the wire), so outcomes were import-only for that
-  release. In 8.2+ the JSONL tailer runs the same pipeline as `budi
-  import`, so outcomes are emitted live from the transcript without a
-  proxy round-trip ([ADR-0089](docs/adr/0089-reverse-proxy-first-jsonl-tailing-as-sole-live-path.md)
+  contract. Messages with no tool uses carry no outcome tag. Scope
+  ([#336](https://github.com/siropkin/budi/issues/336)): the JSONL
+  extractor only walks the array-of-blocks (`UserContent::Blocks`)
+  encoding Claude Code has used since inception. Plain-string user
+  messages (`UserContent::Text`) never carry structured tool results
+  and are deliberately not string-probed for `"type":"tool_result"`
+  substrings — any future provider with a different tool-result shape
+  should land a dedicated extractor keyed on the `provider` label
+  rather than silently widening this one. In 8.1.x the parallel proxy
+  ingest path did not emit outcomes (tool names and IDs weren't
+  captured on the wire), so outcomes were import-only for that release.
+  In 8.2+ the JSONL tailer runs the same pipeline as `budi import`, so
+  outcomes are emitted live from the transcript without a proxy
+  round-trip ([ADR-0089](docs/adr/0089-reverse-proxy-first-jsonl-tailing-as-sole-live-path.md)
   §1). The 8.1 proxy ingest path is removed in 8.2 R2.1 (#322).
 
 - **`work_outcome`** (session-scoped) — derived in R1.5 from local
@@ -368,11 +376,18 @@ in [#302](https://github.com/siropkin/budi/issues/302) / #303 / #304 / #305):
   `branch_merged`, `no_commit`, or `unknown`. The derivation runs
   `git` locally — no remote Git/PR API calls, no content capture —
   and fails open to `unknown` whenever the branch is missing, is an
-  integration branch (`main`, `master`, `develop`), or the repo root
-  can't be resolved. A one-line rationale accompanies every label so
-  operators can see which rule fired. List surfaces skip the
-  derivation (one `git` invocation per session list row is too
-  expensive); only the detail view surfaces it.
+  integration branch, or the repo root can't be resolved. The
+  integration-branch set (`main`, `master`, `develop`, `HEAD`) is
+  shared with the pipeline ticket extractor via
+  `budi_core::pipeline::is_integration_branch`
+  ([#336](https://github.com/siropkin/budi/issues/336)) so the two
+  derivations can't disagree about what counts as a non-feature
+  branch; the literal `HEAD` sentinel is rejected here as well so a
+  detached-HEAD session can't be falsely credited as
+  `branch_merged` via the merge-base fallback. A one-line rationale
+  accompanies every label so operators can see which rule fired. List
+  surfaces skip the derivation (one `git` invocation per session list
+  row is too expensive); only the detail view surfaces it.
 
 ### Statusline contract (R2.3, #224)
 

--- a/crates/budi-core/src/jsonl.rs
+++ b/crates/budi-core/src/jsonl.rs
@@ -259,6 +259,30 @@ impl Default for ParsedMessage {
 ///
 /// The content text itself is inspected in-memory only — we never
 /// persist it. See ADR-0083 §3.
+///
+/// # Scope of supported user-content encodings (#336)
+///
+/// This extractor only walks the [`UserContent::Blocks`] variant — the
+/// array-of-blocks shape Claude Code has emitted since inception and the
+/// only shape known to carry `tool_result` entries in the wild. Plain
+/// [`UserContent::Text`] user messages (a single string body) do not
+/// contain structured tool results and are intentionally skipped by the
+/// caller in `parse_line`.
+///
+/// Intentional non-goals:
+///
+/// - **No raw-JSON fallback.** We do not string-probe the original line
+///   for `"type":"tool_result"`. The current providers never use that
+///   encoding for tool results, and a fallback would widen the classifier
+///   to partial / truncated / quoted matches with no test coverage.
+/// - **No cross-provider normalization.** If/when Cursor agents or
+///   another coverage target in #294 start emitting tool results in a
+///   different shape, they should land a dedicated extractor (keyed on
+///   the `ParsedMessage::provider` label) rather than quietly widening
+///   this one.
+///
+/// The tool-outcome contract in `SOUL.md` documents the same scope so
+/// operators know when this derivation is authoritative.
 pub(crate) fn extract_user_tool_outcomes(
     content: Option<&Vec<serde_json::Value>>,
 ) -> Vec<ToolOutcome> {
@@ -1019,6 +1043,21 @@ mod tests {
         assert_eq!(msg.tool_outcomes.len(), 1);
         assert_eq!(msg.tool_outcomes[0].tool_use_id, "t-1");
         assert_eq!(msg.tool_outcomes[0].outcome, TOOL_OUTCOME_SUCCESS);
+    }
+
+    #[test]
+    fn parse_user_text_message_has_no_tool_outcomes() {
+        // Scope guard for #336: plain-text user content is the
+        // `UserContent::Text` variant and carries no structured
+        // `tool_result` blocks. The extractor must not invent outcomes
+        // out of a body that happens to mention "tool_result" in prose.
+        let line = r#"{"parentUuid":"a1","isSidechain":false,"type":"user","message":{"role":"user","content":"please run the tool_result on this"},"uuid":"u1","timestamp":"2026-03-14T18:13:42.614Z","sessionId":"s1"}"#;
+        let msg = parse_line(line).expect("text-bodied user message should parse");
+        assert_eq!(msg.role, "user");
+        assert!(
+            msg.tool_outcomes.is_empty(),
+            "text-variant user content must not emit tool outcomes",
+        );
     }
 
     #[test]

--- a/crates/budi-core/src/pipeline/mod.rs
+++ b/crates/budi-core/src/pipeline/mod.rs
@@ -421,8 +421,23 @@ pub const TICKET_SOURCE_BRANCH_NUMERIC: &str = "branch_numeric";
 
 /// Branch names that are never tickets — integration branches and the
 /// literal detached-HEAD sentinel. Kept in one place so live tailing,
-/// `budi import`, and legacy-history handling stay aligned.
+/// `budi import`, and legacy-history handling stay aligned. Prefer the
+/// [`is_integration_branch`] helper over touching this list directly so
+/// downstream derivations (ticket extraction, work-outcome correlation)
+/// can never disagree about what counts as a non-feature branch (#336).
 const INTEGRATION_BRANCHES: &[&str] = &["main", "master", "develop", "HEAD"];
+
+/// Return `true` when `branch` is an integration / non-feature branch
+/// and therefore should not be treated as a ticket source or as a
+/// session's feature branch for work-outcome correlation.
+///
+/// Centralized for #336 so the pipeline ticket extractor and
+/// `derive_work_outcome` agree on the same bounded set. Matching is
+/// case-sensitive and exact — callers are expected to hand in the
+/// already-normalized branch name as it appears in the transcript.
+pub fn is_integration_branch(branch: &str) -> bool {
+    INTEGRATION_BRANCHES.contains(&branch)
+}
 
 /// Extract a ticket ID (e.g. `PAVA-2057`) from a branch name.
 /// Matches `[a-zA-Z]{2,}-\d+` and returns it uppercased.
@@ -454,7 +469,7 @@ pub fn extract_ticket_id(branch: &str) -> Option<String> {
 ///    conventions that many GitHub-flow teams rely on and keeps
 ///    transcript-derived rows consistent with retained legacy data.
 pub fn extract_ticket_from_branch(branch: &str) -> Option<(String, &'static str)> {
-    if branch.is_empty() || INTEGRATION_BRANCHES.contains(&branch) {
+    if branch.is_empty() || is_integration_branch(branch) {
         return None;
     }
     if let Some(id) = extract_ticket_alpha(branch) {

--- a/crates/budi-core/src/work_outcome.rs
+++ b/crates/budi-core/src/work_outcome.rs
@@ -48,11 +48,15 @@ use chrono::{DateTime, Utc};
 /// round, debuggable default; callers can override for tests.
 pub const DEFAULT_GRACE: chrono::Duration = chrono::Duration::hours(24);
 
-/// Integration branches we treat as the merge target when asking
-/// whether a session's branch shipped. Same list the pipeline uses to
-/// filter out integration branches from ticket extraction, kept in sync
-/// so the two derivations agree on what "merged" means.
-const INTEGRATION_BRANCHES: &[&str] = &["main", "master", "develop"];
+/// Integration branches we use as the *merge target* when asking
+/// whether a session's branch shipped. Intentionally narrower than
+/// [`crate::pipeline::is_integration_branch`]: `HEAD` is never a
+/// meaningful ref to resolve against or run `git merge-base` against
+/// here — it would either alias the current checkout (noisy) or fail
+/// silently. The "is this a non-feature branch?" check is delegated to
+/// the shared helper so ticket extraction and work-outcome correlation
+/// can never disagree (#336).
+const MERGE_TARGETS: &[&str] = &["main", "master", "develop"];
 
 /// Bounded set of outcome labels. Matches the set listed in #293 plus
 /// `Unknown`; analytics queries pivot on the raw string value so the
@@ -124,7 +128,7 @@ pub struct WorkOutcomeInputs<'a> {
 /// hiding the session entirely.
 pub fn derive_work_outcome(inputs: &WorkOutcomeInputs<'_>) -> WorkOutcome {
     let branch = inputs.branch.trim();
-    if branch.is_empty() || INTEGRATION_BRANCHES.contains(&branch) {
+    if branch.is_empty() || crate::pipeline::is_integration_branch(branch) {
         return WorkOutcome::unknown("no non-integration branch on session — nothing to correlate");
     }
     if !inputs.repo_root.exists() || !inputs.repo_root.join(".git").exists() {
@@ -234,7 +238,7 @@ fn branch_shares_tip_with_integration(repo: &Path, branch: &str) -> bool {
     let Some(branch_tip) = resolve_ref(repo, branch) else {
         return false;
     };
-    for integration in INTEGRATION_BRANCHES {
+    for integration in MERGE_TARGETS {
         if let Some(tip) = resolve_ref(repo, integration)
             && tip == branch_tip
         {
@@ -264,7 +268,7 @@ fn branch_was_merged(repo: &Path, branch: &str) -> bool {
     // which is the definition we care about. Skip integration refs
     // that don't exist locally so we don't spray `fatal:` messages to
     // stderr on scratch repos that only carry `main`.
-    for integration in INTEGRATION_BRANCHES {
+    for integration in MERGE_TARGETS {
         if resolve_ref(repo, integration).is_none() {
             continue;
         }
@@ -293,7 +297,7 @@ fn count_commits_on_branch(
     // from being credited with main's shared history just because the
     // bootstrap commit landed inside the correlation window.
     let mut args: Vec<String> = vec!["log".into(), branch.into()];
-    for integration in INTEGRATION_BRANCHES {
+    for integration in MERGE_TARGETS {
         // `--not` excludes commits reachable from this ref. Silently
         // skipped when the ref doesn't exist (the command still
         // succeeds), which matches the behavior of scratch repos that
@@ -345,7 +349,13 @@ mod tests {
 
     #[test]
     fn unknown_on_integration_branch() {
-        for b in ["main", "master", "develop"] {
+        // Includes `HEAD` (the detached-HEAD sentinel) so work-outcome
+        // correlation agrees with the pipeline ticket extractor's
+        // integration-branch set (#336). Under normal ingest the proxy
+        // / JSONL path normalizes detached HEAD to empty, but a future
+        // importer that lets the literal string through must not be
+        // credited as a `branch_merged` via the merge-base fallback.
+        for b in ["main", "master", "develop", "HEAD"] {
             let inputs = WorkOutcomeInputs {
                 repo_root: Path::new("/"),
                 branch: b,
@@ -357,6 +367,26 @@ mod tests {
                 derive_work_outcome(&inputs).label,
                 WorkOutcomeLabel::Unknown,
                 "{b} must not correlate as work outcome"
+            );
+        }
+    }
+
+    #[test]
+    fn is_integration_branch_is_shared_across_pipeline_and_work_outcome() {
+        // Guard against the asymmetry called out in #336: if someone
+        // narrows the work-outcome set to drop `HEAD`, the pipeline
+        // ticket extractor would still skip HEAD while work-outcome
+        // correlation would attempt to merge-base against it.
+        for b in ["main", "master", "develop", "HEAD"] {
+            assert!(
+                crate::pipeline::is_integration_branch(b),
+                "{b} must be treated as an integration branch"
+            );
+        }
+        for b in ["PROJ-1-feature", "03-20-pava-2120_desc", "", "feature/x"] {
+            assert!(
+                !crate::pipeline::is_integration_branch(b),
+                "{b} must not be treated as an integration branch"
             );
         }
     }


### PR DESCRIPTION
## Summary

Closes #336.

Two adjacent R1.5 gaps from the #217 audit, bundled per the ticket.

1. **Shared integration-branch predicate.** The pipeline ticket
   extractor treated `main` / `master` / `develop` / `HEAD` as
   non-feature branches, but `budi_core::work_outcome` only treated
   the first three. The proxy and JSONL paths normalize detached HEAD
   to empty today, so this was latent — but any future importer that
   lets the literal string `HEAD` through would reach
   `branch_was_merged`, where `git merge-base --is-ancestor HEAD main`
   happily succeeds and the session would be incorrectly credited as
   `branch_merged`.

   - New helper `budi_core::pipeline::is_integration_branch(&str)` is
     the single source of truth.
   - `extract_ticket_from_branch` and `derive_work_outcome` both call
     it.
   - `work_outcome` keeps a narrower `MERGE_TARGETS` list (`main`,
     `master`, `develop`) for the ref-resolution / merge-base loops
     because `HEAD` isn't a meaningful ref to resolve against.

2. **`tool_result` scope.** The JSONL extractor only walks
   \`UserContent::Blocks\` — the only shape Claude Code has ever used
   for tool results. Picked the documentation branch of the ticket
   rather than inventing a raw-JSON fallback that would widen
   classification into untested territory for no current provider.

   - Rustdoc on `extract_user_tool_outcomes` explicitly states the
     scope, the non-goals (no raw-JSON string probe, no
     cross-provider normalization), and the extension pattern.
   - `SOUL.md`'s `tool_outcome` contract carries the same wording so
     operators know when the derivation is authoritative.

## Risks / compatibility notes

- **Behavior change, narrow.** A session with `git_branch = \"HEAD\"`
  now returns `WorkOutcomeLabel::Unknown` early instead of continuing
  through to the merge-base fallback. Under normal ingest this is
  unreachable (the proxy + JSONL paths normalize detached HEAD to
  empty), so no surface visible to current operators changes.
- No wire-format change: `tool_outcome` tag values are unchanged, and
  the extractor's behavior on the only encoding providers actually
  emit is unchanged.
- No new dependencies.
- No shell-profile, Cursor-settings, or Codex-config mutation paths.
- No docs under \`docs/research/\`, \`docs/releases/\`, or
  \`scripts/research/\`; the tool-outcome scope documentation lives
  in \`SOUL.md\` and the rustdoc on the extractor itself.

## Validation

- \`cargo fmt --all\`
- \`cargo clippy --workspace --all-targets --locked -- -D warnings\`
- \`cargo test --workspace --locked\`
  - New regressions passing:
    - \`work_outcome::tests::is_integration_branch_is_shared_across_pipeline_and_work_outcome\`
    - \`work_outcome::tests::unknown_on_integration_branch\` (extended to cover \`HEAD\`)
    - \`jsonl::tests::parse_user_text_message_has_no_tool_outcomes\`


Made with [Cursor](https://cursor.com)