### PR TITLE
[8.2.1] cloud_sync worker: use RAII guard for busy flag (#343)

### DIFF
--- a/crates/budi-daemon/src/routes/cloud.rs
+++ b/crates/budi-daemon/src/routes/cloud.rs
@@ -20,6 +20,7 @@ use budi_core::config::{self, CloudConfig};
 use serde_json::{Value, json};
 
 use crate::AppState;
+use crate::workers::cloud_sync::CloudBusyFlagGuard;
 
 /// Variants are snake_case so CLI / dashboard consumers can switch on a
 /// stable string rather than parsing free-form error messages. Mirrors the
@@ -172,25 +173,6 @@ fn report_to_json(report: SyncTickReport) -> Value {
         "sessions_attempted": envelope_sessions,
         "watermark": server_watermark,
     })
-}
-
-/// RAII guard that clears the `cloud_syncing` flag on drop. Mirrors the
-/// existing `BusyFlagGuard` used by transcript ingest — kept local so the
-/// two busy flags stay independent.
-struct CloudBusyFlagGuard {
-    flag: std::sync::Arc<std::sync::atomic::AtomicBool>,
-}
-
-impl CloudBusyFlagGuard {
-    fn new(flag: std::sync::Arc<std::sync::atomic::AtomicBool>) -> Self {
-        Self { flag }
-    }
-}
-
-impl Drop for CloudBusyFlagGuard {
-    fn drop(&mut self) {
-        self.flag.store(false, std::sync::atomic::Ordering::SeqCst);
-    }
 }
 
 #[cfg(test)]

--- a/crates/budi-daemon/src/workers/cloud_sync.rs
+++ b/crates/budi-daemon/src/workers/cloud_sync.rs
@@ -67,14 +67,20 @@ pub async fn run(db_path: PathBuf, config: CloudConfig, cloud_syncing: Arc<Atomi
             continue;
         }
 
-        // Normal sync tick
+        // Normal sync tick.
+        //
+        // We clear the `cloud_syncing` flag via an RAII guard rather than a
+        // trailing `flag.store(false)`. If `sync_tick` ever panics inside
+        // `spawn_blocking`, a manual reset would be skipped and the flag
+        // would stay `true` forever — wedging both this worker and every
+        // `POST /cloud/sync` (409 Conflict) until the daemon was restarted.
+        // See issue #343.
         let db = db_path.clone();
         let cfg = config.clone();
         let flag = cloud_syncing.clone();
         let result = tokio::task::spawn_blocking(move || {
-            let res = cloud_sync::sync_tick(&db, &cfg);
-            flag.store(false, Ordering::SeqCst);
-            res
+            let _guard = CloudBusyFlagGuard::new(flag);
+            cloud_sync::sync_tick(&db, &cfg)
         })
         .await;
 
@@ -126,5 +132,60 @@ pub async fn run(db_path: PathBuf, config: CloudConfig, cloud_syncing: Arc<Atomi
 
         // Normal interval sleep
         tokio::time::sleep(interval).await;
+    }
+}
+
+/// RAII guard that clears the `cloud_syncing` busy flag on drop.
+///
+/// Shared between the background worker and the manual `POST /cloud/sync`
+/// route so a panic inside either sync path still releases the flag. Without
+/// this guard, a panicking `sync_tick` would leave `cloud_syncing = true`
+/// forever — every subsequent background tick would log "another sync
+/// already in progress" and every manual flush would return 409 Conflict
+/// until the daemon restarted.
+pub(crate) struct CloudBusyFlagGuard {
+    flag: Arc<AtomicBool>,
+}
+
+impl CloudBusyFlagGuard {
+    pub(crate) fn new(flag: Arc<AtomicBool>) -> Self {
+        Self { flag }
+    }
+}
+
+impl Drop for CloudBusyFlagGuard {
+    fn drop(&mut self) {
+        self.flag.store(false, Ordering::SeqCst);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn guard_clears_flag_on_normal_drop() {
+        let flag = Arc::new(AtomicBool::new(true));
+        {
+            let _guard = CloudBusyFlagGuard::new(flag.clone());
+        }
+        assert!(!flag.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn guard_clears_flag_on_panic_unwind() {
+        // Simulates `sync_tick` panicking inside `spawn_blocking`: the
+        // worker would otherwise leave `cloud_syncing` stuck at `true`.
+        let flag = Arc::new(AtomicBool::new(true));
+        let flag_in = flag.clone();
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _guard = CloudBusyFlagGuard::new(flag_in);
+            panic!("sync_tick blew up");
+        }));
+        assert!(result.is_err(), "expected the closure to panic");
+        assert!(
+            !flag.load(Ordering::SeqCst),
+            "guard must reset the cloud_syncing flag even on panic"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Lift `CloudBusyFlagGuard` from `routes/cloud.rs` into `workers/cloud_sync.rs` and share it between the background worker and the manual `POST /cloud/sync` route.
- The background worker now holds the guard across `sync_tick` instead of calling `flag.store(false, …)` manually after it. If `sync_tick` ever panics inside `spawn_blocking`, the guard still clears `cloud_syncing` on unwind, so the next tick can proceed and `POST /cloud/sync` no longer returns 409 Conflict forever.
- Add two unit tests on the shared guard: normal-drop and panic-unwind both leave the flag cleared.

Closes #343

## Risks / compatibility notes

- Behavior change is defensive only: on the success and every existing `SyncResult::*` path the flag is still cleared exactly once before the next loop iteration, matching the previous semantics.
- No new runtime dependencies and no public API changes; `CloudBusyFlagGuard` is `pub(crate)` and shared across two internal modules.
- No schema, config, CLI, or wire-protocol changes.

## Validation

- `cargo fmt --all`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked` (27 daemon unit tests pass, including the two new `workers::cloud_sync::tests::guard_clears_flag_*` cases that exercise the panic-unwind path)

Made with [Cursor](https://cursor.com)