### PR TITLE
stats: Agents block counts user+assistant so it sums to Total (#482)

### DIFF
--- a/crates/budi-cli/src/commands/stats.rs
+++ b/crates/budi-cli/src/commands/stats.rs
@@ -443,6 +443,16 @@ pub fn cmd_stats(
         let (since, until) = period_date_range(period);
         let summary = client.summary(since.as_deref(), until.as_deref(), provider.as_deref())?;
         let cost = client.cost(since.as_deref(), until.as_deref(), provider.as_deref())?;
+        // #482 acceptance: expose per-provider counts so scripts can
+        // reconcile `sum(providers.total_messages) == total_messages`
+        // both ways (user + assistant split, and the combined total).
+        let providers = client
+            .providers(since.as_deref(), until.as_deref())
+            .unwrap_or_default();
+        let filtered_providers: Vec<&analytics::ProviderStats> = providers
+            .iter()
+            .filter(|p| provider.as_deref().is_none_or(|sel| p.provider == sel))
+            .collect();
         let mut obj = serde_json::to_value(&summary)?;
         if let Some(map) = obj.as_object_mut() {
             map.insert("total_cost".to_string(), serde_json::json!(cost.total_cost));
@@ -462,6 +472,10 @@ pub fn cmd_stats(
             map.insert(
                 "cache_savings".to_string(),
                 serde_json::json!(cost.cache_savings),
+            );
+            map.insert(
+                "providers".to_string(),
+                serde_json::to_value(&filtered_providers)?,
             );
             // Expose the resolved window so scripting users can verify
             // which period `--period today|week|month|Nd|Nw|Nm|all`
@@ -599,6 +613,12 @@ fn format_summary(
         )
         .unwrap();
     } else {
+        // #482: render the per-provider row's message count as
+        // `total_messages` (user + assistant) so the column label `msgs`
+        // carries the same unit as the Total row below
+        // (`3050 messages (1680 user, 1370 assistant)`). Pre-8.3.1 this
+        // was assistant-only, which read as a slice of Total but actually
+        // undercounted by `total_user_messages`.
         for ps in &displayed_providers {
             let total_tokens = ps.input_tokens
                 + ps.output_tokens
@@ -613,7 +633,7 @@ fn format_summary(
                 out,
                 "    {cyan}{:<14}{reset} {:>5} msgs  {}  {yellow}{}{reset}",
                 ps.display_name,
-                ps.message_count,
+                ps.total_messages,
                 format_tokens(total_tokens),
                 format_cost(cost),
             )
@@ -2844,10 +2864,18 @@ mod tests {
         msgs: u64,
         cents: f64,
     ) -> analytics::ProviderStats {
+        // #482: `msgs` is interpreted as the assistant-side count (same
+        // unit every pre-8.3.1 caller passed). The fixture picks a
+        // user_messages value slightly larger than assistant so
+        // `total_messages = assistant + user` stays unambiguous across
+        // snapshot tests.
+        let user = msgs.saturating_add(3);
         analytics::ProviderStats {
             provider: provider.into(),
             display_name: display.into(),
-            message_count: msgs,
+            assistant_messages: msgs,
+            user_messages: user,
+            total_messages: msgs + user,
             input_tokens: 100_000,
             output_tokens: 50_000,
             cache_creation_tokens: 10_000,
@@ -3188,6 +3216,100 @@ mod tests {
             &palette,
         );
         assert!(!r.contains("Cursor cost data may lag"));
+    }
+
+    #[test]
+    fn summary_agents_block_count_matches_total_row_unit() {
+        // #482: the Agents block's `msgs` column is the same unit as
+        // `Total {n} messages` (user + assistant), not the pre-8.3.1
+        // assistant-only count. Without this, a fresh reader seeing
+        // `Claude Code 1358 msgs` on top of `Total 3050 messages` has
+        // no way to tell that `1358` undercounts by `total_user_messages`.
+        //
+        // Contract: the per-provider count printed in the Agents block
+        // equals `ProviderStats.total_messages`, AND `sum(displayed
+        // providers.total_messages) == summary.total_messages` when no
+        // filter is active.
+        let summary = budi_core::analytics::UsageSummary {
+            total_messages: 3050,
+            total_user_messages: 1680,
+            total_assistant_messages: 1370,
+            total_input_tokens: 1_300_000,
+            total_output_tokens: 874_100,
+            total_cache_creation_tokens: 50_000,
+            total_cache_read_tokens: 200_000,
+            total_cost_cents: 12_640.0,
+        };
+        let est = fixture_cost(0.0);
+        // Hand-built providers so we can pin the exact split seen on
+        // the 2026-04-22 audit machine.
+        let claude = analytics::ProviderStats {
+            provider: "claude_code".into(),
+            display_name: "Claude Code".into(),
+            assistant_messages: 1358,
+            user_messages: 1670,
+            total_messages: 3028,
+            input_tokens: 1_300_000,
+            output_tokens: 874_100,
+            cache_creation_tokens: 50_000,
+            cache_read_tokens: 200_000,
+            estimated_cost: 126.40,
+            total_cost_cents: 12_640.0,
+        };
+        let cursor = analytics::ProviderStats {
+            provider: "cursor".into(),
+            display_name: "Cursor".into(),
+            assistant_messages: 12,
+            user_messages: 10,
+            total_messages: 22,
+            input_tokens: 0,
+            output_tokens: 0,
+            cache_creation_tokens: 0,
+            cache_read_tokens: 0,
+            estimated_cost: 0.0,
+            total_cost_cents: 0.0,
+        };
+        let providers = vec![claude.clone(), cursor.clone()];
+        let palette = SummaryPalette::plain();
+
+        let rendered = format_summary(
+            StatsPeriod::Today,
+            None,
+            &summary,
+            &est,
+            &providers,
+            &palette,
+        );
+
+        // The per-provider row renders `total_messages`, not
+        // `assistant_messages`. Locking the exact substring prevents a
+        // future renderer from quietly swapping back to assistant-only.
+        assert!(
+            rendered.contains(&format!("{} msgs", claude.total_messages)),
+            "Claude Code row must render total_messages ({}), not assistant_messages ({}):\n{rendered}",
+            claude.total_messages,
+            claude.assistant_messages,
+        );
+        assert!(
+            rendered.contains(&format!("{} msgs", cursor.total_messages)),
+            "Cursor row must render total_messages ({}):\n{rendered}",
+            cursor.total_messages,
+        );
+        assert!(
+            !rendered.contains(&format!("{} msgs", claude.assistant_messages)),
+            "must not render assistant-only count ({}) in Agents column:\n{rendered}",
+            claude.assistant_messages,
+        );
+
+        // Per-provider totals reconcile to the summary total to within
+        // the sync-lag budget. Here the fixture is internally consistent
+        // so the delta is exactly 0.
+        let agg: u64 = providers.iter().map(|p| p.total_messages).sum();
+        assert_eq!(
+            agg, summary.total_messages,
+            "sum of Agents-block counts ({}) must match Total row ({})",
+            agg, summary.total_messages,
+        );
     }
 
     // ─── #450 breakdown polish tests ──────────────────────────────────

--- a/crates/budi-core/src/analytics/queries.rs
+++ b/crates/budi-core/src/analytics/queries.rs
@@ -3502,11 +3502,29 @@ pub fn statusline_stats(
 // ---------------------------------------------------------------------------
 
 /// Per-provider aggregate stats for the /analytics/providers endpoint.
+///
+/// ## Message counts (8.3.1 / #482)
+///
+/// Token and cost fields are assistant-only (a user turn has no LLM spend).
+/// The three message-count fields disambiguate what a row counts:
+///
+/// - `assistant_messages` — assistant replies. Same unit every other breakdown
+///   uses (`SessionStats.message_count`, `RepoUsage.message_count`, etc.).
+/// - `user_messages` — user prompts.
+/// - `total_messages` — user + assistant. Matches `UsageSummary.total_messages`
+///   so the Agents block sums back to the grand Total row in `budi stats`.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ProviderStats {
     pub provider: String,
     pub display_name: String,
-    pub message_count: u64,
+    /// Assistant-side message count. Pre-8.3.1 this was exposed as
+    /// `message_count`; the alias keeps older deserializers working.
+    #[serde(alias = "message_count")]
+    pub assistant_messages: u64,
+    /// User-side message count (8.3.1+, #482).
+    pub user_messages: u64,
+    /// User + assistant. Reconciles to `UsageSummary.total_messages`.
+    pub total_messages: u64,
     pub input_tokens: u64,
     pub output_tokens: u64,
     pub cache_creation_tokens: u64,
@@ -3530,7 +3548,10 @@ fn provider_stats_from_rollups(
     window: &RollupWindow,
     filters: &DimensionFilters,
 ) -> Result<Vec<ProviderStats>> {
-    let mut conditions = vec!["role = 'assistant'".to_string()];
+    // #482: count user + assistant rows and split via CASE so the Agents
+    // block sums back to `UsageSummary.total_messages`. Tokens and cost
+    // stay assistant-only because a user turn has no LLM spend.
+    let mut conditions: Vec<String> = Vec::new();
     let mut params: Vec<String> = Vec::new();
     append_rollup_time_filters(&mut conditions, &mut params, window);
     apply_dimension_filters(
@@ -3542,20 +3563,27 @@ fn provider_stats_from_rollups(
         "repo_id",
         "git_branch",
     );
+    let where_clause = if conditions.is_empty() {
+        String::new()
+    } else {
+        format!("WHERE {}", conditions.join(" AND "))
+    };
     let sql = format!(
         "SELECT provider as p,
-                COALESCE(SUM(message_count), 0) as msgs,
-                COALESCE(SUM(input_tokens), 0),
-                COALESCE(SUM(output_tokens), 0),
-                COALESCE(SUM(cache_creation_tokens), 0),
-                COALESCE(SUM(cache_read_tokens), 0),
-                COALESCE(SUM(cost_cents), 0.0)
+                COALESCE(SUM(message_count), 0) as total_msgs,
+                COALESCE(SUM(CASE WHEN role = 'user' THEN message_count ELSE 0 END), 0) as user_msgs,
+                COALESCE(SUM(CASE WHEN role = 'assistant' THEN message_count ELSE 0 END), 0) as asst_msgs,
+                COALESCE(SUM(CASE WHEN role = 'assistant' THEN input_tokens ELSE 0 END), 0),
+                COALESCE(SUM(CASE WHEN role = 'assistant' THEN output_tokens ELSE 0 END), 0),
+                COALESCE(SUM(CASE WHEN role = 'assistant' THEN cache_creation_tokens ELSE 0 END), 0),
+                COALESCE(SUM(CASE WHEN role = 'assistant' THEN cache_read_tokens ELSE 0 END), 0),
+                COALESCE(SUM(CASE WHEN role = 'assistant' THEN cost_cents ELSE 0.0 END), 0.0)
          FROM {}
-         WHERE {}
+         {}
          GROUP BY p
-         ORDER BY msgs DESC",
+         ORDER BY asst_msgs DESC",
         rollup_table(window.level),
-        conditions.join(" AND ")
+        where_clause
     );
     let param_refs: Vec<&dyn rusqlite::types::ToSql> = params
         .iter()
@@ -3572,7 +3600,9 @@ fn provider_stats_from_rollups(
                 row.get::<_, u64>(3)?,
                 row.get::<_, u64>(4)?,
                 row.get::<_, u64>(5)?,
-                row.get::<_, f64>(6)?,
+                row.get::<_, u64>(6)?,
+                row.get::<_, u64>(7)?,
+                row.get::<_, f64>(8)?,
             ))
         })?
         .filter_map(|r| r.ok())
@@ -3580,7 +3610,18 @@ fn provider_stats_from_rollups(
 
     let providers = crate::provider::all_providers();
     let mut result = Vec::new();
-    for (prov, messages, input, output, cache_create, cache_read, sum_cost_cents) in rows {
+    for (
+        prov,
+        total_msgs,
+        user_msgs,
+        asst_msgs,
+        input,
+        output,
+        cache_create,
+        cache_read,
+        sum_cost_cents,
+    ) in rows
+    {
         let display_name = providers
             .iter()
             .find(|p| p.name() == prov)
@@ -3590,7 +3631,9 @@ fn provider_stats_from_rollups(
         result.push(ProviderStats {
             provider: prov,
             display_name,
-            message_count: messages,
+            assistant_messages: asst_msgs,
+            user_messages: user_msgs,
+            total_messages: total_msgs,
             input_tokens: input,
             output_tokens: output,
             cache_creation_tokens: cache_create,
@@ -3614,7 +3657,10 @@ pub fn provider_stats_with_filters(
         return provider_stats_from_rollups(conn, &window, filters);
     }
 
-    let mut conditions = vec!["role = 'assistant'".to_string()];
+    // #482: count user + assistant rows and split via CASE so the Agents
+    // block sums back to `UsageSummary.total_messages`. Tokens and cost
+    // stay assistant-only because a user turn has no LLM spend.
+    let mut conditions: Vec<String> = Vec::new();
     let mut param_values = Vec::new();
     if let Some(s) = since
         && is_valid_timestamp(s)
@@ -3640,21 +3686,27 @@ pub fn provider_stats_with_filters(
         &project_expr,
         &branch_expr,
     );
-    let where_clause = format!("WHERE {}", conditions.join(" AND "));
+    let where_clause = if conditions.is_empty() {
+        String::new()
+    } else {
+        format!("WHERE {}", conditions.join(" AND "))
+    };
     let param_refs: Vec<&dyn rusqlite::types::ToSql> = param_values
         .iter()
         .map(|s| s as &dyn rusqlite::types::ToSql)
         .collect();
     let sql = format!(
         "SELECT provider as p,
-                COUNT(*) as msgs,
-                COALESCE(SUM(input_tokens), 0),
-                COALESCE(SUM(output_tokens), 0),
-                COALESCE(SUM(cache_creation_tokens), 0),
-                COALESCE(SUM(cache_read_tokens), 0),
-                COALESCE(SUM(cost_cents), 0.0)
+                COUNT(*) as total_msgs,
+                COALESCE(SUM(CASE WHEN role = 'user' THEN 1 ELSE 0 END), 0) as user_msgs,
+                COALESCE(SUM(CASE WHEN role = 'assistant' THEN 1 ELSE 0 END), 0) as asst_msgs,
+                COALESCE(SUM(CASE WHEN role = 'assistant' THEN input_tokens ELSE 0 END), 0),
+                COALESCE(SUM(CASE WHEN role = 'assistant' THEN output_tokens ELSE 0 END), 0),
+                COALESCE(SUM(CASE WHEN role = 'assistant' THEN cache_creation_tokens ELSE 0 END), 0),
+                COALESCE(SUM(CASE WHEN role = 'assistant' THEN cache_read_tokens ELSE 0 END), 0),
+                COALESCE(SUM(CASE WHEN role = 'assistant' THEN cost_cents ELSE 0.0 END), 0.0)
          FROM messages {}
-         GROUP BY p ORDER BY msgs DESC",
+         GROUP BY p ORDER BY asst_msgs DESC",
         where_clause
     );
 
@@ -3668,7 +3720,9 @@ pub fn provider_stats_with_filters(
                 row.get::<_, u64>(3)?,
                 row.get::<_, u64>(4)?,
                 row.get::<_, u64>(5)?,
-                row.get::<_, f64>(6)?,
+                row.get::<_, u64>(6)?,
+                row.get::<_, u64>(7)?,
+                row.get::<_, f64>(8)?,
             ))
         })?
         .filter_map(|r| match r {
@@ -3683,7 +3737,18 @@ pub fn provider_stats_with_filters(
     let providers = crate::provider::all_providers();
     let mut result = Vec::new();
 
-    for (prov, messages, input, output, cache_create, cache_read, sum_cost_cents) in rows {
+    for (
+        prov,
+        total_msgs,
+        user_msgs,
+        asst_msgs,
+        input,
+        output,
+        cache_create,
+        cache_read,
+        sum_cost_cents,
+    ) in rows
+    {
         let display_name = providers
             .iter()
             .find(|p| p.name() == prov)
@@ -3696,7 +3761,9 @@ pub fn provider_stats_with_filters(
         result.push(ProviderStats {
             provider: prov,
             display_name,
-            message_count: messages,
+            assistant_messages: asst_msgs,
+            user_messages: user_msgs,
+            total_messages: total_msgs,
             input_tokens: input,
             output_tokens: output,
             cache_creation_tokens: cache_create,

--- a/crates/budi-core/src/analytics/tests.rs
+++ b/crates/budi-core/src/analytics/tests.rs
@@ -1391,8 +1391,19 @@ fn multi_provider_ingest_and_query() {
     assert_eq!(pstats.len(), 2);
     let cc_stats = pstats.iter().find(|p| p.provider == "claude_code").unwrap();
     let cu_stats = pstats.iter().find(|p| p.provider == "cursor").unwrap();
-    assert_eq!(cc_stats.message_count, 1);
-    assert_eq!(cu_stats.message_count, 1);
+    // #482: Agents-block fields — assistant_messages is the pre-8.3.1
+    // unit (assistant-only), user_messages is new, total_messages = sum.
+    // The Agents block sums back to `UsageSummary.total_messages` via
+    // `total_messages`, not `assistant_messages`.
+    assert_eq!(cc_stats.assistant_messages, 1);
+    assert_eq!(cc_stats.user_messages, 1);
+    assert_eq!(cc_stats.total_messages, 2);
+    assert_eq!(cu_stats.assistant_messages, 1);
+    assert_eq!(cu_stats.user_messages, 1);
+    assert_eq!(cu_stats.total_messages, 2);
+    // Per-provider totals reconcile to the grand `UsageSummary.total_messages`.
+    let summed: u64 = pstats.iter().map(|p| p.total_messages).sum();
+    assert_eq!(summed, all.total_messages);
 
     assert_eq!(cc_stats.display_name, "Claude Code");
     assert!(cc_stats.estimated_cost > 0.0);


### PR DESCRIPTION
## Summary

The `budi stats` Agents block labeled its column `msgs` but counted
**assistant-only** messages, while the `Total` row counted both sides
(`3050 messages (1680 user, 1370 assistant)`). A fresh reader seeing
`Claude Code 1358 msgs` on top of `Total 3050 messages` naturally read
it as "1358 of 3050 were Claude Code" — which was wrong by
`total_user_messages`.

This PR picks **Option 1** from the ticket's three candidates: match
the Total row's unit. The per-provider `msgs` column now renders
`ProviderStats.total_messages` (user + assistant) so
`sum(displayed providers.total_messages) == summary.total_messages` on
the same screen.

## Changes

- `budi-core::analytics::queries::ProviderStats`:
  - rename `message_count` → `assistant_messages` (`#[serde(alias = "message_count")]` kept so older-client JSON round-trips)
  - add `user_messages: u64` and `total_messages: u64`
  - SQL (both rollup + non-rollup paths) uses `CASE WHEN role = ...` to split per-role counts in one scan; tokens + cost stay assistant-only because a user turn has no LLM spend
- `budi-cli stats` Agents-block row uses `ps.total_messages`
- `budi stats --format json` gains a `providers[]` field on the default summary so scripts can reconcile both ways (ticket acceptance)
- New `#451` summary-shape test `summary_agents_block_count_matches_total_row_unit` pins the contract on the 2026-04-22 audit fixture (1358 asst + 1670 user per Claude Code, etc.). A renderer change that swaps back to `assistant_messages` will fail the assertion.

## Risks / compatibility notes

- JSON wire change: `/analytics/providers` response body renames
  `message_count` → `assistant_messages` and gains two new fields
  (`user_messages`, `total_messages`). Kept `#[serde(alias)]` so older
  in-flight deserializers still parse pre-8.3.1 payloads. This endpoint
  is not part of a documented public API — only consumer is the budi
  CLI which ships in lockstep.
- Storage contract unchanged: no migration; the query just widens what
  it reports from existing `role` / `message_count` columns.
- Rationale documented inline for the option chosen (ticket requires
  documenting in `#451`'s summary-format contract).
- Doesn't touch `assistant_messages`-only breakdowns elsewhere
  (`--projects` / `--tickets` / etc.) — those breakdowns count work
  units (one assistant reply = one work unit) and stay as-is.

## Validation

- `cargo fmt --all --check` — clean
- `cargo clippy --workspace --all-targets --locked -- -D warnings` — clean
- `cargo test --workspace --locked` — 446 budi-core + 37 budi-daemon + CLI suites all pass, including the new `summary_agents_block_count_matches_total_row_unit` assertion and the updated `per_provider_message_breakdown_is_split_by_role` assertions in `analytics::tests`.

Closes #482
Refs #481
Refs #451