### PR TITLE
tests: anchor today-reconcile fixture at noon UTC (#502)

### DIFF
--- a/crates/budi-core/src/analytics/tests.rs
+++ b/crates/budi-core/src/analytics/tests.rs
@@ -5339,10 +5339,24 @@ fn breakdown_tickets_reconcile_across_today_7d_and_30d() {
     // `today/7d/30d`. We plant tickets at three different anchor dates
     // and query with the corresponding `since` bound so each window's
     // total is a known strict subset of the universe.
+    //
+    // Fix (#502 / D-4): anchor `now` to noon UTC of today's UTC date
+    // rather than the wall clock. Pre-fix the test used `Utc::now()`
+    // directly, so a CI run at 00:07 UTC on 2026-04-23 put the today
+    // cohort at `now - 1h = 23:07 UTC on 2026-04-22` — the previous
+    // UTC day — and the `today_since = midnight UTC of today_date`
+    // window filtered every today row out, dropping `shown_rows` from
+    // the expected 30 to 0. Noon UTC is > 12h away from midnight on
+    // both sides so the `- 1h` anchor stays inside today's UTC day
+    // regardless of when the test runs.
     use chrono::{Duration, Utc};
 
     let mut conn = test_db();
-    let now = Utc::now();
+    let now = Utc::now()
+        .date_naive()
+        .and_hms_opt(12, 0, 0)
+        .expect("12:00:00 is a valid time")
+        .and_utc();
     // Anchor ticket cohorts in each of the three windows. Each cohort
     // has 40 distinct tickets so the default cap of 30 forces
     // truncation, and each cost is unique (0.5 cent steps) so every row


### PR DESCRIPTION
## Summary

`analytics::tests::breakdown_tickets_reconcile_across_today_7d_and_30d` is
flaky near UTC midnight. This PR pins the fixture's \`now\` to noon UTC
of the current UTC date so the test is deterministic regardless of
wall-clock time.

Blocking #501 (RC-1) and every subsequent 8.3.1 PR whose CI happens to
run near UTC midnight — fix goes in first.

## Repro

Pre-fix the test used \`Utc::now()\` directly. At CI run time 00:07 UTC
on 2026-04-23 (which is still 2026-04-22 evening PDT):

- today cohort anchored at \`now - 1h = 23:07 UTC on 2026-04-22\`
- \`today_since = (now - 0d).date_naive().and_hms(0,0,0).and_utc() = 00:00 UTC 2026-04-23\`
- Filter predicate \`timestamp >= today_since\` drops every today row
- \`page.shown_rows == 0\`, test asserts \`== 30\`, fails.

Reproduced on the RC-1 Ubuntu / macOS / Windows CI runs for PR #501 at
~00:11 UTC, and on clean \`main\` at the v8.3.0 tag via \`git stash && cargo test …\`.

## Fix

Anchor the fixture's \`now\` to \`today_utc_date + 12:00:00\`. Noon UTC is
> 12h away from midnight on both sides, so \`now - 1h\` stays inside
today's UTC day regardless of when the test runs.

## Risks / compatibility notes

- Test-only change (\`crates/budi-core/src/analytics/tests.rs\`). No
  production code touched.
- Fix is purely deterministic — removes the wall-clock dependency
  without changing what the test actually exercises (reconciliation
  across today / 7d / 30d on a planted cohort).

## Validation

- Targeted: \`cargo test -p budi-core --lib breakdown_tickets_reconcile_across_today_7d_and_30d\` — passes at 00:15 UTC.
- Full: \`cargo test --workspace --locked\` — 446 budi-core + 37 budi-daemon tests all pass.
- \`cargo fmt --all --check\` — clean.

Closes #502
Refs #481