### PR TITLE
chore: sweep dead code and stale dead_code allows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1455,9 +1455,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/SOUL.md
+++ b/SOUL.md
@@ -537,7 +537,7 @@ Key points:
 - `crates/budi-core/src/migration.rs` - Schema v1, all migration paths
 - `crates/budi-core/src/cloud_sync.rs` - Cloud sync worker: envelope builder, watermark tracking, HTTPS-only HTTP client with retry/backoff, privacy-safe rollup extraction
 - `crates/budi-core/src/autostart.rs` - Platform-native daemon autostart: launchd (macOS), systemd (Linux), Task Scheduler (Windows). Install/uninstall/status.
-- `crates/budi-core/src/config.rs` - BudiConfig, ProxyConfig (legacy test/compat knobs), AgentsConfig, StatuslineConfig, TagsConfig, CloudConfig
+- `crates/budi-core/src/config.rs` - BudiConfig, AgentsConfig, StatuslineConfig, TagsConfig, CloudConfig
 - `crates/budi-cli/build.rs` - Build script: creates empty vsix placeholder if not pre-built
 - `crates/budi-daemon/src/main.rs` - HTTP server (port 7878) + cloud sync worker + startup hooks for tailer / migration / legacy-residue notices.
 - `crates/budi-daemon/src/workers/cloud_sync.rs` - Background cloud sync loop: configurable interval, backoff, auth/schema error handling

--- a/crates/budi-cli/src/commands/statusline.rs
+++ b/crates/budi-cli/src/commands/statusline.rs
@@ -88,7 +88,7 @@ fn build_slot_values(data: &Value) -> HashMap<String, String> {
 }
 
 /// Render a custom format template by replacing {slot} placeholders.
-pub fn render_template(template: &str, values: &HashMap<String, String>) -> String {
+fn render_template(template: &str, values: &HashMap<String, String>) -> String {
     let mut result = template.to_string();
     for (key, val) in values {
         result = result.replace(&format!("{{{key}}}"), val);

--- a/crates/budi-core/src/config.rs
+++ b/crates/budi-core/src/config.rs
@@ -47,7 +47,6 @@ pub fn home_dir() -> Result<PathBuf> {
 
 pub const DEFAULT_DAEMON_HOST: &str = "127.0.0.1";
 pub const DEFAULT_DAEMON_PORT: u16 = 7878;
-pub const DEFAULT_PROXY_PORT: u16 = 9878;
 
 /// Known agent identifiers used in `agents.toml`.
 pub const KNOWN_AGENTS: &[&str] = &["claude-code", "codex-cli", "cursor", "copilot-cli"];
@@ -362,76 +361,6 @@ pub fn load_tags_config() -> Option<TagsConfig> {
     }
 }
 
-/// Proxy configuration loaded from `[proxy]` section of `config.toml`.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(default)]
-pub struct ProxyConfig {
-    pub enabled: bool,
-    pub port: u16,
-    pub anthropic_upstream: String,
-    pub openai_upstream: String,
-}
-
-impl Default for ProxyConfig {
-    fn default() -> Self {
-        Self {
-            enabled: true,
-            port: DEFAULT_PROXY_PORT,
-            anthropic_upstream: "https://api.anthropic.com".to_string(),
-            openai_upstream: "https://api.openai.com".to_string(),
-        }
-    }
-}
-
-impl ProxyConfig {
-    /// Resolve the effective proxy port, respecting env var override.
-    pub fn effective_port(&self) -> u16 {
-        if let Ok(val) = env::var("BUDI_PROXY_PORT")
-            && let Ok(port) = val.trim().parse::<u16>()
-        {
-            return port;
-        }
-        self.port
-    }
-
-    /// Resolve whether the proxy is enabled, respecting env var override.
-    pub fn effective_enabled(&self) -> bool {
-        if let Ok(val) = env::var("BUDI_PROXY_ENABLED") {
-            return val.trim().eq_ignore_ascii_case("true") || val.trim() == "1";
-        }
-        self.enabled
-    }
-
-    /// Resolve the effective Anthropic upstream URL, respecting env var override.
-    ///
-    /// `BUDI_ANTHROPIC_UPSTREAM` lets local e2e tests and air-gapped deployments
-    /// redirect proxy traffic to a mock or internal endpoint without editing
-    /// on-disk config. Mirrors `BUDI_PROXY_PORT` / `BUDI_PROXY_ENABLED`.
-    pub fn effective_anthropic_upstream(&self) -> String {
-        if let Ok(val) = env::var("BUDI_ANTHROPIC_UPSTREAM") {
-            let trimmed = val.trim();
-            if !trimmed.is_empty() {
-                return trimmed.to_string();
-            }
-        }
-        self.anthropic_upstream.clone()
-    }
-
-    /// Resolve the effective OpenAI upstream URL, respecting env var override.
-    ///
-    /// `BUDI_OPENAI_UPSTREAM` is the OpenAI-side counterpart to
-    /// `BUDI_ANTHROPIC_UPSTREAM`.
-    pub fn effective_openai_upstream(&self) -> String {
-        if let Ok(val) = env::var("BUDI_OPENAI_UPSTREAM") {
-            let trimmed = val.trim();
-            if !trimmed.is_empty() {
-                return trimmed.to_string();
-            }
-        }
-        self.openai_upstream.clone()
-    }
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct BudiConfig {
@@ -439,8 +368,6 @@ pub struct BudiConfig {
     pub daemon_host: String,
     /// Port the daemon listens on. Default: 7878.
     pub daemon_port: u16,
-    /// Proxy configuration.
-    pub proxy: ProxyConfig,
 }
 
 impl Default for BudiConfig {
@@ -448,7 +375,6 @@ impl Default for BudiConfig {
         Self {
             daemon_host: DEFAULT_DAEMON_HOST.to_string(),
             daemon_port: DEFAULT_DAEMON_PORT,
-            proxy: ProxyConfig::default(),
         }
     }
 }
@@ -1016,107 +942,6 @@ enabled = true
         let config: AgentsConfig = toml::from_str(toml_str).unwrap();
         assert!(config.claude_code.enabled);
         assert!(!config.cursor.enabled);
-    }
-
-    #[test]
-    fn proxy_config_defaults() {
-        let config = ProxyConfig::default();
-        assert!(config.enabled);
-        assert_eq!(config.port, 9878);
-        assert_eq!(config.anthropic_upstream, "https://api.anthropic.com");
-        assert_eq!(config.openai_upstream, "https://api.openai.com");
-    }
-
-    #[test]
-    fn proxy_config_parses_toml() {
-        let toml_str = r#"
-enabled = false
-port = 9999
-anthropic_upstream = "https://custom-anthropic.example.com"
-openai_upstream = "https://custom-openai.example.com"
-"#;
-        let config: ProxyConfig = toml::from_str(toml_str).unwrap();
-        assert!(!config.enabled);
-        assert_eq!(config.port, 9999);
-        assert_eq!(
-            config.anthropic_upstream,
-            "https://custom-anthropic.example.com"
-        );
-        assert_eq!(config.openai_upstream, "https://custom-openai.example.com");
-    }
-
-    #[test]
-    fn proxy_config_in_budi_config() {
-        let toml_str = r#"
-daemon_host = "127.0.0.1"
-daemon_port = 7878
-
-[proxy]
-enabled = true
-port = 9878
-"#;
-        let config: BudiConfig = toml::from_str(toml_str).unwrap();
-        assert!(config.proxy.enabled);
-        assert_eq!(config.proxy.port, 9878);
-    }
-
-    #[test]
-    fn proxy_config_effective_upstreams_prefer_env_vars() {
-        // Uses `unsafe` in 2024-edition Rust: mutating process env from tests is
-        // intrinsically racy. We isolate by using a mutex over just these two vars
-        // and clearing them before/after.
-        use std::sync::Mutex;
-        static LOCK: Mutex<()> = Mutex::new(());
-        let _guard = LOCK.lock().unwrap();
-
-        let config = ProxyConfig::default();
-
-        unsafe {
-            env::remove_var("BUDI_ANTHROPIC_UPSTREAM");
-            env::remove_var("BUDI_OPENAI_UPSTREAM");
-        }
-        assert_eq!(
-            config.effective_anthropic_upstream(),
-            "https://api.anthropic.com"
-        );
-        assert_eq!(config.effective_openai_upstream(), "https://api.openai.com");
-
-        unsafe {
-            env::set_var("BUDI_ANTHROPIC_UPSTREAM", "http://127.0.0.1:19333");
-            env::set_var("BUDI_OPENAI_UPSTREAM", "http://127.0.0.1:19444");
-        }
-        assert_eq!(
-            config.effective_anthropic_upstream(),
-            "http://127.0.0.1:19333"
-        );
-        assert_eq!(config.effective_openai_upstream(), "http://127.0.0.1:19444");
-
-        // Empty / whitespace-only overrides fall back to config value.
-        unsafe {
-            env::set_var("BUDI_ANTHROPIC_UPSTREAM", "   ");
-            env::set_var("BUDI_OPENAI_UPSTREAM", "");
-        }
-        assert_eq!(
-            config.effective_anthropic_upstream(),
-            "https://api.anthropic.com"
-        );
-        assert_eq!(config.effective_openai_upstream(), "https://api.openai.com");
-
-        unsafe {
-            env::remove_var("BUDI_ANTHROPIC_UPSTREAM");
-            env::remove_var("BUDI_OPENAI_UPSTREAM");
-        }
-    }
-
-    #[test]
-    fn budi_config_without_proxy_uses_defaults() {
-        let toml_str = r#"
-daemon_host = "127.0.0.1"
-daemon_port = 7878
-"#;
-        let config: BudiConfig = toml::from_str(toml_str).unwrap();
-        assert!(config.proxy.enabled);
-        assert_eq!(config.proxy.port, 9878);
     }
 
     // --- Cloud config tests ---

--- a/crates/budi-core/src/migration.rs
+++ b/crates/budi-core/src/migration.rs
@@ -976,14 +976,12 @@ fn table_exists(conn: &Connection, table: &str) -> Result<bool> {
     Ok(count > 0)
 }
 
-#[allow(dead_code)]
 fn has_column(conn: &Connection, table: &str, column: &str) -> Result<bool> {
     let mut stmt = conn.prepare(&format!("PRAGMA table_info({table})"))?;
     let cols = stmt.query_map([], |row| row.get::<_, String>(1))?;
     Ok(cols.filter_map(|c| c.ok()).any(|c| c == column))
 }
 
-#[allow(dead_code)]
 fn ensure_column(conn: &Connection, table: &str, column: &str, column_decl: &str) -> Result<bool> {
     if !table_exists(conn, table)? {
         return Ok(false);

--- a/crates/budi-core/src/pricing/mod.rs
+++ b/crates/budi-core/src/pricing/mod.rs
@@ -700,7 +700,6 @@ fn snapshot_unknowns() -> Vec<UnknownModelEntry> {
 /// that exercise [`install_manifest`] or [`warn_once_unknown`] need a way
 /// to reset it between cases.
 #[cfg(test)]
-#[allow(dead_code)] // Consumed by the test module added with #376 test gates.
 pub(crate) fn reset_state_for_test() {
     let mut guard = state().write().expect("pricing state RwLock poisoned");
     guard.manifest = load_embedded_manifest().unwrap_or_else(|_| Manifest {
@@ -717,7 +716,6 @@ pub(crate) fn reset_state_for_test() {
 }
 
 #[cfg(test)]
-#[allow(dead_code)] // Consumed by the test module added with #376 test gates.
 pub(crate) fn install_for_test(entries: HashMap<String, ManifestEntry>, source: PricingSource) {
     let manifest = Manifest {
         version: match &source {


### PR DESCRIPTION
## Summary

- Drop `ProxyConfig` struct, its `[proxy]` config section wiring, and the four `effective_*` env-var helpers from `budi-core::config`. The proxy runtime was deleted in 8.2 R2.1 (#322); nothing outside `config.rs` tests has consumed `ProxyConfig` or the `BUDI_PROXY_*` / `BUDI_ANTHROPIC_UPSTREAM` / `BUDI_OPENAI_UPSTREAM` env overrides since. Existing user configs with a legacy `[proxy]` section keep parsing — serde silently ignores the now-unknown section. Also drops `DEFAULT_PROXY_PORT` and the four `proxy_config_*` tests.
- Narrow `commands::statusline::render_template` to a module-private `fn` (only called within the same file, tests included).
- Remove four stale `#[allow(dead_code)]` annotations whose items are actually live: `migration::{has_column, ensure_column}` (called from `reconcile_schema`) and the two `pricing::*_for_test` helpers (consumed directly by the `#[cfg(test)] mod pricing_tests` block).
- Update `SOUL.md` key-files line to match the new `config.rs` surface.

Net: **+2 / -181**.

## Test plan

- [x] `cargo build --workspace --all-targets` — clean
- [x] `cargo test --workspace` — **641 tests pass** (157 + 447 + 37, 0 failures)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [ ] Spot-check that a legacy `~/.config/budi/config.toml` with a `[proxy]` section still parses (manual, user-side verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)