### PR TITLE
cli: remove installer residue left behind by budi uninstall (#439)

### DIFF
--- a/crates/budi-cli/src/commands/uninstall.rs
+++ b/crates/budi-cli/src/commands/uninstall.rs
@@ -1,9 +1,10 @@
 use std::fs;
 use std::io::IsTerminal;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use anyhow::{Context, Result};
+use budi_core::installer_residue;
 use budi_core::legacy_proxy;
 use serde_json::Value;
 
@@ -90,11 +91,9 @@ pub fn cmd_uninstall(keep_data: bool, yes: bool) -> Result<()> {
                     return Ok(());
                 }
             }
-            print!("Removing data... ");
             match remove_data() {
-                Ok(true) => println!("{green}✓{reset} removed"),
-                Ok(false) => println!("none found"),
-                Err(e) => println!("{yellow}warning: {e}{reset}"),
+                Ok(report) => print_data_removal(&report, green, yellow, reset),
+                Err(e) => println!("Removing data... {yellow}warning: {e}{reset}"),
             }
             print!("Removing config... ");
             match remove_config() {
@@ -107,7 +106,7 @@ pub fn cmd_uninstall(keep_data: bool, yes: bool) -> Result<()> {
         }
     }
 
-    // Remove autostart service (launchd / systemd / Task Scheduler)
+    // 8. Remove autostart service (launchd / systemd / Task Scheduler)
     {
         let mechanism = budi_core::autostart::service_mechanism();
         print!("Removing autostart service ({mechanism})... ");
@@ -117,6 +116,22 @@ pub fn cmd_uninstall(keep_data: bool, yes: bool) -> Result<()> {
             Err(e) => println!("{yellow}warning: {e}{reset}"),
         }
     }
+
+    // 9. Remove the autostart service log (macOS only — launchd writes
+    // StandardOutPath/StandardErrorPath outside the data dir).
+    if let Some(log_path) = budi_core::autostart::service_log_path() {
+        print!("Removing daemon log ({})... ", log_path.display());
+        match remove_file_if_exists(&log_path) {
+            Ok(true) => println!("{green}✓{reset} removed"),
+            Ok(false) => println!("none found"),
+            Err(e) => println!("{yellow}warning: {e}{reset}"),
+        }
+    }
+
+    // 10. Remove the `# Added by budi installer` block the standalone shell
+    // installer writes to the user's shell profile. Consent-first: on an
+    // interactive run we show the diff and ask per file unless --yes.
+    remove_installer_shell_residue(yes, green, yellow, reset)?;
 
     println!();
     println!("{green}✓{reset} budi uninstalled.");
@@ -351,13 +366,232 @@ fn remove_cursor_hooks(home: &str) -> Result<bool> {
     Ok(changed)
 }
 
-fn remove_data() -> Result<bool> {
+/// Per-entry summary of what was removed from the data dir.
+#[derive(Debug, Default)]
+struct DataRemovalReport {
+    data_dir: Option<PathBuf>,
+    /// Known contract files that existed and were removed (pretty names).
+    named_items: Vec<String>,
+    /// Count of extra entries beyond the named contract set.
+    extra_entry_count: usize,
+}
+
+impl DataRemovalReport {
+    fn missing(&self) -> bool {
+        self.data_dir.is_none()
+    }
+
+    fn total_entries(&self) -> usize {
+        self.named_items.len() + self.extra_entry_count
+    }
+}
+
+fn remove_data() -> Result<DataRemovalReport> {
     let data_dir = budi_core::config::budi_home_dir()?;
     if !data_dir.exists() {
+        return Ok(DataRemovalReport::default());
+    }
+
+    let inventory = inventory_data_dir(&data_dir);
+
+    fs::remove_dir_all(&data_dir)
+        .with_context(|| format!("Failed to remove {}", data_dir.display()))?;
+
+    Ok(DataRemovalReport {
+        data_dir: Some(data_dir),
+        named_items: inventory.named_items,
+        extra_entry_count: inventory.extra_entry_count,
+    })
+}
+
+struct DataInventory {
+    named_items: Vec<String>,
+    extra_entry_count: usize,
+}
+
+/// Walk the data dir once and classify its top-level entries against the
+/// documented ADR-0083 / ADR-0086 contract. The caller deletes the dir
+/// afterwards — this inventory is purely so the CLI can print a
+/// human-readable enumeration of what was removed.
+fn inventory_data_dir(data_dir: &Path) -> DataInventory {
+    let entries = match fs::read_dir(data_dir) {
+        Ok(entries) => entries,
+        Err(_) => {
+            return DataInventory {
+                named_items: Vec::new(),
+                extra_entry_count: 0,
+            };
+        }
+    };
+
+    let mut db_file = false;
+    let mut db_sidecar_count = 0usize;
+    let mut repos_subdir_count: Option<usize> = None;
+    let mut has_cursor_sessions = false;
+    let mut has_pricing_json = false;
+    let mut has_upgrade_flags = false;
+    let mut extra = 0usize;
+
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let name_str = name.to_string_lossy().to_string();
+        match name_str.as_str() {
+            "analytics.db" => db_file = true,
+            "analytics.db-shm" | "analytics.db-wal" => db_sidecar_count += 1,
+            "cursor-sessions.json" => has_cursor_sessions = true,
+            "pricing.json" => has_pricing_json = true,
+            "repos" => {
+                let count = fs::read_dir(entry.path())
+                    .map(|iter| iter.flatten().count())
+                    .unwrap_or(0);
+                repos_subdir_count = Some(count);
+            }
+            "upgrade-flags" => has_upgrade_flags = true,
+            _ => extra += 1,
+        }
+    }
+
+    let mut named_items = Vec::new();
+    if db_file {
+        let label = if db_sidecar_count > 0 {
+            format!("analytics.db (+{} sidecar)", db_sidecar_count)
+        } else {
+            "analytics.db".to_string()
+        };
+        named_items.push(label);
+    } else if db_sidecar_count > 0 {
+        named_items.push(format!("analytics.db sidecar ({db_sidecar_count})"));
+    }
+    if let Some(count) = repos_subdir_count {
+        let word = if count == 1 { "repo" } else { "repos" };
+        named_items.push(format!("repos/ ({count} {word})"));
+    }
+    if has_cursor_sessions {
+        named_items.push("cursor-sessions.json".to_string());
+    }
+    if has_pricing_json {
+        named_items.push("pricing.json".to_string());
+    }
+    if has_upgrade_flags {
+        named_items.push("upgrade-flags/".to_string());
+    }
+
+    DataInventory {
+        named_items,
+        extra_entry_count: extra,
+    }
+}
+
+fn print_data_removal(report: &DataRemovalReport, green: &str, yellow: &str, reset: &str) {
+    if report.missing() {
+        println!("Removing data... none found");
+        return;
+    }
+    let Some(dir) = &report.data_dir else {
+        return;
+    };
+
+    let total = report.total_entries();
+    if total == 0 {
+        println!(
+            "Removing data... {green}✓{reset} removed empty {}",
+            dir.display()
+        );
+        return;
+    }
+
+    println!(
+        "Removing data... {green}✓{reset} removed {} from {}",
+        pluralize_items(total),
+        dir.display()
+    );
+    for item in &report.named_items {
+        println!("    - {item}");
+    }
+    if report.extra_entry_count > 0 {
+        println!(
+            "    - {yellow}+{}{reset} other entr{}",
+            report.extra_entry_count,
+            if report.extra_entry_count == 1 {
+                "y"
+            } else {
+                "ies"
+            }
+        );
+    }
+}
+
+fn pluralize_items(count: usize) -> String {
+    if count == 1 {
+        "1 item".to_string()
+    } else {
+        format!("{count} items")
+    }
+}
+
+fn remove_file_if_exists(path: &Path) -> Result<bool> {
+    if !path.exists() {
         return Ok(false);
     }
-    fs::remove_dir_all(&data_dir)?;
+    fs::remove_file(path).with_context(|| format!("Failed to remove {}", path.display()))?;
     Ok(true)
+}
+
+fn remove_installer_shell_residue(yes: bool, green: &str, yellow: &str, reset: &str) -> Result<()> {
+    let scan = match installer_residue::scan() {
+        Ok(scan) => scan,
+        Err(e) => {
+            println!("Removing installer PATH block... {yellow}warning: {e}{reset}");
+            return Ok(());
+        }
+    };
+
+    if !scan.has_residue() {
+        println!("Removing installer PATH block... none found");
+        return Ok(());
+    }
+
+    println!("Removing installer PATH block:");
+
+    let interactive = std::io::stdin().is_terminal();
+    for residue in &scan.files {
+        println!("  {}:", residue.path.display());
+        for line in &residue.removed_lines {
+            println!("    - L{}: {}", line.line_number, line.content);
+        }
+
+        let apply = if yes {
+            true
+        } else if !interactive {
+            println!("    {yellow}skipped{reset} (non-interactive; rerun with --yes to remove)");
+            false
+        } else {
+            prompt_confirm(&format!(
+                "  Remove these lines from {}? [y/N] ",
+                residue.path.display()
+            ))?
+        };
+
+        if !apply {
+            continue;
+        }
+
+        match residue.apply_cleanup() {
+            Ok(true) => println!("    {green}✓{reset} removed"),
+            Ok(false) => println!("    (no change)"),
+            Err(e) => println!("    {yellow}warning: {e}{reset}"),
+        }
+    }
+    Ok(())
+}
+
+fn prompt_confirm(prompt: &str) -> Result<bool> {
+    eprint!("{prompt}");
+    let mut answer = String::new();
+    std::io::stdin()
+        .read_line(&mut answer)
+        .context("Failed to read stdin")?;
+    Ok(matches!(answer.trim(), "y" | "Y"))
 }
 
 fn remove_config() -> Result<bool> {
@@ -401,4 +635,89 @@ fn verify_no_budi_hooks_cursor(path: &PathBuf) -> bool {
             .map(|a| a.iter().any(super::is_budi_cursor_hook_entry))
             .unwrap_or(false)
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn unique_temp_dir(name: &str) -> PathBuf {
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "budi-uninstall-test-{name}-{}-{stamp}",
+            std::process::id()
+        ))
+    }
+
+    #[test]
+    fn inventory_enumerates_known_contract_files() {
+        let dir = unique_temp_dir("inventory-known");
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("analytics.db"), b"db").unwrap();
+        fs::write(dir.join("analytics.db-shm"), b"shm").unwrap();
+        fs::write(dir.join("analytics.db-wal"), b"wal").unwrap();
+        fs::write(dir.join("cursor-sessions.json"), b"{}").unwrap();
+        fs::write(dir.join("pricing.json"), b"{}").unwrap();
+        fs::create_dir_all(dir.join("repos/repo-a")).unwrap();
+        fs::create_dir_all(dir.join("repos/repo-b")).unwrap();
+        fs::create_dir_all(dir.join("upgrade-flags")).unwrap();
+
+        let inv = inventory_data_dir(&dir);
+        assert_eq!(inv.extra_entry_count, 0);
+        assert!(
+            inv.named_items
+                .iter()
+                .any(|s| s.starts_with("analytics.db"))
+        );
+        assert!(inv.named_items.iter().any(|s| s.starts_with("repos/ (2")));
+        assert!(inv.named_items.iter().any(|s| s == "cursor-sessions.json"));
+        assert!(inv.named_items.iter().any(|s| s == "pricing.json"));
+        assert!(inv.named_items.iter().any(|s| s == "upgrade-flags/"));
+
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn inventory_counts_unknown_entries_separately() {
+        let dir = unique_temp_dir("inventory-unknown");
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("analytics.db"), b"db").unwrap();
+        fs::write(dir.join("stray.tmp"), b"x").unwrap();
+        fs::write(dir.join("other-leftover"), b"y").unwrap();
+
+        let inv = inventory_data_dir(&dir);
+        assert_eq!(inv.extra_entry_count, 2);
+        assert!(
+            inv.named_items
+                .iter()
+                .any(|s| s.starts_with("analytics.db"))
+        );
+
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn remove_file_if_exists_is_idempotent() {
+        let dir = unique_temp_dir("remove-file");
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("daemon.log");
+        fs::write(&path, b"hi").unwrap();
+
+        assert!(remove_file_if_exists(&path).unwrap());
+        assert!(!remove_file_if_exists(&path).unwrap());
+
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn pluralize_items_matches_english() {
+        assert_eq!(pluralize_items(1), "1 item");
+        assert_eq!(pluralize_items(2), "2 items");
+        assert_eq!(pluralize_items(0), "0 items");
+    }
 }

--- a/crates/budi-core/src/autostart.rs
+++ b/crates/budi-core/src/autostart.rs
@@ -118,6 +118,20 @@ pub fn service_file_path() -> Option<PathBuf> {
     None
 }
 
+/// Return the path the autostart service writes its stdout/stderr to, if any.
+///
+/// On macOS this is `~/Library/Logs/budi-daemon.log`, which launchd writes
+/// independently of Budi's own data directory. On Linux the systemd unit
+/// logs to journald, and on Windows Task Scheduler has no standalone log
+/// file, so both return `None`.
+pub fn service_log_path() -> Option<PathBuf> {
+    #[cfg(target_os = "macos")]
+    return launchd_log_path().ok();
+
+    #[cfg(not(target_os = "macos"))]
+    None
+}
+
 /// Return a human-readable description of the service mechanism for this platform.
 pub fn service_mechanism() -> &'static str {
     #[cfg(target_os = "macos")]

--- a/crates/budi-core/src/installer_residue.rs
+++ b/crates/budi-core/src/installer_residue.rs
@@ -1,0 +1,438 @@
+//! Detects and removes residue the standalone shell / PowerShell installers
+//! wrote outside Budi's own data/config directories.
+//!
+//! The standalone installers (`scripts/install-standalone.sh`,
+//! `scripts/install.sh`) append a two-line block to the user's shell profile
+//! when `BIN_DIR` is not already on `$PATH`:
+//!
+//! ```text
+//! # Added by budi installer
+//! export PATH="$BIN_DIR:$PATH"
+//! ```
+//!
+//! (or `fish_add_path $BIN_DIR` for fish). `budi uninstall` used to leave
+//! those lines behind, which permanently polluted `$PATH` after the user
+//! believed they had uninstalled. This module scans the candidate shell
+//! profiles, finds the `# Added by budi installer` marker + the matching
+//! PATH modification on the next line, and produces a cleaned text suitable
+//! for `apply_cleanup()`.
+//!
+//! Only the marker + one immediately following PATH-modification line are
+//! removed. Everything else (including fuzzy PATH edits the user made by
+//! hand) is left untouched — consent-first cleanup per ADR-0081.
+
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+
+pub const INSTALLER_MARKER: &str = "# Added by budi installer";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InstallerPlatform {
+    Macos,
+    Linux,
+    Windows,
+}
+
+fn current_platform() -> InstallerPlatform {
+    #[cfg(target_os = "macos")]
+    {
+        InstallerPlatform::Macos
+    }
+    #[cfg(target_os = "windows")]
+    {
+        return InstallerPlatform::Windows;
+    }
+    #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
+    {
+        InstallerPlatform::Linux
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemovedLine {
+    pub line_number: usize,
+    pub content: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ShellProfileResidue {
+    pub path: PathBuf,
+    pub original_text: String,
+    pub cleaned_text: String,
+    pub removed_lines: Vec<RemovedLine>,
+}
+
+impl ShellProfileResidue {
+    pub fn apply_cleanup(&self) -> Result<bool> {
+        if self.removed_lines.is_empty() || self.cleaned_text == self.original_text {
+            return Ok(false);
+        }
+        fs::write(&self.path, &self.cleaned_text)
+            .with_context(|| format!("Failed writing {}", self.path.display()))?;
+        Ok(true)
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct InstallerResidueScan {
+    pub files: Vec<ShellProfileResidue>,
+}
+
+impl InstallerResidueScan {
+    pub fn has_residue(&self) -> bool {
+        !self.files.is_empty()
+    }
+}
+
+pub fn scan() -> Result<InstallerResidueScan> {
+    let home = crate::config::home_dir()?;
+    let shell = std::env::var("SHELL").ok();
+    Ok(scan_with_env(&home, current_platform(), shell.as_deref()))
+}
+
+pub fn scan_with_env(
+    home: &Path,
+    platform: InstallerPlatform,
+    shell: Option<&str>,
+) -> InstallerResidueScan {
+    let mut files = Vec::new();
+    for path in shell_profile_candidates(home, platform, shell) {
+        if let Some(residue) = scan_shell_profile(&path) {
+            files.push(residue);
+        }
+    }
+    InstallerResidueScan { files }
+}
+
+fn scan_shell_profile(path: &Path) -> Option<ShellProfileResidue> {
+    if !path.exists() {
+        return None;
+    }
+    let original_text = fs::read_to_string(path).ok()?;
+    let (cleaned_text, removed_lines) = strip_installer_blocks(&original_text);
+    if removed_lines.is_empty() {
+        return None;
+    }
+    Some(ShellProfileResidue {
+        path: path.to_path_buf(),
+        original_text,
+        cleaned_text,
+        removed_lines,
+    })
+}
+
+/// Remove every `# Added by budi installer` block from `raw`.
+///
+/// A block is the marker line + the immediately following line when that
+/// line looks like a PATH modification (`export PATH=...`, `PATH=...`, or
+/// `fish_add_path ...`). We also eat a single blank line immediately
+/// preceding the marker so the installer's `printf '\n# Added...'` produces
+/// a byte-identical round-trip when the surrounding file does not end with
+/// a blank line already.
+fn strip_installer_blocks(raw: &str) -> (String, Vec<RemovedLine>) {
+    let lines: Vec<&str> = raw.lines().collect();
+    let mut skip: HashSet<usize> = HashSet::new();
+    let mut removed = Vec::new();
+
+    for (idx, line) in lines.iter().enumerate() {
+        if line.trim() != INSTALLER_MARKER {
+            continue;
+        }
+        let next_idx = idx + 1;
+        let Some(next_line) = lines.get(next_idx) else {
+            continue;
+        };
+        if !looks_like_path_modification(next_line) {
+            continue;
+        }
+
+        skip.insert(idx);
+        skip.insert(next_idx);
+        removed.push(RemovedLine {
+            line_number: idx + 1,
+            content: line.to_string(),
+        });
+        removed.push(RemovedLine {
+            line_number: next_idx + 1,
+            content: next_line.to_string(),
+        });
+
+        if idx > 0 && lines[idx - 1].trim().is_empty() && !skip.contains(&(idx - 1)) {
+            skip.insert(idx - 1);
+        }
+    }
+
+    let kept: Vec<&str> = lines
+        .iter()
+        .enumerate()
+        .filter_map(|(i, l)| (!skip.contains(&i)).then_some(*l))
+        .collect();
+
+    (rebuild_text(&kept, raw), removed)
+}
+
+fn looks_like_path_modification(line: &str) -> bool {
+    let trimmed = line.trim_start();
+    let without_export = trimmed.strip_prefix("export ").unwrap_or(trimmed);
+    let without_export = without_export.trim_start();
+    if let Some(rest) = without_export.strip_prefix("PATH") {
+        return rest.trim_start().starts_with('=');
+    }
+    if let Some(rest) = trimmed.strip_prefix("fish_add_path") {
+        return rest.starts_with(char::is_whitespace);
+    }
+    false
+}
+
+fn rebuild_text(kept: &[&str], original: &str) -> String {
+    if kept.is_empty() && !original.is_empty() {
+        // Fully-stripped file: return empty string (no newline).
+        return String::new();
+    }
+    let newline = if original.contains("\r\n") {
+        "\r\n"
+    } else {
+        "\n"
+    };
+    let mut out = kept.join(newline);
+    if original.ends_with("\r\n") {
+        out.push_str("\r\n");
+    } else if original.ends_with('\n') {
+        out.push('\n');
+    }
+    out
+}
+
+fn shell_profile_candidates(
+    home: &Path,
+    platform: InstallerPlatform,
+    shell: Option<&str>,
+) -> Vec<PathBuf> {
+    if platform == InstallerPlatform::Windows {
+        return Vec::new();
+    }
+
+    let zsh = home.join(".zshrc");
+    let bashrc = home.join(".bashrc");
+    let bash_profile = home.join(".bash_profile");
+    let profile = home.join(".profile");
+    let fish = home.join(".config/fish/config.fish");
+
+    let mut candidates = Vec::new();
+    if let Some(shell) = shell {
+        let lower = shell.to_ascii_lowercase();
+        if lower.contains("zsh") {
+            candidates.push(zsh.clone());
+        }
+        if lower.contains("bash") {
+            candidates.push(bashrc.clone());
+            candidates.push(bash_profile.clone());
+            candidates.push(profile.clone());
+        }
+        if lower.contains("fish") {
+            candidates.push(fish.clone());
+        }
+    }
+    candidates.push(zsh);
+    candidates.push(bashrc);
+    candidates.push(bash_profile);
+    candidates.push(profile);
+    candidates.push(fish);
+    dedup_paths(candidates)
+}
+
+fn dedup_paths(paths: Vec<PathBuf>) -> Vec<PathBuf> {
+    let mut seen = HashSet::new();
+    let mut deduped = Vec::new();
+    for path in paths {
+        if seen.insert(path.clone()) {
+            deduped.push(path);
+        }
+    }
+    deduped
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn unique_temp_dir(name: &str) -> PathBuf {
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "budi-installer-residue-{name}-{}-{stamp}",
+            std::process::id()
+        ))
+    }
+
+    #[test]
+    fn strip_removes_marker_plus_path_line_plus_leading_blank() {
+        let raw =
+            "alpha\nbeta\n\n# Added by budi installer\nexport PATH=\"/home/u/.local/bin:$PATH\"\n";
+        let (cleaned, removed) = strip_installer_blocks(raw);
+        assert_eq!(cleaned, "alpha\nbeta\n");
+        assert_eq!(removed.len(), 2);
+        assert_eq!(removed[0].content, "# Added by budi installer");
+    }
+
+    #[test]
+    fn strip_handles_fish_add_path() {
+        let raw =
+            "set -x EDITOR vim\n\n# Added by budi installer\nfish_add_path /home/u/.local/bin\n";
+        let (cleaned, removed) = strip_installer_blocks(raw);
+        assert_eq!(cleaned, "set -x EDITOR vim\n");
+        assert_eq!(removed.len(), 2);
+    }
+
+    #[test]
+    fn strip_leaves_unrelated_path_edits_alone() {
+        let raw = "# My own PATH\nexport PATH=\"/opt/tools:$PATH\"\n";
+        let (cleaned, removed) = strip_installer_blocks(raw);
+        assert_eq!(cleaned, raw);
+        assert!(removed.is_empty());
+    }
+
+    #[test]
+    fn strip_requires_path_modification_on_next_line() {
+        // Marker without a matching PATH line is left untouched so we never
+        // accidentally eat a comment the user happened to copy-paste.
+        let raw = "# Added by budi installer\nunset EDITOR\n";
+        let (cleaned, removed) = strip_installer_blocks(raw);
+        assert_eq!(cleaned, raw);
+        assert!(removed.is_empty());
+    }
+
+    #[test]
+    fn strip_preserves_crlf_line_endings() {
+        let raw = "alpha\r\n\r\n# Added by budi installer\r\nexport PATH=\"/home/u/.local/bin:$PATH\"\r\n";
+        let (cleaned, _) = strip_installer_blocks(raw);
+        assert_eq!(cleaned, "alpha\r\n");
+    }
+
+    #[test]
+    fn strip_handles_file_without_trailing_newline() {
+        let raw = "alpha\n\n# Added by budi installer\nexport PATH=\"/home/u/.local/bin:$PATH\"";
+        let (cleaned, _) = strip_installer_blocks(raw);
+        assert_eq!(cleaned, "alpha");
+    }
+
+    #[test]
+    fn looks_like_path_modification_variants() {
+        assert!(looks_like_path_modification(
+            "export PATH=\"/home/u/.local/bin:$PATH\""
+        ));
+        assert!(looks_like_path_modification(
+            "  export PATH=\"/home/u/.local/bin:$PATH\""
+        ));
+        assert!(looks_like_path_modification("PATH=/usr/bin:/bin"));
+        assert!(looks_like_path_modification("fish_add_path /opt/budi/bin"));
+        assert!(!looks_like_path_modification("echo hello"));
+        assert!(!looks_like_path_modification("# PATH= in comment"));
+        assert!(!looks_like_path_modification("fish_add_paths bogus"));
+    }
+
+    #[test]
+    fn apply_cleanup_is_noop_when_file_unchanged() {
+        let dir = unique_temp_dir("noop");
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join(".zshrc");
+        let text = "alpha\nbeta\n";
+        fs::write(&path, text).unwrap();
+
+        let residue = ShellProfileResidue {
+            path: path.clone(),
+            original_text: text.to_string(),
+            cleaned_text: text.to_string(),
+            removed_lines: Vec::new(),
+        };
+        let changed = residue.apply_cleanup().unwrap();
+        assert!(!changed);
+        assert_eq!(fs::read_to_string(&path).unwrap(), text);
+
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn apply_cleanup_roundtrip_preserves_bytes_when_block_absent() {
+        let dir = unique_temp_dir("roundtrip");
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join(".zshrc");
+        let text = "alias ll='ls -la'\nexport EDITOR=vim\n";
+        fs::write(&path, text).unwrap();
+
+        let scan = scan_with_env(&dir, InstallerPlatform::Linux, Some("/bin/zsh"));
+        assert!(scan.files.is_empty(), "no residue should be detected");
+        assert_eq!(fs::read_to_string(&path).unwrap(), text);
+
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn scan_finds_and_apply_removes_installer_block() {
+        let dir = unique_temp_dir("scan-and-strip");
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join(".zshrc");
+        let pre = "alias ll='ls -la'\nexport EDITOR=vim\n";
+        let residue_block =
+            "\n# Added by budi installer\nexport PATH=\"/home/u/.local/bin:$PATH\"\n";
+        let installed = format!("{pre}{residue_block}");
+        fs::write(&path, &installed).unwrap();
+
+        let scan = scan_with_env(&dir, InstallerPlatform::Linux, Some("/bin/zsh"));
+        assert_eq!(scan.files.len(), 1);
+        assert_eq!(scan.files[0].removed_lines.len(), 2);
+
+        assert!(scan.files[0].apply_cleanup().unwrap());
+        assert_eq!(fs::read_to_string(&path).unwrap(), pre);
+
+        // Idempotent — second scan finds nothing.
+        let second = scan_with_env(&dir, InstallerPlatform::Linux, Some("/bin/zsh"));
+        assert!(second.files.is_empty());
+
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn scan_detects_multiple_blocks_from_repeated_installs() {
+        let dir = unique_temp_dir("multi");
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join(".zshrc");
+        // A previous smoke test left a stale block pointing at /tmp; the
+        // current install added another. Both must be removed.
+        let raw = "alpha\n\n# Added by budi installer\nexport PATH=\"/tmp/budi-smoke/fake-prefix:$PATH\"\n\n# Added by budi installer\nexport PATH=\"/home/u/.local/bin:$PATH\"\n";
+        fs::write(&path, raw).unwrap();
+
+        let scan = scan_with_env(&dir, InstallerPlatform::Linux, Some("/bin/zsh"));
+        assert_eq!(scan.files.len(), 1);
+        assert_eq!(scan.files[0].removed_lines.len(), 4);
+        assert!(scan.files[0].apply_cleanup().unwrap());
+        assert_eq!(fs::read_to_string(&path).unwrap(), "alpha\n");
+
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn shell_profile_candidates_respects_shell_hint_but_includes_fallbacks() {
+        let home = Path::new("/tmp/home");
+        let zsh = shell_profile_candidates(home, InstallerPlatform::Macos, Some("/bin/zsh"));
+        assert_eq!(zsh[0], home.join(".zshrc"));
+        assert!(zsh.contains(&home.join(".bashrc")));
+        assert!(zsh.contains(&home.join(".config/fish/config.fish")));
+
+        let fish =
+            shell_profile_candidates(home, InstallerPlatform::Linux, Some("/usr/local/bin/fish"));
+        assert_eq!(fish[0], home.join(".config/fish/config.fish"));
+    }
+
+    #[test]
+    fn shell_profile_candidates_empty_on_windows() {
+        let home = Path::new("C:/Users/test");
+        assert!(shell_profile_candidates(home, InstallerPlatform::Windows, None).is_empty());
+    }
+}

--- a/crates/budi-core/src/lib.rs
+++ b/crates/budi-core/src/lib.rs
@@ -6,6 +6,7 @@ pub mod cost;
 pub mod file_attribution;
 pub mod hooks;
 pub mod identity;
+pub mod installer_residue;
 pub mod integrations;
 pub mod jsonl;
 pub mod legacy_proxy;


### PR DESCRIPTION
## Summary

The 2026-04-20 fresh-user smoke pass caught `budi uninstall --yes` claiming `✓ removed` while leaving behind:

- `~/Library/Logs/budi-daemon.log` (launchd writes it via the plist's `StandardOutPath` / `StandardErrorPath`, outside the data dir the uninstaller walks).
- The `# Added by budi installer` block `scripts/install-standalone.sh` and `scripts/install.sh` append to the user's shell profile — never cleaned up, permanently polluting `$PATH` after the user believed they had uninstalled.
- No enumeration of what was actually deleted from the data dir, so users couldn't spot leftovers.

This PR narrows all three. It does **not** add any new install surface — only the uninstaller learns about what the installer already writes (per rule 7 scope constraint).

- New `budi_core::installer_residue` module scans the candidate shell profiles (`~/.zshrc`, `~/.bashrc`, `~/.bash_profile`, `~/.profile`, `~/.config/fish/config.fish`), matches the `# Added by budi installer` marker against the immediately-following PATH modification (`export PATH=...`, `PATH=...`, `fish_add_path ...`), and produces a cleaned text. A single preceding blank line is also eaten so the installer's `printf '\n# Added...'` round-trips byte-identical. Marker without a matching PATH line on the next line is left alone — consent-first, never eat a stray comment.
- `budi_core::autostart::service_log_path()` exposes the macOS launchd log path (`~/Library/Logs/budi-daemon.log`); Linux (journald) and Windows (Task Scheduler) have no standalone log so it returns `None`. `cmd_uninstall` now deletes this file after `uninstall_service()`.
- `cmd_uninstall` walks the data dir once before `remove_dir_all` and prints a bulleted enumeration matching the documented ADR-0083 / ADR-0086 contract (`analytics.db` + sidecars, `repos/ (N repo[s])`, `cursor-sessions.json`, `pricing.json`, `upgrade-flags/`). Anything else is surfaced as `+N other entries`.
- Shell-profile cleanup is consent-first per ADR-0081: interactive runs show the exact lines we plan to remove and prompt Y/n per file; `--yes` skips the prompt; non-interactive runs without `--yes` skip the removal with a reminder.

### Before / after (maintainer's `~/.zshrc` post-uninstall)

Before: leftover `# Added by budi installer\nexport PATH="..."` block surviving forever.
After: lines enumerated, confirmed (or auto-confirmed under `--yes`), and removed. A fresh scan returns empty, and the surrounding file bytes are preserved.

### Acceptance criteria from #439

- [x] After `budi uninstall --yes`, `find ~/.local/share/budi ~/Library/Logs/budi*` returns nothing and `~/.zshrc` has no `# Added by budi installer` block.
- [x] Output enumerates exactly what was deleted — data dir enumeration + per-line shell-residue listing.
- [x] Regression test that the installer + uninstaller round-trip leaves the user's shell profile byte-identical (see `scan_finds_and_apply_removes_installer_block` and `apply_cleanup_roundtrip_preserves_bytes_when_block_absent`).

Tracker: #436 (Round D). Refs #439.

Closes #439

## Risks / compatibility notes

- **No new dependencies.** `Cargo.toml` / `Cargo.lock` untouched; `cargo deny` delta is zero.
- **No schema change, no DB migration, no daemon HTTP shape change.** Purely uninstall-side CLI logic + one new core module.
- **No new runtime network calls.** Per rule 7.
- **No new install / mutation surface.** Per rule 7 (`#439 narrows the existing path; it does not add a new one`). The only new code paths are in the uninstaller and in a scanner-only core module.
- **Consent-first for user-visible removal.** Per rule 5 lessons-carried-forward — the shell-profile block is shown line-by-line before removal and prompts Y/n per file unless `--yes`.
- **UTF-8 boundary safety.** Per rule 8: the stripper uses `&str` line iteration and `HashSet<usize>` for indices; no byte-index slicing on user content. Non-ASCII content in shell profiles is preserved verbatim.
- **Platform scoping.** Launchd log removal is `#[cfg(target_os = "macos")]` via `service_log_path()`. The shell-profile scanner returns an empty candidate list on Windows (installer does not write shell-profile blocks there — it writes user-registry PATH, which `scripts/uninstall-standalone.ps1` already handles).
- **Byte-identical round-trip** only guaranteed when the pre-install profile ended with a trailing newline, which matches every installer flow we ship. Profiles without a trailing newline are a preexisting edge case; stripping still produces a sensible result, just not byte-identical.

## Validation

- `cargo fmt --all`
- `cargo clippy --workspace --all-targets --locked -- -D warnings` → clean.
- `cargo test --workspace --locked` → 157 + 452 + 37 = **646 passed, 0 failed** (13 new `installer_residue` tests, 4 new uninstall inventory tests).
- Manual smoke: ran `HOME=/tmp/budi-439-smoke SHELL=/bin/zsh target/debug/budi uninstall --yes` against a fake home containing only `.zshrc` with the installer block. Output enumerates the residue, removes the lines, and `diff` vs. the pre-install file returns nothing (byte-identical).