### PR TITLE
docs: explain rolling vs calendar window semantics (#350)

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,15 @@ budi uninstall --keep-data         # uninstall but keep analytics database
 
 All data commands support `--period today|week|month|all` and `--format json`.
 
+## Windows: rolling vs calendar
+
+Budi's `1d` / `7d` / `30d` labels show up on two surfaces that deliberately mean different things, so a developer clicking from the statusline into the cloud dashboard with the same window selected can legitimately see different totals:
+
+- **Rolling** — `budi statusline` (and, by inheritance, the Cursor extension that renders the shared status contract) reports the last 24 hours, the last 7 days, and the last 30 days ending at "now". These are the primary live signals and never reset at midnight (ADR-0088 §4, [`docs/statusline-contract.md`](docs/statusline-contract.md)).
+- **Calendar** — `budi stats --period today|week|month` and the cloud dashboard's cost charts use calendar-day ranges (`today` = today-so-far, `week` / `month` = the last 7 / 30 calendar days including today). These are the reporting views and reset with the local calendar.
+
+Same chip label, different denominator: a fresh-morning `1d` rolling window still carries yesterday's afternoon spend; a `today` calendar window does not. Pick the surface that matches the question you are asking — "am I spending too fast right now?" is rolling, "what did this week cost?" is calendar.
+
 ## Tags & cost attribution
 
 Assistant messages are tagged with core attribution keys: `provider`, `model`, `ticket_id`, `ticket_prefix`, `ticket_source`, `activity`, `activity_source`, `activity_confidence`, `file_path`, `file_path_source`, `file_path_confidence`, `tool_outcome`, `tool_outcome_source`, `tool_outcome_confidence`, `composer_mode`, `permission_mode`, `duration`, `tool`, `tool_use_id`, `user_email`, `platform`, `machine`, `user`, `git_user`.

--- a/docs/statusline-contract.md
+++ b/docs/statusline-contract.md
@@ -54,7 +54,7 @@ All parameters are optional. Omit them to get unscoped, context-free totals.
 
 ### Field semantics
 
-- **Windows are rolling**, not calendar. `cost_1d` = spend in the last 24 hours. `cost_7d` = spend in the last 7 days. `cost_30d` = spend in the last 30 days. This is a deliberate shift from 8.0 (which used calendar today / Monday-of-week / first-of-month), governed by ADR-0088 §4. `budi stats` keeps its calendar semantics — the rolling windows live only on the statusline surface.
+- **Windows are rolling**, not calendar. `cost_1d` = spend in the last 24 hours. `cost_7d` = spend in the last 7 days. `cost_30d` = spend in the last 30 days. This is a deliberate shift from 8.0 (which used calendar today / Monday-of-week / first-of-month), governed by ADR-0088 §4. `budi stats` and the cloud dashboard's cost charts keep calendar semantics — the rolling windows live only on the statusline surface and the Cursor extension that renders this contract. See [README → Windows: rolling vs calendar](../README.md#windows-rolling-vs-calendar) for the user-facing explanation.
 - **Costs are in dollars**, rounded to two decimal places at the rendering layer.
 - **Provider scoping is strict.** When `provider=claude_code`, a machine that also uses Cursor will not see Cursor spend in `cost_1d` / `cost_7d` / `cost_30d`. This is the fix for the 8.0 bug where Claude Code's statusline showed blended multi-provider totals (ADR-0088 §4, #224).
 - **Empty window vs stalled data.** All three cost fields are always present and default to `0.0` when the DB has no matching rows. An empty 30d window with a healthy daemon means "you have not used this provider in 30 days", not "the daemon is broken".


### PR DESCRIPTION
## Summary

- Add a "Windows: rolling vs calendar" section to `README.md` right after the CLI reference so developers understand why the `1d` / `7d` / `30d` chip on `budi statusline` (rolling, last-24h / last-7d / last-30d ending now) and the `budi stats` / cloud dashboard cost charts (calendar today / last-7 / last-30 calendar days) can legitimately show different totals for the "same" window.
- Cross-link from `docs/statusline-contract.md` back to the new README section and extend the existing rolling-vs-calendar note in the contract to mention that the cloud dashboard's cost charts use calendar semantics (the statusline contract itself remains the only surface that stays rolling end-to-end).
- No code changes.

Closes #350

## Risks / compatibility notes

- Docs-only change. No runtime, CLI, API, or config surface touched.
- No new dependencies.
- No behavioral change to the statusline contract; the added sentence describes existing reality (`budi stats --period today|week|month` and `budi-cloud`'s `dateRangeFromDays`) rather than introducing a new guarantee.
- ADR-0088 §4 already governs the rolling-statusline rule; this PR is the propagation into `README.md` that the `#371`-shaped lesson in `#396` asks for.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- Manually re-read `README.md` § "Windows: rolling vs calendar" and `docs/statusline-contract.md` "Field semantics" to confirm anchors render and the cross-link resolves.


Made with [Cursor](https://cursor.com)