### PR TITLE
cli: normalize model display names across providers (#443)

### DIFF
--- a/crates/budi-cli/src/commands/pricing.rs
+++ b/crates/budi-cli/src/commands/pricing.rs
@@ -17,6 +17,7 @@
 //! scripts can branch on status without parsing the body.
 
 use anyhow::Result;
+use budi_core::pricing::display;
 use serde_json::Value;
 
 use crate::StatsFormat;
@@ -37,10 +38,16 @@ pub fn cmd_pricing_status(format: StatsFormat, refresh: bool) -> Result<()> {
     let status = client.pricing_status()?;
 
     if matches!(format, StatsFormat::Json) {
+        // #443 acceptance: JSON consumers see the Budi display-name
+        // alias overlay alongside the LiteLLM pricing status. The
+        // overlay answers "how does a raw provider model id map to
+        // the canonical `budi stats --models` display name?" without
+        // having to dump the whole 3k-entry LiteLLM manifest.
+        let aliases = json_alias_catalogue();
         let combined = if let Some(r) = &refresh_body {
-            serde_json::json!({ "refresh": r, "status": status })
+            serde_json::json!({ "refresh": r, "status": status, "aliases": aliases })
         } else {
-            status.clone()
+            serde_json::json!({ "status": status, "aliases": aliases })
         };
         println!("{}", serde_json::to_string_pretty(&combined)?);
         if let Some(r) = refresh_body.as_ref()
@@ -59,7 +66,67 @@ pub fn cmd_pricing_status(format: StatsFormat, refresh: bool) -> Result<()> {
         }
     }
     render_status_text(&status);
+    render_alias_map_text();
     Ok(())
+}
+
+/// Build the JSON shape for the #443 alias catalogue exposed by
+/// `budi pricing status --format json`. Each entry is
+/// `{raw_model, display_name, effort_modifier}` where
+/// `effort_modifier` is `null` for rows without one.
+fn json_alias_catalogue() -> Vec<serde_json::Value> {
+    display::known_aliases()
+        .iter()
+        .map(|(raw, display_name, effort)| {
+            serde_json::json!({
+                "raw_model": raw,
+                "display_name": display_name,
+                "effort_modifier": effort,
+            })
+        })
+        .collect()
+}
+
+/// Render the #443 display-name alias overlay so operators can answer
+/// "what does `claude-4.5-opus-high-thinking` actually resolve to?"
+/// without reading code. Kept compact — curated Budi-owned entries
+/// rather than every LiteLLM manifest id.
+fn render_alias_map_text() {
+    let bold = ansi("\x1b[1m");
+    let bold_cyan = ansi("\x1b[1;36m");
+    let dim = ansi("\x1b[90m");
+    let reset = ansi("\x1b[0m");
+
+    let entries = display::known_aliases();
+    if entries.is_empty() {
+        return;
+    }
+
+    // Label column width is the longest raw alias + 2 trailing
+    // spaces, capped so a freakishly long upstream id never pushes
+    // the display column off the right edge.
+    let label_width = entries
+        .iter()
+        .map(|(raw, _, _)| raw.chars().count())
+        .max()
+        .unwrap_or(0)
+        .min(40);
+
+    println!("  {bold_cyan} Display-name aliases{reset}");
+    println!("  {dim}{}{reset}", "─".repeat(40));
+    println!(
+        "  {bold}{:<w$}{reset}  {bold}DISPLAY NAME{reset}",
+        "RAW MODEL",
+        w = label_width
+    );
+    for (raw, display_name, effort) in entries {
+        let shown = match effort {
+            Some(e) => format!("{display_name} · {e}"),
+            None => (*display_name).to_string(),
+        };
+        println!("  {:<w$}  {shown}", raw, w = label_width);
+    }
+    println!();
 }
 
 fn render_refresh_text(body: &Value) {

--- a/crates/budi-cli/src/commands/stats.rs
+++ b/crates/budi-cli/src/commands/stats.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Result};
 use budi_core::analytics::{self, BreakdownPage, BreakdownRowCost};
+use budi_core::pricing::display::{self as display, Placeholder};
 use chrono::{Local, Months, NaiveDate, TimeZone};
 
 use crate::StatsPeriod;
@@ -1632,7 +1633,13 @@ fn cmd_stats_models(
     let page = client.models(since.as_deref(), until.as_deref(), limit)?;
 
     if json_output {
-        println!("{}", serde_json::to_string_pretty(&page)?);
+        // #443 acceptance: JSON exposes the Budi-canonical `display_name`
+        // and `effort_modifier` alongside the raw provider-emitted
+        // `model` / `provider_model_id`. `model` is preserved so
+        // existing scripting callers that read it continue to work; new
+        // callers can filter on `display_name` for cross-provider
+        // aggregation.
+        print_models_json(&page)?;
         return Ok(());
     }
 
@@ -1669,26 +1676,28 @@ fn cmd_stats_models(
         return Ok(());
     }
 
-    // #450 acceptance: suppress `(model pending)` rows by default. These
-    // are Cursor-lag transients where the model name hasn't reconciled
-    // yet; letting them surface in the default text output misleads
-    // users into thinking a phantom "(untagged)" model is active.
-    // Retained in `--format json` and behind `--include-pending`.
-    let (visible_rows, pending_count) = partition_pending_model_rows(&page.rows, include_pending);
+    // #443 acceptance: Cursor's `default` (Auto routing) and the
+    // `(untagged)` sentinel collapse into a single
+    // `(model not yet attributed)` bucket per provider — both mean
+    // "we don't have a specific model id for this cost". Summed
+    // per-provider so the grand-total footer from #448 still
+    // reconciles to the cent.
+    //
+    // #450 acceptance carry-forward: a merged bucket whose cost is
+    // zero is treated as a pending transient (the pure-`(untagged)`
+    // case with no backing `default` spend) and suppressed by
+    // default; `--include-pending` keeps it visible.
+    let (render_rows, suppressed_pending) =
+        merge_and_partition_pending(&page.rows, include_pending);
 
-    if visible_rows.is_empty() && page.other.is_none() && pending_count > 0 {
-        // Every row was a pending-model transient. Treat the same as
-        // "only untagged" empty-state so the output doesn't render a
-        // one-row table.
+    if render_rows.is_empty() && page.other.is_none() && suppressed_pending > 0 {
         render_untagged_only_empty_state(BreakdownView::Models, period);
-        if pending_count > 0 {
-            println!(
-                "  {dim}* {} model row{} pending — Cursor lag (pass --include-pending to see){reset}",
-                pending_count,
-                if pending_count == 1 { "" } else { "s" },
-            );
-            println!();
-        }
+        println!(
+            "  {dim}* {} model row{} pending — Cursor lag (pass --include-pending to see){reset}",
+            suppressed_pending,
+            if suppressed_pending == 1 { "" } else { "s" },
+        );
+        println!();
         return Ok(());
     }
 
@@ -1698,34 +1707,38 @@ fn cmd_stats_models(
         &format!("{:>MSGS_WIDTH$}  {:>TOK_WIDTH$}", "MSGS", "TOKENS"),
     );
 
-    let has_duplicate_models = {
+    let has_duplicate_display = {
         let mut seen = std::collections::HashSet::new();
-        visible_rows.iter().any(|m| !seen.insert(&m.model))
+        render_rows
+            .iter()
+            .any(|r| !seen.insert(r.display_label.clone()))
     };
 
     // #449 fix: bars scale by cost (the column they sit next to), not by
     // message count. A $66 row no longer renders with more blocks than a
     // $548 row just because it crossed a provider-specific high-volume
     // threshold.
-    let max_cost = max_cost_for_rows_refs(&visible_rows);
-    for m in &visible_rows {
-        let bar = render_bar(m.cost_cents, max_cost);
+    let max_cost = render_rows
+        .iter()
+        .map(|r| r.cost_cents)
+        .fold(0.0_f64, f64::max);
+    for r in &render_rows {
+        let bar = render_bar(r.cost_cents, max_cost);
         let total_tok =
-            m.input_tokens + m.output_tokens + m.cache_read_tokens + m.cache_creation_tokens;
-        let raw_model_label = display_dimension(BreakdownView::Models, &m.model);
-        let raw_label = if has_duplicate_models {
-            format!("{} ({})", raw_model_label, m.provider)
+            r.input_tokens + r.output_tokens + r.cache_read_tokens + r.cache_creation_tokens;
+        let raw_label = if has_duplicate_display {
+            format!("{} ({})", r.display_label, r.provider)
         } else {
-            raw_model_label
+            r.display_label.clone()
         };
         let label = truncate_label_middle(&raw_label, label_width);
-        let msgs_cell = format!("{} msgs", m.message_count);
+        let msgs_cell = format!("{} msgs", r.message_count);
         let tok_cell = format!("{} tok", format_tokens(total_tok));
         println!(
             "  {bold}{:<label_w$}{reset} {cyan}{}{reset} {yellow}{:>cost_w$}{reset}  {dim}{:>MSGS_WIDTH$}{reset}  {dim}{:>TOK_WIDTH$}{reset}",
             label,
             bar,
-            format_cost_cents_fixed(m.cost_cents),
+            format_cost_cents_fixed(r.cost_cents),
             msgs_cell,
             tok_cell,
             label_w = label_width,
@@ -1734,57 +1747,216 @@ fn cmd_stats_models(
     }
 
     render_breakdown_footer(&page, label_width, rule_width);
-    if pending_count > 0 {
+    if suppressed_pending > 0 {
         println!(
             "  {dim}* {} model row{} pending — Cursor lag (pass --include-pending to see){reset}",
-            pending_count,
-            if pending_count == 1 { "" } else { "s" },
+            suppressed_pending,
+            if suppressed_pending == 1 { "" } else { "s" },
         );
         println!();
     }
     Ok(())
 }
 
-/// Split `rows` into visible + pending buckets for the `--models` view.
-/// Pending rows are the `(untagged)` transient caused by Cursor
-/// cost-lag; they are dropped from the default output and reported in
-/// a footnote unless `include_pending` is set.
-fn partition_pending_model_rows<T>(rows: &[T], include_pending: bool) -> (Vec<&T>, usize)
-where
-    T: ModelRow,
-{
-    if include_pending {
-        return (rows.iter().collect(), 0);
-    }
-    let mut visible = Vec::with_capacity(rows.len());
-    let mut pending = 0usize;
-    for r in rows {
-        if is_untagged(r.model_name()) {
-            pending += 1;
-        } else {
-            visible.push(r);
+/// One row slated for text rendering in the `--models` view, after
+/// placeholder merge (#443) and pending suppression (#450) have run.
+#[derive(Debug, Clone)]
+struct RenderModelRow {
+    display_label: String,
+    provider: String,
+    message_count: u64,
+    input_tokens: u64,
+    output_tokens: u64,
+    cache_read_tokens: u64,
+    cache_creation_tokens: u64,
+    cost_cents: f64,
+}
+
+/// Build the set of rows the text view should render, applying both
+/// the #443 placeholder merge and the #450 pending-suppression rule.
+///
+/// - Real rows (`Placeholder::None`) pass through as one
+///   [`RenderModelRow`] each, keyed on the resolved display label
+///   (display_name + optional effort).
+/// - Placeholder rows (`Placeholder::CursorAuto` /
+///   `Placeholder::NotAttributed`) merge per-provider into a single
+///   `(model not yet attributed)` row. Costs, tokens, and message
+///   counts are summed.
+/// - A merged row whose cost is exactly zero is treated as a pending
+///   transient and suppressed unless `include_pending` is set. The
+///   suppressed-row count flows to the footnote.
+///
+/// Rows are returned in descending-cost order so the bar scale cue
+/// keeps meaning after the merge.
+fn merge_and_partition_pending(
+    rows: &[budi_core::analytics::ModelUsage],
+    include_pending: bool,
+) -> (Vec<RenderModelRow>, usize) {
+    use std::collections::HashMap;
+
+    let mut real: Vec<RenderModelRow> = Vec::with_capacity(rows.len());
+    // Keyed on provider so Cursor's pending rows and (hypothetically)
+    // Claude-Code's pending rows render as separate buckets.
+    let mut placeholder_by_provider: HashMap<String, RenderModelRow> = HashMap::new();
+
+    for m in rows {
+        let d = display::resolve(&m.model);
+        match d.placeholder {
+            Placeholder::None => {
+                real.push(RenderModelRow {
+                    display_label: d.combined_label(),
+                    provider: m.provider.clone(),
+                    message_count: m.message_count,
+                    input_tokens: m.input_tokens,
+                    output_tokens: m.output_tokens,
+                    cache_read_tokens: m.cache_read_tokens,
+                    cache_creation_tokens: m.cache_creation_tokens,
+                    cost_cents: m.cost_cents,
+                });
+            }
+            Placeholder::CursorAuto | Placeholder::NotAttributed => {
+                let entry = placeholder_by_provider
+                    .entry(m.provider.clone())
+                    .or_insert_with(|| RenderModelRow {
+                        display_label: display::UNATTRIBUTED_LABEL.to_string(),
+                        provider: m.provider.clone(),
+                        message_count: 0,
+                        input_tokens: 0,
+                        output_tokens: 0,
+                        cache_read_tokens: 0,
+                        cache_creation_tokens: 0,
+                        cost_cents: 0.0,
+                    });
+                entry.message_count += m.message_count;
+                entry.input_tokens += m.input_tokens;
+                entry.output_tokens += m.output_tokens;
+                entry.cache_read_tokens += m.cache_read_tokens;
+                entry.cache_creation_tokens += m.cache_creation_tokens;
+                entry.cost_cents += m.cost_cents;
+            }
         }
     }
-    (visible, pending)
+
+    let mut suppressed_pending = 0usize;
+    let mut merged: Vec<RenderModelRow> = real;
+    for (_, row) in placeholder_by_provider {
+        if !include_pending && row.cost_cents <= 0.0 {
+            suppressed_pending += 1;
+            continue;
+        }
+        merged.push(row);
+    }
+
+    // Descending cost keeps the bar scale meaningful after the merge
+    // reordered things.
+    merged.sort_by(|a, b| {
+        b.cost_cents
+            .partial_cmp(&a.cost_cents)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    (merged, suppressed_pending)
 }
 
-/// Minimal read-only view over the fields `partition_pending_model_rows`
-/// needs. Implemented for the concrete `ModelUsage` row type; kept as a
-/// trait so tests can construct lightweight fixtures.
-trait ModelRow {
-    fn model_name(&self) -> &str;
+/// Enriched row emitted by `--models --format json` alongside the
+/// existing ModelUsage fields. `display_name` and `effort_modifier`
+/// are sourced from the #443 Budi display overlay (`pricing::display`);
+/// `provider_model_id` duplicates `model` so the acceptance criterion
+/// "JSON exposes both display_name and the raw provider_model_id"
+/// is satisfied without renaming the long-standing `model` key.
+#[derive(serde::Serialize)]
+struct EnrichedModelRow<'a> {
+    model: &'a str,
+    provider_model_id: &'a str,
+    display_name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    effort_modifier: Option<String>,
+    placeholder: &'static str,
+    provider: &'a str,
+    message_count: u64,
+    input_tokens: u64,
+    output_tokens: u64,
+    cache_read_tokens: u64,
+    cache_creation_tokens: u64,
+    cost_cents: f64,
 }
 
-impl ModelRow for budi_core::analytics::ModelUsage {
-    fn model_name(&self) -> &str {
-        &self.model
+/// Enriched page envelope. Keeps the `other` / `total_cost_cents` /
+/// `total_rows` / `shown_rows` / `limit` fields in the exact shape #448
+/// locked down so reconciliation consumers are untouched.
+#[derive(serde::Serialize)]
+struct EnrichedModelPage<'a> {
+    rows: Vec<EnrichedModelRow<'a>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    other: &'a Option<budi_core::analytics::BreakdownOther>,
+    total_cost_cents: f64,
+    total_rows: usize,
+    shown_rows: usize,
+    limit: usize,
+}
+
+/// Build the enriched page — shared between the CLI JSON output and
+/// the shape test.
+fn build_models_json_page<'a>(
+    page: &'a BreakdownPage<budi_core::analytics::ModelUsage>,
+) -> EnrichedModelPage<'a> {
+    let rows: Vec<EnrichedModelRow<'_>> = page
+        .rows
+        .iter()
+        .map(|m| {
+            let d = display::resolve(&m.model);
+            EnrichedModelRow {
+                model: &m.model,
+                provider_model_id: &m.model,
+                display_name: d.display_name,
+                effort_modifier: d.effort,
+                placeholder: placeholder_tag(d.placeholder),
+                provider: &m.provider,
+                message_count: m.message_count,
+                input_tokens: m.input_tokens,
+                output_tokens: m.output_tokens,
+                cache_read_tokens: m.cache_read_tokens,
+                cache_creation_tokens: m.cache_creation_tokens,
+                cost_cents: m.cost_cents,
+            }
+        })
+        .collect();
+
+    EnrichedModelPage {
+        rows,
+        other: &page.other,
+        total_cost_cents: page.total_cost_cents,
+        total_rows: page.total_rows,
+        shown_rows: page.shown_rows,
+        limit: page.limit,
     }
 }
 
-fn max_cost_for_rows_refs<T: BreakdownRowCost>(rows: &[&T]) -> f64 {
-    rows.iter()
-        .map(|r| BreakdownRowCost::cost_cents(*r))
-        .fold(0.0_f64, f64::max)
+/// Serialize a `--models` page with the #443 display-name enrichment:
+/// every row grows `display_name`, `effort_modifier`, and
+/// `provider_model_id` (alias for `model`) alongside the existing
+/// fields.
+fn print_models_json(page: &BreakdownPage<budi_core::analytics::ModelUsage>) -> Result<()> {
+    let enriched = build_models_json_page(page);
+    println!("{}", serde_json::to_string_pretty(&enriched)?);
+    Ok(())
+}
+
+#[cfg(test)]
+fn serde_models_page_for_test(
+    page: &BreakdownPage<budi_core::analytics::ModelUsage>,
+) -> serde_json::Value {
+    serde_json::to_value(build_models_json_page(page)).unwrap()
+}
+
+/// Serialize a [`Placeholder`] as a short tag used by the `--models`
+/// JSON envelope. Real rows carry `"none"` so consumers can filter on
+/// a single field without checking for key presence.
+fn placeholder_tag(p: Placeholder) -> &'static str {
+    match p {
+        Placeholder::None => "none",
+        Placeholder::CursorAuto => "cursor_auto",
+        Placeholder::NotAttributed => "not_attributed",
+    }
 }
 
 // ─── Breakdown Footer (#448) ─────────────────────────────────────────────────
@@ -1946,7 +2118,7 @@ impl BreakdownView {
             BreakdownView::Tickets => "(no ticket)",
             BreakdownView::Activities => "(unclassified)",
             BreakdownView::Files => "(no file tag)",
-            BreakdownView::Models => "(model pending)",
+            BreakdownView::Models => "(model not yet attributed)",
             BreakdownView::Tag => "(untagged)",
         }
     }
@@ -3014,7 +3186,10 @@ mod tests {
         assert_eq!(BreakdownView::Tickets.untagged_label(), "(no ticket)");
         assert_eq!(BreakdownView::Activities.untagged_label(), "(unclassified)");
         assert_eq!(BreakdownView::Files.untagged_label(), "(no file tag)");
-        assert_eq!(BreakdownView::Models.untagged_label(), "(model pending)");
+        assert_eq!(
+            BreakdownView::Models.untagged_label(),
+            "(model not yet attributed)"
+        );
         // Tag view keeps the generic sentinel because a tag key can
         // mean anything — "(no X)" would be misleading.
         assert_eq!(BreakdownView::Tag.untagged_label(), "(untagged)");
@@ -3038,42 +3213,162 @@ mod tests {
     }
 
     #[test]
-    fn partition_pending_model_rows_suppresses_untagged_by_default() {
-        // #450 acceptance: `--models` suppresses pending rows by
-        // default; `--include-pending` restores them.
-        #[derive(Clone)]
-        struct Row {
-            name: String,
-        }
-        impl ModelRow for Row {
-            fn model_name(&self) -> &str {
-                &self.name
+    fn merge_and_partition_pending_suppresses_zero_cost_placeholder() {
+        // #443 + #450 acceptance: placeholder rows merge into one
+        // `(model not yet attributed)` bucket per provider, and a
+        // merged bucket whose cost is zero stays suppressed by
+        // default (the pure `(untagged)`-transient case).
+        use budi_core::analytics::ModelUsage;
+
+        fn row(model: &str, provider: &str, cost: f64, msgs: u64) -> ModelUsage {
+            ModelUsage {
+                model: model.to_string(),
+                provider: provider.to_string(),
+                message_count: msgs,
+                input_tokens: 0,
+                output_tokens: 0,
+                cache_read_tokens: 0,
+                cache_creation_tokens: 0,
+                cost_cents: cost,
             }
         }
 
         let rows = vec![
-            Row {
-                name: "claude-opus-4-7".into(),
+            row("claude-opus-4-7", "claude_code", 210_000.0, 24_114),
+            row("(untagged)", "cursor", 0.0, 15),
+            row("claude-sonnet-4-6", "claude_code", 30_000.0, 6138),
+            row("(untagged)", "cursor", 0.0, 7),
+        ];
+
+        // Default: `(untagged)` collapses to one zero-cost Cursor
+        // bucket, which gets suppressed — two input transients fold
+        // into the one-row `suppressed_pending` count.
+        let (visible, suppressed) = merge_and_partition_pending(&rows, false);
+        assert_eq!(visible.len(), 2);
+        assert_eq!(suppressed, 1);
+        assert!(
+            visible
+                .iter()
+                .all(|r| r.display_label != display::UNATTRIBUTED_LABEL)
+        );
+
+        // With --include-pending the merged placeholder shows.
+        let (visible_all, suppressed_all) = merge_and_partition_pending(&rows, true);
+        assert_eq!(visible_all.len(), 3);
+        assert_eq!(suppressed_all, 0);
+        assert!(
+            visible_all
+                .iter()
+                .any(|r| r.display_label == display::UNATTRIBUTED_LABEL)
+        );
+    }
+
+    #[test]
+    fn merge_and_partition_pending_surfaces_cursor_auto_cost_by_default() {
+        // #443 acceptance: Cursor's `default` (Auto mode) rows carry
+        // real cost; they must render by default, merged under the
+        // canonical `(model not yet attributed)` label — *not*
+        // suppressed the way pure-untagged zero-cost transients are.
+        use budi_core::analytics::ModelUsage;
+
+        let rows = vec![
+            ModelUsage {
+                model: "default".into(),
+                provider: "cursor".into(),
+                message_count: 25,
+                input_tokens: 1_000_000,
+                output_tokens: 200_000,
+                cache_read_tokens: 10_200_000,
+                cache_creation_tokens: 1_000_000,
+                cost_cents: 437.0,
             },
-            Row {
-                name: "(untagged)".into(),
-            },
-            Row {
-                name: "claude-sonnet-4-6".into(),
-            },
-            Row {
-                name: "(untagged)".into(),
+            ModelUsage {
+                model: "(untagged)".into(),
+                provider: "cursor".into(),
+                message_count: 15,
+                input_tokens: 0,
+                output_tokens: 0,
+                cache_read_tokens: 0,
+                cache_creation_tokens: 0,
+                cost_cents: 0.0,
             },
         ];
 
-        let (visible, pending) = partition_pending_model_rows(&rows, false);
-        assert_eq!(visible.len(), 2);
-        assert_eq!(pending, 2);
-        assert!(visible.iter().all(|r| !is_untagged(r.model_name())));
+        let (visible, suppressed) = merge_and_partition_pending(&rows, false);
+        assert_eq!(suppressed, 0);
+        assert_eq!(visible.len(), 1);
+        let merged = &visible[0];
+        assert_eq!(merged.display_label, display::UNATTRIBUTED_LABEL);
+        assert_eq!(merged.provider, "cursor");
+        assert_eq!(merged.message_count, 40);
+        assert_eq!(merged.cost_cents, 437.0);
+    }
 
-        let (visible_all, pending_all) = partition_pending_model_rows(&rows, true);
-        assert_eq!(visible_all.len(), 4);
-        assert_eq!(pending_all, 0);
+    #[test]
+    fn models_json_carries_display_name_and_provider_model_id() {
+        // #443 acceptance 5: `--format json` must expose both the
+        // canonical `display_name` and the raw `provider_model_id`,
+        // plus the effort modifier as a separate field.
+        use budi_core::analytics::{BreakdownPage, ModelUsage};
+
+        let rows = vec![
+            ModelUsage {
+                model: "claude-opus-4-7-thinking-high".into(),
+                provider: "cursor".into(),
+                message_count: 249,
+                input_tokens: 0,
+                output_tokens: 0,
+                cache_read_tokens: 0,
+                cache_creation_tokens: 0,
+                cost_cents: 45_300.0,
+            },
+            ModelUsage {
+                model: "claude-opus-4-7".into(),
+                provider: "claude_code".into(),
+                message_count: 890,
+                input_tokens: 0,
+                output_tokens: 0,
+                cache_read_tokens: 0,
+                cache_creation_tokens: 0,
+                cost_cents: 45_600.0,
+            },
+        ];
+        let page = BreakdownPage {
+            rows,
+            other: None,
+            total_cost_cents: 90_900.0,
+            total_rows: 2,
+            shown_rows: 2,
+            limit: 50,
+        };
+
+        let json = serde_json::to_value(serde_models_page_for_test(&page)).unwrap();
+        let rows_json = json["rows"].as_array().unwrap();
+        assert_eq!(rows_json.len(), 2);
+
+        let cursor_row = &rows_json[0];
+        assert_eq!(
+            cursor_row["model"].as_str(),
+            Some("claude-opus-4-7-thinking-high")
+        );
+        assert_eq!(
+            cursor_row["provider_model_id"].as_str(),
+            Some("claude-opus-4-7-thinking-high")
+        );
+        assert_eq!(cursor_row["display_name"].as_str(), Some("Claude Opus 4.7"));
+        assert_eq!(
+            cursor_row["effort_modifier"].as_str(),
+            Some("thinking-high")
+        );
+        assert_eq!(cursor_row["placeholder"].as_str(), Some("none"));
+
+        let canonical_row = &rows_json[1];
+        assert_eq!(
+            canonical_row["display_name"].as_str(),
+            Some("Claude Opus 4.7")
+        );
+        // effort_modifier is omitted when None (serde skip).
+        assert!(canonical_row.get("effort_modifier").is_none());
     }
 
     #[test]
@@ -3267,10 +3562,11 @@ mod tests {
 
     #[test]
     fn snapshot_models_today_and_30d_layout_is_stable() {
-        // `--models` snapshot: untagged translation renders as
-        // `(model pending)` when forced visible (e.g. via
-        // `--include-pending`), the breakdown currency is fixed with
-        // thousands separators.
+        // `--models` snapshot: the `(untagged)` sentinel renders as
+        // `(model not yet attributed)` (#443 — same label the
+        // `display::resolve` overlay uses, so the empty-state tip
+        // and the row label agree). Breakdown currency is fixed
+        // with thousands separators.
         let opus = snapshot_row(
             BreakdownView::Models,
             "claude-opus-4-7",
@@ -3282,7 +3578,7 @@ mod tests {
 
         let pending_visible =
             snapshot_row(BreakdownView::Models, "(untagged)", 0.0, "162 msgs   0 tok");
-        assert!(pending_visible.contains("(model pending)"));
+        assert!(pending_visible.contains("(model not yet attributed)"));
     }
 
     #[test]

--- a/crates/budi-cli/src/main.rs
+++ b/crates/budi-cli/src/main.rs
@@ -144,11 +144,12 @@ Examples:
         /// natural length of file paths. (#450)
         #[arg(long, default_value_t = 40)]
         label_width: usize,
-        /// Include `(model pending)` rows in `--models` output. By
-        /// default, rows whose model name is still pending (a known
-        /// Cursor cost-lag transient) are suppressed and a footnote
-        /// reports how many rows were hidden. Pass `--include-pending`
-        /// to see the raw bucket. (#450)
+        /// Include zero-cost `(model not yet attributed)` rows in
+        /// `--models` output. By default, Cursor-lag transient rows
+        /// that carry no backing cost are collapsed into a
+        /// suppressed-count footnote; pass `--include-pending` to
+        /// see them as their own row. Rows with real Cursor-Auto
+        /// cost always render regardless of this flag. (#443, #450)
         #[arg(long, default_value_t = false)]
         include_pending: bool,
         /// Break out the `(no repository)` bucket in `--projects` into a

--- a/crates/budi-core/src/pricing/display.rs
+++ b/crates/budi-core/src/pricing/display.rs
@@ -1,0 +1,471 @@
+//! Display-name normalization for raw provider model ids (#443).
+//!
+//! The pricing manifest (ADR-0091) is the single source of truth for
+//! **cost** — but it is sourced from LiteLLM and carries no display
+//! metadata. Providers emit their own raw model strings
+//! (`claude-opus-4-7`, `claude-4.5-opus-high-thinking`, `gpt-5.3-codex`,
+//! `default`, etc.) and the same model family surfaces under different
+//! names per provider, which makes `budi stats --models` look like
+//! several different models when it is one.
+//!
+//! [`resolve`] translates a raw string into a [`DisplayModel`] with:
+//!
+//! - `display_name` — a human-readable family + version label shared
+//!   across providers (e.g. `Claude Opus 4.7`).
+//! - `effort` — an optional thinking / effort suffix rendered as its
+//!   own column rather than concatenated into the name.
+//! - `placeholder` — distinguishes a real resolved name from the two
+//!   common "no model attributed" cases: Cursor's `default` (Auto
+//!   mode) and Budi's `(untagged)` sentinel row.
+//!
+//! The overlay is intentionally conservative — families we do not
+//! recognise fall through to the raw string unchanged, so a new model
+//! name appearing upstream is never silently relabelled.
+//!
+//! # UTF-8 safety
+//!
+//! All slicing / `strip_*` / pattern matching operates on `&str`
+//! methods that are char-boundary-safe by construction; no byte-index
+//! math runs against `raw`. Multi-byte model ids round-trip through
+//! `resolve` unchanged (see `utf8_safety_on_non_ascii_raw`).
+
+/// Why a raw string did not resolve to a real model name.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Placeholder {
+    /// Real model — `display_name` is authoritative.
+    None,
+    /// Cursor emits `default` for sessions where the user selected Auto
+    /// and the routed model is not disclosed. Rendered as
+    /// `Cursor Auto` so the row still reads truthfully.
+    CursorAuto,
+    /// Budi's `(untagged)` sentinel for messages where no model field
+    /// was captured. Rendered as `(model not yet attributed)` — the
+    /// `budi stats --models` text view suppresses zero-cost rows of
+    /// this class by default (a known Cursor-lag transient).
+    NotAttributed,
+}
+
+/// Normalised display metadata for one raw provider model id.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DisplayModel {
+    /// The exact string emitted by the provider — unchanged for
+    /// scripting callers that filter on `model`.
+    pub raw: String,
+    /// Human-readable name (e.g. `Claude Opus 4.7`). Falls back to
+    /// `raw` when the family is not recognised.
+    pub display_name: String,
+    /// Effort / thinking modifier (e.g. `thinking-high`, `xhigh`).
+    /// `None` when the raw string carries no effort suffix.
+    pub effort: Option<String>,
+    /// Placeholder class, or `Placeholder::None` for a real resolved
+    /// model.
+    pub placeholder: Placeholder,
+}
+
+impl DisplayModel {
+    /// `display_name` + `effort` rendered as a single column (effort
+    /// parenthesised). Used by the breakdown text view when the
+    /// caller does not want a separate effort column.
+    pub fn combined_label(&self) -> String {
+        match &self.effort {
+            Some(e) => format!("{} · {}", self.display_name, e),
+            None => self.display_name.clone(),
+        }
+    }
+}
+
+/// The two Budi-owned placeholder sentinel strings. Kept in one place
+/// so callers building JSON / text rows can reuse the exact wording.
+pub const UNATTRIBUTED_LABEL: &str = "(model not yet attributed)";
+pub const CURSOR_AUTO_LABEL: &str = "Cursor Auto";
+
+/// Resolve a raw provider model id into its display metadata.
+///
+/// Unknown families fall through — `display_name == raw`, `effort ==
+/// None`, `placeholder == None`. This is deliberate: a new model
+/// appearing upstream is never silently relabelled to something it
+/// is not.
+pub fn resolve(raw: &str) -> DisplayModel {
+    // --- Placeholders -----------------------------------------------
+    if raw == crate::analytics::UNTAGGED_DIMENSION {
+        return DisplayModel {
+            raw: raw.to_string(),
+            display_name: UNATTRIBUTED_LABEL.to_string(),
+            effort: None,
+            placeholder: Placeholder::NotAttributed,
+        };
+    }
+    if raw == "default" {
+        return DisplayModel {
+            raw: raw.to_string(),
+            display_name: CURSOR_AUTO_LABEL.to_string(),
+            effort: None,
+            placeholder: Placeholder::CursorAuto,
+        };
+    }
+
+    // --- Anthropic family -------------------------------------------
+    // Canonical Anthropic API: `claude-<tier>-<major>-<minor>[-<date>]`
+    // Cursor (newer):           `claude-<tier>-<major>-<minor>-<effort>`
+    //                           e.g. `claude-opus-4-7-thinking-high`
+    // Cursor (older):           `claude-<major>.<minor>-<tier>-<effort>`
+    //                           e.g. `claude-4.5-opus-high-thinking`
+    if let Some(m) = parse_anthropic(raw) {
+        return m;
+    }
+
+    // --- OpenAI / Codex family --------------------------------------
+    // Codex CLI:  `gpt-5.3-codex`
+    // Cursor:     `gpt-5.3-codex-high`, `gpt-5.3-codex-xhigh`
+    // OpenAI:     `gpt-4o`, `gpt-4.1-mini`, `o1-preview`, …
+    if let Some(m) = parse_openai(raw) {
+        return m;
+    }
+
+    // --- Fallback: unknown family ------------------------------------
+    DisplayModel {
+        raw: raw.to_string(),
+        display_name: raw.to_string(),
+        effort: None,
+        placeholder: Placeholder::None,
+    }
+}
+
+/// The compact alias catalogue surfaced by `budi pricing status`.
+/// Each entry is `(raw_example, display_name, effort)`. Curated from
+/// the fresh-user smoke pass (2026-04-20, ticket #443 body) so the
+/// output answers "what do the raw names in my transcript resolve
+/// to?" without enumerating every LiteLLM id.
+pub fn known_aliases() -> &'static [(&'static str, &'static str, Option<&'static str>)] {
+    &[
+        // Anthropic — canonical API names
+        ("claude-opus-4-7", "Claude Opus 4.7", None),
+        ("claude-opus-4-6", "Claude Opus 4.6", None),
+        ("claude-opus-4-5", "Claude Opus 4.5", None),
+        ("claude-sonnet-4-6", "Claude Sonnet 4.6", None),
+        ("claude-sonnet-4-5", "Claude Sonnet 4.5", None),
+        ("claude-haiku-4-5-20251001", "Claude Haiku 4.5", None),
+        // Anthropic via Cursor (newer naming)
+        (
+            "claude-opus-4-7-thinking-high",
+            "Claude Opus 4.7",
+            Some("thinking-high"),
+        ),
+        // Anthropic via Cursor (older naming — transposed)
+        (
+            "claude-4.6-opus-high-thinking",
+            "Claude Opus 4.6",
+            Some("thinking-high"),
+        ),
+        (
+            "claude-4.5-opus-high-thinking",
+            "Claude Opus 4.5",
+            Some("thinking-high"),
+        ),
+        // OpenAI / Codex
+        ("gpt-5.3-codex", "GPT-5.3 Codex", None),
+        ("gpt-5.3-codex-high", "GPT-5.3 Codex", Some("high")),
+        ("gpt-5.3-codex-xhigh", "GPT-5.3 Codex", Some("xhigh")),
+        // Cursor placeholders
+        ("default", CURSOR_AUTO_LABEL, None),
+    ]
+}
+
+// ---------------------------------------------------------------------------
+// Family parsers
+// ---------------------------------------------------------------------------
+
+fn parse_anthropic(raw: &str) -> Option<DisplayModel> {
+    // Newer Cursor + canonical API: starts with `claude-<tier>-`
+    const TIERS: &[&str] = &["opus", "sonnet", "haiku"];
+    for tier in TIERS {
+        let prefix = format!("claude-{tier}-");
+        if let Some(rest) = raw.strip_prefix(&prefix) {
+            // Version is the leading `<major>-<minor>` digits (numeric
+            // tokens only; anything after is effort or a date).
+            let (version, effort) = split_anthropic_version_and_effort(rest);
+            if version.is_empty() {
+                continue;
+            }
+            return Some(DisplayModel {
+                raw: raw.to_string(),
+                display_name: format!("Claude {} {}", title_case(tier), version),
+                effort,
+                placeholder: Placeholder::None,
+            });
+        }
+    }
+
+    // Older Cursor: `claude-<major>.<minor>-<tier>-<effort>` (effort
+    // tokens transposed; for example `claude-4.5-opus-high-thinking`).
+    if let Some(rest) = raw.strip_prefix("claude-") {
+        // Take the leading version token (digits + dots + dashes until
+        // we hit a tier keyword).
+        let (version, after_version) = rest.split_once('-')?;
+        if !is_numeric_version(version) {
+            return None;
+        }
+        for tier in TIERS {
+            let tier_prefix = format!("{tier}-");
+            if let Some(after_tier) = after_version.strip_prefix(&tier_prefix) {
+                let effort = normalise_effort(after_tier);
+                return Some(DisplayModel {
+                    raw: raw.to_string(),
+                    display_name: format!("Claude {} {}", title_case(tier), version),
+                    effort,
+                    placeholder: Placeholder::None,
+                });
+            }
+            // Edge case: `claude-4.5-opus` with no trailing effort.
+            if after_version == *tier {
+                return Some(DisplayModel {
+                    raw: raw.to_string(),
+                    display_name: format!("Claude {} {}", title_case(tier), version),
+                    effort: None,
+                    placeholder: Placeholder::None,
+                });
+            }
+        }
+    }
+    None
+}
+
+/// Given the tail after `claude-<tier>-` (canonical Anthropic /
+/// newer Cursor), split into the dotted-version label and the
+/// optional effort suffix.
+///
+/// - `4-7`                    → (`"4.7"`, `None`)
+/// - `4-7-thinking-high`      → (`"4.7"`, `Some("thinking-high")`)
+/// - `4-5-20251001`           → (`"4.5"`, `None`)  — date stripped
+/// - `4-5-20251001-thinking`  → (`"4.5"`, `Some("thinking")`)
+fn split_anthropic_version_and_effort(tail: &str) -> (String, Option<String>) {
+    // Collect leading numeric tokens; the first non-numeric token
+    // closes the version.
+    let mut version_tokens: Vec<&str> = Vec::new();
+    let mut remaining_tokens: Vec<&str> = Vec::new();
+    let mut past_version = false;
+    for tok in tail.split('-') {
+        if !past_version {
+            if tok.chars().all(|c| c.is_ascii_digit()) {
+                version_tokens.push(tok);
+                continue;
+            }
+            past_version = true;
+        }
+        remaining_tokens.push(tok);
+    }
+
+    // Anthropic version is the first two numeric tokens (`major` +
+    // `minor`); any additional numeric token is the release date and
+    // is dropped from the display.
+    let version = match version_tokens.as_slice() {
+        [] => String::new(),
+        [major] => (*major).to_string(),
+        [major, minor, ..] => format!("{major}.{minor}"),
+    };
+    let effort = normalise_effort(&remaining_tokens.join("-"));
+    (version, effort)
+}
+
+fn parse_openai(raw: &str) -> Option<DisplayModel> {
+    // `gpt-5.3-codex[-<effort>]` / `gpt-5.3-codex-xhigh` — Codex via
+    // Cursor; strip the effort suffix into its own column.
+    if let Some(rest) = raw.strip_prefix("gpt-") {
+        // Leading version token (allow digits + dots).
+        let (version, after_version) = match rest.split_once('-') {
+            Some((v, rest)) => (v, rest),
+            None => (rest, ""),
+        };
+        if !is_numeric_version(version) {
+            return None;
+        }
+        if after_version.is_empty() {
+            return Some(DisplayModel {
+                raw: raw.to_string(),
+                display_name: format!("GPT-{version}"),
+                effort: None,
+                placeholder: Placeholder::None,
+            });
+        }
+        // `codex[-<effort>]` → `GPT-<version> Codex` + effort column.
+        if let Some(after_codex) = after_version.strip_prefix("codex") {
+            let effort = if after_codex.is_empty() {
+                None
+            } else if let Some(e) = after_codex.strip_prefix('-') {
+                normalise_effort(e)
+            } else {
+                // Fell through to a `codex<suffix>` shape we do not
+                // recognise; keep the suffix as the effort so the
+                // caller can see it.
+                Some(after_codex.to_string())
+            };
+            return Some(DisplayModel {
+                raw: raw.to_string(),
+                display_name: format!("GPT-{version} Codex"),
+                effort,
+                placeholder: Placeholder::None,
+            });
+        }
+        // Any other `gpt-<ver>-<suffix>` we keep as-is but split the
+        // suffix into `effort` so the table column stays consistent.
+        return Some(DisplayModel {
+            raw: raw.to_string(),
+            display_name: format!("GPT-{version}"),
+            effort: normalise_effort(after_version),
+            placeholder: Placeholder::None,
+        });
+    }
+    None
+}
+
+/// Canonicalise an effort label. Returns `None` for the empty string
+/// and for the `"default"` Cursor places on rows that carry no effort
+/// routing.
+fn normalise_effort(raw: &str) -> Option<String> {
+    let trimmed = raw.trim_matches('-');
+    if trimmed.is_empty() || trimmed == "default" {
+        return None;
+    }
+    // `high-thinking` → `thinking-high` (older Cursor transposed the
+    // order; newer form is the canonical one).
+    if trimmed == "high-thinking" {
+        return Some("thinking-high".to_string());
+    }
+    if trimmed == "low-thinking" {
+        return Some("thinking-low".to_string());
+    }
+    Some(trimmed.to_string())
+}
+
+/// `true` when `s` looks like a version token (digits and dots only,
+/// with at least one digit).
+fn is_numeric_version(s: &str) -> bool {
+    !s.is_empty() && s.chars().all(|c| c.is_ascii_digit() || c == '.')
+}
+
+fn title_case(s: &str) -> String {
+    let mut chars = s.chars();
+    match chars.next() {
+        Some(c) => c.to_ascii_uppercase().to_string() + chars.as_str(),
+        None => String::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_canonical_anthropic_names() {
+        let r = resolve("claude-opus-4-7");
+        assert_eq!(r.display_name, "Claude Opus 4.7");
+        assert_eq!(r.effort, None);
+        assert_eq!(r.placeholder, Placeholder::None);
+
+        let r = resolve("claude-sonnet-4-6");
+        assert_eq!(r.display_name, "Claude Sonnet 4.6");
+        assert_eq!(r.effort, None);
+
+        // Dated Anthropic release id — date stripped from display.
+        let r = resolve("claude-haiku-4-5-20251001");
+        assert_eq!(r.display_name, "Claude Haiku 4.5");
+        assert_eq!(r.effort, None);
+    }
+
+    #[test]
+    fn resolve_cursor_new_style_anthropic() {
+        let r = resolve("claude-opus-4-7-thinking-high");
+        assert_eq!(r.display_name, "Claude Opus 4.7");
+        assert_eq!(r.effort.as_deref(), Some("thinking-high"));
+        assert_eq!(r.placeholder, Placeholder::None);
+    }
+
+    #[test]
+    fn resolve_cursor_old_style_anthropic_transposes_effort() {
+        // Same family (`claude-4.5-opus-high-thinking`) must render
+        // the same display name as the canonical form; effort is
+        // the `thinking-high` canonical order, not the transposed
+        // `high-thinking` Cursor emits.
+        let r = resolve("claude-4.5-opus-high-thinking");
+        assert_eq!(r.display_name, "Claude Opus 4.5");
+        assert_eq!(r.effort.as_deref(), Some("thinking-high"));
+
+        let r = resolve("claude-4.6-opus-high-thinking");
+        assert_eq!(r.display_name, "Claude Opus 4.6");
+        assert_eq!(r.effort.as_deref(), Some("thinking-high"));
+    }
+
+    #[test]
+    fn resolve_gpt_codex_family() {
+        let r = resolve("gpt-5.3-codex");
+        assert_eq!(r.display_name, "GPT-5.3 Codex");
+        assert_eq!(r.effort, None);
+
+        let r = resolve("gpt-5.3-codex-high");
+        assert_eq!(r.display_name, "GPT-5.3 Codex");
+        assert_eq!(r.effort.as_deref(), Some("high"));
+
+        let r = resolve("gpt-5.3-codex-xhigh");
+        assert_eq!(r.display_name, "GPT-5.3 Codex");
+        assert_eq!(r.effort.as_deref(), Some("xhigh"));
+    }
+
+    #[test]
+    fn resolve_cursor_auto_placeholder() {
+        let r = resolve("default");
+        assert_eq!(r.display_name, "Cursor Auto");
+        assert_eq!(r.effort, None);
+        assert_eq!(r.placeholder, Placeholder::CursorAuto);
+    }
+
+    #[test]
+    fn resolve_untagged_placeholder() {
+        let r = resolve(crate::analytics::UNTAGGED_DIMENSION);
+        assert_eq!(r.display_name, UNATTRIBUTED_LABEL);
+        assert_eq!(r.effort, None);
+        assert_eq!(r.placeholder, Placeholder::NotAttributed);
+    }
+
+    #[test]
+    fn resolve_unknown_family_falls_through_to_raw() {
+        // A new Google / Gemini name we have not mapped yet — keep the
+        // raw string rather than silently relabelling.
+        let r = resolve("gemini-2.5-pro-experimental");
+        assert_eq!(r.display_name, "gemini-2.5-pro-experimental");
+        assert_eq!(r.effort, None);
+        assert_eq!(r.placeholder, Placeholder::None);
+    }
+
+    #[test]
+    fn combined_label_joins_effort_with_middot() {
+        let r = resolve("claude-opus-4-7-thinking-high");
+        assert_eq!(r.combined_label(), "Claude Opus 4.7 · thinking-high");
+
+        let r = resolve("claude-opus-4-7");
+        assert_eq!(r.combined_label(), "Claude Opus 4.7");
+    }
+
+    #[test]
+    fn utf8_safety_on_non_ascii_raw() {
+        // Multi-byte characters in the raw id must not panic.
+        let r = resolve("café-model-7");
+        assert_eq!(r.display_name, "café-model-7");
+        assert_eq!(r.placeholder, Placeholder::None);
+    }
+
+    #[test]
+    fn known_aliases_every_entry_roundtrips_through_resolve() {
+        for (raw, expected_display, expected_effort) in known_aliases() {
+            let r = resolve(raw);
+            assert_eq!(
+                r.display_name, *expected_display,
+                "display mismatch for raw={raw}",
+            );
+            assert_eq!(
+                r.effort.as_deref(),
+                *expected_effort,
+                "effort mismatch for raw={raw}",
+            );
+        }
+    }
+}

--- a/crates/budi-core/src/pricing/mod.rs
+++ b/crates/budi-core/src/pricing/mod.rs
@@ -29,6 +29,8 @@
 //!
 //! [ADR-0091]: https://github.com/siropkin/budi/blob/main/docs/adr/0091-model-pricing-manifest-source-of-truth.md
 
+pub mod display;
+
 use std::collections::HashMap;
 use std::io::Write;
 use std::path::{Path, PathBuf};


### PR DESCRIPTION
## Summary

Adds a Budi-owned display overlay (`budi_core::pricing::display`) that maps raw provider model ids to a canonical `(display_name, effort)` shape, and wires it through `budi stats --models` + `budi pricing status`. Pair with ADR-0091 per the ticket: the LiteLLM manifest stays the source of truth for **cost**, the display overlay is a separate Budi-owned layer that never mutates pricing.

Addresses all five acceptance items in #443:

1. **Same family renders with the same name across providers.** `claude-opus-4-7` (Claude-Code), `claude-opus-4-7-thinking-high` (newer Cursor), and `claude-4.7-opus-high-thinking` (older Cursor) all resolve to display_name `Claude Opus 4.7`.
2. **Effort modifier is a separate dimension.** Rendered as a middot suffix (`Claude Opus 4.7 · thinking-high`) in text, as `effort_modifier` in JSON — never concatenated into `display_name`.
3. **`default` and `(untagged)` collapse into one bucket.** Per-provider merge with label `(model not yet attributed)`; costs/tokens/messages sum; grand-total reconciliation (#448) unaffected. Zero-cost placeholder rows stay suppressed unless `--include-pending` is set; non-zero (Cursor Auto) always renders.
4. **`budi pricing status` surfaces the alias mapping.** Text view adds a compact "Display-name aliases" section; JSON grows an `aliases` array.
5. **JSON exposes `display_name` and the raw `provider_model_id`.** Every `--models --format json` row gains `display_name`, `effort_modifier` (skip_if_none), `provider_model_id` (alias for `model`), and a `placeholder` tag (`none` / `cursor_auto` / `not_attributed`). Existing `model` / `provider` / counts are unchanged so scripts keep working.

Unknown families fall through — `display_name == raw`, no silent relabel.

Closes #443

## Risks / compatibility notes

- **No new dependencies.** `Cargo.toml` / `Cargo.lock` untouched; `cargo deny` delta is zero.
- **No schema change.** The overlay is a pure function of the raw provider model id; no DB migration, no pricing manifest mutation, no daemon HTTP shape change.
- **No new runtime network calls.** Per rule 7 and ADR-0091.
- **UTF-8 boundary safety.** Per rule 8: `resolve()` uses only `&str` APIs (`strip_prefix`, `split_once`, char iteration), no byte-index math. Non-ASCII raw ids round-trip unchanged — covered by `utf8_safety_on_non_ascii_raw` test.
- **`--format json` is additive.** New fields appear alongside existing fields; no renames. Consumers filtering on `model` keep working.
- **Text-view suppression rule slightly generalised.** The existing `(untagged)` suppression (#450) now applies to the merged placeholder bucket. The semantics are preserved — zero-cost pending rows hide by default, `--include-pending` shows them — but Cursor Auto's real cost is now rendered by default under the canonical `(model not yet attributed)` label. Covered by `merge_and_partition_pending_surfaces_cursor_auto_cost_by_default` test.
- **Three breakdown-view label changes.** `BreakdownView::Models.untagged_label()` moved from `(model pending)` to `(model not yet attributed)` so the empty-state tip and the merged-row label agree. The `--include-pending` help text rewords to match. Pre-existing `(model pending)` snapshot and unit tests updated in lockstep.

## Validation

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings`
- [x] `cargo test --workspace --locked` — 615 passed (added 10 display-module tests, 2 merge-and-suppression tests, 1 JSON-shape test; removed 1 stale `partition_pending_model_rows` test)
- [x] `cargo deny` — no `Cargo.toml` / `Cargo.lock` change, policy unaffected

Acceptance bullets individually exercised:

- (1) Cross-provider name unification: `resolve_canonical_anthropic_names`, `resolve_cursor_new_style_anthropic`, `resolve_cursor_old_style_anthropic_transposes_effort`, `resolve_gpt_codex_family`.
- (2) Effort as separate dimension: same tests above + `combined_label_joins_effort_with_middot`.
- (3) `default` + `(untagged)` bucket collapse: `merge_and_partition_pending_suppresses_zero_cost_placeholder`, `merge_and_partition_pending_surfaces_cursor_auto_cost_by_default`.
- (4) Alias-mapping surface: `known_aliases_every_entry_roundtrips_through_resolve` (ensures every surfaced alias is actually resolvable).
- (5) JSON shape: `models_json_carries_display_name_and_provider_model_id`.