### PR TITLE
cli: strip internal issue refs from --help (#495)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,33 @@ jobs:
           ./target/release/budi --version
           ./target/release/budi-daemon --version
 
+      - name: Help-text cleanliness (no internal issue refs; #495)
+        run: |
+          set -euo pipefail
+          LEAKS=0
+          for cmd in \
+            "" "stats" "sessions" "status" "statusline" "doctor" "vitals" \
+            "update" "uninstall" "integrations" "integrations list" \
+            "integrations install" "autostart" "autostart status" \
+            "autostart install" "autostart uninstall" "db" "db migrate" \
+            "db repair" "db import" "cloud" "cloud init" "cloud status" \
+            "cloud sync" "pricing" "pricing status"; do
+            OUT=$(./target/release/budi $cmd --help 2>&1 || true)
+            # Regex matches internal ticket / ADR refs and Round-N.M labels.
+            # Deliberately excludes bare `N.M` version-like strings since
+            # release notes legitimately cite `8.3.0` etc.
+            if HITS=$(printf '%s\n' "$OUT" | grep -nE '#[0-9]+|ADR-[0-9]+|R[0-9]+\.[0-9]+'); then
+              echo "::error::'budi $cmd --help' leaks internal refs:"
+              printf '%s\n' "$HITS"
+              LEAKS=$((LEAKS + 1))
+            fi
+          done
+          if [ "$LEAKS" -gt 0 ]; then
+            echo "::error::$LEAKS help surfaces leak internal refs. Move them to rustdoc."
+            exit 1
+          fi
+          echo "Help text is free of internal issue / ADR references."
+
       - name: Integration smoke test (daemon endpoints)
         env:
           SMOKE_PORT: 19876

--- a/crates/budi-cli/src/main.rs
+++ b/crates/budi-cli/src/main.rs
@@ -113,13 +113,12 @@ Examples:
         /// emitted by the pipeline when tool-call arguments point at a
         /// file inside the repo root). Mirrors `--tickets` / `--activities`
         /// so file-level attribution is a first-class CLI dimension.
-        /// Added in R1.4 (#292).
         #[arg(long, default_value_t = false)]
         files: bool,
         /// Show cost details for a specific file (repo-relative path,
         /// forward-slashed, inside the repo root). Mirrors `--ticket <ID>`
         /// and includes per-branch and per-ticket breakdowns so you can see
-        /// which tickets touched the file. Added in R1.4 (#292).
+        /// which tickets touched the file.
         #[arg(long, value_name = "PATH")]
         file: Option<String>,
         /// Optional repository filter for --branch, --ticket, --activity,
@@ -139,14 +138,14 @@ Examples:
         /// `--branches`, `--tickets`, `--activities`, `--files`,
         /// `--models`, `--tag`). `0` = no cap (show every matching row).
         /// Truncated rows collapse into an `(other N: $X)` aggregate so
-        /// the Total footer always reconciles to the cent (#448).
+        /// the Total footer always reconciles to the cent.
         #[arg(long, default_value_t = 30)]
         limit: usize,
         /// Maximum characters for labels and label-like extra columns
         /// (branch / file path / ticket id) in breakdown views. Values
         /// longer than this truncate with a middle ellipsis (`…`). The
         /// default balances readability on an 80-col terminal with the
-        /// natural length of file paths. (#450)
+        /// natural length of file paths.
         #[arg(long, default_value_t = 40)]
         label_width: usize,
         /// Include zero-cost `(model not yet attributed)` rows in
@@ -154,13 +153,13 @@ Examples:
         /// that carry no backing cost are collapsed into a
         /// suppressed-count footnote; pass `--include-pending` to
         /// see them as their own row. Rows with real Cursor-Auto
-        /// cost always render regardless of this flag. (#443, #450)
+        /// cost always render regardless of this flag.
         #[arg(long, default_value_t = false)]
         include_pending: bool,
         /// Break out the `(no repository)` bucket in `--projects` into a
         /// per-folder breakdown keyed on the cwd basename. Off by
         /// default so the main Repositories table stays clean of
-        /// `Desktop` / `~` / scratch-dir rows. (#442)
+        /// `Desktop` / `~` / scratch-dir rows.
         #[arg(long, default_value_t = false)]
         include_non_repo: bool,
         /// Output format: text (default) or json
@@ -187,10 +186,9 @@ Examples:
     },
     /// Database admin commands (migrate, repair, import historical transcripts)
     ///
-    /// Groups migrate / repair / import under a single namespace (R2.1
-    /// CLI audit follow-up, #368). The pre-8.2.1 bare verbs
-    /// (`budi migrate` / `budi repair` / `budi import`) were removed in
-    /// 8.3.0 (#428); use `budi db <verb>` instead.
+    /// Groups migrate / repair / import under a single namespace. The
+    /// pre-8.2.1 bare verbs (`budi migrate` / `budi repair` /
+    /// `budi import`) were removed in 8.3.0; use `budi db <verb>` instead.
     #[command(after_help = "\
 Examples:
   budi db migrate                Run database migration explicitly
@@ -244,7 +242,7 @@ Examples:
         ticket: Option<String>,
         /// Filter sessions by activity (e.g. `bugfix`, `refactor`). Matches
         /// the `activity` tag emitted by the prompt classifier; promoted to
-        /// a first-class session filter in 8.1 (#305).
+        /// a first-class session filter in 8.1.
         #[arg(long, value_name = "NAME")]
         activity: Option<String>,
         /// Max sessions to show (default: 20)
@@ -252,7 +250,7 @@ Examples:
         limit: usize,
         /// Render the full 36-character session UUID instead of the
         /// 8-character short form (useful for scripting and for
-        /// `budi sessions <id>` lookup). #445.
+        /// `budi sessions <id>` lookup).
         #[arg(long, default_value_t = false)]
         full_uuid: bool,
         /// Output format: text (default) or json
@@ -263,8 +261,8 @@ Examples:
     Status,
     /// Show AI spending in your shell prompt (reads editor context from stdin when piped)
     ///
-    /// Emits the shared provider-scoped status contract (ADR-0088 §4, #224).
-    /// Rolling `1d` / `7d` / `30d` windows. The `--format claude` surface is
+    /// Emits the shared provider-scoped status contract. Rolling
+    /// `1d` / `7d` / `30d` windows. The `--format claude` surface is
     /// automatically scoped to `claude_code` usage; downstream consumers
     /// (Cursor extension, cloud dashboard) pass `--provider` explicitly.
     #[command(after_help = "\
@@ -305,11 +303,11 @@ Examples:
     ///
     /// `budi cloud init` generates a commented `~/.config/budi/cloud.toml`
     /// template so the user can paste their API key without guessing the
-    /// schema (issue #446). `budi cloud sync` pushes queued local rollups
-    /// and session summaries to the cloud now (same work the background
-    /// worker runs on an interval — ADR-0083 §9, issue #225). `budi cloud
-    /// status` reports whether cloud sync is enabled, when it last
-    /// succeeded, and how many records are queued locally.
+    /// schema. `budi cloud sync` pushes queued local rollups and session
+    /// summaries to the cloud now (same work the background worker runs
+    /// on an interval). `budi cloud status` reports whether cloud sync
+    /// is enabled, when it last succeeded, and how many records are
+    /// queued locally.
     #[command(after_help = "\
 Examples:
   budi cloud init                Generate ~/.config/budi/cloud.toml template
@@ -321,7 +319,7 @@ Examples:
         #[command(subcommand)]
         action: CloudAction,
     },
-    /// Pricing manifest: view status, trigger a manual refresh (ADR-0091)
+    /// Pricing manifest: view status, trigger a manual refresh
     #[command(after_help = "\
 Examples:
   budi pricing status              Show current manifest layer, version, and unknown models
@@ -372,10 +370,10 @@ enum CloudAction {
     /// Generate `~/.config/budi/cloud.toml` from a commented template
     ///
     /// Writes a starter config with every field commented so a fresh user
-    /// never has to read ADR-0083 to bootstrap cloud sync. Without flags it
-    /// leaves `api_key = "PASTE_YOUR_KEY_HERE"` and `enabled = false`;
-    /// `--api-key <K>` writes the real key and flips `enabled = true` in
-    /// one shot.
+    /// never has to consult external docs to bootstrap cloud sync.
+    /// Without flags it leaves `api_key = "PASTE_YOUR_KEY_HERE"` and
+    /// `enabled = false`; `--api-key <K>` writes the real key and flips
+    /// `enabled = true` in one shot.
     Init {
         /// Paste your API key directly and set `enabled = true` in the template.
         /// Without this flag the template still writes a stub that must be
@@ -441,14 +439,14 @@ enum AutostartAction {
 
 /// `--period` / `-p` argument for `budi stats` and `budi sessions`.
 ///
-/// Two flavors are supported (#404):
+/// Two flavors are supported:
 ///
 /// * **Named windows** (`today`, `week`, `month`, `all`). `today` is
 ///   anchored to the start of the current local calendar day.
 ///   `week` and `month` resolve to rolling 7 / 30 days ending now —
 ///   identical to `-p 7d` / `-p 30d` — matching the README's
-///   "last 7 / 30 calendar days including today" contract. Before 8.3
-///   (#447), `week` was calendar-week-starting-Monday and `month` was
+///   "last 7 / 30 calendar days including today" contract. Before 8.3,
+///   `week` was calendar-week-starting-Monday and `month` was
 ///   first-of-calendar-month, which collapsed to a single day of data
 ///   on Mondays and on the 1st of the month respectively.
 /// * **Rolling windows** (`Nd`, `Nw`, `Nm` where `N` is a positive integer) —
@@ -456,8 +454,7 @@ enum AutostartAction {
 ///   days / weeks from the local calendar day, and `Nm` uses calendar
 ///   months (same day-of-month N months ago, clamped to the end of the
 ///   target month). This matches the rolling `1d` / `7d` / `30d`
-///   windows used by the statusline surface and the cloud dashboard
-///   (ADR-0088 §4, #350).
+///   windows used by the statusline surface and the cloud dashboard.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum StatsPeriod {
     Today,


### PR DESCRIPTION
## Summary

The 2026-04-22 fresh-user audit found \`#448 / #450 / #442 / #443 /
#292 / R1.4 / ADR-0083 / ADR-0088 / ADR-0091\` leaking into user-facing
\`--help\` output on \`budi stats\`, \`budi cloud\`, \`budi cloud init\`,
\`budi pricing\`, \`budi sessions\`, and \`budi statusline\`. These are
dev breadcrumbs — a fresh user shouldn't need a github.com/siropkin/budi
tab to decode a \`--help\` message.

This PR removes every \`#NNN / ADR-NNN / RN.N\` reference from
clap-visible doc comments while keeping the prose explaining what each
flag does. Internal context stays in rustdoc on non-clap surfaces.

## Changes

- 10 \`///\` doc comments in \`crates/budi-cli/src/main.rs\` rewritten:
  - \`--files\` / \`--file\` descriptions (dropped \`R1.4 (#292)\`)
  - \`--limit\` / \`--label-width\` / \`--include-pending\` / \`--include-non-repo\` (dropped \`#448 / #450 / #442 / #443\`)
  - \`Db\` subcommand about (dropped \`#368 / #428\`)
  - \`--activity\` filter on \`sessions\` (dropped \`#305\`)
  - \`--full-uuid\` on \`sessions\` (dropped \`#445\`)
  - \`Statusline\` command about (dropped \`ADR-0088 §4, #224\`)
  - \`Cloud\` command about (dropped \`#446 / ADR-0083 §9 / #225\`)
  - \`Pricing\` command about (dropped \`ADR-0091\`)
  - \`Cloud init\` description (replaced \`ADR-0083\` with "external docs")
  - \`StatsPeriod\` enum-level rustdoc (dropped \`#404 / #447 / ADR-0088 §4 / #350\`)
- \`//\` (non-doc) internal comments in function bodies are unchanged
  since they don't surface in \`--help\`.
- New CI step in \`rust-checks\`: renders \`--help\` for every subcommand
  and fails if any output matches \`#[0-9]+|ADR-[0-9]+|RN.N\`. A regex
  prevents this class of regression from coming back, regardless of
  which file the next dev adds a \`///\` comment to.

## Risks / compatibility notes

- CLI help output is user-visible prose, not a contract. No risk to
  consumers. No flag was renamed, no semantics changed.
- The new CI grep guard runs only the release binary's actual
  \`--help\` output, so false positives on internal rustdoc / body
  comments are structurally impossible.

## Validation

- \`./target/release/budi <cmd> --help\` for every subcommand — no matches for \`#NNN / ADR-NNN / RN.N\`.
- \`cargo fmt --all --check\` — clean.
- \`cargo test --workspace --locked\` — 38 budi-daemon + 447 budi-core tests pass.

Closes #495
Refs #481