### PR TITLE
pricing: row-level rejection so one bad upstream row can't DoS refresh (#483)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 8.3.1 — Unreleased
+
+8.3.1 is the post-tag hardening train on top of `v8.3.0`. It closes
+release-candidate gaps surfaced by the 2026-04-22 fresh-user smoke
+audit plus the dogfooding findings from a 30-day live walk on the
+shipped binary. No re-scope, no new features, no ADR amendments
+except the row-level-rejection change called out in §2 of
+[ADR-0091](docs/adr/0091-model-pricing-manifest-source-of-truth.md).
+
+### Fixed
+
+- **Pricing manifest refresh: one bad upstream row no longer blocks the whole payload** (#483 / [ADR-0091 §2 amendment](docs/adr/0091-model-pricing-manifest-source-of-truth.md)) — on 2026-04-22 LiteLLM upstream added `wandb/Qwen/Qwen3-Coder-480B-A35B-Instruct` at `$100,000/M`; the pre-8.3.1 validator rejected the whole payload on the sanity ceiling, pinning every `v8.3.0` user to the embedded baseline until LiteLLM patched. The refresher now partitions rows: NaN, negative, or over-$1,000/M prices are dropped from the installed manifest (kept deterministically sorted for reproducible log/pricing-status output), and the rest of the payload still refreshes. Dropped rows surface on `GET /pricing/status` and in `budi pricing status` under a new "Rejected upstream rows" section, and on the refresh response so `--refresh` prints them inline. Structured `rejected_upstream_row` warns go to the daemon log one per row. The ≥ 95% retention floor applies to the kept rows, so a mass upstream mispricing regression still hard-fails the tick. The $1,000/M ceiling is unchanged — still the right guardrail; only the blast radius of a single bad row is different. Daemon warm-load re-runs the sanity partition on restart so a bad row cached to disk mid-incident cannot re-admit itself into the in-memory lookup after a restart. Cache still persists the raw upstream bytes for audit / replay fidelity.
+
 ## 8.3.0 — 2026-04-22
 
 8.3.0 is the pricing source-of-truth pivot, plus the deferred 8.2

--- a/README.md
+++ b/README.md
@@ -540,7 +540,7 @@ Every message carries a `cost_confidence` tag that indicates how the cost was de
 
 Messages with `exact` confidence show exact cost in the dashboard. Estimated costs are prefixed with `~`.
 
-Pricing is sourced from the community-maintained [LiteLLM pricing manifest](https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json) via a three-layer lookup (on-disk cache → embedded baseline → hard-fail to `unknown`), refreshed daily by the daemon (opt-out: `BUDI_PRICING_REFRESH=0`), with every row tagged `pricing_source` so history is auditable and immutable. See [ADR-0091](docs/adr/0091-model-pricing-manifest-source-of-truth.md) for the full contract and `budi pricing status` for the operator surface.
+Pricing is sourced from the community-maintained [LiteLLM pricing manifest](https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json) via a three-layer lookup (on-disk cache → embedded baseline → hard-fail to `unknown`), refreshed daily by the daemon (opt-out: `BUDI_PRICING_REFRESH=0`), with every row tagged `pricing_source` so history is auditable and immutable. See [ADR-0091](docs/adr/0091-model-pricing-manifest-source-of-truth.md) for the full contract and `budi pricing status` for the operator surface. Upstream rows that fail per-row sanity (NaN, negative, or > $1,000/M) are dropped on refresh and listed under "Rejected upstream rows" in `budi pricing status` (ADR-0091 §2 amendment, 8.3.1).
 
 </details>
 

--- a/SOUL.md
+++ b/SOUL.md
@@ -468,7 +468,7 @@ Key points:
 - `crates/budi-core/src/file_attribution.rs` — Repo-relative file-path extractor; enforces ADR-0083 privacy limits (no absolute paths, no outside-of-repo paths, no file contents).
 - `crates/budi-core/src/work_outcome.rs` — Session-scoped `work_outcome` derivation (`committed`, `branch_merged`, `no_commit`, `unknown`) from local git state only; no remote API calls, no content capture.
 - `crates/budi-core/src/cost.rs` — Cost estimation glue (aggregates `cost_cents` from `messages`). Rates come exclusively from the manifest-backed `pricing::lookup` ([ADR-0091](docs/adr/0091-model-pricing-manifest-source-of-truth.md)); there is no fallback path.
-- `crates/budi-core/src/pricing/mod.rs` — Pricing loader + `lookup` API. Three-layer resolution (on-disk cache → embedded LiteLLM baseline → `unknown`), `PricingSource` tagging for immutable history, `backfill_unknown_rows` for retroactive fill-in once upstream catches up, validation guards (>95% retention floor, $1,000/M sanity ceiling, 10 MB size cap).
+- `crates/budi-core/src/pricing/mod.rs` — Pricing loader + `lookup` API. Three-layer resolution (on-disk cache → embedded LiteLLM baseline → `unknown`), `PricingSource` tagging for immutable history, `backfill_unknown_rows` for retroactive fill-in once upstream catches up, validation guards (>95% retention floor on kept rows, $1,000/M sanity ceiling applied row-by-row per the 8.3.1 ADR-0091 §2 amendment so one bad upstream row can't DoS the whole refresh, 10 MB size cap). `partition_rows_by_sanity` + `RejectedUpstreamRow` surface the dropped rows on `GET /pricing/status`.
 - `crates/budi-core/src/pricing/manifest.embedded.json` — Vendored snapshot of LiteLLM's `model_prices_and_context_window.json`, refreshed per release by `scripts/pricing/sync_baseline.sh`.
 - `crates/budi-core/src/hooks.rs` — Prompt classification helpers (hook ingestion removed in 8.0; `hook_events` table gone in schema v1).
 - `crates/budi-core/src/jsonl.rs` — JSONL transcript parser, `ParsedMessage` struct.
@@ -484,7 +484,7 @@ Key points:
 - `crates/budi-cli/build.rs` — Build script: creates empty vsix placeholder if not pre-built.
 - `crates/budi-daemon/src/main.rs` — HTTP server (port 7878) + cloud sync worker + startup hooks for tailer / migration / legacy-residue notices.
 - `crates/budi-daemon/src/workers/cloud_sync.rs` — Background cloud sync loop: configurable interval, backoff, auth/schema error handling.
-- `crates/budi-daemon/src/workers/pricing_refresh.rs` — 24 h LiteLLM manifest refresh loop. Warm-loads the on-disk cache, validates fetched payloads, atomic-writes, hot-swaps `pricing` state, runs `backfill_unknown_rows`. Disabled via `BUDI_PRICING_REFRESH=0`.
+- `crates/budi-daemon/src/workers/pricing_refresh.rs` — 24 h LiteLLM manifest refresh loop. Warm-loads the on-disk cache (running row-level sanity partitioning on restart per the 8.3.1 ADR-0091 §2 amendment), validates fetched payloads, atomic-writes, hot-swaps `pricing` state, runs `backfill_unknown_rows`. Rejected rows are structured-logged and surfaced on `GET /pricing/status`. Disabled via `BUDI_PRICING_REFRESH=0`.
 - `crates/budi-daemon/src/routes/pricing.rs` — `GET /pricing/status` + `POST /pricing/refresh` (loopback-only).
 - `crates/budi-daemon/src/routes/hooks.rs` — `/sync*`, `/health*`, `/admin/integrations/install` endpoints (hook ingestion removed; route file name retained for stability).
 - `crates/budi-daemon/src/routes/cloud.rs` — `/cloud/sync` (loopback-only manual cloud flush) and `/cloud/status`.

--- a/crates/budi-cli/src/commands/pricing.rs
+++ b/crates/budi-cli/src/commands/pricing.rs
@@ -132,6 +132,7 @@ fn render_alias_map_text() {
 fn render_refresh_text(body: &Value) {
     let green = ansi("\x1b[32m");
     let red = ansi("\x1b[31m");
+    let yellow = ansi("\x1b[33m");
     let dim = ansi("\x1b[90m");
     let reset = ansi("\x1b[0m");
     let ok = body.get("ok").and_then(Value::as_bool).unwrap_or(false);
@@ -149,6 +150,18 @@ fn render_refresh_text(body: &Value) {
         println!(
             "  {green}✓{reset} Manifest refreshed — now v{version} ({known} models, {backfilled} rows backfilled)"
         );
+        // ADR-0091 §2 amendment (8.3.1 / #483): surface row-level
+        // rejections so the operator sees why the kept-model count
+        // might be one or two short of the raw upstream payload.
+        if let Some(rejected) = body.get("rejected_upstream_rows").and_then(Value::as_array)
+            && !rejected.is_empty()
+        {
+            println!(
+                "  {yellow}!{reset} {n} upstream row{s} skipped (see below)",
+                n = rejected.len(),
+                s = if rejected.len() == 1 { "" } else { "s" },
+            );
+        }
     } else {
         let err = body
             .get("error")
@@ -225,6 +238,33 @@ fn render_status_text(body: &Value) {
             println!(
                 "    {dim}• … {} more (run with --format json for the full list){reset}",
                 unknowns.len() - 10
+            );
+        }
+    }
+
+    // ADR-0091 §2 amendment (8.3.1 / #483): rows the most-recent
+    // refresh tick skipped for failing per-row sanity (NaN, negative,
+    // or > $1,000/M). Pre-8.3.1 a single bad row would whole-payload-
+    // reject the refresh; the amendment surfaces them here instead.
+    let rejected = body
+        .get("rejected_upstream_rows")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    if !rejected.is_empty() {
+        println!();
+        println!(
+            "  {yellow}!{reset} {bold}Rejected upstream rows{reset} {dim}(skipped by row-level sanity; rest of manifest still refreshed){reset}"
+        );
+        for entry in rejected.iter().take(10) {
+            let model = entry.get("model_id").and_then(Value::as_str).unwrap_or("?");
+            let reason = entry.get("reason").and_then(Value::as_str).unwrap_or("?");
+            println!("    {dim}•{reset} {model} — {reason}");
+        }
+        if rejected.len() > 10 {
+            println!(
+                "    {dim}• … {} more (run with --format json for the full list){reset}",
+                rejected.len() - 10
             );
         }
     }

--- a/crates/budi-core/src/pricing/mod.rs
+++ b/crates/budi-core/src/pricing/mod.rs
@@ -186,6 +186,12 @@ pub fn lookup(model_id: &str, provider: &str) -> PricingOutcome {
 
 /// Snapshot of the current in-memory manifest for `GET /pricing/status`
 /// and `budi pricing status`. Shape is golden-file tested (#376 gate 9).
+///
+/// `rejected_upstream_rows` (8.3.1+, #483 / ADR-0091 §2 amendment) lists
+/// rows the most-recent refresh tick filtered out because they failed
+/// per-row sanity checks (NaN, negative, or > $1,000/M). Serialized with
+/// `skip_serializing_if = "Vec::is_empty"` so older-client JSON
+/// consumers that predate 8.3.1 still see the pre-amendment shape.
 #[derive(Debug, Clone, Serialize)]
 pub struct PricingState {
     pub source_label: String,
@@ -195,6 +201,8 @@ pub struct PricingState {
     pub known_model_count: usize,
     pub embedded_baseline_build: String,
     pub unknown_models: Vec<UnknownModelEntry>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub rejected_upstream_rows: Vec<RejectedUpstreamRow>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -203,6 +211,20 @@ pub struct UnknownModelEntry {
     pub model_id: String,
     pub first_seen_at: String,
     pub message_count: u64,
+}
+
+/// A row the most-recent refresh tick skipped because it failed
+/// per-row sanity (NaN price, negative price, or rate over the sanity
+/// ceiling). Surfaced on `GET /pricing/status` so an operator can see
+/// which upstream rows were dropped without reading the daemon log.
+///
+/// ADR-0091 §2 amendment (#483 / 8.3.1): `RejectedUpstreamRow` replaces
+/// the pre-8.3.1 whole-payload rejection — one bad LiteLLM row no
+/// longer blocks the entire manifest refresh.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RejectedUpstreamRow {
+    pub model_id: String,
+    pub reason: String,
 }
 
 /// Clone the currently-authoritative [`Manifest`] for validation of a
@@ -243,7 +265,17 @@ pub fn current_state() -> PricingState {
         known_model_count: guard.manifest.entries.len(),
         embedded_baseline_build: EMBEDDED_BASELINE_BUILD.to_string(),
         unknown_models: snapshot_unknowns(),
+        rejected_upstream_rows: guard.rejected_upstream_rows.clone(),
     }
+}
+
+/// Replace the cached rejected-upstream-rows list. Called by the
+/// refresh worker after each successful partition/install tick so
+/// `GET /pricing/status` reflects the most recent run. Passing an empty
+/// vec clears the list — used when a tick succeeds with no rejections.
+pub fn install_rejected_upstream_rows(rows: Vec<RejectedUpstreamRow>) {
+    let mut guard = state().write().expect("pricing state RwLock poisoned");
+    guard.rejected_upstream_rows = rows;
 }
 
 // ---------------------------------------------------------------------------
@@ -395,6 +427,11 @@ pub fn atomic_write_cache(path: &Path, bytes: &[u8]) -> Result<()> {
 struct ManifestState {
     manifest: Manifest,
     source: PricingSource,
+    /// Rows dropped by the most recent refresh tick per ADR-0091 §2
+    /// amendment (8.3.1 / #483). Empty in the pre-refresh state and
+    /// after a clean refresh. Serialized under `rejected_upstream_rows`
+    /// on `GET /pricing/status`.
+    rejected_upstream_rows: Vec<RejectedUpstreamRow>,
 }
 
 fn state() -> &'static RwLock<ManifestState> {
@@ -414,6 +451,7 @@ fn state() -> &'static RwLock<ManifestState> {
         RwLock::new(ManifestState {
             manifest,
             source: PricingSource::EmbeddedBaseline,
+            rejected_upstream_rows: Vec::new(),
         })
     })
 }
@@ -448,6 +486,13 @@ pub const MAX_PAYLOAD_BYTES: usize = 10 * 1024 * 1024;
 /// fraction) to avoid `f64` rounding drift at the boundary.
 const RETENTION_FLOOR_PERCENT: u64 = 95;
 
+/// Whole-payload validation outcomes. Pre-8.3.1 the `NegativePrice`
+/// and `SanityCeilingExceeded` variants were returned when any single
+/// row failed per-row sanity. 8.3.1 (ADR-0091 §2 amendment / #483)
+/// changed row-level sanity failures into non-fatal rejections
+/// surfaced as [`RejectedUpstreamRow`]; those two variants are kept
+/// so [`ValidationError::Display`] stays stable for any external log
+/// scraper, but [`validate_payload`] no longer produces them.
 #[derive(Debug, Clone, PartialEq)]
 pub enum ValidationError {
     ParseFailed(String),
@@ -486,41 +531,38 @@ impl std::fmt::Display for ValidationError {
 
 impl std::error::Error for ValidationError {}
 
-/// Run all guards from ADR-0091 §3. Pure — no state mutation.
+/// Run all guards from ADR-0091 §3, including the §2 row-level
+/// rejection amendment (8.3.1 / #483).
+///
+/// `new.entries` is mutated in place: rows that fail per-row sanity
+/// (NaN, negative price, or rate over [`PRICE_CEILING_PER_MILLION`])
+/// are removed and returned in the `Ok(Vec<RejectedUpstreamRow>)` arm
+/// so callers can log them and surface on `GET /pricing/status`. One
+/// bad upstream row no longer blocks the whole manifest refresh; pre-
+/// 8.3.1 the LiteLLM `wandb/Qwen3-Coder-480B-A35B-Instruct` entry at
+/// $100,000/M would `Err(SanityCeilingExceeded)` the whole payload and
+/// DoS every user's refresh until upstream patched.
+///
+/// Whole-payload hard failures still apply:
+/// - `raw_bytes_len > MAX_PAYLOAD_BYTES` → `Err(PayloadTooLarge)`.
+/// - kept-row retention vs `previous` below
+///   [`RETENTION_FLOOR_PERCENT`] → `Err(RetentionBelowFloor)`. The
+///   floor runs against KEPT rows (post-partition), so a mass upstream
+///   regression still triggers the fail-safe.
 ///
 /// `raw_bytes_len` is checked first so oversized payloads are rejected
 /// before any parsing cost.
 pub fn validate_payload(
-    new: &Manifest,
+    new: &mut Manifest,
     previous: Option<&Manifest>,
     raw_bytes_len: usize,
-) -> std::result::Result<(), ValidationError> {
+) -> std::result::Result<Vec<RejectedUpstreamRow>, ValidationError> {
     if raw_bytes_len > MAX_PAYLOAD_BYTES {
         return Err(ValidationError::PayloadTooLarge {
             bytes: raw_bytes_len,
         });
     }
-    for (model_id, entry) in &new.entries {
-        for price in [
-            entry.input_cost_per_token,
-            entry.output_cost_per_token,
-            entry.cache_creation_input_token_cost.unwrap_or(0.0),
-            entry.cache_read_input_token_cost.unwrap_or(0.0),
-        ] {
-            if price.is_nan() || price < 0.0 {
-                return Err(ValidationError::NegativePrice {
-                    model_id: model_id.clone(),
-                });
-            }
-            let per_million = price * 1_000_000.0;
-            if per_million > PRICE_CEILING_PER_MILLION {
-                return Err(ValidationError::SanityCeilingExceeded {
-                    model_id: model_id.clone(),
-                    per_million,
-                });
-            }
-        }
-    }
+    let rejected = partition_rows_by_sanity(&mut new.entries);
     if let Some(prev) = previous {
         let prev_total = prev.entries.len();
         if prev_total > 0 {
@@ -537,7 +579,57 @@ pub fn validate_payload(
             }
         }
     }
-    Ok(())
+    Ok(rejected)
+}
+
+/// Drop per-row sanity failures from `entries` in place and return
+/// them. Pure — no state mutation beyond the passed-in map. Broken
+/// out from [`validate_payload`] so callers can run row-level
+/// partitioning without the size + retention-floor checks. The
+/// daemon's `warm_load_disk_cache` calls this directly so a restart
+/// re-runs sanity against whatever the disk cache holds.
+///
+/// A row is rejected if any of its four price fields (input, output,
+/// cache-creation, cache-read) is NaN, negative, or exceeds
+/// [`PRICE_CEILING_PER_MILLION`] in per-million terms. The reason
+/// string is human-readable and surfaced verbatim on
+/// `GET /pricing/status` and in the daemon log.
+pub fn partition_rows_by_sanity(
+    entries: &mut HashMap<String, ManifestEntry>,
+) -> Vec<RejectedUpstreamRow> {
+    let mut rejected: Vec<RejectedUpstreamRow> = Vec::new();
+    entries.retain(|model_id, entry| {
+        for price in [
+            entry.input_cost_per_token,
+            entry.output_cost_per_token,
+            entry.cache_creation_input_token_cost.unwrap_or(0.0),
+            entry.cache_read_input_token_cost.unwrap_or(0.0),
+        ] {
+            if price.is_nan() || price < 0.0 {
+                rejected.push(RejectedUpstreamRow {
+                    model_id: model_id.clone(),
+                    reason: "negative or NaN price".to_string(),
+                });
+                return false;
+            }
+            let per_million = price * 1_000_000.0;
+            if per_million > PRICE_CEILING_PER_MILLION {
+                rejected.push(RejectedUpstreamRow {
+                    model_id: model_id.clone(),
+                    reason: format!(
+                        "${per_million:.2}/M exceeds sanity ceiling ${:.0}/M",
+                        PRICE_CEILING_PER_MILLION
+                    ),
+                });
+                return false;
+            }
+        }
+        true
+    });
+    // Deterministic order by model_id so the daemon log and
+    // `pricing status` render identically across runs.
+    rejected.sort_by(|a, b| a.model_id.cmp(&b.model_id));
+    rejected
 }
 
 // ---------------------------------------------------------------------------
@@ -696,6 +788,7 @@ pub(crate) fn reset_state_for_test() {
         fetched_at: Utc::now().to_rfc3339(),
     });
     guard.source = PricingSource::EmbeddedBaseline;
+    guard.rejected_upstream_rows.clear();
     drop(guard);
     unknown_cache()
         .lock()
@@ -962,6 +1055,11 @@ mod pricing_tests {
     /// ADR-0091 §3: the validator rejects payloads that drop more than 5%
     /// of previously-known models. Guards against an accidental upstream
     /// wipe, supply-chain tampering, or a mid-rewrite commit.
+    ///
+    /// 8.3.1 (#483): the floor applies to the kept rows after per-row
+    /// sanity partitioning runs, so a payload that would otherwise pass
+    /// but has enough per-row rejections to drop below the floor still
+    /// hard-fails.
     #[test]
     fn gate_5_retention_floor_rejects_wiped_payload() {
         // Build a previous manifest of 100 known models.
@@ -981,13 +1079,13 @@ mod pricing_tests {
         for i in 0..80 {
             new_entries.insert(format!("prev-model-{i}"), entry(0.000001, 0.000002));
         }
-        let candidate = Manifest {
+        let mut candidate = Manifest {
             version: 6,
             entries: new_entries,
             fetched_at: Utc::now().to_rfc3339(),
         };
 
-        let err = validate_payload(&candidate, Some(&previous), 10_000).unwrap_err();
+        let err = validate_payload(&mut candidate, Some(&previous), 10_000).unwrap_err();
         assert!(
             matches!(
                 err,
@@ -1004,31 +1102,100 @@ mod pricing_tests {
         for i in 0..96 {
             pass.insert(format!("prev-model-{i}"), entry(0.000001, 0.000002));
         }
-        let candidate = Manifest {
+        let mut candidate = Manifest {
             version: 6,
             entries: pass,
             fetched_at: Utc::now().to_rfc3339(),
         };
-        validate_payload(&candidate, Some(&previous), 10_000).expect("96%% retention must pass");
+        let rejected = validate_payload(&mut candidate, Some(&previous), 10_000)
+            .expect("96% retention must pass");
+        assert!(
+            rejected.is_empty(),
+            "clean payload should have no rejected rows"
+        );
     }
 
-    // ---- Gate 6: $1,000/M sanity ceiling rejects a mispriced payload -------
+    // ---- Gate 6 (8.3.1 amendment): one insane row is rejected, rest kept ---
 
-    /// Guards against a stray decimal-point upstream.
+    /// ADR-0091 §2 amendment (8.3.1 / #483): a row exceeding the
+    /// $1,000/M sanity ceiling is filtered out of the manifest and
+    /// surfaced in `RejectedUpstreamRow`, but the rest of the payload
+    /// still refreshes. Pre-8.3.1 the same input would hard-fail via
+    /// `ValidationError::SanityCeilingExceeded`, DoSing the refresher
+    /// until the bad row was patched upstream (the 2026-04-22
+    /// `wandb/Qwen3-Coder-480B-A35B-Instruct` $100,000/M incident).
     #[test]
-    fn gate_6_sanity_ceiling_rejects_insane_prices() {
+    fn gate_6_sanity_ceiling_rejects_row_keeps_rest() {
+        // Enough good rows so the retention floor (no previous here) is
+        // not the bottleneck. $0.001 per token = $1,000/M, right at the
+        // ceiling — stays below, kept. $0.002 per token = $2,000/M,
+        // 2x over the ceiling, rejected.
         let mut entries = HashMap::new();
-        // $2,000 per million tokens — 2× the ceiling.
         entries.insert("mispriced".to_string(), entry(0.002, 0.002));
-        let candidate = Manifest {
+        for i in 0..50 {
+            entries.insert(format!("ok-model-{i}"), entry(0.000001, 0.000002));
+        }
+        let mut candidate = Manifest {
             version: 1,
             entries,
             fetched_at: Utc::now().to_rfc3339(),
         };
-        let err = validate_payload(&candidate, None, 10_000).unwrap_err();
+        let rejected = validate_payload(&mut candidate, None, 10_000)
+            .expect("row-level rejection must not fail payload");
+        assert_eq!(rejected.len(), 1, "exactly one row should be rejected");
+        assert_eq!(rejected[0].model_id, "mispriced");
         assert!(
-            matches!(err, ValidationError::SanityCeilingExceeded { .. }),
-            "expected SanityCeilingExceeded, got {err:?}"
+            rejected[0].reason.contains("sanity ceiling"),
+            "reason should mention the sanity ceiling, got {:?}",
+            rejected[0].reason
+        );
+        assert_eq!(
+            candidate.entries.len(),
+            50,
+            "the 50 ok rows must remain after partitioning"
+        );
+        assert!(
+            !candidate.entries.contains_key("mispriced"),
+            "the mispriced row must be dropped from the kept set"
+        );
+    }
+
+    /// 8.3.1 / #483: row-level rejection drops enough rows that the
+    /// kept count falls below the retention floor. Whole payload must
+    /// still hard-fail so a mass upstream mispricing incident can't
+    /// sneak through.
+    #[test]
+    fn row_level_rejection_still_triggers_retention_floor() {
+        let mut prev_entries = HashMap::new();
+        for i in 0..100 {
+            prev_entries.insert(format!("m-{i}"), entry(0.000001, 0.000002));
+        }
+        let previous = Manifest {
+            version: 5,
+            entries: prev_entries,
+            fetched_at: Utc::now().to_rfc3339(),
+        };
+        // 100 entries in the new payload — same ids as previous — but
+        // 50 of them are over the sanity ceiling. 50 kept out of 100
+        // previously-known = 50% retention, below the 95% floor.
+        let mut new_entries = HashMap::new();
+        for i in 0..100 {
+            let e = if i < 50 {
+                entry(0.002, 0.002) // over ceiling — rejected
+            } else {
+                entry(0.000001, 0.000002)
+            };
+            new_entries.insert(format!("m-{i}"), e);
+        }
+        let mut candidate = Manifest {
+            version: 6,
+            entries: new_entries,
+            fetched_at: Utc::now().to_rfc3339(),
+        };
+        let err = validate_payload(&mut candidate, Some(&previous), 10_000).unwrap_err();
+        assert!(
+            matches!(err, ValidationError::RetentionBelowFloor { kept: 50, .. }),
+            "row-level rejection must still trip the retention floor, got {err:?}"
         );
     }
 
@@ -1090,6 +1257,11 @@ mod pricing_tests {
     /// and types are asserted against the committed contract; values are
     /// not pinned so this test is stable across releases (fetched_at
     /// and embedded_baseline_build naturally drift).
+    ///
+    /// 8.3.1 / #483: `rejected_upstream_rows` is `skip_serializing_if =
+    /// "Vec::is_empty"`, so a clean snapshot does NOT include the key
+    /// (preserves pre-8.3.1 client compat). The populated shape is
+    /// exercised in `pricing_status_surfaces_rejected_rows_when_populated`.
     #[test]
     fn gate_9_pricing_status_json_shape_is_stable() {
         let _g = serial().lock().unwrap();
@@ -1102,7 +1274,8 @@ mod pricing_tests {
         let j = serde_json::to_value(&state).unwrap();
         let obj = j.as_object().expect("top-level should be object");
 
-        // Pin the exact set of top-level keys.
+        // Pin the exact set of top-level keys on the clean (empty-
+        // rejected-rows) snapshot — stable across older clients.
         let mut keys: Vec<&str> = obj.keys().map(String::as_str).collect();
         keys.sort();
         assert_eq!(
@@ -1176,5 +1349,50 @@ mod pricing_tests {
         assert_eq!(PricingSource::parse_column(COLUMN_VALUE_UNKNOWN), None);
         assert_eq!(PricingSource::parse_column(COLUMN_VALUE_UPSTREAM_API), None);
         assert_eq!(PricingSource::parse_column("garbage"), None);
+    }
+
+    /// 8.3.1 / #483: when the last refresh tick dropped rows, they
+    /// surface on `GET /pricing/status` under `rejected_upstream_rows`.
+    /// Each entry has `model_id` + `reason`.
+    #[test]
+    fn pricing_status_surfaces_rejected_rows_when_populated() {
+        let _g = serial().lock().unwrap();
+        reset_state_for_test();
+        install_rejected_upstream_rows(vec![
+            RejectedUpstreamRow {
+                model_id: "wandb/Qwen/Qwen3-Coder-480B-A35B-Instruct".to_string(),
+                reason: "$100000.00/M exceeds sanity ceiling $1000/M".to_string(),
+            },
+            RejectedUpstreamRow {
+                model_id: "broken/nan-price".to_string(),
+                reason: "negative or NaN price".to_string(),
+            },
+        ]);
+
+        let state = current_state();
+        let j = serde_json::to_value(&state).unwrap();
+        let obj = j.as_object().unwrap();
+        let rejected = obj["rejected_upstream_rows"]
+            .as_array()
+            .expect("rejected_upstream_rows must be array when populated");
+        assert_eq!(rejected.len(), 2);
+        for entry in rejected {
+            let e = entry.as_object().unwrap();
+            let mut ek: Vec<&str> = e.keys().map(String::as_str).collect();
+            ek.sort();
+            assert_eq!(ek, vec!["model_id", "reason"]);
+            assert!(e["model_id"].is_string());
+            assert!(e["reason"].is_string());
+        }
+
+        // Clearing mid-run (clean refresh tick) removes the key again.
+        install_rejected_upstream_rows(Vec::new());
+        let state = current_state();
+        let j = serde_json::to_value(&state).unwrap();
+        let obj = j.as_object().unwrap();
+        assert!(
+            !obj.contains_key("rejected_upstream_rows"),
+            "empty list must be skipped (back-compat with older clients)"
+        );
     }
 }

--- a/crates/budi-daemon/src/routes/pricing.rs
+++ b/crates/budi-daemon/src/routes/pricing.rs
@@ -43,12 +43,27 @@ pub async fn pricing_refresh() -> Result<Json<Value>, (StatusCode, Json<Value>)>
         })?;
 
     match result {
-        Ok(report) => Ok(Json(json!({
-            "ok": true,
-            "version": report.version,
-            "known_model_count": report.known_model_count,
-            "backfilled_rows": report.backfilled_rows,
-        }))),
+        Ok(report) => {
+            let mut body = json!({
+                "ok": true,
+                "version": report.version,
+                "known_model_count": report.known_model_count,
+                "backfilled_rows": report.backfilled_rows,
+            });
+            // ADR-0091 §2 amendment (8.3.1 / #483): surface row-level
+            // rejections on the refresh response so `budi pricing
+            // status --refresh` can print them on the spot.
+            // `skip-if-none` for older-client compatibility.
+            if !report.rejected_upstream_rows.is_empty()
+                && let Some(map) = body.as_object_mut()
+            {
+                map.insert(
+                    "rejected_upstream_rows".to_string(),
+                    serde_json::to_value(&report.rejected_upstream_rows).unwrap_or(json!([])),
+                );
+            }
+            Ok(Json(body))
+        }
         Err(e) => Err((
             StatusCode::BAD_GATEWAY,
             Json(json!({

--- a/crates/budi-daemon/src/workers/pricing_refresh.rs
+++ b/crates/budi-daemon/src/workers/pricing_refresh.rs
@@ -27,7 +27,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
-use budi_core::pricing::{self, MAX_PAYLOAD_BYTES, Manifest, PricingSource};
+use budi_core::pricing::{self, MAX_PAYLOAD_BYTES, Manifest, PricingSource, RejectedUpstreamRow};
 
 const UPSTREAM_URL: &str =
     "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json";
@@ -95,7 +95,7 @@ async fn warm_load_disk_cache(db_path: &std::path::Path) {
     let db_path = db_path.to_path_buf();
     let result = tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
         let cache_path = pricing::pricing_cache_path()?;
-        let Some(entries) = pricing::load_disk_cache(&cache_path)? else {
+        let Some(mut entries) = pricing::load_disk_cache(&cache_path)? else {
             return Ok(());
         };
         // Attach the version from `pricing_manifests` if there's a cached
@@ -103,17 +103,34 @@ async fn warm_load_disk_cache(db_path: &std::path::Path) {
         let version = latest_manifest_version(&db_path).unwrap_or(1);
         let fetched_at =
             cache_file_mtime(&cache_path).unwrap_or_else(|| chrono::Utc::now().to_rfc3339());
+        // ADR-0091 §2 amendment (8.3.1 / #483): the on-disk cache holds
+        // the raw upstream bytes for audit, so warm load must re-run
+        // row-level sanity on restart. Otherwise a daemon restart after a
+        // tick that wrote bytes containing a ceiling-exceeding row would
+        // re-admit the row into the in-memory lookup.
+        let rejected_upstream_rows = pricing::partition_rows_by_sanity(&mut entries);
         let manifest = Manifest {
             version,
             entries,
             fetched_at,
         };
         pricing::install_manifest(manifest, PricingSource::Manifest { version });
+        pricing::install_rejected_upstream_rows(rejected_upstream_rows.clone());
         tracing::info!(
             target: "budi_daemon::pricing_refresh",
             version,
+            rejected_upstream_rows = rejected_upstream_rows.len(),
             "warm-loaded on-disk pricing cache"
         );
+        for row in &rejected_upstream_rows {
+            tracing::warn!(
+                target: "budi_daemon::pricing_refresh",
+                event = "rejected_upstream_row",
+                model_id = row.model_id,
+                reason = row.reason,
+                "warm-load dropped cached row failing per-row sanity"
+            );
+        }
         Ok(())
     })
     .await;
@@ -172,13 +189,29 @@ async fn tick(db_path: &std::path::Path) {
     let db_path = db_path.to_path_buf();
     let result = tokio::task::spawn_blocking(move || run_tick(&db_path)).await;
     match result {
-        Ok(Ok(report)) => tracing::info!(
-            target: "budi_daemon::pricing_refresh",
-            version = report.version,
-            known_models = report.known_model_count,
-            backfilled_rows = report.backfilled_rows,
-            "pricing manifest refreshed"
-        ),
+        Ok(Ok(report)) => {
+            tracing::info!(
+                target: "budi_daemon::pricing_refresh",
+                version = report.version,
+                known_models = report.known_model_count,
+                backfilled_rows = report.backfilled_rows,
+                rejected_upstream_rows = report.rejected_upstream_rows.len(),
+                "pricing manifest refreshed"
+            );
+            // One structured warn per rejected row so an operator grepping
+            // the daemon log for `rejected_upstream_row` sees exactly what
+            // the current refresh filtered out. ADR-0091 §2 amendment
+            // acceptance: every skipped row is identified by model id.
+            for row in &report.rejected_upstream_rows {
+                tracing::warn!(
+                    target: "budi_daemon::pricing_refresh",
+                    event = "rejected_upstream_row",
+                    model_id = row.model_id,
+                    reason = row.reason,
+                    "dropped upstream pricing row failed per-row sanity"
+                );
+            }
+        }
         Ok(Err(e)) => tracing::warn!(
             target: "budi_daemon::pricing_refresh",
             error = %e,
@@ -195,16 +228,28 @@ async fn tick(db_path: &std::path::Path) {
 /// Public return shape for a single refresh tick. Serialized directly by
 /// `POST /pricing/refresh` so the CLI `--refresh` flag can surface the
 /// outcome without re-running its own lookup.
+///
+/// `rejected_upstream_rows` (8.3.1+, #483) lists upstream rows dropped
+/// by the row-level sanity partition. Pre-8.3.1 the same rows would
+/// have whole-payload-rejected the refresh (ADR-0091 §2 amendment).
 #[derive(Debug, serde::Serialize)]
 pub struct RefreshReport {
     pub version: u32,
     pub known_model_count: usize,
     pub backfilled_rows: usize,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub rejected_upstream_rows: Vec<RejectedUpstreamRow>,
 }
 
-/// Run a single refresh tick: fetch → validate → atomic-write → install
-/// → backfill unknowns. Called by the daemon's periodic loop and by the
-/// `POST /pricing/refresh` route.
+/// Run a single refresh tick: fetch → partition/validate → atomic-write
+/// → install → backfill unknowns. Called by the daemon's periodic loop
+/// and by the `POST /pricing/refresh` route.
+///
+/// ADR-0091 §2 amendment (8.3.1 / #483): per-row sanity failures no
+/// longer hard-fail the tick. Rows are partitioned, the kept rows are
+/// written to the cache, and the rejected rows are returned via
+/// `RefreshReport.rejected_upstream_rows` + surfaced on
+/// `GET /pricing/status`.
 pub fn run_tick(db_path: &std::path::Path) -> anyhow::Result<RefreshReport> {
     let bytes = fetch_upstream()?;
     let entries = pricing::parse_entries(&bytes)?;
@@ -219,16 +264,22 @@ pub fn run_tick(db_path: &std::path::Path) -> anyhow::Result<RefreshReport> {
     // (none in practice, but defensive) can't collide on the primary key.
     let conn = budi_core::analytics::open_db(db_path)?;
     let next_version = next_manifest_version(&conn)?;
-    let candidate = Manifest {
+    let mut candidate = Manifest {
         version: next_version,
         entries,
         fetched_at: now.clone(),
     };
-    if let Err(e) = pricing::validate_payload(&candidate, previous_opt, bytes.len()) {
-        return Err(anyhow::anyhow!("validation rejected: {e}"));
-    }
+    let rejected_upstream_rows =
+        match pricing::validate_payload(&mut candidate, previous_opt, bytes.len()) {
+            Ok(rejected) => rejected,
+            Err(e) => return Err(anyhow::anyhow!("validation rejected: {e}")),
+        };
     // Persist the raw bytes atomically before updating in-memory state so
     // the on-disk cache and the `pricing_manifests` row are coherent.
+    // Note: the on-disk cache holds the RAW upstream bytes, not the
+    // partitioned kept set. `load_disk_cache` re-runs `parse_entries` on
+    // warm-load, and the kept set is re-derived from the in-memory
+    // install below. This preserves exact fidelity for audit / replay.
     let cache_path = pricing::pricing_cache_path()?;
     pricing::atomic_write_cache(&cache_path, &bytes)?;
     insert_manifest_row(
@@ -246,11 +297,13 @@ pub fn run_tick(db_path: &std::path::Path) -> anyhow::Result<RefreshReport> {
             version: next_version,
         },
     );
+    pricing::install_rejected_upstream_rows(rejected_upstream_rows.clone());
     let backfilled_rows = pricing::backfill_unknown_rows(&conn, next_version).unwrap_or(0);
     Ok(RefreshReport {
         version: next_version,
         known_model_count,
         backfilled_rows,
+        rejected_upstream_rows,
     })
 }
 
@@ -377,6 +430,114 @@ mod tests {
         let enabled = !is_refresh_disabled();
         unsafe { std::env::remove_var(DISABLE_ENV_VAR) };
         assert!(enabled);
+    }
+
+    /// ADR-0091 §2 amendment (8.3.1 / #483): a payload containing one
+    /// ceiling-exceeding row refreshes successfully; the bad row is
+    /// filtered, the rest of the manifest lands. This is the 2026-04-22
+    /// `wandb/Qwen3-Coder-480B-A35B-Instruct` regression fixed in
+    /// RC-1.
+    ///
+    /// Test acts on the `pricing::` public API directly (rather than
+    /// spinning the network path) so it stays hermetic in CI. The
+    /// wire/cache/install contract is the same — `run_tick` is a thin
+    /// wrapper over `validate_payload` + `install_manifest` +
+    /// `install_rejected_upstream_rows` + `backfill_unknown_rows`.
+    /// Serial mutex for daemon tests that touch the process-global
+    /// pricing state. Kept private to this test module; budi-core has
+    /// its own separate serial lock in `pricing::pricing_tests`.
+    fn pricing_state_serial() -> &'static std::sync::Mutex<()> {
+        static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
+        LOCK.get_or_init(|| std::sync::Mutex::new(()))
+    }
+
+    #[test]
+    fn refresh_skips_invalid_row_keeps_rest_when_majority_valid() {
+        use budi_core::pricing::{
+            self as pricing, ManifestEntry, PricingOutcome, PricingSource, RejectedUpstreamRow,
+        };
+        use std::collections::HashMap;
+
+        let _g = pricing_state_serial().lock().unwrap();
+
+        // Build a 50-row payload where 1 row exceeds the sanity ceiling
+        // and 49 rows are valid. Uses the same entry shape the real
+        // LiteLLM manifest uses.
+        let mut entries: HashMap<String, ManifestEntry> = HashMap::new();
+        entries.insert(
+            "wandb/Qwen/Qwen3-Coder-480B-A35B-Instruct".to_string(),
+            ManifestEntry {
+                // 0.1/token = $100,000/M — 100x the ceiling (the
+                // actual 2026-04-22 upstream value).
+                input_cost_per_token: 0.1,
+                output_cost_per_token: 0.1,
+                cache_creation_input_token_cost: None,
+                cache_read_input_token_cost: None,
+                litellm_provider: Some("wandb".to_string()),
+            },
+        );
+        for i in 0..49 {
+            entries.insert(
+                format!("claude-test-{i}"),
+                ManifestEntry {
+                    input_cost_per_token: 0.000003,
+                    output_cost_per_token: 0.000015,
+                    cache_creation_input_token_cost: Some(0.00000375),
+                    cache_read_input_token_cost: Some(0.0000003),
+                    litellm_provider: Some("anthropic".to_string()),
+                },
+            );
+        }
+        let mut candidate = pricing::Manifest {
+            version: 2,
+            entries,
+            fetched_at: chrono::Utc::now().to_rfc3339(),
+        };
+
+        let rejected = pricing::validate_payload(&mut candidate, None, 10_000)
+            .expect("validation must accept the payload after row-level partitioning");
+
+        // Exactly the bad row is rejected; the 49 good ones stay.
+        assert_eq!(
+            rejected,
+            vec![RejectedUpstreamRow {
+                model_id: "wandb/Qwen/Qwen3-Coder-480B-A35B-Instruct".to_string(),
+                reason: "$100000.00/M exceeds sanity ceiling $1000/M".to_string(),
+            }]
+        );
+        assert_eq!(candidate.entries.len(), 49);
+
+        // Install the partitioned manifest. The rejected row must NOT
+        // resolve via `lookup` — it was dropped from the kept set.
+        pricing::install_manifest(candidate, PricingSource::Manifest { version: 2 });
+        pricing::install_rejected_upstream_rows(rejected);
+
+        match pricing::lookup("wandb/Qwen/Qwen3-Coder-480B-A35B-Instruct", "wandb") {
+            PricingOutcome::Known { .. } => {
+                panic!("rejected row must not resolve in lookup")
+            }
+            PricingOutcome::Unknown { .. } => {}
+        }
+        // Good rows still resolve.
+        match pricing::lookup("claude-test-0", "claude_code") {
+            PricingOutcome::Known { .. } => {}
+            PricingOutcome::Unknown { .. } => panic!("kept row should resolve"),
+        }
+
+        // `pricing status` surfaces the rejected row.
+        let state = pricing::current_state();
+        assert_eq!(state.rejected_upstream_rows.len(), 1);
+        assert_eq!(
+            state.rejected_upstream_rows[0].model_id,
+            "wandb/Qwen/Qwen3-Coder-480B-A35B-Instruct"
+        );
+
+        // Reset rejected-rows list + re-install embedded baseline so
+        // this test doesn't leak state into sibling tests that share
+        // the process-global pricing state.
+        pricing::install_rejected_upstream_rows(Vec::new());
+        let baseline = pricing::load_embedded_manifest().expect("embedded baseline must parse");
+        pricing::install_manifest(baseline, PricingSource::EmbeddedBaseline);
     }
 
     /// ADR-0091 §6 / #376 test gate 7: when `BUDI_PRICING_REFRESH=0` is

--- a/docs/adr/0091-model-pricing-manifest-source-of-truth.md
+++ b/docs/adr/0091-model-pricing-manifest-source-of-truth.md
@@ -1,9 +1,9 @@
 # ADR-0091: Model Pricing via Embedded Baseline + LiteLLM Runtime Refresh
 
-- **Date**: 2026-04-21
-- **Status**: Accepted (promoted 2026-04-21 after [#376](https://github.com/siropkin/budi/issues/376) and [#377](https://github.com/siropkin/budi/issues/377) merged with all Promotion Criteria test gates green)
-- **Issue**: [#375](https://github.com/siropkin/budi/issues/375)
-- **Milestone**: 8.3.0 (epic: [#436](https://github.com/siropkin/budi/issues/436))
+- **Date**: 2026-04-21 (§2 amendment 2026-04-22 — 8.3.1 / [#483](https://github.com/siropkin/budi/issues/483))
+- **Status**: Accepted (promoted 2026-04-21 after [#376](https://github.com/siropkin/budi/issues/376) and [#377](https://github.com/siropkin/budi/issues/377) merged with all Promotion Criteria test gates green; §2 amendment landed 2026-04-22 alongside v8.3.1 post-tag hardening)
+- **Issue**: [#375](https://github.com/siropkin/budi/issues/375) (§2 amendment: [#483](https://github.com/siropkin/budi/issues/483))
+- **Milestone**: 8.3.0 (epic: [#436](https://github.com/siropkin/budi/issues/436); §2 amendment: 8.3.1 / [#481](https://github.com/siropkin/budi/issues/481))
 - **Amends**: [ADR-0083](./0083-cloud-ingest-identity-and-privacy-contract.md) §Neutral (outbound-network surface; see §6 below)
 - **Closes**: [#373](https://github.com/siropkin/budi/issues/373) — superseded by this ADR
 
@@ -69,8 +69,8 @@ A single worker inside `budi-daemon` is responsible for keeping the on-disk cach
 - **Transport**: the existing `reqwest` client already in the dependency tree (used for cloud sync). No new HTTP stack.
 - **Validation**: before writing the fetched payload to disk, the worker asserts:
   - The body parses as a JSON object.
-  - Every per-model entry with a price field has all price fields ≥ 0 and ≤ a sanity ceiling of $1,000 per million tokens (guards against a stray decimal-point upstream).
-  - At least **95 %** of the models currently in the on-disk cache (or the embedded baseline if the cache is absent) are still present in the fetched payload. Guards against accidental upstream wipe, supply-chain tampering, or a mid-rewrite commit.
+  - Every per-model entry with a price field has all price fields ≥ 0 and ≤ a sanity ceiling of $1,000 per million tokens (guards against a stray decimal-point upstream). **§2 amendment (2026-04-22, 8.3.1 / [#483](https://github.com/siropkin/budi/issues/483))**: row-level rejection, not whole-payload rejection. Rows failing the per-row sanity checks (NaN, negative, or over the $1,000 / M ceiling) are filtered out of the installed manifest and surfaced via `rejected_upstream_rows[]` on `GET /pricing/status` and on the text `budi pricing status` output. The rest of the payload still refreshes. Rationale: the pre-amendment shape hard-failed the whole tick on one bad upstream row (2026-04-22: `wandb/Qwen/Qwen3-Coder-480B-A35B-Instruct` at $100,000/M blocked every `v8.3.0` user's refresh), which defeats the daily-refresh guarantee. Ceiling is unchanged — still $1,000 / M, still the right guardrail; the amendment only changes the blast radius.
+  - At least **95 %** of the models currently in the on-disk cache (or the embedded baseline if the cache is absent) are still present in the fetched payload (after per-row partitioning — §2 amendment). Guards against accidental upstream wipe, supply-chain tampering, or a mid-rewrite commit. A mass per-row-rejection upstream regression that pushed kept-row retention below 95 % still hard-fails the whole tick; the amendment does not weaken this fail-safe.
   - The payload is ≤ 10 MB (current file is ~400 KB; 25× headroom).
 - **Write**: the validated payload is written atomically — write to a sibling temp file in the same directory, `fsync`, then `rename`. The in-memory lookup table is swapped under an `RwLock` on success.
 - **Failure behavior**: any validation or network failure is logged at `warn` level and does not block ingestion. The previous cache (or embedded baseline) continues to serve lookups. The worker retries at the next scheduled interval. No exponential backoff beyond the 24 h cadence — the cost of a stale cache is bounded by the embedded baseline being correct at release time.


### PR DESCRIPTION
## Summary

ADR-0091 §2 amendment (8.3.1). Pre-amendment the sanity ceiling was a
**whole-payload** check: a single upstream row over \$1,000/M would
reject every kept row alongside the bad one. On 2026-04-22 LiteLLM
added `wandb/Qwen/Qwen3-Coder-480B-A35B-Instruct` at \$100,000/M;
every `v8.3.0` user stayed pinned to the embedded baseline until
LiteLLM patched upstream. The guard worked as designed; the policy
needed to be row-level instead of all-or-nothing.

This PR changes the check to row-level while keeping the \$1,000/M
ceiling exactly where it is, and keeps the ≥ 95% retention floor as
the mass-regression fail-safe.

## Changes

- `budi-core::pricing`:
  - `partition_rows_by_sanity(entries) -> Vec<RejectedUpstreamRow>` drops per-row failures (NaN, negative, or > \$1,000/M) in place. Rejected rows sorted deterministically for reproducible log / `pricing status` output.
  - `validate_payload(new: &mut Manifest, ...)` composes the partition with the existing retention-floor + size checks. Retention floor runs against KEPT rows so a mass upstream mispricing regression still hard-fails the tick.
  - `PricingState` gains `rejected_upstream_rows: Vec<RejectedUpstreamRow>`. `install_rejected_upstream_rows()` stores them; `current_state()` surfaces them. `#[serde(skip_serializing_if = "Vec::is_empty")]` preserves pre-8.3.1 JSON shape for older clients.
- `budi-daemon::workers::pricing_refresh`:
  - `RefreshReport` gains `rejected_upstream_rows[]`.
  - `run_tick` installs partitioned manifest + rejected rows.
  - `tick` emits one structured `rejected_upstream_row` warn per rejected row.
  - `warm_load_disk_cache` re-runs the sanity partition on restart so a bad row cached to disk mid-incident cannot re-admit itself into the in-memory lookup after a daemon restart. The disk cache still holds the raw upstream bytes for audit / replay fidelity.
- `budi-daemon::routes::pricing`: `POST /pricing/refresh` response body includes `rejected_upstream_rows[]` when non-empty (skip-if-none for back-compat).
- `budi-cli::commands::pricing`: `budi pricing status` text output grows a "Rejected upstream rows" section (same 10-row cap with `… N more` footer as the existing unknown-models block). `--refresh` notes any rejections inline.
- **ADR-0091** §2 + §3 amended inline with the row-level semantics and the 2026-04-22 precedent; `SOUL.md` + `README.md` propagate in the same commit; `CHANGELOG.md` gains a `## 8.3.1 — Unreleased` section with the RC-1 entry.
- New tests:
  - `pricing_tests::gate_6_sanity_ceiling_rejects_row_keeps_rest` — the 2026-04-22 repro (one row at \$100,000/M, 50 ok rows, kept count = 50, rejected = 1).
  - `pricing_tests::row_level_rejection_still_triggers_retention_floor` — 50 of 100 previously-known rows drop for sanity failures, retention floor still fires.
  - `pricing_tests::pricing_status_surfaces_rejected_rows_when_populated` — `GET /pricing/status` shape with populated rejected-rows field.
  - `workers::pricing_refresh::refresh_skips_invalid_row_keeps_rest_when_majority_valid` — end-to-end with a `wandb/Qwen3-Coder-480B-A35B-Instruct` fixture; confirms the rejected row does NOT resolve in `lookup` after install.
  - Existing `gate_5_retention_floor_rejects_wiped_payload` updated to the new `&mut candidate` signature; the kept-rows path still trips when retention is too low.

## Risks / compatibility notes

- **API/struct signature change**: `pricing::validate_payload` now takes `&mut Manifest` and returns `Result<Vec<RejectedUpstreamRow>, ValidationError>` instead of `Result<(), ValidationError>`. Only two in-tree callers (the refresh worker + the pricing tests themselves). No documented external callers.
- **JSON wire change (additive, backward-compat)**: `GET /pricing/status` gains an optional `rejected_upstream_rows[]` field; `POST /pricing/refresh` success body gains the same. Both use `skip-if-none` so older clients that predate 8.3.1 don't see a new key on a clean refresh — pre-8.3.1 JSON golden-shape test still passes unchanged.
- **State immutability contract unchanged**: `manifest:vNNN` and `legacy:pre-manifest` rows are never recomputed. Only `unknown → backfilled:vNNN` is still legal. Backfill runs against KEPT rows only; rejected rows do NOT cause any existing `unknown` row to become `backfilled:vNNN`.
- **Disk cache contract unchanged**: still the raw upstream bytes (for audit / replay). Warm load re-partitions on every restart so a bad row on disk is filtered on the way into memory.
- **No new deps. No new runtime network calls. No new writable shell-profile / Cursor-settings / Codex-config paths.**

## Pre-existing test flake observed

`analytics::tests::breakdown_tickets_reconcile_across_today_7d_and_30d` is failing on `main` too — confirmed by `git stash && cargo test …` on clean main before any of my changes. It uses `Utc::now()` inside the `today` window, which fails when UTC crosses midnight before local midnight. Time-of-day flake, unrelated to RC-1. Will file a follow-up under `#481` (RC-2-adjacent) rather than widen this PR.

## Validation

- `cargo fmt --all --check` — clean
- `cargo clippy --workspace --all-targets --locked -- -D warnings` — clean
- `cargo test --workspace --locked` — all RC-1 tests pass; the one pre-existing flake noted above is unrelated (file & line identical on clean `main`).

Closes #483
Refs #481