### PR TITLE
release: prep v8.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 8.3.0 — Unreleased
+## 8.3.0 — 2026-04-22
 
 8.3.0 is the pricing source-of-truth pivot, plus the deferred 8.2
 `docs/` + `scripts/` hygiene sweep, plus the two audit passes filed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,7 +175,7 @@ dependencies = [
 
 [[package]]
 name = "budi-cli"
-version = "8.2.1"
+version = "8.3.0"
 dependencies = [
  "anyhow",
  "budi-core",
@@ -193,7 +193,7 @@ dependencies = [
 
 [[package]]
 name = "budi-core"
-version = "8.2.1"
+version = "8.3.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -209,7 +209,7 @@ dependencies = [
 
 [[package]]
 name = "budi-daemon"
-version = "8.2.1"
+version = "8.3.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "8.2.1"
+version = "8.3.0"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"


### PR DESCRIPTION
## Summary

Release-prep PR for `v8.3.0`. Mechanical changes only:

- `Cargo.toml` — `[workspace.package].version` bumped from `8.2.1`
  to `8.3.0`. Crates (`budi-cli`, `budi-core`, `budi-daemon`)
  inherit via `version.workspace = true`.
- `Cargo.lock` — refreshed with `cargo check --workspace --offline`
  (before any `--locked` validation, per the 8.2.1 lesson carried
  forward in #436). Only the three workspace crate versions
  changed; no upstream bumps.
- `CHANGELOG.md` — `§8.3.0 — Unreleased` renamed to
  `§8.3.0 — 2026-04-22`. The prose body is unchanged; the release
  page preamble will link this section rather than re-author the
  narrative.

No code changes, no dependency changes, no ADR/policy changes.
Tracking ticket: #479.

## Risks / compatibility notes

- **Non-blocking for downstream consumers.** `8.3.0` is a forward
  tag bump; no `8.2.x` behaviour changes here. Scripts that pin
  `budi --version == 8.2.1` will need to re-pin after install,
  same as every prior minor.
- **No new dependencies.** `cargo deny check` is green locally
  (`advisories ok, bans ok, licenses ok, sources ok`). No entries
  added to `deny.toml`.
- **No new runtime network calls** added in this PR. The
  ADR-0091 pricing manifest fetch shipped in `#376`; this PR
  does not modify it.
- **Pre-tag gates intentionally not walked yet.** The operator
  walk of the fresh-user smoke (per #479 §"Pre-tag smoke-test
  gate") and the `budi stats` reconciliation (per #479 §"Pre-tag
  `budi stats` reconciliation gate") happens on the merge
  candidate — not a blocker for opening this PR for review, but
  a blocker for merge + tag. Both checklists have evidence slots
  waiting on #479.
- **Release-page preamble deferred to tag time.** Per #436 rule
  12 (release notes live on the GitHub release page, not as
  `docs/releases/8.3.0.md`) and per #479 §"Post-tag verification",
  the curated pivot-narrative preamble lands on the GitHub
  release body after `release.yml` publishes — not in this PR
  and not as a repo file.

## Validation

Ran the full gate locally against this branch (commit `f18efaf`)
after the lockfile refresh:

- `cargo fmt --all --check` — clean.
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
  — clean (all three crates compile at `v8.3.0` with zero
  warnings).
- `cargo test --workspace --locked` — **640 passed, 0 failed,
  0 ignored** (budi-cli: 157, budi-core: 446, budi-daemon: 37,
  doc-tests: 0). Full per-crate summary:

  ```
  test result: ok. 157 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.07s
  test result: ok. 446 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 3.70s
  test result: ok. 37 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 16.43s
  test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
  ```

- `cargo deny check` — `advisories ok, bans ok, licenses ok,
  sources ok`. No new findings against the `#432` policy.

CI gate (`rust-checks`, `macos-build`, `windows-build`,
`supply-chain`, `ci-success`) must be green on this PR before
merge per #479 — the `release.yml` `ci-check` job blocks on
`ci-success` for the tagged commit.

Refs #479, #436.