### PR TITLE
cloud_sync: simplify configured check in current_cloud_status

### DIFF
--- a/crates/budi-core/src/cloud_sync.rs
+++ b/crates/budi-core/src/cloud_sync.rs
@@ -203,7 +203,10 @@ pub fn current_cloud_status(db_path: &Path, config: &CloudConfig) -> CloudSyncSt
     let endpoint = config.effective_endpoint();
     let enabled = config.effective_enabled();
     let ready = config.is_ready();
-    let configured = config.api_key.is_some() || config.effective_api_key().is_some();
+    // `effective_api_key()` already returns `api_key.clone().or_else(env lookups)`,
+    // so the earlier `api_key.is_some() || effective_api_key().is_some()` was
+    // strictly dominated by the second check (see #346).
+    let configured = config.effective_api_key().is_some();
 
     let mut last_synced_at = None;
     let mut rollup_watermark = None;


### PR DESCRIPTION
## Summary

`CloudSyncStatus::configured` in `current_cloud_status` was computed as
`config.api_key.is_some() || config.effective_api_key().is_some()`.
Since `CloudConfig::effective_api_key()` is defined as
`self.api_key.clone().or_else(env lookups)`, the first disjunct is
strictly dominated by the second — the OR was a cosmetic redundancy
flagged during the R2.5 review pass.

Collapsed to a single, self-describing call:

```rust
let configured = config.effective_api_key().is_some();
```

A short comment now records why this is equivalent, so the next reader
does not re-introduce the belt-and-suspenders OR.

No behavior change: `configured` returns the same boolean for every
input that was reachable before (including the env-override case, which
was already the only reason the OR looked non-trivial).

Closes #346

## Risks / compatibility notes

- No behavior change. `configured` evaluates to the same value for every
  input: if `api_key` is `Some`, `effective_api_key()` is `Some`; if
  `api_key` is `None` but `BUDI_CLOUD_API_KEY` is set,
  `effective_api_key()` still returns `Some`; otherwise both return
  `None`.
- No API change to `/cloud/status` — the `configured` field in
  `CloudSyncStatus` is unchanged in type and semantics.
- No schema change.
- No new dependencies.

## Validation

- `cargo fmt --all`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked` (workspace: 64 + 425 + 27 tests, all
  passing; includes the existing
  `current_cloud_status_reports_disabled_when_config_default` and
  `current_cloud_status_reports_pending_counts_when_ready` coverage)

Made with [Cursor](https://cursor.com)