### PR TITLE
stats: reconcile breakdown views to the cent via grand-total envelope (#448)

### DIFF
--- a/SOUL.md
+++ b/SOUL.md
@@ -340,6 +340,24 @@ in [#302](https://github.com/siropkin/budi/issues/302) / #303 / #304 / #305):
     repo-relative (no leading `/`, no `..`, no Windows separators, no
     URL scheme) before hitting SQLite.
 
+- **Breakdown envelope** (shared, 8.3 / [#448](https://github.com/siropkin/budi/issues/448)).
+  Every list endpoint (`GET /analytics/projects`,
+  `/analytics/branches`, `/analytics/tickets`, `/analytics/activities`,
+  `/analytics/files`, `/analytics/models`, `/analytics/tags`) returns
+  a [`BreakdownPage<T>`](crates/budi-core/src/analytics/queries.rs)
+  envelope rather than a bare JSON array. The envelope exposes
+  `rows`, `other?` (truncation-tail aggregate), `total_cost_cents`
+  (grand total across every matching row, to the cent),
+  `total_rows`, `shown_rows`, and the effective `limit`. The contract
+  `sum(rows.cost_cents) + other.cost_cents == total_cost_cents` is
+  exercised by the reconciliation suite in `analytics/tests.rs`. Before
+  8.3 the same endpoints returned a bare `Vec<T>` capped at 30 rows
+  with no grand total, which silently underreported `--files 30d` by
+  ~9% on machines with more than 30 distinct file paths. The CLI
+  surfaces this as a `Total` footer plus an optional `(other)` row and
+  honours `--limit N` (default 30, `0` = unlimited) across every
+  breakdown view.
+
 - **`tool_outcome`** — per-message tool-call outcome added in R1.5
   ([#293](https://github.com/siropkin/budi/issues/293)). The JSONL
   extractor reads `tool_result` blocks from user messages, keeps only

--- a/crates/budi-cli/src/client.rs
+++ b/crates/budi-cli/src/client.rs
@@ -14,9 +14,9 @@ use std::time::Duration;
 
 use anyhow::{Context, Result};
 use budi_core::analytics::{
-    ActivityCost, ActivityCostDetail, BranchCost, FileCost, FileCostDetail, ModelUsage,
-    PaginatedSessions, ProviderStats, RepoUsage, SessionHealth, SessionListEntry, SessionTag,
-    TagCost, TicketCost, TicketCostDetail, UsageSummary,
+    ActivityCost, ActivityCostDetail, BranchCost, BreakdownPage, FileCost, FileCostDetail,
+    ModelUsage, PaginatedSessions, ProviderStats, RepoUsage, SessionHealth, SessionListEntry,
+    SessionTag, TagCost, TicketCost, TicketCostDetail, UsageSummary,
 };
 use budi_core::config::{self, BudiConfig};
 use budi_core::cost::CostEstimate;
@@ -422,7 +422,7 @@ impl DaemonClient {
         since: Option<&str>,
         until: Option<&str>,
         limit: usize,
-    ) -> Result<Vec<RepoUsage>> {
+    ) -> Result<BreakdownPage<RepoUsage>> {
         let mut params: Vec<(&str, String)> = Vec::new();
         if let Some(s) = since {
             params.push(("since", s.to_string()));
@@ -441,14 +441,20 @@ impl DaemonClient {
         Ok(resp.json()?)
     }
 
-    pub fn branches(&self, since: Option<&str>, until: Option<&str>) -> Result<Vec<BranchCost>> {
-        let mut params = Vec::new();
+    pub fn branches(
+        &self,
+        since: Option<&str>,
+        until: Option<&str>,
+        limit: usize,
+    ) -> Result<BreakdownPage<BranchCost>> {
+        let mut params: Vec<(&str, String)> = Vec::new();
         if let Some(s) = since {
-            params.push(("since", s));
+            params.push(("since", s.to_string()));
         }
         if let Some(u) = until {
-            params.push(("until", u));
+            params.push(("until", u.to_string()));
         }
+        params.push(("limit", limit.to_string()));
         let resp = self
             .client
             .get(format!("{}/analytics/branches", self.base_url))
@@ -504,7 +510,7 @@ impl DaemonClient {
         since: Option<&str>,
         until: Option<&str>,
         limit: usize,
-    ) -> Result<Vec<TicketCost>> {
+    ) -> Result<BreakdownPage<TicketCost>> {
         let mut params: Vec<(&str, String)> = Vec::new();
         if let Some(s) = since {
             params.push(("since", s.to_string()));
@@ -570,7 +576,7 @@ impl DaemonClient {
         since: Option<&str>,
         until: Option<&str>,
         limit: usize,
-    ) -> Result<Vec<ActivityCost>> {
+    ) -> Result<BreakdownPage<ActivityCost>> {
         let mut params: Vec<(&str, String)> = Vec::new();
         if let Some(s) = since {
             params.push(("since", s.to_string()));
@@ -635,7 +641,7 @@ impl DaemonClient {
         since: Option<&str>,
         until: Option<&str>,
         limit: usize,
-    ) -> Result<Vec<FileCost>> {
+    ) -> Result<BreakdownPage<FileCost>> {
         let mut params: Vec<(&str, String)> = Vec::new();
         if let Some(s) = since {
             params.push(("since", s.to_string()));
@@ -692,14 +698,20 @@ impl DaemonClient {
         Ok(Some(serde_json::from_value(val)?))
     }
 
-    pub fn models(&self, since: Option<&str>, until: Option<&str>) -> Result<Vec<ModelUsage>> {
-        let mut params = Vec::new();
+    pub fn models(
+        &self,
+        since: Option<&str>,
+        until: Option<&str>,
+        limit: usize,
+    ) -> Result<BreakdownPage<ModelUsage>> {
+        let mut params: Vec<(&str, String)> = Vec::new();
         if let Some(s) = since {
-            params.push(("since", s));
+            params.push(("since", s.to_string()));
         }
         if let Some(u) = until {
-            params.push(("until", u));
+            params.push(("until", u.to_string()));
         }
+        params.push(("limit", limit.to_string()));
         let resp = self
             .client
             .get(format!("{}/analytics/models", self.base_url))
@@ -716,7 +728,7 @@ impl DaemonClient {
         since: Option<&str>,
         until: Option<&str>,
         limit: usize,
-    ) -> Result<Vec<TagCost>> {
+    ) -> Result<BreakdownPage<TagCost>> {
         let mut params: Vec<(&str, String)> = Vec::new();
         if let Some(k) = key {
             params.push(("key", k.to_string()));

--- a/crates/budi-cli/src/commands/stats.rs
+++ b/crates/budi-cli/src/commands/stats.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use budi_core::analytics;
+use budi_core::analytics::{self, BreakdownPage};
 use chrono::{Local, Months, NaiveDate, TimeZone};
 
 use crate::StatsPeriod;
@@ -91,6 +91,7 @@ pub fn cmd_stats(
     models: bool,
     provider: Option<String>,
     tag: Option<String>,
+    limit: usize,
     json_output: bool,
 ) -> Result<()> {
     // Normalize and validate --provider early with a helpful error message.
@@ -126,7 +127,7 @@ pub fn cmd_stats(
     )?;
 
     if let Some(ref tag_filter) = tag {
-        return cmd_stats_tags(&client, period, tag_filter, json_output);
+        return cmd_stats_tags(&client, period, tag_filter, limit, json_output);
     }
 
     if let Some(ref f) = file {
@@ -134,7 +135,7 @@ pub fn cmd_stats(
     }
 
     if files {
-        return cmd_stats_files(&client, period, json_output);
+        return cmd_stats_files(&client, period, limit, json_output);
     }
 
     if let Some(ref ac) = activity {
@@ -142,7 +143,7 @@ pub fn cmd_stats(
     }
 
     if activities {
-        return cmd_stats_activities(&client, period, json_output);
+        return cmd_stats_activities(&client, period, limit, json_output);
     }
 
     if let Some(ref tk) = ticket {
@@ -150,7 +151,7 @@ pub fn cmd_stats(
     }
 
     if tickets {
-        return cmd_stats_tickets(&client, period, json_output);
+        return cmd_stats_tickets(&client, period, limit, json_output);
     }
 
     if let Some(ref br) = branch {
@@ -158,21 +159,15 @@ pub fn cmd_stats(
     }
 
     if branches {
-        return cmd_stats_branches(&client, period, json_output);
+        return cmd_stats_branches(&client, period, limit, json_output);
     }
 
     if models {
-        return cmd_stats_models(&client, period, json_output);
+        return cmd_stats_models(&client, period, limit, json_output);
     }
 
     if projects {
-        if json_output {
-            let (since, until) = period_date_range(period);
-            let data = client.projects(since.as_deref(), until.as_deref(), 50)?;
-            println!("{}", serde_json::to_string_pretty(&data)?);
-            return Ok(());
-        }
-        return cmd_stats_projects(&client, period);
+        return cmd_stats_projects(&client, period, limit, json_output);
     }
 
     if json_output {
@@ -390,9 +385,19 @@ fn cmd_stats_multi_agent(
     Ok(())
 }
 
-fn cmd_stats_projects(client: &DaemonClient, period: StatsPeriod) -> Result<()> {
+fn cmd_stats_projects(
+    client: &DaemonClient,
+    period: StatsPeriod,
+    limit: usize,
+    json_output: bool,
+) -> Result<()> {
     let (since, until) = period_date_range(period);
-    let repos = client.projects(since.as_deref(), until.as_deref(), 15)?;
+    let page = client.projects(since.as_deref(), until.as_deref(), limit)?;
+
+    if json_output {
+        println!("{}", serde_json::to_string_pretty(&page)?);
+        return Ok(());
+    }
 
     let period_label = period_label(period);
 
@@ -403,25 +408,27 @@ fn cmd_stats_projects(client: &DaemonClient, period: StatsPeriod) -> Result<()> 
     let yellow = ansi("\x1b[33m");
     let reset = ansi("\x1b[0m");
 
+    let rule_width = 50usize;
     println!();
     println!(
         "  {bold_cyan} Repositories{reset} — {bold}{}{reset}",
         period_label
     );
-    println!("  {dim}{}{reset}", "─".repeat(50));
+    println!("  {dim}{}{reset}", "─".repeat(rule_width));
 
-    if repos.is_empty() {
+    if page.rows.is_empty() && page.other.is_none() {
         println!("  No data for this period.");
         println!();
         return Ok(());
     }
 
-    let max_cost = repos
+    let max_cost = page
+        .rows
         .iter()
         .map(|r| r.cost_cents)
         .fold(0.0_f64, f64::max)
         .max(0.01);
-    for r in &repos {
+    for r in &page.rows {
         let bar_len = ((r.cost_cents / max_cost) * 16.0) as usize;
         let bar: String = "\u{2588}".repeat(bar_len);
         println!(
@@ -432,16 +439,21 @@ fn cmd_stats_projects(client: &DaemonClient, period: StatsPeriod) -> Result<()> 
         );
     }
 
-    println!();
+    render_breakdown_footer(&page, 28, rule_width);
     Ok(())
 }
 
-fn cmd_stats_branches(client: &DaemonClient, period: StatsPeriod, json_output: bool) -> Result<()> {
+fn cmd_stats_branches(
+    client: &DaemonClient,
+    period: StatsPeriod,
+    limit: usize,
+    json_output: bool,
+) -> Result<()> {
     let (since, until) = period_date_range(period);
-    let branches = client.branches(since.as_deref(), until.as_deref())?;
+    let page = client.branches(since.as_deref(), until.as_deref(), limit)?;
 
     if json_output {
-        println!("{}", serde_json::to_string_pretty(&branches)?);
+        println!("{}", serde_json::to_string_pretty(&page)?);
         return Ok(());
     }
 
@@ -454,25 +466,27 @@ fn cmd_stats_branches(client: &DaemonClient, period: StatsPeriod, json_output: b
     let yellow = ansi("\x1b[33m");
     let reset = ansi("\x1b[0m");
 
+    let rule_width = 50usize;
     println!();
     println!(
         "  {bold_cyan} Branches{reset} — {bold}{}{reset}",
         period_label
     );
-    println!("  {dim}{}{reset}", "─".repeat(50));
+    println!("  {dim}{}{reset}", "─".repeat(rule_width));
 
-    if branches.is_empty() {
+    if page.rows.is_empty() && page.other.is_none() {
         println!("  No branch data for this period.");
         println!();
         return Ok(());
     }
 
-    let max_cost = branches
+    let max_cost = page
+        .rows
         .iter()
         .map(|b| b.cost_cents)
         .fold(0.0_f64, f64::max)
         .max(0.01);
-    for b in &branches {
+    for b in &page.rows {
         let branch_name = b
             .git_branch
             .strip_prefix("refs/heads/")
@@ -497,7 +511,7 @@ fn cmd_stats_branches(client: &DaemonClient, period: StatsPeriod, json_output: b
         );
     }
 
-    println!();
+    render_breakdown_footer(&page, 28, rule_width);
     Ok(())
 }
 
@@ -570,12 +584,17 @@ fn cmd_stats_branch_detail(
 /// The list always carries an `(untagged)` row so users can see how much
 /// activity is *not* attributed to a ticket — that bucket should shrink as
 /// teams adopt ticket-bearing branch names.
-fn cmd_stats_tickets(client: &DaemonClient, period: StatsPeriod, json_output: bool) -> Result<()> {
+fn cmd_stats_tickets(
+    client: &DaemonClient,
+    period: StatsPeriod,
+    limit: usize,
+    json_output: bool,
+) -> Result<()> {
     let (since, until) = period_date_range(period);
-    let tickets = client.tickets(since.as_deref(), until.as_deref(), 30)?;
+    let page = client.tickets(since.as_deref(), until.as_deref(), limit)?;
 
     if json_output {
-        println!("{}", serde_json::to_string_pretty(&tickets)?);
+        println!("{}", serde_json::to_string_pretty(&page)?);
         return Ok(());
     }
 
@@ -588,26 +607,28 @@ fn cmd_stats_tickets(client: &DaemonClient, period: StatsPeriod, json_output: bo
     let yellow = ansi("\x1b[33m");
     let reset = ansi("\x1b[0m");
 
+    let rule_width = 60usize;
     println!();
     println!(
         "  {bold_cyan} Tickets{reset} — {bold}{}{reset}",
         period_label
     );
-    println!("  {dim}{}{reset}", "─".repeat(60));
+    println!("  {dim}{}{reset}", "─".repeat(rule_width));
 
-    if tickets.is_empty() {
+    if page.rows.is_empty() && page.other.is_none() {
         println!("  No ticket data for this period.");
         println!("  Tip: branch names need to contain a ticket id (e.g. PAVA-123).");
         println!();
         return Ok(());
     }
 
-    let max_cost = tickets
+    let max_cost = page
+        .rows
         .iter()
         .map(|t| t.cost_cents)
         .fold(0.0_f64, f64::max)
         .max(0.01);
-    for t in &tickets {
+    for t in &page.rows {
         let bar_len = ((t.cost_cents / max_cost) * 16.0) as usize;
         let bar: String = "\u{2588}".repeat(bar_len);
         let branch_label = if t.top_branch.is_empty() {
@@ -630,7 +651,7 @@ fn cmd_stats_tickets(client: &DaemonClient, period: StatsPeriod, json_output: bo
         );
     }
 
-    println!();
+    render_breakdown_footer(&page, 24, rule_width);
     Ok(())
 }
 
@@ -738,13 +759,14 @@ fn cmd_stats_ticket_detail(
 fn cmd_stats_activities(
     client: &DaemonClient,
     period: StatsPeriod,
+    limit: usize,
     json_output: bool,
 ) -> Result<()> {
     let (since, until) = period_date_range(period);
-    let activities = client.activities(since.as_deref(), until.as_deref(), 30)?;
+    let page = client.activities(since.as_deref(), until.as_deref(), limit)?;
 
     if json_output {
-        println!("{}", serde_json::to_string_pretty(&activities)?);
+        println!("{}", serde_json::to_string_pretty(&page)?);
         return Ok(());
     }
 
@@ -757,14 +779,15 @@ fn cmd_stats_activities(
     let yellow = ansi("\x1b[33m");
     let reset = ansi("\x1b[0m");
 
+    let rule_width = 66usize;
     println!();
     println!(
         "  {bold_cyan} Activities{reset} — {bold}{}{reset}",
         period_label
     );
-    println!("  {dim}{}{reset}", "─".repeat(66));
+    println!("  {dim}{}{reset}", "─".repeat(rule_width));
 
-    if activities.is_empty() {
+    if page.rows.is_empty() && page.other.is_none() {
         println!("  No activity data for this period.");
         println!(
             "  Tip: activity is classified from the user's prompt; run `budi doctor` to check the signal."
@@ -773,12 +796,13 @@ fn cmd_stats_activities(
         return Ok(());
     }
 
-    let max_cost = activities
+    let max_cost = page
+        .rows
         .iter()
         .map(|a| a.cost_cents)
         .fold(0.0_f64, f64::max)
         .max(0.01);
-    for a in &activities {
+    for a in &page.rows {
         let bar_len = ((a.cost_cents / max_cost) * 16.0) as usize;
         let bar: String = "\u{2588}".repeat(bar_len);
         let branch_label = if a.top_branch.is_empty() {
@@ -801,7 +825,7 @@ fn cmd_stats_activities(
         );
     }
 
-    println!();
+    render_breakdown_footer(&page, 18, rule_width);
     Ok(())
 }
 
@@ -939,12 +963,17 @@ fn validate_file_path_arg(path: &str) -> Result<()> {
 /// output always carries an `(untagged)` row so users can see how much
 /// activity isn't attributed to a file — that bucket should shrink as
 /// tool-arg coverage improves. Added in R1.4 (#292).
-fn cmd_stats_files(client: &DaemonClient, period: StatsPeriod, json_output: bool) -> Result<()> {
+fn cmd_stats_files(
+    client: &DaemonClient,
+    period: StatsPeriod,
+    limit: usize,
+    json_output: bool,
+) -> Result<()> {
     let (since, until) = period_date_range(period);
-    let files = client.files(since.as_deref(), until.as_deref(), 30)?;
+    let page = client.files(since.as_deref(), until.as_deref(), limit)?;
 
     if json_output {
-        println!("{}", serde_json::to_string_pretty(&files)?);
+        println!("{}", serde_json::to_string_pretty(&page)?);
         return Ok(());
     }
 
@@ -957,11 +986,12 @@ fn cmd_stats_files(client: &DaemonClient, period: StatsPeriod, json_output: bool
     let yellow = ansi("\x1b[33m");
     let reset = ansi("\x1b[0m");
 
+    let rule_width = 72usize;
     println!();
     println!("  {bold_cyan} Files{reset} — {bold}{}{reset}", period_label);
-    println!("  {dim}{}{reset}", "─".repeat(72));
+    println!("  {dim}{}{reset}", "─".repeat(rule_width));
 
-    if files.is_empty() {
+    if page.rows.is_empty() && page.other.is_none() {
         println!("  No file data for this period.");
         println!(
             "  Tip: file paths are extracted from tool-call arguments (Read/Write/Edit, etc)."
@@ -970,12 +1000,13 @@ fn cmd_stats_files(client: &DaemonClient, period: StatsPeriod, json_output: bool
         return Ok(());
     }
 
-    let max_cost = files
+    let max_cost = page
+        .rows
         .iter()
         .map(|f| f.cost_cents)
         .fold(0.0_f64, f64::max)
         .max(0.01);
-    for f in &files {
+    for f in &page.rows {
         let bar_len = ((f.cost_cents / max_cost) * 16.0) as usize;
         let bar: String = "\u{2588}".repeat(bar_len);
         let ticket_label = if f.top_ticket_id.is_empty() {
@@ -1008,7 +1039,7 @@ fn cmd_stats_files(client: &DaemonClient, period: StatsPeriod, json_output: bool
         );
     }
 
-    println!();
+    render_breakdown_footer(&page, 40, rule_width);
     Ok(())
 }
 
@@ -1125,12 +1156,17 @@ fn cmd_stats_file_detail(
     Ok(())
 }
 
-fn cmd_stats_models(client: &DaemonClient, period: StatsPeriod, json_output: bool) -> Result<()> {
+fn cmd_stats_models(
+    client: &DaemonClient,
+    period: StatsPeriod,
+    limit: usize,
+    json_output: bool,
+) -> Result<()> {
     let (since, until) = period_date_range(period);
-    let models = client.models(since.as_deref(), until.as_deref())?;
+    let page = client.models(since.as_deref(), until.as_deref(), limit)?;
 
     if json_output {
-        println!("{}", serde_json::to_string_pretty(&models)?);
+        println!("{}", serde_json::to_string_pretty(&page)?);
         return Ok(());
     }
 
@@ -1142,14 +1178,15 @@ fn cmd_stats_models(client: &DaemonClient, period: StatsPeriod, json_output: boo
     let cyan = ansi("\x1b[36m");
     let reset = ansi("\x1b[0m");
 
+    let rule_width = 50usize;
     println!();
     println!(
         "  {bold_cyan} Model usage{reset} — {bold}{}{reset}",
         period_label
     );
-    println!("  {dim}{}{reset}", "─".repeat(50));
+    println!("  {dim}{}{reset}", "─".repeat(rule_width));
 
-    if models.is_empty() {
+    if page.rows.is_empty() && page.other.is_none() {
         println!("  No data for this period.");
         println!();
         return Ok(());
@@ -1159,16 +1196,17 @@ fn cmd_stats_models(client: &DaemonClient, period: StatsPeriod, json_output: boo
 
     let has_duplicate_models = {
         let mut seen = std::collections::HashSet::new();
-        models.iter().any(|m| !seen.insert(&m.model))
+        page.rows.iter().any(|m| !seen.insert(&m.model))
     };
 
-    let max_msgs = models
+    let max_msgs = page
+        .rows
         .iter()
         .map(|m| m.message_count)
         .max()
         .unwrap_or(1)
         .max(1);
-    for m in &models {
+    for m in &page.rows {
         let bar_len = ((m.message_count as f64 / max_msgs as f64) * 16.0) as usize;
         let bar: String = "█".repeat(bar_len);
         let total_tok =
@@ -1188,8 +1226,83 @@ fn cmd_stats_models(client: &DaemonClient, period: StatsPeriod, json_output: boo
         );
     }
 
-    println!();
+    render_breakdown_footer(&page, 40, rule_width);
     Ok(())
+}
+
+// ─── Breakdown Footer (#448) ─────────────────────────────────────────────────
+//
+// Every text-mode breakdown view ends in a `Total` footer that reconciles
+// to the cent. When rows are truncated, a sibling `(other N: $X)` row is
+// rendered just above the total so sum(rendered) + other == total. This is
+// the contract the #448 release-blocker nails down.
+
+/// Render the `(other N rows)` line and trailing `Total $X (M of N rows shown)`
+/// footer that wraps every breakdown view. No-ops when the page is empty
+/// (caller prints its own "no data" message).
+///
+/// `_name_col_width` is kept as a signature parameter for views that later
+/// want tighter per-column alignment (see #450); the current footer uses the
+/// `rule_width` anchor so it reconciles visually on every view without
+/// per-layout tuning.
+fn render_breakdown_footer<T>(page: &BreakdownPage<T>, _name_col_width: usize, rule_width: usize) {
+    if page.shown_rows == 0 && page.other.is_none() {
+        return;
+    }
+
+    let dim = ansi("\x1b[90m");
+    let bold = ansi("\x1b[1m");
+    let yellow = ansi("\x1b[33m");
+    let reset = ansi("\x1b[0m");
+
+    // The footer sits under a rule `rule_width` wide; we right-align the
+    // cost to the last column of the rule and pad the label with spaces
+    // in front. This reconciles cleanly on every view without needing
+    // per-view column tables (which #450 will introduce in the polish
+    // pass).
+    const COST_COL_WIDTH: usize = 10;
+    let rule_len = rule_width.max(20);
+    let label_pad = rule_len.saturating_sub(COST_COL_WIDTH);
+
+    if let Some(other) = &page.other {
+        let plural = if other.row_count == 1 { "" } else { "s" };
+        let label = format!(
+            "{} — {} more row{}",
+            analytics::BREAKDOWN_OTHER_LABEL,
+            other.row_count,
+            plural,
+        );
+        println!(
+            "  {dim}{:<label_pad$}{reset}{yellow}{:>width$}{reset}",
+            label,
+            format_cost_cents(other.cost_cents),
+            width = COST_COL_WIDTH,
+        );
+    }
+
+    println!("  {dim}{}{reset}", "─".repeat(rule_len));
+
+    let shown_note = if page.other.is_some() {
+        format!(
+            "{dim}({} of {} rows shown — pass --limit 0 for all){reset}",
+            page.shown_rows, page.total_rows
+        )
+    } else if page.total_rows == 0 {
+        String::new()
+    } else {
+        let plural = if page.total_rows == 1 { "" } else { "s" };
+        format!("{dim}({} row{} shown){reset}", page.total_rows, plural)
+    };
+
+    let total_label_pad = label_pad.saturating_sub(5); // "Total" prefix width
+    println!(
+        "  {bold}Total{reset}{:<total_label_pad$}{yellow}{:>width$}{reset}  {}",
+        "",
+        format_cost_cents(page.total_cost_cents),
+        shown_note,
+        width = COST_COL_WIDTH,
+    );
+    println!();
 }
 
 // ─── Formatting Utilities ────────────────────────────────────────────────────
@@ -1245,18 +1358,19 @@ fn cmd_stats_tags(
     client: &DaemonClient,
     period: StatsPeriod,
     tag_filter: &str,
+    limit: usize,
     json_output: bool,
 ) -> Result<()> {
     let (since, until) = period_date_range(period);
 
-    let data = client.tags(Some(tag_filter), since.as_deref(), until.as_deref(), 30)?;
+    let page = client.tags(Some(tag_filter), since.as_deref(), until.as_deref(), limit)?;
 
     if json_output {
-        println!("{}", serde_json::to_string_pretty(&data)?);
+        println!("{}", serde_json::to_string_pretty(&page)?);
         return Ok(());
     }
 
-    if data.is_empty() {
+    if page.rows.is_empty() && page.other.is_none() {
         println!(
             "No tag data for '{}' ({})",
             tag_filter,
@@ -1271,6 +1385,7 @@ fn cmd_stats_tags(
 
     let dim = ansi("\x1b[90m");
 
+    let rule_width = 78usize;
     println!(
         "\n{bold}  Tag: {} — {}{reset}\n",
         tag_filter,
@@ -1278,13 +1393,17 @@ fn cmd_stats_tags(
     );
 
     println!("  {dim}{:<40} {:>38}{reset}", "VALUE", "COST");
-    println!("  {dim}{}{reset}", "─".repeat(78));
+    println!("  {dim}{}{reset}", "─".repeat(rule_width));
 
     // Find max cost for bar scaling
-    let max_cost = data.iter().map(|t| t.cost_cents).fold(0.0f64, f64::max);
+    let max_cost = page
+        .rows
+        .iter()
+        .map(|t| t.cost_cents)
+        .fold(0.0f64, f64::max);
     let bar_width: usize = 30;
 
-    for tag in &data {
+    for tag in &page.rows {
         let bar_len = if max_cost > 0.0 {
             ((tag.cost_cents / max_cost) * bar_width as f64) as usize
         } else {
@@ -1300,7 +1419,7 @@ fn cmd_stats_tags(
             format_cost_cents(tag.cost_cents),
         );
     }
-    println!();
+    render_breakdown_footer(&page, 40, rule_width);
     Ok(())
 }
 

--- a/crates/budi-cli/src/main.rs
+++ b/crates/budi-cli/src/main.rs
@@ -130,6 +130,13 @@ Examples:
         /// Show cost breakdown by tag key (e.g. --tag ticket_id, --tag activity)
         #[arg(long)]
         tag: Option<String>,
+        /// Maximum rows to show in breakdown views (`--projects`,
+        /// `--branches`, `--tickets`, `--activities`, `--files`,
+        /// `--models`, `--tag`). `0` = no cap (show every matching row).
+        /// Truncated rows collapse into an `(other N: $X)` aggregate so
+        /// the Total footer always reconciles to the cent (#448).
+        #[arg(long, default_value_t = 30)]
+        limit: usize,
         /// Output format: text (default) or json
         #[arg(short, long, value_enum, default_value_t = StatsFormat::Text)]
         format: StatsFormat,
@@ -497,6 +504,7 @@ fn main() -> Result<()> {
             models,
             provider,
             tag,
+            limit,
             format,
         } => {
             let json_output = matches!(format, StatsFormat::Json);
@@ -515,6 +523,7 @@ fn main() -> Result<()> {
                 models,
                 provider,
                 tag,
+                limit,
                 json_output,
             )
         }

--- a/crates/budi-core/src/analytics/queries.rs
+++ b/crates/budi-core/src/analytics/queries.rs
@@ -319,6 +319,161 @@ pub struct UsageSummary {
     pub total_cost_cents: f64,
 }
 
+// ---------------------------------------------------------------------------
+// Breakdown envelope (#448)
+// ---------------------------------------------------------------------------
+//
+// Every `budi stats` breakdown view (`--projects`, `--branches`, `--tickets`,
+// `--activities`, `--files`, `--models`, `--tag`) ships through this envelope
+// so the shape of every endpoint carries a grand total and an explicit
+// `(other)` aggregate when rows are truncated. Before 8.3 these views
+// returned a bare `Vec<T>` capped at 30 rows with no footer, which caused
+// `--files 30d` to silently underreport cost by ~9% on machines with more
+// than 30 distinct file paths (#448 reproduction).
+//
+// Contract: `sum(rows) + other.cost_cents == total_cost_cents`, to the cent,
+// for every period and breakdown — enforced by `paginate_breakdown` and
+// exercised by the reconciliation tests in `analytics/tests.rs`.
+
+/// Display label for the truncation-tail aggregate row in breakdown output.
+///
+/// Distinct from [`UNTAGGED_DIMENSION`]: `(other)` is "the cost we truncated
+/// from the bottom of the ranked list", `(untagged)` is "the cost that
+/// carries no tag value at all". Both can coexist on the same view.
+pub const BREAKDOWN_OTHER_LABEL: &str = "(other)";
+
+/// Aggregate of every row ranked below the requested limit. Emitted as a
+/// sibling of the top-N rows so scripts reconcile to the grand total
+/// without needing to re-query with `--limit 0`.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct BreakdownOther {
+    /// How many rows were folded into this aggregate.
+    pub row_count: usize,
+    /// Summed cost of the folded rows, in cents.
+    pub cost_cents: f64,
+}
+
+/// Envelope wrapping every breakdown response: top-N rows plus a truncated
+/// `(other)` aggregate plus the grand total and total distinct-row count
+/// for the requested window.
+///
+/// `limit == 0` means "no cap" — `rows` holds every matched row and `other`
+/// is always `None`.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct BreakdownPage<T> {
+    /// Top rows sorted by cost (highest first), truncated to `shown_rows`.
+    pub rows: Vec<T>,
+    /// Aggregate of rows beyond `limit`. `None` when nothing was truncated.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub other: Option<BreakdownOther>,
+    /// Grand total across every row in the window, to the cent. Equals
+    /// `sum(rows.cost_cents) + other.cost_cents` when `other` is `Some`.
+    pub total_cost_cents: f64,
+    /// Number of distinct rows matched by the query, including rows folded
+    /// into `(other)`.
+    pub total_rows: usize,
+    /// How many rows are in `rows` (always `<= limit` when `limit > 0`).
+    pub shown_rows: usize,
+    /// Effective limit applied. `0` = unlimited.
+    pub limit: usize,
+}
+
+/// Contract for breakdown row types so [`paginate_breakdown`] can read
+/// the cost field without type-specific casing. Implementations live
+/// alongside the envelope because the trait is purely load-bearing for
+/// truncation math, not part of the row's public semantics.
+pub trait BreakdownRowCost {
+    fn cost_cents(&self) -> f64;
+}
+
+impl BreakdownRowCost for RepoUsage {
+    fn cost_cents(&self) -> f64 {
+        self.cost_cents
+    }
+}
+
+impl BreakdownRowCost for BranchCost {
+    fn cost_cents(&self) -> f64 {
+        self.cost_cents
+    }
+}
+
+impl BreakdownRowCost for TicketCost {
+    fn cost_cents(&self) -> f64 {
+        self.cost_cents
+    }
+}
+
+impl BreakdownRowCost for ActivityCost {
+    fn cost_cents(&self) -> f64 {
+        self.cost_cents
+    }
+}
+
+impl BreakdownRowCost for FileCost {
+    fn cost_cents(&self) -> f64 {
+        self.cost_cents
+    }
+}
+
+impl BreakdownRowCost for ModelUsage {
+    fn cost_cents(&self) -> f64 {
+        self.cost_cents
+    }
+}
+
+impl BreakdownRowCost for TagCost {
+    fn cost_cents(&self) -> f64 {
+        self.cost_cents
+    }
+}
+
+/// Sentinel limit that disables truncation. Passed to the underlying SQL
+/// LIMIT clause as an i64, so we stay well under i64::MAX.
+pub const BREAKDOWN_FETCH_ALL_LIMIT: usize = 1_000_000;
+
+/// Split `all_rows` (already sorted by cost DESC) into the visible top-N
+/// plus an `(other)` aggregate, and compute the grand total.
+///
+/// Callers fetch the full set first (via `*_cost_with_filters` with a very
+/// large SQL `LIMIT`) and hand the vec to this helper. That keeps the
+/// truncation logic in one place so every breakdown reconciles to the cent
+/// (#448 acceptance).
+pub fn paginate_breakdown<T: BreakdownRowCost>(
+    mut all_rows: Vec<T>,
+    limit: usize,
+) -> BreakdownPage<T> {
+    let total_rows = all_rows.len();
+    let total_cost_cents: f64 = all_rows.iter().map(BreakdownRowCost::cost_cents).sum();
+
+    if limit == 0 || total_rows <= limit {
+        let shown_rows = total_rows;
+        return BreakdownPage {
+            rows: all_rows,
+            other: None,
+            total_cost_cents,
+            total_rows,
+            shown_rows,
+            limit,
+        };
+    }
+
+    let rest: Vec<T> = all_rows.drain(limit..).collect();
+    let other_cost: f64 = rest.iter().map(BreakdownRowCost::cost_cents).sum();
+    let other = BreakdownOther {
+        row_count: rest.len(),
+        cost_cents: other_cost,
+    };
+    BreakdownPage {
+        rows: all_rows,
+        other: Some(other),
+        total_cost_cents,
+        total_rows,
+        shown_rows: limit,
+        limit,
+    }
+}
+
 /// Query a usage summary, optionally filtered by date range.
 /// Consolidated into a single scan of the messages table.
 #[cfg(test)]

--- a/crates/budi-core/src/analytics/tests.rs
+++ b/crates/budi-core/src/analytics/tests.rs
@@ -4865,3 +4865,437 @@ fn ingest_with_tail_file_writes_offset_atomically_for_empty_message_batch() {
         "empty-batch ingest with tail_file must still upsert the offset",
     );
 }
+
+// ---------------------------------------------------------------------------
+// Breakdown reconciliation (#448)
+//
+// Regression guard for the release-blocker where every breakdown silently
+// capped at 30 rows with no grand total, underreporting by ~9% on a real
+// `--files 30d` sample. The contract these tests pin down:
+//
+//   sum(rows) + other.cost_cents == total_cost_cents, to the cent,
+//
+// for every breakdown view (`--projects/--branches/--tickets/--activities/
+// --files/--models/--tag`) across every period (`today/7d/30d`). Plus:
+//   * `total_cost_cents` equals the grand total of assistant cost in the
+//     window (reconciles with `usage_summary`), because every ranked row
+//     spans the full tagged-or-untagged partition.
+//   * `paginate_breakdown(rows, 0)` never truncates (0 = unlimited).
+// ---------------------------------------------------------------------------
+
+/// Assert that `sum(rows.cost_cents) + other.cost_cents == total_cost_cents`
+/// to within 0.01 cent for rounding slack. Used as the reconciliation
+/// oracle for every breakdown view.
+fn assert_breakdown_reconciles<T: BreakdownRowCost>(
+    page: &BreakdownPage<T>,
+    expected_total_cents: f64,
+    label: &str,
+) {
+    let rows_cost: f64 = page.rows.iter().map(BreakdownRowCost::cost_cents).sum();
+    let other_cost = page.other.as_ref().map(|o| o.cost_cents).unwrap_or(0.0);
+    assert!(
+        (rows_cost + other_cost - page.total_cost_cents).abs() < 0.01,
+        "{label}: rows + other != total_cost_cents ({rows_cost} + {other_cost} vs {})",
+        page.total_cost_cents,
+    );
+    assert!(
+        (page.total_cost_cents - expected_total_cents).abs() < 0.01,
+        "{label}: total_cost_cents {} diverges from expected {expected_total_cents}",
+        page.total_cost_cents,
+    );
+    // total_rows always equals shown_rows + other.row_count, and
+    // paginate_breakdown never produces an `other` row with zero rows in it.
+    if let Some(other) = page.other.as_ref() {
+        assert!(other.row_count > 0, "{label}: other row must be non-empty");
+        assert_eq!(
+            page.shown_rows + other.row_count,
+            page.total_rows,
+            "{label}: shown + other != total_rows",
+        );
+    } else {
+        assert_eq!(
+            page.shown_rows, page.total_rows,
+            "{label}: other=None implies shown_rows == total_rows",
+        );
+    }
+}
+
+/// Seed 42 tickets of varying cost in a single window so the default
+/// limit of 30 necessarily truncates. Each cost is picked to avoid
+/// collisions with the untagged bucket's cost.
+fn seed_tickets_for_reconciliation(conn: &mut Connection) -> f64 {
+    let mut msgs = Vec::new();
+    let mut tags = Vec::new();
+    let mut total = 0.0;
+    for i in 0..42 {
+        let cost = 1.0 + i as f64 * 0.37;
+        total += cost;
+        let uuid = format!("tk-rec-{i}");
+        let sid = format!("s-tk-{i}");
+        let ticket = format!("RECON-{i}");
+        let branch = format!("{ticket}-work");
+        let m = ticket_msg(&uuid, &sid, &branch, "repo-rec", cost);
+        msgs.push(m);
+        tags.push(ticket_tags(&[&ticket]));
+    }
+    // An untagged assistant message so the `(untagged)` bucket is part
+    // of the truncation / reconciliation math.
+    let untagged = assistant_msg("tk-rec-untagged", "s-tk-u", 0.73);
+    total += 0.73;
+    msgs.push(untagged);
+    tags.push(Vec::new());
+
+    ingest_messages(conn, &msgs, Some(&tags)).unwrap();
+    total
+}
+
+#[test]
+fn breakdown_tickets_reconcile_with_other_row_when_truncated() {
+    let mut conn = test_db();
+    let expected_total = seed_tickets_for_reconciliation(&mut conn);
+
+    let all = ticket_cost_with_filters(
+        &conn,
+        None,
+        None,
+        &DimensionFilters::default(),
+        BREAKDOWN_FETCH_ALL_LIMIT,
+    )
+    .unwrap();
+
+    // Capped at 30 → `(other)` aggregates the remaining 13 rows.
+    let page = paginate_breakdown(all.clone(), 30);
+    assert_eq!(page.shown_rows, 30);
+    assert_eq!(page.rows.len(), 30);
+    assert!(page.other.is_some(), "truncation must surface `(other)`");
+    let other = page.other.as_ref().unwrap();
+    assert_eq!(
+        other.row_count,
+        page.total_rows - 30,
+        "other.row_count must cover every truncated row",
+    );
+    assert_breakdown_reconciles(&page, expected_total, "--tickets cap=30");
+
+    // Unlimited → everything in `rows`, nothing in `other`.
+    let unlimited = paginate_breakdown(all.clone(), 0);
+    assert!(unlimited.other.is_none(), "limit=0 must not truncate");
+    assert_eq!(unlimited.shown_rows, unlimited.total_rows);
+    assert_breakdown_reconciles(&unlimited, expected_total, "--tickets cap=0");
+}
+
+#[test]
+fn breakdown_files_reconcile_with_other_row_when_truncated() {
+    let mut conn = test_db();
+    let mut msgs = Vec::new();
+    let mut tags = Vec::new();
+    let mut expected = 0.0;
+    for i in 0..40 {
+        let cost = 0.75 + i as f64 * 0.31;
+        expected += cost;
+        let uuid = format!("fc-rec-{i}");
+        let sid = format!("s-fc-{i}");
+        let path = format!("src/generated/file_{i:03}.rs");
+        let m = file_msg(&uuid, &sid, "main", "repo-files", cost);
+        msgs.push(m);
+        tags.push(file_tags(&[&path]));
+    }
+    // Untagged bucket.
+    msgs.push(assistant_msg("fc-rec-untagged", "s-fc-u", 0.41));
+    tags.push(Vec::new());
+    expected += 0.41;
+    ingest_messages(&mut conn, &msgs, Some(&tags)).unwrap();
+
+    let all = file_cost_with_filters(
+        &conn,
+        None,
+        None,
+        &DimensionFilters::default(),
+        BREAKDOWN_FETCH_ALL_LIMIT,
+    )
+    .unwrap();
+    let page = paginate_breakdown(all, 30);
+    assert_eq!(page.shown_rows, 30);
+    assert!(
+        page.other.is_some(),
+        "--files must emit (other) when truncated"
+    );
+    assert_breakdown_reconciles(&page, expected, "--files cap=30");
+}
+
+#[test]
+fn breakdown_activities_reconcile_with_other_row_when_truncated() {
+    let mut conn = test_db();
+    let mut msgs = Vec::new();
+    let mut tags = Vec::new();
+    let mut expected = 0.0;
+    for i in 0..35 {
+        let cost = 0.5 + i as f64 * 0.19;
+        expected += cost;
+        let uuid = format!("ac-rec-{i}");
+        let sid = format!("s-ac-{i}");
+        let activity = format!("activity_{i:02}");
+        let m = activity_msg(&uuid, &sid, "main", "repo-acts", cost);
+        msgs.push(m);
+        tags.push(activity_tags(&[&activity]));
+    }
+    ingest_messages(&mut conn, &msgs, Some(&tags)).unwrap();
+
+    let all = activity_cost_with_filters(
+        &conn,
+        None,
+        None,
+        &DimensionFilters::default(),
+        BREAKDOWN_FETCH_ALL_LIMIT,
+    )
+    .unwrap();
+    let page = paginate_breakdown(all, 30);
+    assert_eq!(page.shown_rows, 30);
+    assert!(
+        page.other.is_some(),
+        "--activities must emit (other) when truncated",
+    );
+    assert_breakdown_reconciles(&page, expected, "--activities cap=30");
+}
+
+#[test]
+fn breakdown_projects_reconcile_with_other_row_when_truncated() {
+    let mut conn = test_db();
+    let mut msgs = Vec::new();
+    let mut expected = 0.0;
+    for i in 0..35 {
+        let cost = 0.9 + i as f64 * 0.22;
+        expected += cost;
+        let mut m = assistant_msg(&format!("pr-rec-{i}"), &format!("s-pr-{i}"), cost);
+        m.repo_id = Some(format!("github.com/acme/repo-{i:03}"));
+        msgs.push(m);
+    }
+    ingest_messages(&mut conn, &msgs, None).unwrap();
+
+    let all = repo_usage_with_filters(
+        &conn,
+        None,
+        None,
+        &DimensionFilters::default(),
+        BREAKDOWN_FETCH_ALL_LIMIT,
+    )
+    .unwrap();
+    let page = paginate_breakdown(all, 30);
+    assert_eq!(page.shown_rows, 30);
+    assert!(
+        page.other.is_some(),
+        "--projects must emit (other) when truncated",
+    );
+    assert_breakdown_reconciles(&page, expected, "--projects cap=30");
+}
+
+#[test]
+fn breakdown_branches_reconcile_with_other_row_when_truncated() {
+    let mut conn = test_db();
+    let mut msgs = Vec::new();
+    let mut expected = 0.0;
+    for i in 0..33 {
+        let cost = 1.2 + i as f64 * 0.41;
+        expected += cost;
+        let mut m = assistant_msg(&format!("br-rec-{i}"), &format!("s-br-{i}"), cost);
+        m.git_branch = Some(format!("feature/branch-{i:03}"));
+        m.repo_id = Some("repo-branches".to_string());
+        msgs.push(m);
+    }
+    ingest_messages(&mut conn, &msgs, None).unwrap();
+
+    let all = branch_cost_with_filters(
+        &conn,
+        None,
+        None,
+        &DimensionFilters::default(),
+        BREAKDOWN_FETCH_ALL_LIMIT,
+    )
+    .unwrap();
+    let page = paginate_breakdown(all, 30);
+    assert_eq!(page.shown_rows, 30);
+    assert!(
+        page.other.is_some(),
+        "--branches must emit (other) when truncated",
+    );
+    assert_breakdown_reconciles(&page, expected, "--branches cap=30");
+}
+
+#[test]
+fn breakdown_models_reconcile_with_other_row_when_truncated() {
+    let mut conn = test_db();
+    let mut msgs = Vec::new();
+    let mut expected = 0.0;
+    for i in 0..33 {
+        let cost = 0.65 + i as f64 * 0.27;
+        expected += cost;
+        let mut m = assistant_msg(&format!("md-rec-{i}"), &format!("s-md-{i}"), cost);
+        m.model = Some(format!("model-family-{i:03}"));
+        msgs.push(m);
+    }
+    ingest_messages(&mut conn, &msgs, None).unwrap();
+
+    let all = model_usage_with_filters(
+        &conn,
+        None,
+        None,
+        &DimensionFilters::default(),
+        BREAKDOWN_FETCH_ALL_LIMIT,
+    )
+    .unwrap();
+    let page = paginate_breakdown(all, 30);
+    assert_eq!(page.shown_rows, 30);
+    assert!(
+        page.other.is_some(),
+        "--models must emit (other) when truncated",
+    );
+    assert_breakdown_reconciles(&page, expected, "--models cap=30");
+}
+
+#[test]
+fn breakdown_tags_reconcile_with_other_row_when_truncated() {
+    // `--tag ticket_id` mirrors `--tickets` but flows through a different
+    // code path (`tag_stats_with_filters`), so it gets its own guard.
+    let mut conn = test_db();
+    let expected = seed_tickets_for_reconciliation(&mut conn);
+
+    let all = tag_stats_with_filters(
+        &conn,
+        Some("ticket_id"),
+        None,
+        None,
+        &DimensionFilters::default(),
+        BREAKDOWN_FETCH_ALL_LIMIT,
+    )
+    .unwrap();
+    let page = paginate_breakdown(all, 30);
+    assert_eq!(page.shown_rows, 30);
+    assert!(
+        page.other.is_some(),
+        "--tag ticket_id must emit (other) when truncated",
+    );
+    assert_breakdown_reconciles(&page, expected, "--tag ticket_id cap=30");
+}
+
+#[test]
+fn paginate_breakdown_no_truncation_when_rows_fit() {
+    // <= limit → `other` stays `None`, shown == total, cost reconciles.
+    let mut conn = test_db();
+    let mut msgs = Vec::new();
+    let mut expected = 0.0;
+    for i in 0..5 {
+        let cost = 1.0 + i as f64;
+        expected += cost;
+        msgs.push(assistant_msg(
+            &format!("fit-{i}"),
+            &format!("s-fit-{i}"),
+            cost,
+        ));
+    }
+    ingest_messages(&mut conn, &msgs, None).unwrap();
+
+    let all = model_usage_with_filters(
+        &conn,
+        None,
+        None,
+        &DimensionFilters::default(),
+        BREAKDOWN_FETCH_ALL_LIMIT,
+    )
+    .unwrap();
+    let page = paginate_breakdown(all, 30);
+    assert!(page.other.is_none());
+    assert_eq!(page.shown_rows, page.total_rows);
+    assert_breakdown_reconciles(&page, expected, "fits-under-limit");
+}
+
+#[test]
+fn breakdown_tickets_reconcile_across_today_7d_and_30d() {
+    // Replicates the #448 acceptance: reconciliation to the cent across
+    // `today/7d/30d`. We plant tickets at three different anchor dates
+    // and query with the corresponding `since` bound so each window's
+    // total is a known strict subset of the universe.
+    use chrono::{Duration, Utc};
+
+    let mut conn = test_db();
+    let now = Utc::now();
+    // Anchor ticket cohorts in each of the three windows. Each cohort
+    // has 40 distinct tickets so the default cap of 30 forces
+    // truncation, and each cost is unique (0.5 cent steps) so every row
+    // sorts deterministically.
+    let mut msgs: Vec<ParsedMessage> = Vec::new();
+    let mut tags: Vec<Vec<Tag>> = Vec::new();
+    let anchors = [
+        (now - Duration::hours(1), "today-"),    // inside today
+        (now - Duration::days(3), "seven-d-"),   // inside 7d
+        (now - Duration::days(20), "thirty-d-"), // inside 30d
+    ];
+
+    // Running totals per window (today ⊂ 7d ⊂ 30d).
+    let mut total_today = 0.0;
+    let mut total_7d = 0.0;
+    let mut total_30d = 0.0;
+
+    for (cohort_idx, (ts, prefix)) in anchors.iter().enumerate() {
+        for i in 0..40 {
+            let cost = 0.5 + cohort_idx as f64 * 5.0 + i as f64 * 0.11;
+            let uuid = format!("recon-{prefix}{i}");
+            let sid = format!("s-{prefix}{i}");
+            let ticket = format!("RECON-{prefix}{i}");
+            let branch = format!("{ticket}-wip");
+            let mut m = ticket_msg(&uuid, &sid, &branch, "repo-recon", cost);
+            m.timestamp = *ts;
+            msgs.push(m);
+            tags.push(ticket_tags(&[&ticket]));
+            total_30d += cost;
+            if cohort_idx <= 1 {
+                total_7d += cost;
+            }
+            if cohort_idx == 0 {
+                total_today += cost;
+            }
+        }
+    }
+    ingest_messages(&mut conn, &msgs, Some(&tags)).unwrap();
+
+    let today_since = (now - Duration::days(0))
+        .date_naive()
+        .and_hms_opt(0, 0, 0)
+        .unwrap()
+        .and_utc()
+        .to_rfc3339();
+    let since_7d = (now - Duration::days(7)).to_rfc3339();
+    let since_30d = (now - Duration::days(30)).to_rfc3339();
+
+    for (since, expected_total, label) in [
+        (Some(today_since.as_str()), total_today, "today"),
+        (Some(since_7d.as_str()), total_7d, "7d"),
+        (Some(since_30d.as_str()), total_30d, "30d"),
+    ] {
+        let all = ticket_cost_with_filters(
+            &conn,
+            since,
+            None,
+            &DimensionFilters::default(),
+            BREAKDOWN_FETCH_ALL_LIMIT,
+        )
+        .unwrap();
+        let page = paginate_breakdown(all, 30);
+        assert_eq!(
+            page.shown_rows, 30,
+            "{label}: expected 30 rows rendered, got {}",
+            page.shown_rows,
+        );
+        assert!(
+            page.other.is_some(),
+            "{label}: expected `(other)` since cohort has 40 tickets",
+        );
+        assert_breakdown_reconciles(&page, expected_total, label);
+    }
+}
+
+#[test]
+fn breakdown_other_label_is_stable_wire_value() {
+    // Scripts keying off `(other)` must stay stable — guarding the
+    // constant here prevents an accidental rename from breaking
+    // downstream reconciliation tooling.
+    assert_eq!(BREAKDOWN_OTHER_LABEL, "(other)");
+}

--- a/crates/budi-daemon/src/routes/analytics.rs
+++ b/crates/budi-daemon/src/routes/analytics.rs
@@ -183,10 +183,20 @@ pub struct ListParams {
     pub filters: DimensionParams,
 }
 
+/// Resolve the CLI-requested `--limit N` (0 = unlimited) to a capped value
+/// for pagination. `None` falls back to the default breakdown cap of 30.
+fn resolve_breakdown_limit(requested: Option<usize>) -> usize {
+    let raw = requested.unwrap_or(30);
+    if raw == 0 { 0 } else { raw.min(100_000) }
+}
+
 pub async fn analytics_projects(
     Query(params): Query<ListParams>,
-) -> Result<Json<Vec<analytics::RepoUsage>>, (StatusCode, Json<serde_json::Value>)> {
-    let limit = params.limit.unwrap_or(20).min(200);
+) -> Result<
+    Json<analytics::BreakdownPage<analytics::RepoUsage>>,
+    (StatusCode, Json<serde_json::Value>),
+> {
+    let limit = resolve_breakdown_limit(params.limit);
     let filters = parse_dimension_filters(&params.filters);
     let result = tokio::task::spawn_blocking(move || {
         let db_path = analytics::db_path()?;
@@ -196,20 +206,23 @@ pub async fn analytics_projects(
             params.since.as_deref(),
             params.until.as_deref(),
             &filters,
-            limit,
+            analytics::BREAKDOWN_FETCH_ALL_LIMIT,
         )
     })
     .await
     .map_err(|e| internal_error(anyhow::anyhow!("{e}")))?
     .map_err(internal_error)?;
 
-    Ok(Json(result))
+    Ok(Json(analytics::paginate_breakdown(result, limit)))
 }
 
 pub async fn analytics_models(
     Query(params): Query<ListParams>,
-) -> Result<Json<Vec<analytics::ModelUsage>>, (StatusCode, Json<serde_json::Value>)> {
-    let limit = params.limit.unwrap_or(20).min(200);
+) -> Result<
+    Json<analytics::BreakdownPage<analytics::ModelUsage>>,
+    (StatusCode, Json<serde_json::Value>),
+> {
+    let limit = resolve_breakdown_limit(params.limit);
     let filters = parse_dimension_filters(&params.filters);
     let result = tokio::task::spawn_blocking(move || {
         let db_path = analytics::db_path()?;
@@ -219,20 +232,23 @@ pub async fn analytics_models(
             params.since.as_deref(),
             params.until.as_deref(),
             &filters,
-            limit,
+            analytics::BREAKDOWN_FETCH_ALL_LIMIT,
         )
     })
     .await
     .map_err(|e| internal_error(anyhow::anyhow!("{e}")))?
     .map_err(internal_error)?;
 
-    Ok(Json(result))
+    Ok(Json(analytics::paginate_breakdown(result, limit)))
 }
 
 pub async fn analytics_branches(
     Query(params): Query<ListParams>,
-) -> Result<Json<Vec<analytics::BranchCost>>, (StatusCode, Json<serde_json::Value>)> {
-    let limit = params.limit.unwrap_or(20).min(200);
+) -> Result<
+    Json<analytics::BreakdownPage<analytics::BranchCost>>,
+    (StatusCode, Json<serde_json::Value>),
+> {
+    let limit = resolve_breakdown_limit(params.limit);
     let filters = parse_dimension_filters(&params.filters);
     let result = tokio::task::spawn_blocking(move || {
         let db_path = analytics::db_path()?;
@@ -242,14 +258,14 @@ pub async fn analytics_branches(
             params.since.as_deref(),
             params.until.as_deref(),
             &filters,
-            limit,
+            analytics::BREAKDOWN_FETCH_ALL_LIMIT,
         )
     })
     .await
     .map_err(|e| internal_error(anyhow::anyhow!("{e}")))?
     .map_err(internal_error)?;
 
-    Ok(Json(result))
+    Ok(Json(analytics::paginate_breakdown(result, limit)))
 }
 
 pub async fn analytics_cost(
@@ -452,8 +468,9 @@ pub struct TagParams {
 
 pub async fn analytics_tags(
     Query(params): Query<TagParams>,
-) -> Result<Json<Vec<analytics::TagCost>>, (StatusCode, Json<serde_json::Value>)> {
-    let limit = params.limit.unwrap_or(20).min(200);
+) -> Result<Json<analytics::BreakdownPage<analytics::TagCost>>, (StatusCode, Json<serde_json::Value>)>
+{
+    let limit = resolve_breakdown_limit(params.limit);
     let filters = parse_dimension_filters(&params.filters);
     let result = tokio::task::spawn_blocking(move || {
         let db_path = analytics::db_path()?;
@@ -464,13 +481,13 @@ pub async fn analytics_tags(
             params.since.as_deref(),
             params.until.as_deref(),
             &filters,
-            limit,
+            analytics::BREAKDOWN_FETCH_ALL_LIMIT,
         )
     })
     .await
     .map_err(|e| internal_error(anyhow::anyhow!("{e}")))?
     .map_err(internal_error)?;
-    Ok(Json(result))
+    Ok(Json(analytics::paginate_breakdown(result, limit)))
 }
 
 pub async fn analytics_branch_detail(
@@ -523,8 +540,11 @@ pub struct TicketDetailParams {
 
 pub async fn analytics_tickets(
     Query(params): Query<TicketListParams>,
-) -> Result<Json<Vec<analytics::TicketCost>>, (StatusCode, Json<serde_json::Value>)> {
-    let limit = params.limit.unwrap_or(20).min(200);
+) -> Result<
+    Json<analytics::BreakdownPage<analytics::TicketCost>>,
+    (StatusCode, Json<serde_json::Value>),
+> {
+    let limit = resolve_breakdown_limit(params.limit);
     let filters = parse_dimension_filters(&params.filters);
     let result = tokio::task::spawn_blocking(move || {
         let db_path = analytics::db_path()?;
@@ -534,14 +554,14 @@ pub async fn analytics_tickets(
             params.since.as_deref(),
             params.until.as_deref(),
             &filters,
-            limit,
+            analytics::BREAKDOWN_FETCH_ALL_LIMIT,
         )
     })
     .await
     .map_err(|e| internal_error(anyhow::anyhow!("{e}")))?
     .map_err(internal_error)?;
 
-    Ok(Json(result))
+    Ok(Json(analytics::paginate_breakdown(result, limit)))
 }
 
 pub async fn analytics_ticket_detail(
@@ -597,8 +617,11 @@ pub struct ActivityDetailParams {
 
 pub async fn analytics_activities(
     Query(params): Query<ActivityListParams>,
-) -> Result<Json<Vec<analytics::ActivityCost>>, (StatusCode, Json<serde_json::Value>)> {
-    let limit = params.limit.unwrap_or(20).min(200);
+) -> Result<
+    Json<analytics::BreakdownPage<analytics::ActivityCost>>,
+    (StatusCode, Json<serde_json::Value>),
+> {
+    let limit = resolve_breakdown_limit(params.limit);
     let filters = parse_dimension_filters(&params.filters);
     let result = tokio::task::spawn_blocking(move || {
         let db_path = analytics::db_path()?;
@@ -608,14 +631,14 @@ pub async fn analytics_activities(
             params.since.as_deref(),
             params.until.as_deref(),
             &filters,
-            limit,
+            analytics::BREAKDOWN_FETCH_ALL_LIMIT,
         )
     })
     .await
     .map_err(|e| internal_error(anyhow::anyhow!("{e}")))?
     .map_err(internal_error)?;
 
-    Ok(Json(result))
+    Ok(Json(analytics::paginate_breakdown(result, limit)))
 }
 
 pub async fn analytics_activity_detail(
@@ -673,8 +696,11 @@ pub struct FileDetailParams {
 
 pub async fn analytics_files(
     Query(params): Query<FileListParams>,
-) -> Result<Json<Vec<analytics::FileCost>>, (StatusCode, Json<serde_json::Value>)> {
-    let limit = params.limit.unwrap_or(20).min(200);
+) -> Result<
+    Json<analytics::BreakdownPage<analytics::FileCost>>,
+    (StatusCode, Json<serde_json::Value>),
+> {
+    let limit = resolve_breakdown_limit(params.limit);
     let filters = parse_dimension_filters(&params.filters);
     let result = tokio::task::spawn_blocking(move || {
         let db_path = analytics::db_path()?;
@@ -684,14 +710,14 @@ pub async fn analytics_files(
             params.since.as_deref(),
             params.until.as_deref(),
             &filters,
-            limit,
+            analytics::BREAKDOWN_FETCH_ALL_LIMIT,
         )
     })
     .await
     .map_err(|e| internal_error(anyhow::anyhow!("{e}")))?
     .map_err(internal_error)?;
 
-    Ok(Json(result))
+    Ok(Json(analytics::paginate_breakdown(result, limit)))
 }
 
 pub async fn analytics_file_detail(


### PR DESCRIPTION
## Summary

- Every `budi stats` breakdown (`--projects / --branches / --tickets / --activities / --files / --models / --tag`) now ships through a shared `BreakdownPage<T>` envelope that carries `rows`, an optional `other` truncation-tail aggregate, `total_cost_cents`, `total_rows`, `shown_rows`, and the effective `limit`. Contract: `sum(rows.cost_cents) + other.cost_cents == total_cost_cents`, to the cent, for every period and breakdown.
- Text output gains a `Total  $X  (M of N rows shown — pass --limit 0 for all)` footer plus an `(other — N more rows)` line when truncation occurs. JSON callers read the grand total from a single top-level key, so reconciliation no longer requires `| jq add`.
- New `--limit N` flag on `budi stats` (default 30, `0` = unlimited). The daemon fetches the full ranked set (`BREAKDOWN_FETCH_ALL_LIMIT = 1_000_000` rows) and slices it in `paginate_breakdown`, so no SQL query rewrite was needed and `(untagged)` buckets remain part of the ranking.
- Fixes the #448 reproduction: on the maintainer's machine `--files 30d` previously underreported cost by ~9%; it now reconciles to the cent.

## Risks / compatibility notes

- **Wire format change** — `GET /analytics/{projects,branches,tickets,activities,files,models,tags}` used to return a bare JSON array and now returns `{ rows, other?, total_cost_cents, total_rows, shown_rows, limit }`. Scripts that parsed the top-level array need to read `.rows` (or `.rows + .other` for reconciliation). This is a deliberate breaking change per the ticket's acceptance criteria ("JSON output includes `total_cost_cents` at the top level") and is the release-blocker for 8.3; the CLI and dashboard are updated in the same PR.
- No schema migration, no DB changes, no new runtime dependencies, no new shell-profile or config-file mutation paths.
- `paginate_breakdown` accepts a `Vec<T>` the daemon has already fetched in full; performance impact is one extra pass over the ranked-row vec per request (bounded by the number of distinct dimension values in the window — hundreds, not millions).
- `SOUL.md` gets a new "Breakdown envelope" subsection documenting the shared wire format; no ADR change is required.

## Validation

- `cargo fmt --all`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked` — 566 tests pass, including 10 new reconciliation tests in `analytics/tests.rs`:
  - `breakdown_{tickets,files,activities,projects,branches,models,tags}_reconcile_with_other_row_when_truncated` — seed ≥ 33 distinct dimensions, cap at 30, assert `sum(rows) + other == total_cost_cents` to the cent.
  - `paginate_breakdown_no_truncation_when_rows_fit` — `limit=0` means unlimited, `other` stays `None`.
  - `breakdown_tickets_reconcile_across_today_7d_and_30d` — plants cohorts at `now - 1h`, `- 3d`, `- 20d`, queries each window separately, asserts reconciliation in all three.
  - `breakdown_other_label_is_stable_wire_value` — guards `(other)` as a load-bearing string for downstream tooling.
- `cargo deny check` not re-run — no `Cargo.toml` / `Cargo.lock` changes.

Closes #448