### PR TITLE
statusline: scope branch_cost to (repo_id, branch) (#347)

### DIFF
--- a/crates/budi-cli/src/commands/statusline.rs
+++ b/crates/budi-cli/src/commands/statusline.rs
@@ -303,6 +303,16 @@ pub fn cmd_statusline(format: StatuslineFormat, provider: Option<String>) -> Res
     }
     if let Some(ref b) = branch {
         query_params.push(("branch", b.clone()));
+        // Scope branch_cost to `(repo_id, branch)` so developers who sit on
+        // `main` / `master` in multiple local repos don't see a silent
+        // cross-repo sum (#347). We only send `repo_id` when we already
+        // send `branch`, since the daemon only uses it for `branch_cost`.
+        if let Some(ref root) = repo_root {
+            let repo_id = budi_core::repo_id::resolve_repo_id(root);
+            if !repo_id.is_empty() {
+                query_params.push(("repo_id", repo_id));
+            }
+        }
     }
     if let Some(ref root) = repo_root
         && needed.contains(&"project".to_string())

--- a/crates/budi-core/src/analytics/queries.rs
+++ b/crates/budi-core/src/analytics/queries.rs
@@ -3007,6 +3007,14 @@ pub struct StatuslineParams {
     pub session_id: Option<String>,
     pub branch: Option<String>,
     pub project_dir: Option<String>,
+    /// Optional repo identity (as produced by `budi_core::repo_id`). When
+    /// set together with `branch`, `branch_cost` is scoped to
+    /// `(repo_id, branch)` so developers who sit on `main` / `master` in
+    /// several repos see only the current repo's activity instead of a
+    /// cross-repo sum. Left as `None` preserves the pre-#347 behavior for
+    /// consumers that can't resolve a repo identity (no git, shell not in a
+    /// repo, etc.). See issue #347.
+    pub repo_id: Option<String>,
     /// Optional provider filter. When set, every numeric field
     /// (`cost_1d/7d/30d`, `session_cost`, `branch_cost`, `project_cost`) and
     /// `active_provider` are scoped to this provider. Provider-scoped
@@ -3110,14 +3118,23 @@ pub fn statusline_stats(
     });
 
     // Branch cost: total cost for messages on a specific branch.
+    //
+    // When `repo_id` is also provided, filter on `(repo_id, branch)` so
+    // developers who keep several local repos checked out on `main`
+    // (or `master` / `develop`) see only the current repo's branch spend
+    // instead of a silent cross-repo sum. See #347.
     let branch_cost = params.branch.as_ref().map(|branch| {
         let mut sql = String::from(
             "SELECT COALESCE(SUM(cost_cents), 0.0) FROM messages \
-             WHERE git_branch = ?1 AND role = 'assistant'",
+             WHERE git_branch = ? AND role = 'assistant'",
         );
         let mut bindings: Vec<String> = vec![branch.clone()];
+        if let Some(repo) = params.repo_id.as_deref() {
+            sql.push_str(" AND COALESCE(repo_id, '') = ?");
+            bindings.push(repo.to_string());
+        }
         if let Some(p) = provider_filter {
-            sql.push_str(" AND provider = ?2");
+            sql.push_str(" AND provider = ?");
             bindings.push(p.to_string());
         }
         let refs: Vec<&dyn rusqlite::types::ToSql> = bindings

--- a/crates/budi-core/src/analytics/tests.rs
+++ b/crates/budi-core/src/analytics/tests.rs
@@ -968,6 +968,115 @@ fn statusline_stats_with_branch_filter() {
 }
 
 #[test]
+fn statusline_stats_branch_cost_scopes_to_repo_id() {
+    // Regression guard for #347: developers who use `main` / `master` /
+    // `develop` across multiple local repos must see only the current
+    // repo's branch spend when `repo_id` is passed alongside `branch`,
+    // not a silent sum across every repo with the same branch name.
+    let mut conn = test_db();
+    let mk = |uuid: &str, session: &str, repo: &str, cost_cents: f64| ParsedMessage {
+        uuid: uuid.to_string(),
+        session_id: Some(session.to_string()),
+        timestamp: "2026-04-15T10:00:00Z".parse().unwrap(),
+        cwd: Some("/proj".to_string()),
+        role: "assistant".to_string(),
+        model: Some("claude-sonnet".to_string()),
+        input_tokens: 10,
+        output_tokens: 5,
+        cache_creation_tokens: 0,
+        cache_read_tokens: 0,
+        git_branch: Some("main".to_string()),
+        repo_id: Some(repo.to_string()),
+        provider: "claude_code".to_string(),
+        cost_cents: Some(cost_cents),
+        session_title: None,
+        parent_uuid: None,
+        user_name: None,
+        machine_name: None,
+        cost_confidence: "exact".to_string(),
+        request_id: None,
+        speed: None,
+        cache_creation_1h_tokens: 0,
+        web_search_requests: 0,
+        prompt_category: None,
+        prompt_category_source: None,
+        prompt_category_confidence: None,
+        tool_names: Vec::new(),
+        tool_use_ids: Vec::new(),
+        tool_files: Vec::new(),
+        tool_outcomes: Vec::new(),
+    };
+    let msgs = vec![
+        mk("repo-a-1", "sess-a", "github.com/org/repo-a", 300.0),
+        mk("repo-b-1", "sess-b", "github.com/org/repo-b", 400.0),
+    ];
+    ingest_messages(&mut conn, &msgs, None).unwrap();
+
+    let since_1d = "2026-04-15T00:00:00Z";
+    let since_7d = "2026-04-10T00:00:00Z";
+    let since_30d = "2026-03-20T00:00:00Z";
+
+    // No repo scope → pre-#347 behavior: both repos summed under `main`.
+    let blended = statusline_stats(
+        &conn,
+        since_1d,
+        since_7d,
+        since_30d,
+        &StatuslineParams {
+            branch: Some("main".to_string()),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(blended.branch_cost, Some(7.0));
+
+    // repo-a → only repo-a's `main` spend.
+    let repo_a = statusline_stats(
+        &conn,
+        since_1d,
+        since_7d,
+        since_30d,
+        &StatuslineParams {
+            branch: Some("main".to_string()),
+            repo_id: Some("github.com/org/repo-a".to_string()),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(repo_a.branch_cost, Some(3.0));
+
+    // repo-b → only repo-b's `main` spend.
+    let repo_b = statusline_stats(
+        &conn,
+        since_1d,
+        since_7d,
+        since_30d,
+        &StatuslineParams {
+            branch: Some("main".to_string()),
+            repo_id: Some("github.com/org/repo-b".to_string()),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(repo_b.branch_cost, Some(4.0));
+
+    // A repo with no matching rows reports $0, not a cross-repo fallback.
+    let empty = statusline_stats(
+        &conn,
+        since_1d,
+        since_7d,
+        since_30d,
+        &StatuslineParams {
+            branch: Some("main".to_string()),
+            repo_id: Some("github.com/org/does-not-exist".to_string()),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(empty.branch_cost, Some(0.0));
+}
+
+#[test]
 fn statusline_stats_with_provider_filter_scopes_all_numeric_fields() {
     // Regression guard for ADR-0088 §4 + #224: the Claude Code statusline
     // must show Claude Code usage only, not blended multi-provider totals.
@@ -1067,6 +1176,7 @@ fn statusline_stats_with_provider_filter_scopes_all_numeric_fields() {
             session_id: Some("claude-sess".to_string()),
             branch: Some("main".to_string()),
             project_dir: Some("/proj/a".to_string()),
+            ..Default::default()
         },
     )
     .unwrap();

--- a/docs/statusline-contract.md
+++ b/docs/statusline-contract.md
@@ -28,6 +28,7 @@ All parameters are optional. Omit them to get unscoped, context-free totals.
 | `provider`     | string | Scopes every numeric field (`cost_1d` / `cost_7d` / `cost_30d`, `session_cost`, `branch_cost`, `project_cost`) and `active_provider` to one provider. Canonical values: `claude_code`, `cursor`, `codex`, `copilot_cli`. Provider-scoped surfaces (the Claude Code statusline, the Cursor extension) **must** set this. |
 | `session_id`   | string | Additionally compute `session_cost` and session health (`health_state`, `health_tip`, `session_msg_cost`). |
 | `branch`       | string | Additionally compute `branch_cost` for this git branch. |
+| `repo_id`      | string | Scope `branch_cost` to `(repo_id, branch)` so developers who sit on `main` / `master` in multiple repos don't get a cross-repo sum. Only meaningful when `branch` is also set. Format matches `budi_core::repo_id` (e.g. `github.com/siropkin/budi`). |
 | `project_dir`  | string | Additionally compute `project_cost` for this directory. |
 
 ## Response shape
@@ -60,6 +61,7 @@ All parameters are optional. Omit them to get unscoped, context-free totals.
 - **`active_provider`** is the most recent `provider` value seen inside the 1d window, after the provider filter is applied. It exists so downstream surfaces can render "last touched" hints without a second API call.
 - **`provider_scope`** echoes back the filter the daemon applied. Consumers should display the scope alongside totals when the filter is active.
 - **Deprecated fields** (`today_cost`, `week_cost`, `month_cost`) are populated with the same rolling values as `cost_1d` / `cost_7d` / `cost_30d` for one release of backward compatibility with 8.0 consumers that predate this contract. They are removed in 9.0. New consumers MUST read the `cost_1d` / `cost_7d` / `cost_30d` fields.
+- **`branch_cost` is repo-scoped when `repo_id` is passed.** Consumers that can resolve a repo identity (the CLI does this via `budi_core::repo_id` when it has a cwd) should pass `repo_id` alongside `branch` so `branch_cost` reflects "this branch in this repo" rather than "this branch name across every repo on the machine". Omitting `repo_id` preserves the pre-8.2.1 behavior, which sums across all repos that share the branch name (#347).
 
 ## Stability guarantees
 


### PR DESCRIPTION
## Summary

`branch_cost` in the `/analytics/statusline` payload was computed
against a branch-name filter only, so developers who keep `main` /
`master` / `develop` checked out across several local repos saw every
repo's activity on that branch silently merged into the statusline
`branch:` slot (pre-existing, re-emitted under the 8.1 `#224`
provider-scoping pass, R2.5 follow-up).

Tightened in two coordinated steps:

- `StatuslineParams` gains an optional `repo_id`. When set alongside
  `branch`, `statusline_stats` now filters the branch-cost SQL on
  `COALESCE(repo_id, '') = ?` so the value is `(repo_id, branch)` rather
  than `branch` alone. Omitting `repo_id` preserves the pre-#347 behavior
  for consumers that cannot resolve a repo identity.
- `budi statusline` resolves the active repo identity via
  `budi_core::repo_id::resolve_repo_id` (the same helper ingest uses,
  so the value matches what's stored in `messages.repo_id`) and
  forwards it alongside `branch` whenever `branch` is forwarded. When
  the shell is outside a git repo, only `branch` is sent.

`docs/statusline-contract.md` documents the new `repo_id` query param
and the scoping rule so `siropkin/budi-cursor` and
`siropkin/budi-cloud` can adopt it without reading source.

Closes #347

## Risks / compatibility notes

- **Contract**: new optional `repo_id` query parameter; no rename or
  retype of existing fields. `branch_cost` semantics get tighter when
  callers pass `repo_id`, identical when they don't. The documented
  response shape is unchanged (no new keys).
- **Behavior drift for existing users**: the CLI statusline now sends
  `repo_id` by default when it's already sending `branch`. Developers
  working in a single repo per branch will see no change. Developers
  who sit on `main` across several repos will see their statusline
  `branch:` value drop to just the current repo's spend — this is the
  intended fix and matches how `session_cost` / `project_cost` already
  behave.
- No schema change, no migration, no new dependency.
- No change to `/analytics/branches` or `/analytics/branches/:branch`
  — those already group / filter on `(git_branch, repo_id)`.

## Validation

- `cargo fmt --all`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked` — workspace passes (426 + 64 + 27
  tests), including the new
  `statusline_stats_branch_cost_scopes_to_repo_id` regression guard
  that seeds `main` in two repos and asserts each `repo_id` sees only
  its own spend, the blended pre-#347 fallback when no `repo_id` is
  sent, and a `$0.00` result (not a cross-repo fallback) for a repo
  with no rows.

Made with [Cursor](https://cursor.com)