### PR TITLE
cli: polish budi stats and budi sessions output (#445)

### DIFF
--- a/crates/budi-cli/src/commands/cloud.rs
+++ b/crates/budi-cli/src/commands/cloud.rs
@@ -184,7 +184,7 @@ pub fn cmd_cloud_sync(format: StatsFormat) -> Result<()> {
     let body = client.cloud_sync()?;
 
     if matches!(format, StatsFormat::Json) {
-        println!("{}", serde_json::to_string_pretty(&body)?);
+        super::print_json(&body)?;
         // Exit non-zero on non-ok result so scripts can branch on status.
         if body.get("ok").and_then(Value::as_bool) != Some(true) {
             std::process::exit(2);
@@ -205,7 +205,7 @@ pub fn cmd_cloud_status(format: StatsFormat) -> Result<()> {
     let body = client.cloud_status()?;
 
     if matches!(format, StatsFormat::Json) {
-        println!("{}", serde_json::to_string_pretty(&body)?);
+        super::print_json(&body)?;
         return Ok(());
     }
 

--- a/crates/budi-cli/src/commands/import.rs
+++ b/crates/budi-cli/src/commands/import.rs
@@ -116,7 +116,7 @@ pub fn cmd_import(force: bool, json: bool) -> Result<()> {
                 }))
                 .collect::<Vec<_>>(),
         });
-        println!("{}", serde_json::to_string_pretty(&body)?);
+        super::print_json(&body)?;
         return Ok(());
     }
 

--- a/crates/budi-cli/src/commands/mod.rs
+++ b/crates/budi-cli/src/commands/mod.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use budi_core::config;
+use serde::Serialize;
 use serde_json::Value;
 
 pub mod autostart;
@@ -127,6 +128,79 @@ pub fn try_resolve_repo_root(candidate: Option<PathBuf>) -> Option<PathBuf> {
     config::find_repo_root(&cwd).ok()
 }
 
+// ---------------------------------------------------------------------------
+// CLI JSON output helpers (#445)
+// ---------------------------------------------------------------------------
+//
+// Every `budi` subcommand that emits `--format json` flows through
+// [`print_json`] so the user-visible output obeys one contract:
+//
+//   - Any JSON field whose key ends in `_cents` serialises as an
+//     integer (rounded half-to-even via `f64::round`). A raw
+//     `f64 cost_cents` on an internal struct surfaces over the wire
+//     as `151767`, not `151766.7552219369` — cents are cents.
+//
+// The normalisation runs on the serialised `serde_json::Value` rather
+// than on the source structs so the internal math can stay in `f64`
+// (where cost pipelines accumulate fractional cents) without forcing
+// every struct to adopt a custom serialiser. Nested objects and
+// arrays are walked recursively.
+
+/// Walk `value` in place and round every numeric field whose key ends
+/// in `_cents` to an integer. Non-numeric values at those keys are
+/// left unchanged. Returns the mutated reference for chaining.
+pub fn round_cents_to_integer(value: &mut Value) -> &mut Value {
+    match value {
+        Value::Object(map) => {
+            for (k, v) in map.iter_mut() {
+                if is_cents_key(k)
+                    && let Some(n) = v.as_f64()
+                {
+                    *v = Value::from(n.round() as i64);
+                    continue;
+                }
+                round_cents_to_integer(v);
+            }
+        }
+        Value::Array(arr) => {
+            for v in arr.iter_mut() {
+                round_cents_to_integer(v);
+            }
+        }
+        _ => {}
+    }
+    value
+}
+
+fn is_cents_key(key: &str) -> bool {
+    key.ends_with("_cents")
+}
+
+/// Serialize `value` as pretty JSON and print it to stdout with the
+/// CLI cents normalisation applied. All `budi` commands that emit
+/// `--format json` should route through this helper so the contract
+/// stays consistent.
+pub fn print_json<T: Serialize>(value: &T) -> Result<()> {
+    let mut v = serde_json::to_value(value).context("serialise to JSON value")?;
+    round_cents_to_integer(&mut v);
+    let out = serde_json::to_string_pretty(&v).context("serialise JSON value to string")?;
+    println!("{out}");
+    Ok(())
+}
+
+/// Compact variant of [`print_json`] for single-line surfaces like
+/// `budi statusline --format json`, where the downstream consumer
+/// (Cursor extension, cloud dashboard, user's starship prompt)
+/// expects a single-line payload but still benefits from the cents
+/// normalisation.
+pub fn print_json_compact<T: Serialize>(value: &T) -> Result<()> {
+    let mut v = serde_json::to_value(value).context("serialise to JSON value")?;
+    round_cents_to_integer(&mut v);
+    let out = serde_json::to_string(&v).context("serialise JSON value to string")?;
+    println!("{out}");
+    Ok(())
+}
+
 /// Format a cost value in dollars: $1.2K, $123, $12.50, $0.42, $0.00
 pub fn format_cost(dollars: f64) -> String {
     if dollars >= 1000.0 {
@@ -179,5 +253,86 @@ mod tests {
         }
         assert!(found_backup, "expected invalid-json backup file");
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // --- round_cents_to_integer (#445 item 4) -----------------------
+
+    #[test]
+    fn round_cents_rounds_ten_digit_float_to_integer() {
+        // The exact regression from #445 item 4: a raw `f64 cents`
+        // value round-trips through serde_json as a 10-digit float
+        // (`151766.7552219369`). After normalisation it must be an
+        // integer `151767`.
+        let mut v = serde_json::json!({ "total_cost_cents": 151766.7552219369 });
+        round_cents_to_integer(&mut v);
+        assert_eq!(v["total_cost_cents"], serde_json::json!(151767));
+    }
+
+    #[test]
+    fn round_cents_recurses_into_nested_objects() {
+        let mut v = serde_json::json!({
+            "summary": {
+                "cost_cents": 1234.567,
+                "input_cost": 12.5,
+            },
+            "breakdown": [
+                { "model": "a", "cost_cents": 100.5 },
+                { "model": "b", "cost_cents": 0.1 },
+                { "model": "c", "cost_cents": 99.49 },
+            ],
+            "window_start": "2026-04-01",
+        });
+        round_cents_to_integer(&mut v);
+        assert_eq!(v["summary"]["cost_cents"], serde_json::json!(1235));
+        // Non-cents fields must be untouched — `input_cost` stays
+        // fractional dollars.
+        assert_eq!(v["summary"]["input_cost"], serde_json::json!(12.5));
+        assert_eq!(v["breakdown"][0]["cost_cents"], serde_json::json!(101));
+        assert_eq!(v["breakdown"][1]["cost_cents"], serde_json::json!(0));
+        assert_eq!(v["breakdown"][2]["cost_cents"], serde_json::json!(99));
+        assert_eq!(v["window_start"], serde_json::json!("2026-04-01"));
+    }
+
+    #[test]
+    fn round_cents_preserves_already_integer_cents() {
+        // Consumers that already pass integer cents (e.g. after cache
+        // savings has been pre-rounded) must not see any change.
+        let mut v = serde_json::json!({ "cost_cents": 42 });
+        let before = v.clone();
+        round_cents_to_integer(&mut v);
+        assert_eq!(v, before);
+    }
+
+    #[test]
+    fn round_cents_ignores_non_numeric_cents_values() {
+        // If a `*_cents` field ever lands as non-numeric (null / string)
+        // the rounder must not panic or mutate it.
+        let mut v = serde_json::json!({
+            "total_cost_cents": serde_json::Value::Null,
+            "other_cents": "n/a",
+        });
+        let before = v.clone();
+        round_cents_to_integer(&mut v);
+        assert_eq!(v, before);
+    }
+
+    #[test]
+    fn round_cents_covers_cache_savings_and_avg_cost_keys() {
+        // Catalogued `*_cents` surfaces in the current
+        // analytics/queries.rs vocabulary: `cost_cents`,
+        // `total_cost_cents`, `cache_savings_cents`,
+        // `avg_cost_per_message_cents`. Every one of them matches
+        // the `_cents` suffix rule without hard-coding a list.
+        let mut v = serde_json::json!({
+            "cost_cents": 1.5,
+            "total_cost_cents": 1000.4,
+            "cache_savings_cents": 250.6,
+            "avg_cost_per_message_cents": 3.49,
+        });
+        round_cents_to_integer(&mut v);
+        assert_eq!(v["cost_cents"], serde_json::json!(2));
+        assert_eq!(v["total_cost_cents"], serde_json::json!(1000));
+        assert_eq!(v["cache_savings_cents"], serde_json::json!(251));
+        assert_eq!(v["avg_cost_per_message_cents"], serde_json::json!(3));
     }
 }

--- a/crates/budi-cli/src/commands/pricing.rs
+++ b/crates/budi-cli/src/commands/pricing.rs
@@ -49,7 +49,7 @@ pub fn cmd_pricing_status(format: StatsFormat, refresh: bool) -> Result<()> {
         } else {
             serde_json::json!({ "status": status, "aliases": aliases })
         };
-        println!("{}", serde_json::to_string_pretty(&combined)?);
+        super::print_json(&combined)?;
         if let Some(r) = refresh_body.as_ref()
             && r.get("ok").and_then(Value::as_bool) != Some(true)
         {

--- a/crates/budi-cli/src/commands/sessions.rs
+++ b/crates/budi-cli/src/commands/sessions.rs
@@ -1,10 +1,28 @@
 use anyhow::{Context, Result};
+use budi_core::pricing::display;
 
 use crate::StatsPeriod;
 use crate::client::DaemonClient;
 use crate::commands::stats::{format_cost_cents, format_tokens, period_date_range, period_label};
 
 use super::ansi;
+use super::print_json;
+
+/// Width budget for the model column in the text-view session list. The
+/// canonical display name (`pricing::display::combined_label`) rarely
+/// exceeds 26 chars for the model families we surface; the column stays
+/// wide enough to render the full canonical name without mid-word
+/// truncation under normal traffic, but still fits an 80-column
+/// terminal alongside repo + cost columns.
+const MODEL_COL_WIDTH: usize = 28;
+
+/// Short-UUID prefix length rendered by `budi sessions` by default
+/// (#445). `--full-uuid` surfaces the 36-char identifier for scripting
+/// and for `budi sessions <id>` lookup. Eight hex chars is long enough
+/// to remain unambiguous at the < 1M session scale Budi is designed
+/// around; the fresh-user smoke pass showed 36 chars dominating the
+/// visible row width.
+const SHORT_UUID_LEN: usize = 8;
 
 pub fn cmd_sessions(
     period: StatsPeriod,
@@ -12,6 +30,7 @@ pub fn cmd_sessions(
     ticket: Option<&str>,
     activity: Option<&str>,
     limit: usize,
+    full_uuid: bool,
     json_output: bool,
 ) -> Result<()> {
     let client = DaemonClient::connect().context(
@@ -30,7 +49,7 @@ pub fn cmd_sessions(
     )?;
 
     if json_output {
-        println!("{}", serde_json::to_string_pretty(&sessions)?);
+        print_json(&sessions)?;
         return Ok(());
     }
 
@@ -75,6 +94,7 @@ pub fn cmd_sessions(
         return Ok(());
     }
 
+    let mut has_extra_models = false;
     for s in &sessions.sessions {
         let time = s
             .started_at
@@ -87,13 +107,21 @@ pub fn cmd_sessions(
             })
             .unwrap_or_else(|| "--".to_string());
 
-        let model = s.models.first().map(|m| m.as_str()).unwrap_or("--");
-        let model_short = shorten_model(model);
-        let model_extra = if s.models.len() > 1 {
-            format!(" +{}", s.models.len() - 1)
+        let raw_model = s.models.first().map(|m| m.as_str()).unwrap_or("--");
+        let model_display = if raw_model == "--" {
+            "--".to_string()
+        } else {
+            display::resolve(raw_model).combined_label()
+        };
+        let extra_count = s.models.len().saturating_sub(1);
+        let model_extra = if extra_count > 0 {
+            has_extra_models = true;
+            format!(" +{extra_count}")
         } else {
             String::new()
         };
+        let model_cell =
+            truncate_on_char_boundary(&format!("{model_display}{model_extra}"), MODEL_COL_WIDTH);
 
         let repo = s
             .repo_ids
@@ -114,18 +142,25 @@ pub fn cmd_sessions(
             format_cost_cents(s.cost_cents)
         };
 
+        let id_cell = render_session_id(&s.id, full_uuid);
+
         println!(
-            "  {health} {dim}{time}{reset}  {dim}{}{reset}  {:<20}  {:<12}  {yellow}{:>8}{reset}",
-            &s.id,
-            format!("{model_short}{model_extra}"),
-            repo,
-            cost_str,
+            "  {health} {dim}{time}{reset}  {dim}{id_cell}{reset}  {model_cell:<width$}  {repo:<12}  {yellow}{cost_str:>8}{reset}",
+            width = MODEL_COL_WIDTH,
         );
     }
 
     let has_lag = sessions.sessions.iter().any(|s| s.cost_lag_hint.is_some());
     if has_lag {
         println!("  {dim}* {}{reset}", budi_core::analytics::CURSOR_LAG_HINT);
+    }
+    if has_extra_models {
+        // Footer legend for the `+N` notation surfaced in the model
+        // column. #445 acceptance: the undocumented compactor needs a
+        // one-line explanation rather than leaving readers to guess.
+        println!(
+            "  {dim}+N = N additional model(s) used in this session (pass --full-uuid and `budi sessions <id>` to see the full list){reset}"
+        );
     }
 
     if sessions.total_count > sessions.sessions.len() as u64 {
@@ -160,7 +195,7 @@ pub fn cmd_session_detail(session_id: &str, json_output: bool) -> Result<()> {
                 map.insert("health".to_string(), serde_json::to_value(&h)?);
             }
         }
-        println!("{}", serde_json::to_string_pretty(&obj)?);
+        print_json(&obj)?;
         return Ok(());
     }
 
@@ -291,9 +326,106 @@ fn format_duration_ms(ms: i64) -> String {
     }
 }
 
-fn shorten_model(model: &str) -> &str {
-    // Take last part after any slash (org/model → model)
-    let base = model.rsplit('/').next().unwrap_or(model);
-    // Truncate for display (max 20 chars)
-    if base.len() > 20 { &base[..20] } else { base }
+/// Render the session id cell. Default is the 8-char short form
+/// (#445); `--full-uuid` surfaces the complete identifier.
+///
+/// UTF-8 safety: the session id is produced by `uuid::Uuid::to_string`
+/// and is always ASCII hex + dashes, so ASCII-byte truncation is
+/// boundary-safe. The helper still uses char iteration rather than
+/// byte slicing so a future non-ASCII id shape (unlikely but not
+/// impossible) would not panic — the #389 / #383 / #404 bug class.
+fn render_session_id(id: &str, full_uuid: bool) -> String {
+    if full_uuid {
+        return id.to_string();
+    }
+    id.chars().take(SHORT_UUID_LEN).collect()
+}
+
+/// Truncate `s` to at most `max` characters (not bytes), appending an
+/// ellipsis when the string was actually shortened. Returns the input
+/// unchanged when it already fits. Used for the model column so a
+/// canonical display label that exceeds the column width degrades
+/// gracefully without slicing mid-codepoint.
+fn truncate_on_char_boundary(s: &str, max: usize) -> String {
+    if max == 0 {
+        return String::new();
+    }
+    let char_count = s.chars().count();
+    if char_count <= max {
+        return s.to_string();
+    }
+    let take = max.saturating_sub(1);
+    let mut out: String = s.chars().take(take).collect();
+    out.push('…');
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Tests (#445)
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn short_uuid_is_eight_chars_by_default() {
+        let id = "1d027675-4ad0-43b2-b396-88b6ee28f7ba";
+        let rendered = render_session_id(id, false);
+        assert_eq!(rendered, "1d027675");
+        assert_eq!(rendered.len(), SHORT_UUID_LEN);
+    }
+
+    #[test]
+    fn full_uuid_returns_unchanged_string() {
+        let id = "1d027675-4ad0-43b2-b396-88b6ee28f7ba";
+        let rendered = render_session_id(id, true);
+        assert_eq!(rendered, id);
+    }
+
+    #[test]
+    fn short_uuid_is_utf8_boundary_safe_on_non_ascii_id() {
+        // Regression guard for the #389 / #383 / #404 byte-slice bug
+        // class — a hypothetical non-ASCII session id must not panic
+        // even though canonical Budi ids are ASCII hex.
+        let id = "café-1234-5678-abcd";
+        let rendered = render_session_id(id, false);
+        // Eight chars — `c`, `a`, `f`, `é`, `-`, `1`, `2`, `3`.
+        assert_eq!(rendered.chars().count(), SHORT_UUID_LEN);
+    }
+
+    #[test]
+    fn truncate_on_char_boundary_preserves_short_strings() {
+        assert_eq!(
+            truncate_on_char_boundary("Claude Opus 4.7", 28),
+            "Claude Opus 4.7"
+        );
+    }
+
+    #[test]
+    fn truncate_on_char_boundary_uses_ellipsis_on_overflow() {
+        let out = truncate_on_char_boundary("Claude Opus 4.7 · thinking-high (experimental)", 28);
+        // Exactly 28 chars — 27 from the source + 1 ellipsis.
+        assert_eq!(out.chars().count(), 28);
+        assert!(out.ends_with('…'));
+        // Must not panic, must not slice mid-codepoint.
+        assert!(out.is_char_boundary(out.len()));
+    }
+
+    #[test]
+    fn truncate_on_char_boundary_handles_multibyte_codepoints() {
+        // Five-character string with four multi-byte codepoints
+        // followed by an ASCII byte. `max = 3` keeps two chars plus
+        // the ellipsis. The previous `shorten_model` implementation
+        // used byte indexing, which would have panicked on this.
+        let out = truncate_on_char_boundary("αβγδe", 3);
+        assert_eq!(out.chars().count(), 3);
+        assert!(out.ends_with('…'));
+        assert!(out.starts_with('α'));
+    }
+
+    #[test]
+    fn truncate_on_char_boundary_zero_max_returns_empty() {
+        assert_eq!(truncate_on_char_boundary("anything", 0), "");
+    }
 }

--- a/crates/budi-cli/src/commands/stats.rs
+++ b/crates/budi-cli/src/commands/stats.rs
@@ -471,7 +471,7 @@ pub fn cmd_stats(
             map.insert("window_start".to_string(), serde_json::json!(since));
             map.insert("window_end".to_string(), serde_json::json!(until));
         }
-        println!("{}", serde_json::to_string_pretty(&obj)?);
+        super::print_json(&obj)?;
         return Ok(());
     }
 
@@ -628,11 +628,21 @@ fn format_summary(
         summary.total_messages, summary.total_user_messages, summary.total_assistant_messages,
     )
     .unwrap();
+    // #445 item 5: the pre-8.3 summary showed only `{input} in, {output}
+    // out` while the per-agent rows above summed **all four** token
+    // components (input + output + cache-write + cache-read). Cursor
+    // traffic is cache-heavy, so the two lines appeared to disagree —
+    // `591.2M + 137.7M + 805.4M` on per-agent rows vs `89.9M in, 6.8M
+    // out` on the summary. Render every token component the per-agent
+    // total includes so the reader can reconcile them without reading
+    // the renderer source.
     writeln!(
         out,
-        "  {bold}Tokens{reset}       {} in, {} out",
+        "  {bold}Tokens{reset}       {} input · {} output · {} cache-write · {} cache-read",
         format_tokens(summary.total_input_tokens),
         format_tokens(summary.total_output_tokens),
+        format_tokens(summary.total_cache_creation_tokens),
+        format_tokens(summary.total_cache_read_tokens),
     )
     .unwrap();
 
@@ -737,9 +747,9 @@ fn cmd_stats_projects(
                 "repositories": &page,
                 "non_repo": &non_repo_rows,
             });
-            println!("{}", serde_json::to_string_pretty(&payload)?);
+            super::print_json(&payload)?;
         } else {
-            println!("{}", serde_json::to_string_pretty(&page)?);
+            super::print_json(&page)?;
         }
         return Ok(());
     }
@@ -834,7 +844,7 @@ fn cmd_stats_branches(
     let page = client.branches(since.as_deref(), until.as_deref(), limit)?;
 
     if json_output {
-        println!("{}", serde_json::to_string_pretty(&page)?);
+        super::print_json(&page)?;
         return Ok(());
     }
 
@@ -914,7 +924,7 @@ fn cmd_stats_branch_detail(
     let result = client.branch_detail(branch, repo, since.as_deref(), until.as_deref())?;
 
     if json_output {
-        println!("{}", serde_json::to_string_pretty(&result)?);
+        super::print_json(&result)?;
         return Ok(());
     }
 
@@ -983,7 +993,7 @@ fn cmd_stats_tickets(
     let page = client.tickets(since.as_deref(), until.as_deref(), limit)?;
 
     if json_output {
-        println!("{}", serde_json::to_string_pretty(&page)?);
+        super::print_json(&page)?;
         return Ok(());
     }
 
@@ -1088,7 +1098,7 @@ fn cmd_stats_ticket_detail(
     let result = client.ticket_detail(ticket, repo, since.as_deref(), until.as_deref())?;
 
     if json_output {
-        println!("{}", serde_json::to_string_pretty(&result)?);
+        super::print_json(&result)?;
         return Ok(());
     }
 
@@ -1186,7 +1196,7 @@ fn cmd_stats_activities(
     let page = client.activities(since.as_deref(), until.as_deref(), limit)?;
 
     if json_output {
-        println!("{}", serde_json::to_string_pretty(&page)?);
+        super::print_json(&page)?;
         return Ok(());
     }
 
@@ -1291,7 +1301,7 @@ fn cmd_stats_activity_detail(
     let result = client.activity_detail(activity, repo, since.as_deref(), until.as_deref())?;
 
     if json_output {
-        println!("{}", serde_json::to_string_pretty(&result)?);
+        super::print_json(&result)?;
         return Ok(());
     }
 
@@ -1421,7 +1431,7 @@ fn cmd_stats_files(
     let page = client.files(since.as_deref(), until.as_deref(), limit)?;
 
     if json_output {
-        println!("{}", serde_json::to_string_pretty(&page)?);
+        super::print_json(&page)?;
         return Ok(());
     }
 
@@ -1522,7 +1532,7 @@ fn cmd_stats_file_detail(
     let result = client.file_detail(file_path, repo, since.as_deref(), until.as_deref())?;
 
     if json_output {
-        println!("{}", serde_json::to_string_pretty(&result)?);
+        super::print_json(&result)?;
         return Ok(());
     }
 
@@ -1937,8 +1947,7 @@ fn build_models_json_page<'a>(
 /// fields.
 fn print_models_json(page: &BreakdownPage<budi_core::analytics::ModelUsage>) -> Result<()> {
     let enriched = build_models_json_page(page);
-    println!("{}", serde_json::to_string_pretty(&enriched)?);
-    Ok(())
+    super::print_json(&enriched)
 }
 
 #[cfg(test)]
@@ -2183,7 +2192,7 @@ fn cmd_stats_tags(
     let page = client.tags(Some(tag_filter), since.as_deref(), until.as_deref(), limit)?;
 
     if json_output {
-        println!("{}", serde_json::to_string_pretty(&page)?);
+        super::print_json(&page)?;
         return Ok(());
     }
 
@@ -2888,6 +2897,64 @@ mod tests {
                 rendered.contains("Cursor cost data may lag"),
                 "missing Cursor-lag footnote when Cursor is in providers (#451):\n{rendered}"
             );
+        }
+    }
+
+    #[test]
+    fn summary_tokens_row_reconciles_with_per_agent_totals() {
+        // #445 item 5: the per-agent rows in the Agents block render a
+        // token total that *includes* cache traffic (input + output +
+        // cache-write + cache-read). Before this fix the summary
+        // Tokens row only showed `{input} in, {output} out`, which
+        // looked like it disagreed with the per-agent row on cache-heavy
+        // workloads. Lock in the four-component shape so a future
+        // renderer change cannot silently regress the reconciliation.
+        let summary = fixture_summary();
+        let est = fixture_cost(0.0);
+        let providers = vec![fixture_provider(
+            "claude_code",
+            "Claude Code",
+            262,
+            summary.total_cost_cents,
+        )];
+        let palette = SummaryPalette::plain();
+        let rendered = format_summary(
+            StatsPeriod::Days(7),
+            None,
+            &summary,
+            &est,
+            &providers,
+            &palette,
+        );
+
+        // Every token component must appear on the Tokens line (not
+        // just input / output).
+        assert!(
+            rendered.contains("input"),
+            "summary missing input label:\n{rendered}"
+        );
+        assert!(
+            rendered.contains("output"),
+            "summary missing output label:\n{rendered}"
+        );
+        assert!(
+            rendered.contains("cache-write"),
+            "summary missing cache-write component (#445 reconciliation):\n{rendered}"
+        );
+        assert!(
+            rendered.contains("cache-read"),
+            "summary missing cache-read component (#445 reconciliation):\n{rendered}"
+        );
+
+        // The pre-#445 shape `<n> in, <n> out` must be gone so consumers
+        // can't rely on it and readers never see it.
+        for line in rendered.lines() {
+            if line.trim_start().starts_with("Tokens") {
+                assert!(
+                    !line.contains(" in, "),
+                    "legacy two-component Tokens line still renders: {line}"
+                );
+            }
         }
     }
 

--- a/crates/budi-cli/src/commands/statusline.rs
+++ b/crates/budi-cli/src/commands/statusline.rs
@@ -360,10 +360,10 @@ pub fn cmd_statusline(format: StatuslineFormat, provider: Option<String>) -> Res
 
     match format {
         StatuslineFormat::Json => {
-            println!(
-                "{}",
-                serde_json::to_string(&statusline_data).unwrap_or_default()
-            );
+            // #445 item 4: surface integer cents so downstream
+            // consumers (Cursor extension, cloud dashboard, starship
+            // templates) never see 10-digit fractional-cent floats.
+            let _ = super::print_json_compact(&statusline_data);
         }
         StatuslineFormat::Custom => {
             if let Some(ref template) = sl_config.format {

--- a/crates/budi-cli/src/main.rs
+++ b/crates/budi-cli/src/main.rs
@@ -245,6 +245,11 @@ Examples:
         /// Max sessions to show (default: 20)
         #[arg(long, default_value_t = 20)]
         limit: usize,
+        /// Render the full 36-character session UUID instead of the
+        /// 8-character short form (useful for scripting and for
+        /// `budi sessions <id>` lookup). #445.
+        #[arg(long, default_value_t = false)]
+        full_uuid: bool,
         /// Output format: text (default) or json
         #[arg(short, long, value_enum, default_value_t = StatsFormat::Text)]
         format: StatsFormat,
@@ -631,6 +636,7 @@ fn main() -> Result<()> {
             ticket,
             activity,
             limit,
+            full_uuid,
             format,
         } => {
             let json_output = matches!(format, StatsFormat::Json);
@@ -643,6 +649,7 @@ fn main() -> Result<()> {
                     ticket.as_deref(),
                     activity.as_deref(),
                     limit,
+                    full_uuid,
                     json_output,
                 )
             }

--- a/crates/budi-core/src/work_outcome.rs
+++ b/crates/budi-core/src/work_outcome.rs
@@ -129,7 +129,16 @@ pub struct WorkOutcomeInputs<'a> {
 pub fn derive_work_outcome(inputs: &WorkOutcomeInputs<'_>) -> WorkOutcome {
     let branch = inputs.branch.trim();
     if branch.is_empty() || crate::pipeline::is_integration_branch(branch) {
-        return WorkOutcome::unknown("no non-integration branch on session — nothing to correlate");
+        // #445 rewrite: the previous message ("no non-integration
+        // branch on session — nothing to correlate") was internal
+        // jargon — a fresh user has no mental model of what
+        // "integration branch" means, and the rationale suggested an
+        // action they could take even though the outcome is inherently
+        // un-derivable. Plain-language phrasing tells the reader why
+        // we showed "unknown" without implying they can change it.
+        return WorkOutcome::unknown(
+            "session wasn't tied to a feature branch, so no merge outcome can be inferred",
+        );
     }
     if !inputs.repo_root.exists() || !inputs.repo_root.join(".git").exists() {
         return WorkOutcome::unknown("repo_root is not a git working tree");
@@ -344,6 +353,37 @@ mod tests {
         assert_eq!(
             derive_work_outcome(&inputs).label,
             WorkOutcomeLabel::Unknown
+        );
+    }
+
+    #[test]
+    fn unknown_rationale_avoids_integration_branch_jargon() {
+        // #445 acceptance: the fresh-user smoke pass found the original
+        // rationale ("no non-integration branch on session — nothing
+        // to correlate") was unreadable — a new user has no mental
+        // model for what "integration branch" is and the wording
+        // implied they should take an action when the outcome is
+        // inherently un-derivable. Lock the jargon out.
+        let inputs = WorkOutcomeInputs {
+            repo_root: Path::new("/"),
+            branch: "main",
+            started_at: Utc::now(),
+            ended_at: Utc::now(),
+            grace: None,
+        };
+        let r = derive_work_outcome(&inputs).rationale;
+        assert!(
+            !r.contains("non-integration"),
+            "rationale still contains `non-integration` jargon: {r}"
+        );
+        assert!(
+            !r.contains("nothing to correlate"),
+            "rationale still contains the `nothing to correlate` phrasing: {r}"
+        );
+        // Must still name the underlying reason.
+        assert!(
+            r.contains("feature branch") || r.contains("merge outcome"),
+            "rationale no longer explains the reason: {r}"
         );
     }
 


### PR DESCRIPTION
## Summary

Bundles the six CLI output polish items surfaced by the 2026-04-20 fresh-user smoke pass (#445). Scope is tight by construction — every sub-item is one small change to one render / serialize site.

1. **`budi sessions` — short UUIDs + canonical model names (item 1).** Renders the 8-character UUID prefix by default with a new `--full-uuid` opt-in for scripting / `budi sessions <id>` lookup. Replaces the pre-#445 `shorten_model` byte-slice truncation with the canonical `pricing::display::combined_label()` from the #443 overlay, so `claude-opus-4-7-thinking-high` now renders as `Claude Opus 4.7 · thinking-high` (no mid-word cut). Column overflow now uses a char-boundary ellipsis (`truncate_on_char_boundary`) — the #389 / #383 / #404 UTF-8 bug class is guarded by a dedicated test on `café-1234-5678-abcd` and `αβγδe`.
2. **`+N` legend (item 2).** When any session row in the list renders the `+N` compactor (multi-model sessions), the page prints a one-line legend under the table: `+N = N additional model(s) used in this session (pass --full-uuid and budi sessions <id> to see the full list)`.
3. **Work-outcome rationale rewrite (item 3).** `work_outcome::derive_work_outcome` no longer emits `"no non-integration branch on session — nothing to correlate"` — the plain-language replacement reads *"session wasn't tied to a feature branch, so no merge outcome can be inferred"* and names the reason without implying the user can change it.
4. **Integer `*_cents` in JSON (item 4).** New `print_json` / `print_json_compact` helpers in `commands::mod` post-process the `serde_json::Value` to round every field whose key ends in `_cents` to an integer. Applied uniformly to: `budi stats` summary, every breakdown view (`--projects/--branches/--tickets/--activities/--files/--models/--tag`), every breakdown detail view, `budi sessions` (list + detail), `budi pricing status`, `budi cloud status/sync`, `budi db import --format json`, and `budi statusline --format json` (the shared status contract consumed by the Cursor extension and the cloud dashboard).
5. **`Tokens` row reconciliation (item 5).** The `budi stats` summary `Tokens` line now lists all four token components (`{input} input · {output} output · {cache-write} cache-write · {cache-read} cache-read`) so the reader can reconcile it against the per-agent rows (which have always summed cache traffic). The pre-#445 `{input} in, {output} out` shape is gone; a snapshot assertion guards against its reintroduction.
6. **Zero-token / zero-cost row suppression (item 6).** Already covered end-to-end by the #443 placeholder merge + #450 pending suppression logic in `merge_and_partition_pending` (reconciled by `merge_and_partition_pending_suppresses_zero_cost_placeholder` + `merge_and_partition_pending_surfaces_cursor_auto_cost_by_default`). No code change required for this item; the behavior is intentionally locked in by the pre-existing tests.

Closes #445

## Risks / compatibility notes

- **No new dependencies.** `Cargo.toml` / `Cargo.lock` untouched; `cargo deny` delta is zero.
- **No schema change.** All changes are in the render / serialize layer (plus one string rewrite in `work_outcome.rs`). No DB migration, no pricing manifest mutation, no daemon HTTP shape change.
- **No new runtime network calls.** Per rule 7 / ADR-0091.
- **UTF-8 boundary safety.** `render_session_id` and `truncate_on_char_boundary` both iterate `&str` chars; the legacy byte-slice `shorten_model(&base[..20])` is removed. Covered by `short_uuid_is_utf8_boundary_safe_on_non_ascii_id` and `truncate_on_char_boundary_handles_multibyte_codepoints` tests. The #389 / #383 / #404 / #445 UTF-8 bug class stays guarded.
- **JSON shape — integer `*_cents` is a narrowing change.** Any consumer that was relying on fractional cents (there should be none — cents by definition are integer) will now see an integer. The new contract is additive for readers (`151767` is exactly the previous value rounded half-to-even via `f64::round`) and the helper is robust to already-integer input (`round_cents_preserves_already_integer_cents`) and non-numeric values (`round_cents_ignores_non_numeric_cents_values`). All current internal consumers (the CLI itself, the Cursor extension, the cloud dashboard) treat this as a display value.
- **`budi sessions` default shape change.** The session id column renders at 8 chars instead of 36, and the model cell width expanded from 20 → 28 with ellipsis-aware truncation. Scripts that parse the text view need `--full-uuid` (the JSON output always carried full ids via `SessionListEntry.id` — unchanged). Legend footer only renders when at least one visible row uses `+N`.
- **Summary `Tokens` row shape change.** The pre-#445 `{input} in, {output} out` string is gone — any regex that matched the literal ` in, ` is no longer valid. The four-component shape (`{} input · {} output · {} cache-write · {} cache-read`) is self-documenting; an explicit assertion (`summary_tokens_row_reconciles_with_per_agent_totals`) locks it in.
- **Work-outcome rationale change.** The rationale string is surfaced by `budi sessions <id>` text and by the `session_detail --format json` payload (`work_outcome_rationale`). Any consumer grepping for the literal `"no non-integration branch on session"` or `"nothing to correlate"` needs updating. A regression test (`unknown_rationale_avoids_integration_branch_jargon`) enforces the new contract and catches accidental reintroduction.

## Validation

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings`
- [x] `cargo test --workspace --locked` — 629 tests pass (153 CLI + 439 core + 37 daemon); 14 new tests across `commands/sessions.rs`, `commands/mod.rs`, `commands/stats.rs`, and `budi-core/src/work_outcome.rs`.
- [x] No `Cargo.toml` / `Cargo.lock` change → `cargo deny` policy unaffected.

Targeted new tests, by item:

- **item 1 (short UUID + canonical names):** `short_uuid_is_eight_chars_by_default`, `full_uuid_returns_unchanged_string`, `short_uuid_is_utf8_boundary_safe_on_non_ascii_id`, `truncate_on_char_boundary_preserves_short_strings`, `truncate_on_char_boundary_uses_ellipsis_on_overflow`, `truncate_on_char_boundary_handles_multibyte_codepoints`, `truncate_on_char_boundary_zero_max_returns_empty`.
- **item 3 (jargon rewrite):** `unknown_rationale_avoids_integration_branch_jargon` (asserts both the forbidden substrings are absent and the replacement retains the reason).
- **item 4 (integer cents JSON):** `round_cents_rounds_ten_digit_float_to_integer`, `round_cents_recurses_into_nested_objects`, `round_cents_preserves_already_integer_cents`, `round_cents_ignores_non_numeric_cents_values`, `round_cents_covers_cache_savings_and_avg_cost_keys`.
- **item 5 (Tokens reconciliation):** `summary_tokens_row_reconciles_with_per_agent_totals`.
- **item 6 (zero-row suppression):** covered by pre-existing `merge_and_partition_pending_suppresses_zero_cost_placeholder` + `merge_and_partition_pending_surfaces_cursor_auto_cost_by_default` (no new test needed — the contract was already locked in by #443 / #450).