### PR TITLE
docs: refresh README and SOUL, prune stale transition narration

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,13 +142,13 @@ If you install with Homebrew, run `budi init` right after `brew install`.
 
 **One install on PATH.** Do not mix Homebrew with `~/.local/bin` (macOS/Linux) or with `%LOCALAPPDATA%\budi\bin` (Windows): you can end up with different `budi` and `budi-daemon` versions and confusing restarts. Keep a single install directory ahead of others on `PATH` (or remove duplicates). `budi init` warns if it detects multiple binaries.
 
-`budi init` is intentionally small in 8.2: it creates the data directory, validates schema/binary state, starts the daemon on port 7878, installs the platform-native autostart service, prints any detected agents based on local transcript roots, and exits.
+`budi init` is intentionally small: it creates the data directory, validates schema/binary state, starts the daemon on port 7878, installs the platform-native autostart service, installs the recommended integrations (Claude Code statusline + Cursor extension, unless `--no-integrations` is passed), prints any detected agents based on local transcript roots, and exits.
 
 It does **not** patch shell profiles, Cursor settings, or Codex config files. Run your agent normally (`claude`, `codex`, `cursor`, `gh copilot`) and Budi will tail the transcripts those tools already write locally.
 
 If you are upgrading from 8.0/8.1 and `budi doctor` reports leftover proxy-era config, run `budi init --cleanup` to review and remove managed Budi blocks with explicit consent.
 
-To install a specific version, set the `VERSION` environment variable: `VERSION=v7.1.0 curl -fsSL ... | bash` (or `$env:VERSION="v7.1.0"` on PowerShell).
+To install a specific version, set the `VERSION` environment variable: `VERSION=v8.2.1 curl -fsSL ... | bash` (or `$env:VERSION="v8.2.1"` on PowerShell).
 
 Run `budi doctor` to verify everything is set up correctly.
 
@@ -187,11 +187,11 @@ Keep only one install source first on PATH (Homebrew **or** standalone path), no
 
 ## Status line
 
-Budi adds a live cost display to Claude Code. `budi init` wires it in by default (pass `--no-integrations` to opt out, or run `budi integrations install --with claude-code-statusline` later). The default is intentionally quiet, stable, and scoped to the current agent surface — the Claude Code statusline shows Claude Code usage only (ADR-0088 §4):
+Budi adds a live cost display to Claude Code. `budi init` wires it in by default (pass `--no-integrations` to opt out, or run `budi integrations install --with claude-code-statusline` later). The default is quiet and scoped to the current agent surface — the Claude Code statusline shows Claude Code usage only:
 
 `budi · $1.24 1d · $8.50 7d · $32.10 30d`
 
-Rolling `1d` / `7d` / `30d` windows are the primary signal. They tell you what you spent in the last 24 hours, the last 7 days, and the last 30 days — not calendar-today or calendar-month. `budi stats` keeps calendar semantics if you want those.
+Rolling `1d` / `7d` / `30d` windows are the primary signal: last 24 hours, last 7 days, last 30 days ending now — not calendar-today / calendar-month. `budi stats` keeps calendar semantics if you want those.
 
 ### Shared status contract
 
@@ -225,7 +225,7 @@ Available slots: `1d`, `7d`, `30d`, `session`, `branch`, `project`, `provider`, 
 
 Budi includes a Cursor/VS Code extension that shows Cursor-only spend in a single status bar item. `budi init` installs it by default (pass `--no-integrations` to opt out) and it can also be installed later via `budi integrations install --with cursor-extension`.
 
-As of v1.1.0 the extension is intentionally statusline-only (ADR-0088 §7, [#232](https://github.com/siropkin/budi/issues/232)) — no sidebar, no session list, no vitals/tips panel. The status bar renders the shared provider-scoped status contract filtered to `provider=cursor` and mirrors the Claude Code statusline byte-for-byte: `🟢 budi · $X 1d · $Y 7d · $Z 30d`. A leading dot glyph reports health (🟢 active, 🟡 reachable but quiet, 🔴 daemon unreachable, ⚪ first run / not installed yet). Click the status bar item to open the cloud dashboard — session list when a Cursor session is active, dashboard root otherwise — matching the Claude Code click-through.
+The extension is statusline-only — no sidebar, no session list, no vitals/tips panel. The status bar renders the shared provider-scoped status contract filtered to `provider=cursor` and mirrors the Claude Code statusline byte-for-byte: `🟢 budi · $X 1d · $Y 7d · $Z 30d`. A leading dot glyph reports health (🟢 active, 🟡 reachable but quiet, 🔴 daemon unreachable, ⚪ first run / not installed yet). Click the status bar item to open the cloud dashboard — session list when a Cursor session is active, dashboard root otherwise — matching the Claude Code click-through.
 
 The extension also works as a **first-run onboarding entry point**: if you discover budi through the VS Code Marketplace before installing the CLI, the extension shows a welcome view with a pre-filled install command and hands you off to `budi init` in an integrated terminal. The hand-off is tracked by local-only integer counters in `~/.local/share/budi/cursor-onboarding.json` (no remote telemetry, ADR-0083 privacy limits preserved) and `budi doctor` prints a one-line summary of those counters so install-funnel health is visible locally.
 
@@ -243,8 +243,8 @@ Then reload Cursor: **Cmd+Shift+P** → **Developer: Reload Window**.
 ## Update
 
 ```bash
-budi update                      # downloads latest release, migrates DB, restarts daemon
-budi update --version 7.1.0     # update to a specific version
+budi update                       # downloads latest release, migrates DB, restarts daemon
+budi update --version 8.2.1       # update to a specific version
 ```
 
 Works for all installation methods — automatically detects Homebrew and runs `brew upgrade` when appropriate. Update refreshes integrations you previously enabled (stored in `~/.config/budi/integrations.toml`). Agent enablement is stored separately in `~/.config/budi/agents.toml`.
@@ -413,13 +413,13 @@ Tips are provider-aware: Claude Code suggestions mention `/compact` or `/clear`,
 | **Context Growth** | Context size is growing enough to add noise | 3x+ growth with meaningful absolute growth | 6x+ growth with large absolute context size |
 | **Cache Reuse** | Recent cache reuse is low for the active model stretch | Below 60% recent reuse | Below 35% recent reuse |
 | **Cost Acceleration** | Later turns/replies cost much more than earlier ones | 2x+ growth and meaningful cost per unit | 4x+ growth and high cost per unit |
-| **Retry Loops** | Agent is stuck in a failing tool loop (disabled since 8.0 — hook-event source removed; will be re-enabled on top of R1.5 tool-outcome signals) | One suspicious retry loop | Repeated or severe retry loops |
+| **Retry Loops** | Agent is stuck in a failing tool loop (currently disabled pending a rebuild on top of the tool-outcome signal) | One suspicious retry loop | Repeated or severe retry loops |
 
-Health state appears in the statusline's opt-in `coach` / `full` presets (see above; the default statusline is quiet and cost-only) and on the session detail page in the cloud dashboard. Yellow means "pay attention soon"; red means "intervene now or start fresh." The Cursor extension is statusline-only as of v1.1.0 and does not render per-session health.
+Health state appears in the statusline's opt-in `coach` / `full` presets (see above; the default statusline is quiet and cost-only) and on the session detail page in the cloud dashboard. Yellow means "pay attention soon"; red means "intervene now or start fresh." The Cursor extension is statusline-only and does not render per-session health.
 
 ## Privacy
 
-Budi is local-first. All data stays on your machine by default (`~/.local/share/budi/` on Unix, `%LOCALAPPDATA%\budi` on Windows). In 8.2, Budi reads the local transcripts/session files the agent already wrote to disk and stores derived analytics metadata locally: timestamps, token counts, model names, costs, and attribution tags. Prompts, code, and responses never leave the machine; cloud sync sends only aggregated rollups and session summaries.
+Budi is local-first. All data stays on your machine by default (`~/.local/share/budi/` on Unix, `%LOCALAPPDATA%\budi` on Windows). Budi reads the local transcripts/session files the agent already wrote to disk and stores derived analytics metadata locally: timestamps, token counts, model names, costs, and attribution tags. Prompts, code, and responses never leave the machine; cloud sync sends only aggregated rollups and session summaries.
 
 **Cloud sync** (optional, disabled by default) pushes pre-aggregated daily rollups and session summaries to a team dashboard at `app.getbudi.dev`. Only numeric metrics cross the wire: token counts, costs, model names, hashed repo IDs, branch names, and ticket IDs. Prompts, code, responses, file paths, email addresses, raw payloads, and tag values are structurally excluded from the sync payload — there is no "full upload" mode.
 
@@ -435,7 +435,7 @@ See [ADR-0083](docs/adr/0083-cloud-ingest-identity-and-privacy-contract.md) for 
 
 ## How it works
 
-A lightweight Rust daemon (port 7878) manages a single SQLite database. The daemon watches each supported provider's local transcript/session roots, tails incremental appends through the shared pipeline, and writes canonical `messages` + tag rows. Cursor cost/token reconciliation still comes from the Usage API on a pull cadence; the CLI is a thin HTTP client and all queries go through the daemon.
+A lightweight Rust daemon (port 7878) manages a single SQLite database. The daemon watches each supported provider's local transcript/session roots, tails incremental appends through the shared pipeline, and writes canonical `messages` + tag rows. Cursor cost/token reconciliation comes from the Usage API on a pull cadence. The CLI is a thin HTTP client and all queries go through the daemon.
 
 ## Details
 
@@ -476,7 +476,7 @@ A lightweight Rust daemon (port 7878) manages a single SQLite database. The daem
        Historical import (`budi db import`)       ┘
 ```
 
-The daemon is the single source of truth — the CLI never opens the database directly. The transcript tailer is the sole live data path in 8.2. Historical data from Claude Code JSONL transcripts, Codex Desktop/CLI sessions, Copilot CLI sessions, and Cursor Usage API can be imported via `budi db import` for one-time backfill.
+The daemon is the single source of truth — the CLI never opens the database directly. The transcript tailer is the sole live data path. Historical data from Claude Code JSONL transcripts, Codex Desktop/CLI sessions, Copilot CLI sessions, and Cursor Usage API can be imported via `budi db import` for one-time backfill.
 
 **Data model** — nine tables, seven data entities + two supporting:
 
@@ -527,34 +527,20 @@ Retention cleanup runs automatically after sync and queued realtime ingestion pr
 </details>
 
 <details>
-<summary>Hooks (removed in 8.0)</summary>
-
-Hook-based ingestion (`budi hook`) and the `hook_events` table have been removed. In 8.2, the transcript tailer is the sole live data source.
-
-</details>
-
-<details>
 <summary>Cost confidence levels</summary>
 
 Every message carries a `cost_confidence` tag that indicates how the cost was derived:
 
 | Level | Source | Accuracy |
 |-------|--------|----------|
-| `proxy_estimated` | Retained 8.1 proxy-era rows (historical only) | Estimated from response body / SSE stream |
 | `exact` | Cursor Usage API / Claude Code JSONL tokens | Exact tokens, calculated cost |
-| `estimated` | JSONL tokens x model pricing | ~92-96% accurate (missing thinking tokens) |
-| `estimated_unknown_model` | JSONL tokens × **unknown** model (8.3+) | `cost_cents = 0` — model id not in pricing manifest; backfilled automatically when upstream catches up ([ADR-0091](docs/adr/0091-model-pricing-manifest-source-of-truth.md)) |
+| `estimated` | JSONL tokens × model pricing | ~92-96% accurate (missing thinking tokens) |
+| `estimated_unknown_model` | JSONL tokens × **unknown** model | `cost_cents = 0` — model id not in pricing manifest; backfilled automatically when upstream catches up ([ADR-0091](docs/adr/0091-model-pricing-manifest-source-of-truth.md)) |
+| `proxy_estimated` | Legacy 8.0/8.1 proxy-era rows (read-only history) | Estimated from response body / SSE stream |
 
 Messages with `exact` confidence show exact cost in the dashboard. Estimated costs are prefixed with `~`.
 
-In 8.3+ pricing is sourced from the community-maintained [LiteLLM pricing manifest](https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json) via a three-layer lookup (on-disk cache → embedded baseline → hard-fail to `unknown`), refreshed daily by the daemon (opt-out: `BUDI_PRICING_REFRESH=0`), with every row tagged `pricing_source` so history is auditable and immutable. See [ADR-0091](docs/adr/0091-model-pricing-manifest-source-of-truth.md) for the full contract and `budi pricing status` for the operator surface.
-
-</details>
-
-<details>
-<summary>OpenTelemetry (removed in 8.0)</summary>
-
-OTEL ingestion endpoints (`POST /v1/logs`, `POST /v1/metrics`) and the `otel_events` table have been removed. As of 8.2.0 live cost capture is handled by the JSONL tailer (per-provider `Provider::watch_roots()`, [ADR-0089](docs/adr/0089-reverse-proxy-first-jsonl-tailing-as-sole-live-path.md)); 8.1.x used the proxy on port 9878 in this slot, which is removed in 8.2 R2.1 (#322).
+Pricing is sourced from the community-maintained [LiteLLM pricing manifest](https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json) via a three-layer lookup (on-disk cache → embedded baseline → hard-fail to `unknown`), refreshed daily by the daemon (opt-out: `BUDI_PRICING_REFRESH=0`), with every row tagged `pricing_source` so history is auditable and immutable. See [ADR-0091](docs/adr/0091-model-pricing-manifest-source-of-truth.md) for the full contract and `budi pricing status` for the operator surface.
 
 </details>
 

--- a/SOUL.md
+++ b/SOUL.md
@@ -2,9 +2,11 @@
 
 Local-first cost analytics for AI coding agents (Claude Code, Codex CLI, Cursor, Copilot CLI). Tracks tokens, costs, and usage per message by tailing the JSONL transcript files those agents already write to disk (see [ADR-0089](docs/adr/0089-reverse-proxy-first-jsonl-tailing-as-sole-live-path.md)). Historical data from the same transcripts and the Cursor Usage API can be backfilled via `budi db import`. Optional cloud sync (disabled by default) pushes pre-aggregated daily rollups to a team dashboard — prompts, code, and responses never leave the machine (see [ADR-0083](docs/adr/0083-cloud-ingest-identity-and-privacy-contract.md)).
 
-> **As of 8.2.0**: JSONL tailing is the sole live ingestion path. The proxy is removed in 8.2 R2.1 (#322); 8.1.x still ships the proxy during the transition window. See [ADR-0089](docs/adr/0089-reverse-proxy-first-jsonl-tailing-as-sole-live-path.md).
->
-> **As of 8.3.0**: model pricing flows through a single manifest-backed `pricing::lookup` — embedded LiteLLM baseline at build time, daily refresh against the upstream manifest, `BUDI_PRICING_REFRESH=0` operator opt-out, every row tagged `pricing_source` so history is immutable. The four legacy `*_pricing_for_model()` functions and their substring dispatch are gone. See [ADR-0091](docs/adr/0091-model-pricing-manifest-source-of-truth.md).
+Architecture highlights:
+
+- **JSONL tailing is the sole live ingestion path** ([ADR-0089](docs/adr/0089-reverse-proxy-first-jsonl-tailing-as-sole-live-path.md)). No proxy, no hooks, no OTEL. The 8.0/8.1 proxy was removed in 8.2; legacy `proxy_estimated` and `otel_exact` rows remain read-only in the DB for historical analytics.
+- **Model pricing flows through a single manifest-backed `pricing::lookup`** ([ADR-0091](docs/adr/0091-model-pricing-manifest-source-of-truth.md)): embedded LiteLLM baseline at build time, daily refresh against the upstream manifest (opt out with `BUDI_PRICING_REFRESH=0`), every row tagged `pricing_source` so history is immutable.
+- **`budi init` never mutates user config on the live path**: it creates the data dir, starts the daemon, installs autostart, and wires the recommended integrations (Claude Code statusline, Cursor extension) idempotently. `--no-integrations` opts out. `--cleanup` is a separate consent-first path for reviewing/removing managed 8.0/8.1 proxy residue.
 
 ## Build & Test
 
@@ -35,14 +37,11 @@ Shell-driven end-to-end tests live under `scripts/e2e/`. They exercise the full 
 
 ```bash
 cargo build --release                                 # once per change
-bash scripts/e2e/test_302_sessions_visibility.sh      # regression guard for #302
-bash scripts/e2e/test_303_branch_attribution.sh       # regression guard for #303
-bash scripts/e2e/test_323_init_no_proxy_mutations.sh # regression guard for #323 (no legacy proxy config writes on init)
-bash scripts/e2e/test_221_ticket_first_class.sh       # regression guard for #221 / #304 (ticket dimension)
-bash scripts/e2e/test_222_activity_classification.sh  # regression guard for #222 / #305 (activity dimension)
-bash scripts/e2e/test_224_statusline_provider_scope.sh # regression guard for #224 (statusline provider scoping)
-bash scripts/e2e/test_454_init_installs_statusline.sh # regression guard for #454 (init wires Claude Code statusline + doctor nudge)
+bash scripts/e2e/test_<issue>_<slug>.sh               # run an individual regression guard
+ls scripts/e2e/                                       # see the full set of guards
 ```
+
+Each guard pins a specific bug or contract; see `scripts/e2e/README.md` for the index.
 
 Each script is a single self-contained bash file that:
 
@@ -91,14 +90,14 @@ Three independent repos (extraction completed per [ADR-0086](docs/adr/0086-extra
 
 ### Crates
 
-- **budi-core** - Business logic: analytics (SQLite queries), providers (Claude Code, Codex, Copilot CLI, Cursor) including each provider's `watch_roots()` for live tailing, pipeline (enrichment), cost calculation, config, migrations, autostart (platform-native daemon service management). The 8.1-era proxy runtime is deleted in R2.1 (#322); R2.5 (#326) keeps proxy-sourced `messages` rows read-only for historical analytics while dropping the obsolete `proxy_events` table on upgrade. Historical hook/OTEL data is read-only (tables kept for schema compat, ingestion removed).
-- **budi-cli** - Thin HTTP client to the daemon. Commands include `init`, `stats`, `sessions`, `status`, `statusline`, `doctor`, `vitals`, `update`, `integrations`, `autostart`, `uninstall`, `cloud`, `pricing`, and the DB admin namespace `db` (`db migrate`, `db repair`, `db import`). `budi init` is the daemon + autostart entry point; legacy launch / enable / disable / proxy-install commands are removed in 8.2. `budi health` remains a hidden backward-compatibility alias for `budi vitals` in 8.3.x — it still runs and prints a one-per-day deprecation hint; removal is punted past 8.3.0 since the alias is quiet and harmless (the bare DB verbs were the noisier case — those were removed in 8.3.0 per #428 as pre-filed). The bare `budi migrate` / `budi repair` / `budi import` verbs moved under `budi db` in 8.2.1 (#368) and were removed entirely in 8.3.0 (#428) after shipping as hidden deprecation aliases during the 8.2.x window. The `budi pricing` namespace (`budi pricing status [--json] [--refresh]`) lands in 8.3.0 alongside the [ADR-0091](docs/adr/0091-model-pricing-manifest-source-of-truth.md) manifest loader.
-- **budi-daemon** - axum HTTP server (port 7878). Owns SQLite exclusively. Serves analytics API and runs the daemon-side filesystem tailer that watches each `Provider::watch_roots()` directory, parses incremental JSONL appends through `Pipeline::default_pipeline()`, and writes to the canonical `messages` / tag tables. JSONL tailing is the sole live ingestion path per [ADR-0089](docs/adr/0089-reverse-proxy-first-jsonl-tailing-as-sole-live-path.md). One-shot historical backfill remains user-initiated via `budi db import`.
+- **budi-core** — Business logic: analytics (SQLite queries), providers (Claude Code, Codex, Copilot CLI, Cursor) including each provider's `watch_roots()` for live tailing, pipeline (enrichment), cost calculation, config, migrations, autostart (platform-native daemon service management). Historical proxy/hook/OTEL rows remain read-only in `messages` for analytics continuity; the ingestion paths are gone.
+- **budi-cli** — Thin HTTP client to the daemon. Commands: `init`, `stats`, `sessions`, `status`, `statusline`, `doctor`, `vitals`, `update`, `integrations`, `autostart`, `uninstall`, `cloud`, `pricing`, and the DB admin namespace `db` (`db migrate`, `db repair`, `db import`). `budi health` is a hidden deprecation alias for `budi vitals` that prints a one-per-day hint. The bare `budi migrate` / `budi repair` / `budi import` verbs were removed in 8.3.0 (#428) after shipping as hidden aliases during the 8.2.x window — use `budi db <verb>`.
+- **budi-daemon** — axum HTTP server (port 7878). Owns SQLite exclusively. Serves the analytics API and runs the filesystem tailer that watches each `Provider::watch_roots()` directory, parses incremental JSONL appends through `Pipeline::default_pipeline()`, and writes to the canonical `messages` / tag tables. One-shot historical backfill is user-initiated via `budi db import` and runs the same pipeline.
 
 ### Data flow
 
 ```
-Live data (8.2+, ADR-0089):
+Live data (ADR-0089):
 Provider watcher (notify FS events on Provider::watch_roots() dirs)
   -> Per-file offset tracked in tail_offsets
   -> Provider::parse_file(path, content, offset) -> incremental ParsedMessage batch
@@ -115,8 +114,6 @@ Sources (Claude Code JSONL, Codex sessions, Copilot CLI sessions, Cursor Usage A
 
 Enricher order is critical — each depends on prior enrichers. Do not reorder. The live tailer and `budi db import` run the **same** pipeline against the **same** transcript files, so every classification feature (ticket extraction, file-level attribution, activity classification, tool outcomes) lands for both paths automatically.
 
-> **Transition window (8.1.x → 8.2)**: in 8.1.x the daemon also runs an HTTP proxy on port 9878 that captures live LLM traffic into a separate `proxy_events` table and a parallel `insert_proxy_message` write path. That path is shipped behind `BUDI_LIVE_TAIL=1` cross-validation in 8.2 R1.3 (#319), made the default in R1.4 (#320 — proxy stops writing `proxy_events`), and the proxy code itself is deleted in 8.2 R2.1 (#322). R2.5 (#326) removes the now-unused `proxy_events` table on upgrade while keeping proxy-sourced `messages` rows read-only; the dedup rule in `analytics/sync.rs` (`proxy_cutoff`) remains only to keep those historical rows from double-counting during the transition.
-
 ```
 Cloud sync (optional, disabled by default):
 Local SQLite daily rollups
@@ -131,12 +128,12 @@ Local SQLite daily rollups
 Config: ~/.config/budi/cloud.toml ([cloud] section), env overrides BUDI_CLOUD_*
 Never uploaded: prompts, responses, code, file paths, email, raw payloads, tag values
 
-Manual cloud sync (since 8.1, R2.1, #225):
+Manual cloud sync:
 `budi cloud sync`     -> POST /cloud/sync (loopback-only) -> same sync_tick as worker
 `budi cloud status`   -> GET /cloud/status -> readiness + watermarks, no network call
 AppState.cloud_syncing AtomicBool guards worker and manual path from double-posting.
 
-Onboarding helper (since 8.3, F #446):
+Onboarding helper:
 `budi cloud init`                        -> write ~/.config/budi/cloud.toml from commented template
 `budi cloud init --api-key KEY`          -> one-shot: write key + `enabled = true`
 `budi cloud init --force [--yes]`        -> overwrite existing config (--yes skips confirm)
@@ -161,87 +158,64 @@ Core tables:
 
 | Source | Confidence | What it provides |
 |--------|-----------|-----------------|
-| **JSONL tailer** (Claude Code, Codex, Copilot CLI) | `estimated` | Per-message tokens parsed from the agent's local transcript as it grows. Same parser as `budi db import`; same enricher chain. Live in 8.2+ via [ADR-0089](docs/adr/0089-reverse-proxy-first-jsonl-tailing-as-sole-live-path.md). |
-| **Cursor Usage API** | `exact` | Per-request tokens + totalCents pulled from Cursor's API. Reconciles cost/token data the JSONL doesn't carry; lag profile was measured in #321 (p50 ≈ 70 s, p99 ≈ 6 min, N = 12) and embedded in [ADR-0089](docs/adr/0089-reverse-proxy-first-jsonl-tailing-as-sole-live-path.md) §7 — the Usage API stays a scheduled pull (not a live path) and a "Cursor cost may lag up to ~10 min" UX disclaimer follow-up is tracked in #381. |
+| **JSONL tailer** (Claude Code, Codex, Copilot CLI) | `estimated` | Per-message tokens parsed from the agent's local transcript as it grows. Same parser as `budi db import`; same enricher chain. |
+| **Cursor Usage API** | `exact` | Per-request tokens + totalCents pulled from Cursor's API. Reconciles cost/token data the JSONL doesn't carry; scheduled pull, not a live path. Lag profile p50 ≈ 70 s, p99 ≈ 6 min (measured in #321, embedded in [ADR-0089](docs/adr/0089-reverse-proxy-first-jsonl-tailing-as-sole-live-path.md) §7). |
 | **JSONL backfill** (`budi db import`) | `estimated` (Claude Code / Codex / Copilot CLI) / `exact` (Cursor) | Same providers, one-shot mode for historical backfill. Used after install or after `budi db import --force`. |
-| **Legacy proxy** (8.1.x only, transition window) | `proxy_estimated` | Pre-8.2 real-time per-request tokens captured by the proxy on port 9878. New writes stop in 8.2 R1.4 (#320); the proxy is deleted in R2.1 (#322). Existing `proxy_estimated` rows remain queryable. |
+| **Legacy proxy** (pre-8.2 history only) | `proxy_estimated` | Rows written by the 8.0/8.1 proxy remain queryable. No new writes; the proxy runtime was deleted in 8.2. |
 
-Historical OTEL data (`otel_exact` confidence) remains queryable but OTEL ingestion has been removed. JSONL tailing is the sole live data source in 8.2+ (ADR-0089).
+Historical OTEL data (`otel_exact` confidence) remains queryable but OTEL ingestion has been removed.
 
-### Attribution contract (R1.0)
+### Attribution contract
 
 Every ingestor that writes to `messages` MUST uphold the following so that the
-CLI, daemon, and dashboard tell the same story (see ADR-0082, [ADR-0088](docs/adr/0088-8x-local-developer-first-product-contract.md) §5, and the R1.0 bugs
-in [#302](https://github.com/siropkin/budi/issues/302) / #303 / #304 / #305):
+CLI, daemon, and dashboard tell the same story (see ADR-0082 and
+[ADR-0088](docs/adr/0088-8x-local-developer-first-product-contract.md) §5):
 
 - **`timestamp`** — RFC3339 string in UTC. Accept both `...Z` and `...+00:00`
   offsets; `session_list_with_filters` and `activity_chart` compare these as
   strings, so never write naive SQLite datetime (`YYYY-MM-DD HH:MM:SS`) or a
   local-offset string. Providers emit RFC3339 from `DateTime::<Utc>::to_rfc3339()`
   (Claude Code JSONL, Codex) or `DateTime::from_timestamp_millis(..).to_rfc3339()`
-  (Cursor, proxy).
-- **`session_id`** — required for every live assistant row. In 8.2+ the
-  JSONL tailer reads `sessionId` (or the per-agent equivalent) directly
-  from each transcript line — Claude Code, Codex, Cursor, and Copilot all
-  write it natively, so there is no header contract, no `X-Budi-Session`
-  shim, and no daemon-side ID synthesis on the live path. Empty-string
-  `session_id` is treated as NULL by the analytics layer, and the insert
-  path normalizes `""` to `NULL` so ghost `(empty)` sessions cannot appear.
-  Rows with NULL/empty `session_id` are invisible to `budi sessions` by
-  design — they indicate an attribution bug upstream, not a display bug.
-  In 8.1.x the parallel proxy path used the agent-provided `X-Budi-Session`
-  header (falling back to `generate_proxy_session_id()`); that path is
-  removed with the rest of the proxy in 8.2 R2.1 (#322).
+  (Cursor).
+- **`session_id`** — required for every live assistant row. The JSONL tailer
+  reads `sessionId` (or the per-agent equivalent) directly from each
+  transcript line — Claude Code, Codex, Cursor, and Copilot all write it
+  natively, so there is no header contract and no daemon-side ID synthesis.
+  Empty-string `session_id` is treated as NULL by the analytics layer, and
+  the insert path normalizes `""` to `NULL` so ghost `(empty)` sessions
+  cannot appear. Rows with NULL/empty `session_id` are invisible to
+  `budi sessions` by design — they indicate an attribution bug upstream.
 - **`provider`** — canonical provider key (`claude_code`, `cursor`, `openai`,
   `copilot`). `COALESCE(provider, 'claude_code')` is the legacy fallback for
   pre-8.0 rows; new writes MUST set it explicitly.
 - **`git_branch`** — written without the `refs/heads/` prefix
-  (`session_list_with_filters` strips it defensively for older rows). In 8.2+
-  the JSONL tailer resolves the branch directly from the per-line `gitBranch`
+  (`session_list_with_filters` strips it defensively for older rows). The
+  `GitEnricher` resolves the branch directly from the per-line `gitBranch`
   field that Claude Code, Codex, and Cursor already write into every
-  transcript message. The `GitEnricher` consumes that field as the primary
-  source — there are no `X-Budi-*` headers and no proxy-side `git
-  rev-parse` shell-outs in the live path. The resolution priority going
-  forward is:
+  transcript message. Resolution priority:
   1. **Per-line `gitBranch` from the transcript** — what the agent itself
-     recorded for the message. This is the only path the live tailer needs
-     in normal operation.
+     recorded for the message. The common case.
   2. **Session-level propagation in `propagate_session_context`** — if a
      transcript line lacks `gitBranch` but a sibling message in the same
      session has one, the pipeline adopts it; later messages backfill
-     earlier NULL-branch rows in the same session. This is the same routine
-     `budi db import` already runs.
+     earlier NULL-branch rows in the same session.
   3. **`Unassigned` repo + empty branch** — last-resort fallback. Rows in
      this state fold into the `(untagged)` DB bucket and render as
      `(no branch)` in `budi stats --branches` (#450).
 
-  A detached HEAD (`gitBranch == "HEAD"` or `git rev-parse --abbrev-ref
-  HEAD` == `"HEAD"` for legacy proxy rows) is explicitly normalized to empty
-  so that worktrees, mid-rebase sessions, and CI runs do not pollute the
-  branches list with a bogus `HEAD` bucket.
+  A detached HEAD (`gitBranch == "HEAD"`) is normalized to empty so that
+  worktrees, mid-rebase sessions, and CI runs do not pollute the branches
+  list with a bogus `HEAD` bucket.
 
-  > **Transition note (8.1 legacy proxy path)**: 8.1 proxy rows resolved
-  > `git_branch` via `ProxyAttribution::resolve` in
-  > `crates/budi-core/src/proxy.rs` (`X-Budi-Branch` header → `X-Budi-Cwd`
-  > header + `git rev-parse` → session-level backfill in
-  > `insert_proxy_message`). That path stops being written in 8.2 R1.4
-  > (#320) and is deleted in R2.1 (#322). Existing 8.1.x rows resolved via
-  > the proxy path remain queryable.
-
-- **`ticket_id`** — promoted to a first-class CLI dimension in 8.1 (R1.0.3,
-  #304) and further hardened in R1.3
-  ([#221](https://github.com/siropkin/budi/issues/221)). The
+- **`ticket_id`** — first-class CLI dimension. The
   `pipeline::extract_ticket_from_branch` extractor is the single source of
   truth: it (1) filters integration branches (`main`, `master`, `develop`,
   `HEAD`), (2) prefers the canonical alphanumeric pattern (e.g. `ENG-123`,
   `PAVA-2120` anywhere in the branch), then (3) falls back to a
-  numeric-only id for branches like `feature/1234` or `42-quick-fix`. In
-  8.2+ this runs inside the `GitEnricher` for both `budi db import` and the
-  live JSONL tailer (one code path, [ADR-0089](docs/adr/0089-reverse-proxy-first-jsonl-tailing-as-sole-live-path.md)
-  §1). The 8.1.x proxy path called the same extractor from
-  `ProxyAttribution::resolve`; that call site is removed with the rest of
-  the proxy in 8.2 R2.1 (#322). Every emitted `ticket_id` tag is paired
-  with:
+  numeric-only id for branches like `feature/1234` or `42-quick-fix`. Runs
+  inside the `GitEnricher` for both the live tailer and `budi db import`
+  (one code path, [ADR-0089](docs/adr/0089-reverse-proxy-first-jsonl-tailing-as-sole-live-path.md) §1).
+  Every emitted `ticket_id` tag is paired with:
     - `ticket_prefix` — alphabetic prefix (`ENG`, `PAVA`), or empty for
       numeric-only ids; and
     - `ticket_source` — explains how the id was derived: `branch` for the
@@ -263,49 +237,39 @@ in [#302](https://github.com/siropkin/budi/issues/302) / #303 / #304 / #305):
     bucket and a `src=…` column showing the dominant `ticket_source`.
   - `budi stats --ticket <ID>` — detail view with per-branch breakdown
     and a `Source` row. Legacy rows without a `ticket_source` sibling
-    tag default to `branch` (the only pre-R1.3 pipeline producer) so
-    older DBs stay readable without a reindex.
+    tag default to `branch` (the legacy pipeline producer) so older
+    DBs stay readable without a reindex.
   - `budi sessions --ticket <ID>` — sessions tagged with the ticket.
   - `GET /analytics/tickets` and `/analytics/tickets/{ticket_id}` mirror
     `/analytics/branches{/branch}` so future cloud/dashboard work can adopt
     the same data contract.
 
-- **`activity`** — promoted to a first-class CLI dimension in 8.1 (R1.0.4,
-  [#305](https://github.com/siropkin/budi/issues/305)); strengthened in
-  R1.2 ([#222](https://github.com/siropkin/budi/issues/222)). The pipeline
-  emits an `activity` tag for every assistant message whose session has a
+- **`activity`** — first-class CLI dimension. The pipeline emits an
+  `activity` tag for every assistant message whose session has a
   classified prompt category (bugfix, refactor, testing, feature, review,
   ops, question, writing, **docs**). Values come from the rule-based
   `hooks::classify_prompt_detailed` and are propagated across the session
   by `propagate_session_context`, so every assistant message in a
-  classified session carries exactly one `activity` tag. R1.2 also emits
-  two companion tags — `activity_source` (`rule` when derived from the
-  rule-based classifier; reserved for future `header` / `hint` sources)
-  and `activity_confidence` (`high` when anchored by a leading
-  action phrase with a strong keyword hit, `medium` for a clear single
-  keyword hit, `low` when the match is weak or based on fallback
-  heuristics). Precedence: a leading question-anchor phrase ("explain",
+  classified session carries exactly one `activity` tag. Companion tags:
+  `activity_source` (`rule` when derived from the rule-based classifier;
+  reserved for future `header` / `hint` sources) and `activity_confidence`
+  (`high` when anchored by a leading action phrase with a strong keyword
+  hit, `medium` for a clear single keyword hit, `low` on weak / fallback
+  matches). Precedence: a leading question-anchor phrase ("explain",
   "what is", "how do I") wins over generic `bugfix` keywords unless the
-  prompt also starts with a bugfix action ("fix the error").   Coverage
-  extends beyond Claude Code JSONL ingestion to:
+  prompt also starts with a bugfix action ("fix the error"). Coverage
+  extends beyond Claude Code JSONL ingestion:
     - **Cursor JSONL ingestion** — user prompts are classified at parse
       time in `providers::cursor::parse_cursor_line`.
-    - **Codex / Copilot JSONL ingestion** — the same `hooks::classify_prompt_detailed`
-      runs in the pipeline once the per-provider parser surfaces the user
-      turn. In 8.2+ the JSONL tailer hits the same code path live; in 8.1.x
-      a parallel proxy path called `budi_core::proxy::classify_request_body`
-      on the request body before forwarding, extracted the last user turn
-      in-memory, and recorded only the derived `(activity, source,
-      confidence)` triple as tags (no prompt text persisted, per
-      [ADR-0083](docs/adr/0083-privacy-constraints.md)). The proxy
-      classification path is removed with the rest of the proxy in 8.2 R2.1
-      (#322); the JSONL path produces equivalent activity tags from the
-      transcript the agent already wrote.
+    - **Codex / Copilot JSONL ingestion** — the same
+      `hooks::classify_prompt_detailed` runs in the pipeline once the
+      per-provider parser surfaces the user turn.
+
   Analytics recompute the dominant `activity_source` /
   `activity_confidence` per activity from the stored tags (most frequent
-  value wins, ties broken alphabetically), falling back to R1.0 defaults
-  (`rule` / `medium`) only when an activity has no companion tags yet
-  (pre-R1.2 data). Surfaces:
+  value wins, ties broken alphabetically), falling back to `rule` /
+  `medium` only when an activity has no companion tags yet (legacy data).
+  Surfaces:
   - `budi stats --activities` — list ranked by cost, with an
     `(unclassified)` bucket (#450) for messages that never matched a
     classification rule (short prompts, slash commands, metadata-only
@@ -318,8 +282,7 @@ in [#302](https://github.com/siropkin/budi/issues/302) / #303 / #304 / #305):
     mirror the ticket endpoints so future cloud/dashboard work can adopt
     the same data contract.
 
-- **`file_path`** — per-file attribution added in R1.4
-  ([#292](https://github.com/siropkin/budi/issues/292)). When an assistant
+- **`file_path`** — per-file attribution. When an assistant
   message uses a file-aware tool (Claude Code's `Read` / `Write` / `Edit` /
   `MultiEdit` / `NotebookEdit` / `Grep` / `Glob`, Cursor's `edit_file` /
   `read_file` / `write_file` / `search_replace` / `delete_file` / …) the
@@ -331,7 +294,7 @@ in [#302](https://github.com/siropkin/budi/issues/302) / #303 / #304 / #305):
        root. Anything that cannot be proven to sit inside the repo root
        is **dropped** — we never record outside-of-repo paths, mtimes,
        sizes, or file contents. See
-       [ADR-0083](docs/adr/0083-privacy-constraints.md).
+       [ADR-0083](docs/adr/0083-cloud-ingest-identity-and-privacy-contract.md).
     4. Collapses `.` / `..` segments; traversals that would escape the
        repo are dropped.
     5. Caps per-message tag fan-out at
@@ -359,8 +322,7 @@ in [#302](https://github.com/siropkin/budi/issues/302) / #303 / #304 / #305):
     repo-relative (no leading `/`, no `..`, no Windows separators, no
     URL scheme) before hitting SQLite.
 
-- **Breakdown envelope** (shared, 8.3 / [#448](https://github.com/siropkin/budi/issues/448)).
-  Every list endpoint (`GET /analytics/projects`,
+- **Breakdown envelope** (shared). Every list endpoint (`GET /analytics/projects`,
   `/analytics/branches`, `/analytics/tickets`, `/analytics/activities`,
   `/analytics/files`, `/analytics/models`, `/analytics/tags`) returns
   a [`BreakdownPage<T>`](crates/budi-core/src/analytics/queries.rs)
@@ -369,16 +331,12 @@ in [#302](https://github.com/siropkin/budi/issues/302) / #303 / #304 / #305):
   (grand total across every matching row, to the cent),
   `total_rows`, `shown_rows`, and the effective `limit`. The contract
   `sum(rows.cost_cents) + other.cost_cents == total_cost_cents` is
-  exercised by the reconciliation suite in `analytics/tests.rs`. Before
-  8.3 the same endpoints returned a bare `Vec<T>` capped at 30 rows
-  with no grand total, which silently underreported `--files 30d` by
-  ~9% on machines with more than 30 distinct file paths. The CLI
+  exercised by the reconciliation suite in `analytics/tests.rs`. The CLI
   surfaces this as a `Total` footer plus an optional `(other)` row and
   honours `--limit N` (default 30, `0` = unlimited) across every
   breakdown view.
 
-- **`tool_outcome`** — per-message tool-call outcome added in R1.5
-  ([#293](https://github.com/siropkin/budi/issues/293)). The JSONL
+- **`tool_outcome`** — per-message tool-call outcome. The JSONL
   extractor reads `tool_result` blocks from user messages, keeps only
   the `tool_use_id` and a bounded classification (`success`, `error`,
   `denied`), and never persists the underlying content. The pipeline
@@ -390,24 +348,17 @@ in [#302](https://github.com/siropkin/budi/issues/302) / #303 / #304 / #305):
   `tool_outcome_source` (`jsonl_tool_result` when direct,
   `heuristic_retry` when promoted) and `tool_outcome_confidence`
   (`high` / `medium`) mirror the `activity_source` / `file_path_source`
-  contract. Messages with no tool uses carry no outcome tag. Scope
-  ([#336](https://github.com/siropkin/budi/issues/336)): the JSONL
-  extractor only walks the array-of-blocks (`UserContent::Blocks`)
+  contract. Messages with no tool uses carry no outcome tag. Scope: the
+  JSONL extractor only walks the array-of-blocks (`UserContent::Blocks`)
   encoding Claude Code has used since inception. Plain-string user
   messages (`UserContent::Text`) never carry structured tool results
   and are deliberately not string-probed for `"type":"tool_result"`
   substrings — any future provider with a different tool-result shape
   should land a dedicated extractor keyed on the `provider` label
-  rather than silently widening this one. In 8.1.x the parallel proxy
-  ingest path did not emit outcomes (tool names and IDs weren't
-  captured on the wire), so outcomes were import-only for that release.
-  In 8.2+ the JSONL tailer runs the same pipeline as `budi db import`, so
-  outcomes are emitted live from the transcript without a proxy
-  round-trip ([ADR-0089](docs/adr/0089-reverse-proxy-first-jsonl-tailing-as-sole-live-path.md)
-  §1). The 8.1 proxy ingest path is removed in 8.2 R2.1 (#322).
+  rather than silently widening this one.
 
-- **`work_outcome`** (session-scoped) — derived in R1.5 from local
-  git state only. `budi session detail <id>` correlates the session's
+- **`work_outcome`** (session-scoped) — derived from local git state
+  only. `budi session detail <id>` correlates the session's
   `git_branch` with commits on that branch between the session's
   start and its end + 24h grace, producing one of `committed`,
   `branch_merged`, `no_commit`, or `unknown`. The derivation runs
@@ -416,28 +367,25 @@ in [#302](https://github.com/siropkin/budi/issues/302) / #303 / #304 / #305):
   integration branch, or the repo root can't be resolved. The
   integration-branch set (`main`, `master`, `develop`, `HEAD`) is
   shared with the pipeline ticket extractor via
-  `budi_core::pipeline::is_integration_branch`
-  ([#336](https://github.com/siropkin/budi/issues/336)) so the two
-  derivations can't disagree about what counts as a non-feature
-  branch; the literal `HEAD` sentinel is rejected here as well so a
-  detached-HEAD session can't be falsely credited as
-  `branch_merged` via the merge-base fallback. A one-line rationale
-  accompanies every label so operators can see which rule fired. List
-  surfaces skip the derivation (one `git` invocation per session list
-  row is too expensive); only the detail view surfaces it.
+  `budi_core::pipeline::is_integration_branch` so the two derivations
+  can't disagree about what counts as a non-feature branch; the
+  literal `HEAD` sentinel is rejected here as well so a detached-HEAD
+  session can't be falsely credited as `branch_merged` via the
+  merge-base fallback. A one-line rationale accompanies every label
+  so operators can see which rule fired. List surfaces skip the
+  derivation (one `git` invocation per session list row is too
+  expensive); only the detail view surfaces it.
 
-### Statusline contract (R2.3, #224)
+### Statusline contract
 
 The JSON shape emitted by `GET /analytics/statusline` and
 `budi statusline --format json` is the single shared provider-scoped
 status contract. It is consumed by the CLI statusline, the Cursor
-extension ([#232](https://github.com/siropkin/budi/issues/232)), and the
-cloud dashboard ([#235](https://github.com/siropkin/budi/issues/235)).
-Provider is an explicit filter rather than a family of per-surface
-shapes — future agent coverage under
-[#294](https://github.com/siropkin/budi/issues/294) slots into the same
-shape. See [`docs/statusline-contract.md`](docs/statusline-contract.md)
-for the full schema.
+extension, and the cloud dashboard. Provider is an explicit filter
+rather than a family of per-surface shapes, so new agent coverage
+slots into the same shape. See
+[`docs/statusline-contract.md`](docs/statusline-contract.md) for the
+full schema.
 
 Key points:
 
@@ -446,64 +394,58 @@ Key points:
   is the canonical rolling view. `budi stats --period today` still
   uses the local-calendar today (today-so-far), but `--period week`
   and `--period month` resolve to rolling 7 / 30 days ending now —
-  identical to `-p 7d` / `-p 30d`. The old calendar-week-starting-Monday
-  and first-of-calendar-month semantics were removed in 8.3 (#447) so
-  the README's "week / month = last 7 / 30 calendar days including
-  today" contract is what the code actually does on every weekday.
+  identical to `-p 7d` / `-p 30d`.
 - **Provider-scoping is strict.** When the request carries
   `provider=claude_code`, every numeric field (`cost_*`, `session_cost`,
   `branch_cost`, `project_cost`) and `active_provider` are filtered to
-  that provider. The Claude Code statusline uses this by default so it
-  never shows blended multi-provider totals (the 8.0 bug #224 was
-  opened against).
+  that provider, so the Claude Code statusline never shows blended
+  multi-provider totals.
 - **Deprecated aliases** `today_cost` / `week_cost` / `month_cost` are
-  kept populated with the same rolling values for one release of
-  backward compatibility and are removed in 9.0. New consumers read
+  still populated with the same rolling values for backward
+  compatibility and will be removed in 9.0. New consumers read
   `cost_1d` / `cost_7d` / `cost_30d`.
 - **Slot config aliases.** `~/.config/budi/statusline.toml` files
   written against the 8.0 vocabulary (`slots = ["today", "week",
   "month"]`) continue to render, since `today` / `week` / `month` are
   normalized to `1d` / `7d` / `30d` at load time.
 - **Default install path is quiet.** `budi init` and
-  `budi integrations install` no longer prompt for a statusline preset;
-  the default is the rolling `1d` / `7d` / `30d` cost view. The
-  `coach` and `full` presets remain as opt-in advanced variants
-  documented in `README.md`.
-- **`budi init` installs the statusline by default (#454).** A fresh
+  `budi integrations install` install the rolling `1d` / `7d` / `30d`
+  preset without prompting. The `coach` and `full` presets remain
+  opt-in advanced variants documented in `README.md`.
+- **`budi init` installs the statusline by default.** A fresh
   `budi init` wires the Budi statusline into `~/.claude/settings.json`
   (and installs the Cursor extension when the Cursor CLI is on PATH)
   without prompting. Pass `--no-integrations` to opt out, or run
   `budi integrations install --with claude-code-statusline` / `--with
-  cursor-extension` later to install them piecewise. The installer is
-  idempotent — repeat `budi init` runs merge with an existing
-  `statusLine` command rather than clobbering it, and skip the
-  Cursor-extension install when one is already present.
+  cursor-extension` later. The installer is idempotent: repeat runs
+  merge with an existing `statusLine` command rather than clobbering
+  it, and skip the Cursor-extension install when one is already
+  present.
 - **`budi doctor` flags a missing statusline.** When `~/.claude`
   exists but `~/.claude/settings.json` carries no Budi-backed
   `statusLine`, doctor surfaces a WARN with the exact `budi
   integrations install` command to repair it. Install paths that
   legitimately want no Claude integration (CI, containers,
-  hand-rolled settings) pass `budi init --no-integrations` to suppress
-  the nudge from day one.
+  hand-rolled settings) pass `budi init --no-integrations` to
+  suppress the nudge from day one.
 
 `budi doctor` runs three attribution checks:
 
-- **Session visibility** for the `today`, `7d`, and `30d` windows (R1.0.1,
-  #302) — fails when a window has assistant rows but zero returned sessions.
-- **Branch attribution (7d, per provider)** (R1.0.2, #303) — yellow at >10%
-  of assistant rows missing `git_branch`, red at >50%. A red result points
-  at a broken attribution path for that provider (no headers, no resolvable
-  cwd, session propagation not rescuing the session) even if overall cost
-  numbers look healthy.
-- **Activity attribution (7d, per provider)** (R1.0.4, #305) — red when
-  a provider's recent assistant rows are effectively fully silent
-  (≥99.9% missing an `activity` tag, float-tolerant so a single legacy
-  row without an activity doesn't save an otherwise-silent classifier)
-  and it has at least 5 rows in the window (a silent classifier
-  regression). Yellow at >90% to hint at an over-aggressive skip path
-  without tripping a hard fail; a moderate missing-ratio is expected
-  because one-word prompts and slash commands never carry an `activity`
-  tag by design. See `activity_attribution` in
+- **Session visibility** for the `today`, `7d`, and `30d` windows — fails
+  when a window has assistant rows but zero returned sessions.
+- **Branch attribution (7d, per provider)** — yellow at >10% of assistant
+  rows missing `git_branch`, red at >50%. A red result points at a broken
+  attribution path for that provider (no resolvable `gitBranch`, session
+  propagation not rescuing the session) even if overall cost numbers look
+  healthy.
+- **Activity attribution (7d, per provider)** — red when a provider's
+  recent assistant rows are effectively fully silent (≥99.9% missing an
+  `activity` tag, float-tolerant so one legacy row doesn't save an
+  otherwise-silent classifier) and the window has at least 5 rows (a
+  silent classifier regression). Yellow at >90% to hint at an
+  over-aggressive skip path without tripping a hard fail; a moderate
+  missing-ratio is expected because one-word prompts and slash commands
+  never carry an `activity` tag by design. See `activity_attribution` in
   `crates/budi-cli/src/commands/doctor.rs`.
 
 ### Key concepts
@@ -511,64 +453,60 @@ Key points:
 - **cost_confidence**: determines `~` prefix in dashboard for non-exact costs
 - **Source of truth vs derived**: `messages` remains canonical; rollup tables are derived caches maintained incrementally via SQLite triggers during ingest/update/delete
 - **Session context propagation**: git_branch/repo_id flow from user -> assistant messages within a session
-- **Repository identity (8.3+, #442)**: `repo_id` is `Some("host/owner/repo")` only when the cwd is inside a git repo with a remote origin. Non-repo work (scratch dirs, `~/Desktop`, brew-tap checkouts, local-only repos without upstream) persists `repo_id = NULL` and rolls up into a single `(no repository)` bucket in `budi stats --projects`. An idempotent one-shot backfill on startup rewrites any pre-8.3 bare-folder-name values (`Desktop`, `ivan.seredkin`, …) to NULL; `--include-non-repo` opts back into the per-folder detail.
+- **Repository identity**: `repo_id` is `Some("host/owner/repo")` only when the cwd is inside a git repo with a remote origin. Non-repo work (scratch dirs, `~/Desktop`, brew-tap checkouts, local-only repos without upstream) persists `repo_id = NULL` and rolls up into a single `(no repository)` bucket in `budi stats --projects`. An idempotent one-shot backfill on startup rewrites any pre-8.3 bare-folder-name values (`Desktop`, `ivan.seredkin`, …) to NULL; `--include-non-repo` opts back into the per-folder detail.
 - **Progressive sync**: files processed newest-first so dashboard shows recent data quickly
-- **Historical import**: `budi db import` = full history backfill, `budi db import --force` = clear all data and re-ingest from scratch. The pre-8.2.1 bare verbs (`budi migrate` / `budi repair` / `budi import`) were removed in 8.3.0 (#428) after shipping as hidden deprecation aliases for the 8.2.x window; `budi db <verb>` is now the only surface.
-- **Legacy proxy residue (upgrade only)**: 8.2 does not route live traffic through a proxy. The only remaining proxy-related code scans for 8.0/8.1 residue in shell profiles and agent configs, reports retained `proxy_estimated` history honestly, and lets users remove managed blocks via `budi init --cleanup` (consent-first) or `budi uninstall` (managed cleanup parity).
+- **Historical import**: `budi db import` = full history backfill, `budi db import --force` = clear all data and re-ingest from scratch. `budi db <verb>` is the only surface — the pre-8.2.1 bare verbs (`budi migrate` / `budi repair` / `budi import`) were removed in 8.3.
+- **Legacy proxy residue (upgrade only)**: live traffic no longer flows through a proxy. The only remaining proxy-related code scans for 8.0/8.1 residue in shell profiles and agent configs, reports retained `proxy_estimated` history honestly, and lets users remove managed blocks via `budi init --cleanup` (consent-first) or `budi uninstall` (managed cleanup parity).
 
 ## Key files
 
 - `crates/budi-core/src/analytics/mod.rs` - SQLite storage, sync pipeline, all query functions
 - `crates/budi-core/src/analytics/health.rs` - Session health vitals, ProviderKind-aware tips, overall-state logic
 - `crates/budi-core/src/analytics/tests.rs` - Analytics + session health unit tests
-- `crates/budi-core/src/pipeline/mod.rs` - Pipeline struct, Enricher trait, default_pipeline() (ordered: IdentityEnricher → GitEnricher → ToolEnricher → FileEnricher → CostEnricher → TagEnricher); also hosts the cross-message tool-outcome correlation and retry heuristic that emit `tool_outcome` / `tool_outcome_source` / `tool_outcome_confidence` tags after the per-message enricher pass
-- `crates/budi-core/src/pipeline/enrichers.rs` - All 6 enricher implementations (`IdentityEnricher`, `GitEnricher`, `ToolEnricher`, `FileEnricher`, `CostEnricher`, `TagEnricher`; `HookEnricher` removed in 8.0, `FileEnricher` added in R1.4 #292)
-- `crates/budi-core/src/file_attribution.rs` - R1.4 (#292) repo-relative file-path extractor, enforces ADR-0083 privacy limits (no absolute paths, no outside-of-repo paths, no file contents)
-- `crates/budi-core/src/work_outcome.rs` - R1.5 (#293) session-scoped `work_outcome` derivation (`committed`, `branch_merged`, `no_commit`, `unknown`) from local git state only — no remote API calls, no content capture
-- `crates/budi-core/src/cost.rs` - Cost estimation glue (aggregates `cost_cents` from `messages`). `ModelPricing` lives in `provider.rs`; rates come exclusively from the manifest-backed `pricing::lookup` ([ADR-0091](docs/adr/0091-model-pricing-manifest-source-of-truth.md)). The four per-provider `*_pricing_for_model()` functions were removed in #377 — there is no fallback path
-- `crates/budi-core/src/pricing/mod.rs` - 8.3+ pricing loader + `lookup` API. Three-layer resolution (on-disk cache → embedded LiteLLM baseline → `unknown`), `PricingSource` tagging for immutable history, `backfill_unknown_rows` for Rule A (ADR-0091 §5), validation guards (>95% retention floor, $1,000/M sanity ceiling, 10 MB size cap). See [ADR-0091](docs/adr/0091-model-pricing-manifest-source-of-truth.md)
-- `crates/budi-core/src/pricing/manifest.embedded.json` - Vendored snapshot of LiteLLM's `model_prices_and_context_window.json`, refreshed per release by `scripts/pricing/sync_baseline.sh` (ADR-0091 §10)
-- `crates/budi-core/src/hooks.rs` - Prompt classification and migration helpers (hook ingestion removed in 8.0; `hook_events` table no longer exists in schema v1)
-- `crates/budi-core/src/jsonl.rs` - JSONL transcript parser, ParsedMessage struct
-- `crates/budi-core/src/providers/claude_code.rs` - Claude Code provider (JSONL discovery). Pricing flows through `pricing::lookup` per [ADR-0091](docs/adr/0091-model-pricing-manifest-source-of-truth.md); the 8.2-era `claude_pricing_for_model` shim was removed in #377
-- `crates/budi-core/src/providers/codex.rs` - Codex provider (Codex Desktop/CLI transcript import from `~/.codex/sessions/`). Pricing flows through `pricing::lookup` per [ADR-0091](docs/adr/0091-model-pricing-manifest-source-of-truth.md); the 8.2-era `codex_pricing_for_model` shim was removed in #377
-- `crates/budi-core/src/providers/copilot.rs` - Copilot CLI provider (transcript import from `~/.copilot/session-state/`). Pricing flows through `pricing::lookup` per [ADR-0091](docs/adr/0091-model-pricing-manifest-source-of-truth.md); the 8.2-era `copilot_pricing_for_model` delegator was removed in #377
-- `crates/budi-core/src/providers/cursor.rs` - Cursor provider (Usage API primary, transcript fallback; auth/session context from state.vscdb across macOS/Linux/Windows layouts). Usage-API rows write `pricing_source = 'upstream:api'` (ADR-0091 §4 sixth column value); transcript-fallback rows flow through `pricing::lookup`
-- `crates/budi-core/src/migration.rs` - Schema v1, all migration paths
-- `crates/budi-core/src/cloud_sync.rs` - Cloud sync worker: envelope builder, watermark tracking, HTTPS-only HTTP client with retry/backoff, privacy-safe rollup extraction
-- `crates/budi-core/src/autostart.rs` - Platform-native daemon autostart: launchd (macOS), systemd (Linux), Task Scheduler (Windows). Install/uninstall/status.
-- `crates/budi-core/src/config.rs` - BudiConfig, AgentsConfig, StatuslineConfig, TagsConfig, CloudConfig
-- `crates/budi-cli/build.rs` - Build script: creates empty vsix placeholder if not pre-built
-- `crates/budi-daemon/src/main.rs` - HTTP server (port 7878) + cloud sync worker + startup hooks for tailer / migration / legacy-residue notices.
-- `crates/budi-daemon/src/workers/cloud_sync.rs` - Background cloud sync loop: configurable interval, backoff, auth/schema error handling
-- `crates/budi-daemon/src/workers/pricing_refresh.rs` - 24 h LiteLLM manifest refresh loop ([ADR-0091](docs/adr/0091-model-pricing-manifest-source-of-truth.md) §3). Warm-loads the on-disk cache, validates fetched payloads, atomic-writes, hot-swaps `pricing` state, runs `backfill_unknown_rows`. Disabled via `BUDI_PRICING_REFRESH=0`
-- `crates/budi-daemon/src/routes/pricing.rs` - `GET /pricing/status` + `POST /pricing/refresh` (loopback-only) ([ADR-0091](docs/adr/0091-model-pricing-manifest-source-of-truth.md) §8)
-- `crates/budi-cli/src/commands/pricing.rs` - `budi pricing status [--json] [--refresh]` CLI surface ([ADR-0091](docs/adr/0091-model-pricing-manifest-source-of-truth.md) §8)
-- `crates/budi-daemon/src/routes/hooks.rs` - /sync, /sync/all, /sync/reset, /sync/status, /health, /health/integrations, /health/check-update, /admin/integrations/install endpoints (hook ingestion removed)
-- `crates/budi-daemon/src/routes/cloud.rs` - /cloud/sync (loopback-only manual cloud flush) and /cloud/status (cloud readiness + watermarks); added in R2.1 (#225)
-- `crates/budi-cli/src/commands/cloud.rs` - `budi cloud sync` / `budi cloud status` (R2.1 #225): text + JSON output, exit code 2 on non-ok sync
-- `crates/budi-daemon/src/routes/analytics.rs` - All analytics + admin endpoints (summary, messages, projects, cost, models, activity, branches, tags, providers, statusline, cache-efficiency, session-cost-curve, cost-confidence, subagent-cost, sessions, session-health, session-audit, admin/providers, admin/schema, admin/migrate, admin/repair)
-- `crates/budi-core/src/legacy_proxy.rs` - Upgrade-only detection/cleanup for managed 8.0/8.1 proxy residue in shell profiles and agent configs.
-- `crates/budi-cli/src/commands/init.rs` - `budi init` (daemon + autostart + detected-agent output) plus consent-first `--cleanup`.
-- `crates/budi-cli/src/commands/doctor.rs` - `budi doctor` checks daemon health, schema, transcript visibility, leftover legacy proxy residue, and retained proxy-era history.
-- `crates/budi-cli/src/commands/uninstall.rs` - `budi uninstall` removes autostart, Claude/Cursor integrations, and managed legacy proxy residue.
-- `crates/budi-cli/src/commands/sessions.rs` - `budi sessions` list and detail view (Rich CLI)
-- `crates/budi-cli/src/commands/status.rs` - `budi status` quick overview (daemon, tailer contract hints, today's cost). When the daemon is healthy but no messages are recorded for today, the command prints a first-run hint pointing the user at their agents and at `budi doctor` (R2.2, #228)
-- `crates/budi-cli/src/commands/statusline.rs` - Statusline rendering (default: quiet rolling `1d` / `7d` / `30d`, provider-scoped per ADR-0088 §4 / [docs/statusline-contract.md](docs/statusline-contract.md); `coach` / `full` presets remain as opt-in advanced variants) + installation
+- `crates/budi-core/src/pipeline/mod.rs` — `Pipeline` struct, `Enricher` trait, `default_pipeline()` (ordered: IdentityEnricher → GitEnricher → ToolEnricher → FileEnricher → CostEnricher → TagEnricher). Hosts the cross-message tool-outcome correlation and retry heuristic that emit `tool_outcome` / `tool_outcome_source` / `tool_outcome_confidence` tags after the per-message enricher pass.
+- `crates/budi-core/src/pipeline/enrichers.rs` — All enricher implementations (`IdentityEnricher`, `GitEnricher`, `ToolEnricher`, `FileEnricher`, `CostEnricher`, `TagEnricher`).
+- `crates/budi-core/src/file_attribution.rs` — Repo-relative file-path extractor; enforces ADR-0083 privacy limits (no absolute paths, no outside-of-repo paths, no file contents).
+- `crates/budi-core/src/work_outcome.rs` — Session-scoped `work_outcome` derivation (`committed`, `branch_merged`, `no_commit`, `unknown`) from local git state only; no remote API calls, no content capture.
+- `crates/budi-core/src/cost.rs` — Cost estimation glue (aggregates `cost_cents` from `messages`). Rates come exclusively from the manifest-backed `pricing::lookup` ([ADR-0091](docs/adr/0091-model-pricing-manifest-source-of-truth.md)); there is no fallback path.
+- `crates/budi-core/src/pricing/mod.rs` — Pricing loader + `lookup` API. Three-layer resolution (on-disk cache → embedded LiteLLM baseline → `unknown`), `PricingSource` tagging for immutable history, `backfill_unknown_rows` for retroactive fill-in once upstream catches up, validation guards (>95% retention floor, $1,000/M sanity ceiling, 10 MB size cap).
+- `crates/budi-core/src/pricing/manifest.embedded.json` — Vendored snapshot of LiteLLM's `model_prices_and_context_window.json`, refreshed per release by `scripts/pricing/sync_baseline.sh`.
+- `crates/budi-core/src/hooks.rs` — Prompt classification helpers (hook ingestion removed in 8.0; `hook_events` table gone in schema v1).
+- `crates/budi-core/src/jsonl.rs` — JSONL transcript parser, `ParsedMessage` struct.
+- `crates/budi-core/src/providers/claude_code.rs` — Claude Code provider (JSONL discovery + live watch).
+- `crates/budi-core/src/providers/codex.rs` — Codex provider (Codex Desktop/CLI transcripts under `~/.codex/sessions/`).
+- `crates/budi-core/src/providers/copilot.rs` — Copilot CLI provider (transcripts under `~/.copilot/session-state/`).
+- `crates/budi-core/src/providers/cursor.rs` — Cursor provider (Usage API primary + transcript fallback; auth/session context from `state.vscdb` across macOS/Linux/Windows). Usage-API rows write `pricing_source = 'upstream:api'`; transcript-fallback rows flow through `pricing::lookup`.
+- `crates/budi-core/src/migration.rs` — Schema v1, all migration paths.
+- `crates/budi-core/src/cloud_sync.rs` — Cloud sync worker: envelope builder, watermark tracking, HTTPS-only HTTP client with retry/backoff, privacy-safe rollup extraction.
+- `crates/budi-core/src/autostart.rs` — Platform-native daemon autostart: launchd (macOS), systemd (Linux), Task Scheduler (Windows). Install/uninstall/status.
+- `crates/budi-core/src/config.rs` — `BudiConfig`, `AgentsConfig`, `StatuslineConfig`, `TagsConfig`, `CloudConfig`.
+- `crates/budi-core/src/legacy_proxy.rs` — Upgrade-only detection/cleanup for managed 8.0/8.1 proxy residue in shell profiles and agent configs.
+- `crates/budi-cli/build.rs` — Build script: creates empty vsix placeholder if not pre-built.
+- `crates/budi-daemon/src/main.rs` — HTTP server (port 7878) + cloud sync worker + startup hooks for tailer / migration / legacy-residue notices.
+- `crates/budi-daemon/src/workers/cloud_sync.rs` — Background cloud sync loop: configurable interval, backoff, auth/schema error handling.
+- `crates/budi-daemon/src/workers/pricing_refresh.rs` — 24 h LiteLLM manifest refresh loop. Warm-loads the on-disk cache, validates fetched payloads, atomic-writes, hot-swaps `pricing` state, runs `backfill_unknown_rows`. Disabled via `BUDI_PRICING_REFRESH=0`.
+- `crates/budi-daemon/src/routes/pricing.rs` — `GET /pricing/status` + `POST /pricing/refresh` (loopback-only).
+- `crates/budi-daemon/src/routes/hooks.rs` — `/sync*`, `/health*`, `/admin/integrations/install` endpoints (hook ingestion removed; route file name retained for stability).
+- `crates/budi-daemon/src/routes/cloud.rs` — `/cloud/sync` (loopback-only manual cloud flush) and `/cloud/status`.
+- `crates/budi-daemon/src/routes/analytics.rs` — All analytics + admin endpoints.
+- `crates/budi-cli/src/commands/init.rs` — `budi init` (daemon + autostart + recommended-integrations + detected-agent output) plus consent-first `--cleanup`.
+- `crates/budi-cli/src/commands/doctor.rs` — `budi doctor` health checks (daemon, schema, transcript visibility, statusline wiring, attribution ratios, legacy proxy residue).
+- `crates/budi-cli/src/commands/uninstall.rs` — `budi uninstall` removes autostart, Claude/Cursor integrations, and managed legacy proxy residue.
+- `crates/budi-cli/src/commands/sessions.rs` — `budi sessions` list and detail view.
+- `crates/budi-cli/src/commands/status.rs` — `budi status` quick overview (daemon, today's cost, first-run hints).
+- `crates/budi-cli/src/commands/statusline.rs` — Statusline rendering (default quiet rolling `1d` / `7d` / `30d`, provider-scoped; `coach` / `full` opt-in variants).
+- `crates/budi-cli/src/commands/cloud.rs` — `budi cloud sync` / `budi cloud status` / `budi cloud init` (text + JSON; exit code 2 on non-ok sync).
+- `crates/budi-cli/src/commands/pricing.rs` — `budi pricing status [--json] [--refresh]`.
 <!-- budi-cursor and budi-cloud live in their own repos: siropkin/budi-cursor, siropkin/budi-cloud -->
 
 ## Dev notes
 
-- CLI never touches SQLite directly - all queries go through the daemon HTTP API
-- CostEnricher is the single source of truth for cost - sets cost_cents during pipeline. Skips if cost already set (API data). In 8.3+ it calls `pricing::lookup(model_id, provider)` which resolves against a three-layer stack (on-disk cache → embedded LiteLLM baseline → `unknown`) per [ADR-0091](docs/adr/0091-model-pricing-manifest-source-of-truth.md); unknown models land with `cost_cents = 0`, `pricing_source = 'unknown'`, and a warn, then auto-backfill to `backfilled:vNNN` once upstream catches up. History is immutable — `manifest:vNNN` and `legacy:pre-manifest` rows are never auto-recomputed, and there is no `budi pricing recompute` command.
-- `budi init` creates the data dir, validates schema/binary state, starts the daemon, installs autostart, prints detected agents from `Provider::watch_roots()`, and exits. It does not mutate shell profiles or editor configs on the live path. `budi init --cleanup` is the explicit upgrade-only path for reviewing/removing managed 8.0/8.1 proxy residue. `budi doctor` is the canonical end-to-end verifier and prints the matching first-run nudge when the DB has no assistant activity yet, so day-zero users do not misread empty attribution as a setup failure. Install scripts close with the same `budi doctor` recommendation.
-- Tags are auto-detected (`provider`, `model`, `tool`, `tool_use_id`, `ticket_id`, `ticket_source`, `activity`, `activity_source`, `activity_confidence`, `file_path`, `file_path_source`, `file_path_confidence`, `tool_outcome`, `tool_outcome_source`, `tool_outcome_confidence`, and conditional tags like `cost_confidence` / `speed`) + custom rules via `~/.config/budi/tags.toml`
-- git_branch is a column on messages (not a tag) for fast queries
-- **Session health**: Four vitals computed per session - context growth (context-size growth), cache reuse (cache hit rate), cost acceleration (per-reply cost growth), retry loops (currently disabled — hook ingestion removed in 8.0; `hook_events` table no longer exists in schema v1). Each vital has green/yellow/red state. New sessions start green - the default is always positive; vitals only degrade to yellow/red when there is clear evidence of a problem. Tips are provider-aware via `ProviderKind` enum (Claude Code -> `/compact`/`/clear`, Cursor -> "new composer session", Other -> neutral). When no session ID is provided, health auto-select prefers the latest session with assistant activity, then falls back to session timestamps. Statusline "coach" mode shows health icon + session cost + tip. Dashboard session detail page has a health panel with vitals grid and tips section.
-- **Cursor extension** ([siropkin/budi-cursor](https://github.com/siropkin/budi-cursor)): VS Code extension that renders Cursor-only spend in a **single status bar item** (no sidebar, no session list, no vitals / tips panel — all retired in v1.1.0 per R3.2 / #232 / ADR-0088 §7). The status bar consumes the shared provider-scoped status contract with `?provider=cursor`, mirrors the Claude Code statusline byte-for-byte (`🟢 budi · $X 1d · $Y 7d · $Z 30d`), and click-through opens the same cloud URL the Claude Code statusline opens (session detail when a Cursor session is active; dashboard root otherwise). Installed via VS Code Marketplace or `budi integrations install --with cursor-extension`. Communicates with daemon via HTTP and also spawns `budi statusline --format json --provider cursor`. Writes `~/.local/share/budi/cursor-sessions.json` (v1 contract, ADR-0086 §3.4) to signal the active workspace. Checks daemon `api_version` on startup (`MIN_API_VERSION = 1`) and warns if incompatible. As of v1.2.0 (R2.4, #314) the extension also acts as a first-class onboarding entry point for users who install it from the marketplace before installing the daemon: a dedicated `firstRun` state, an in-editor welcome view with a pre-filled install command, and a local-only `~/.local/share/budi/cursor-onboarding.json` v1 counter file (`welcome_view_impressions`, `open_terminal_clicks`, `handoffs_completed`) that `budi doctor` surfaces so we can see install-funnel health without any remote telemetry. Cross-surface local→cloud linking UX is owned by #235 (R3) per ADR-0088 §6.
-- **Cloud dashboard** ([siropkin/budi-cloud](https://github.com/siropkin/budi-cloud)) is a Next.js 16 app deployed to app.getbudi.dev. Uses Supabase Auth (GitHub/Google/magic link) for web sign-in. Dashboard pages: Overview, Team, Models, Repos, Sessions, Settings. Manager role sees all org data; member sees own data.
-- Analytics endpoints: `/analytics/summary`, `/analytics/filter-options`, `/analytics/messages`, `/analytics/messages/{message_uuid}/detail`, `/analytics/projects`, `/analytics/cost`, `/analytics/models`, `/analytics/activity` (activity chart timeline), `/analytics/activities`, `/analytics/activities/{name}` (activity buckets — #305), `/analytics/branches`, `/analytics/branches/{branch}`, `/analytics/tickets`, `/analytics/tickets/{ticket_id}`, `/analytics/files`, `/analytics/files/{*path}`, `/analytics/tags`, `/analytics/providers`, `/analytics/statusline`, `/analytics/cache-efficiency`, `/analytics/session-cost-curve`, `/analytics/cost-confidence`, `/analytics/subagent-cost`, `/analytics/sessions`, `/analytics/sessions/{id}`, `/analytics/sessions/{id}/messages`, `/analytics/sessions/{id}/curve`, `/analytics/sessions/{id}/tags`, `/analytics/session-health`, `/analytics/session-audit` (session attribution stats for debugging ingestion)
-- Admin endpoints (loopback-only): `/admin/providers` (registered providers), `/admin/schema` (schema version), `/admin/migrate` (run migration), `/admin/repair` (repair schema drift + run migration), `/admin/integrations/install` (integration installer orchestration)
-- Sync mutation endpoints (loopback-only): `/sync` (30-day), `/sync/all` (full history), `/sync/reset` (wipe sync state + full re-sync)
-- Sync status endpoint: `/sync/status` (syncing flag + last_synced)
-- Health endpoints: `/health` (ok + version + api_version), `/health/integrations` (statusline/extension status + DB stats + paths), `/health/check-update` (GitHub releases)
+- CLI never touches SQLite directly — all queries go through the daemon HTTP API.
+- `CostEnricher` is the single source of truth for cost. It sets `cost_cents` during the pipeline, skipping when cost is already set (e.g., Cursor Usage API rows). It calls `pricing::lookup(model_id, provider)`, which resolves against a three-layer stack (on-disk cache → embedded LiteLLM baseline → `unknown`) per [ADR-0091](docs/adr/0091-model-pricing-manifest-source-of-truth.md). Unknown models land with `cost_cents = 0`, `pricing_source = 'unknown'`, and a warn, then auto-backfill to `backfilled:vNNN` once upstream catches up. History is immutable — `manifest:vNNN` and `legacy:pre-manifest` rows are never auto-recomputed, and there is no `budi pricing recompute` command.
+- `budi init` creates the data dir, validates schema/binary state, starts the daemon, installs autostart, wires recommended integrations (Claude Code statusline + Cursor extension) idempotently, prints detected agents from `Provider::watch_roots()`, and exits. `budi doctor` is the canonical end-to-end verifier and prints a first-run nudge when the DB has no assistant activity yet, so day-zero users don't misread empty attribution as a setup failure. Install scripts close with the same `budi doctor` recommendation. `budi init --cleanup` is the explicit upgrade-only path for reviewing/removing managed 8.0/8.1 proxy residue.
+- Tags are auto-detected (`provider`, `model`, `tool`, `tool_use_id`, `ticket_id`, `ticket_source`, `activity`, `activity_source`, `activity_confidence`, `file_path`, `file_path_source`, `file_path_confidence`, `tool_outcome`, `tool_outcome_source`, `tool_outcome_confidence`, plus conditional tags like `cost_confidence` / `speed`) with custom rules available via `~/.config/budi/tags.toml`.
+- `git_branch` is a column on `messages` (not a tag) for fast queries.
+- **Session health**: four vitals — context growth, cache reuse, cost acceleration, retry loops (currently disabled pending a rebuild on top of the tool-outcome signal). Each vital has green/yellow/red state. New sessions start green; vitals only degrade when there is clear evidence of a problem. Tips are provider-aware via the `ProviderKind` enum (Claude Code → `/compact`/`/clear`, Cursor → "new composer session", Other → neutral). When no session ID is provided, auto-select prefers the latest session with assistant activity, then falls back to session timestamps. The statusline `coach` preset shows health icon + session cost + tip; the cloud dashboard session detail page has a full health panel.
+- **Cursor extension** ([siropkin/budi-cursor](https://github.com/siropkin/budi-cursor)) is a statusline-only VS Code extension (no sidebar, no session list, no vitals/tips panel). The status bar consumes the shared provider-scoped status contract with `?provider=cursor`, mirrors the Claude Code statusline byte-for-byte (`🟢 budi · $X 1d · $Y 7d · $Z 30d`), and click-through opens the same cloud URL the Claude Code statusline opens. Installed via the VS Code Marketplace or `budi integrations install --with cursor-extension`. Communicates with the daemon via HTTP and spawns `budi statusline --format json --provider cursor`. Writes `~/.local/share/budi/cursor-sessions.json` (v1 contract, ADR-0086 §3.4) to signal the active workspace. Checks daemon `api_version` on startup (`MIN_API_VERSION = 1`) and warns if incompatible. Also acts as a first-class onboarding entry point for users who install it before the daemon: a welcome view with a pre-filled install command, and a local-only `~/.local/share/budi/cursor-onboarding.json` counter file that `budi doctor` surfaces so install-funnel health is visible without remote telemetry.
+- **Cloud dashboard** ([siropkin/budi-cloud](https://github.com/siropkin/budi-cloud)) is a Next.js 16 app deployed to `app.getbudi.dev`. Uses Supabase Auth (GitHub/Google/magic link) for web sign-in. Dashboard pages: Overview, Team, Models, Repos, Sessions, Settings. Manager role sees all org data; member sees own data.
+- For the full HTTP surface (analytics, admin, sync, health, pricing, cloud), see the README "Daemon API" details block — that table is the canonical list and is kept in sync with the route files.


### PR DESCRIPTION
## Summary

Pass across `README.md` and `SOUL.md` to remove stale transition-window narrative now that 8.2 has shipped (8.2.1 is the latest release, 8.3 work is landed and awaiting a release cut) and to condense over-detailed sections.

### README
- Update `VERSION=v7.1.0` examples to `v8.2.1` in the install and update sections.
- Drop the two "Hooks (removed in 8.0)" and "OTEL (removed in 8.0)" detail blocks — they only documented ingestion paths that no longer exist.
- Trim "in 8.2" / "as of v1.1.0" version-shoulder phrasing that is no longer a meaningful distinction.
- Reorder the cost-confidence table so current levels lead and `proxy_estimated` is labelled as legacy read-only history.
- Keep all legitimate 8.0/8.1 upgrade-residue guidance intact (first-run checklist, troubleshooting, `budi init --cleanup`).

### SOUL
- Fold the two "As of 8.2.0 / 8.3.0" blockquotes at the top into a single **Architecture highlights** list.
- Strip per-field 8.1 proxy-path narration from the attribution contract (`session_id`, `git_branch`, `ticket_id`, `activity`, `tool_outcome`, `work_outcome`) and the data-flow section — the proxy was removed in 8.2, so the contract now documents the current pipeline directly.
- Drop R1.0 / R1.2 / R1.4 / R2.1 / R2.3 / R2.4 milestone anchors that have no bearing on current behavior.
- Condense the e2e-test enumeration to point at `scripts/e2e/` instead of listing every guard inline.
- Tighten the statusline contract and doctor-check subsections.
- Slim the key-files list, consolidating removed-shim footnotes.
- Replace the duplicated HTTP-endpoint enumeration at the bottom with a pointer to the README's "Daemon API" block, which is the canonical list.
- Fix one broken ADR-0083 link (`0083-privacy-constraints.md` → `0083-cloud-ingest-identity-and-privacy-contract.md`).

Net: `-258 / +182` lines (SOUL shrinks ~11%, README ~2%), no behavior changes.

## Test plan

- [x] `grep` sweep for stale anchors (R-milestones, `#322`, `proxy_events`, dated "in 8.2+" phrasing) — only legitimate upgrade-residue references remain.
- [x] ADR link resolver: confirmed every `docs/adr/00XX-*.md` link in the edited files resolves to a real file.
- [ ] Reviewer sanity-check on the attribution-contract compression — the rewrite should read the same for a fresh contributor who never touched the 8.1 proxy code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)