### PR TITLE
cli: statusline --format text alias + --tag help prose (#485, #491)

### DIFF
--- a/crates/budi-cli/src/main.rs
+++ b/crates/budi-cli/src/main.rs
@@ -131,8 +131,14 @@ Examples:
         /// Filter by provider (e.g. claude_code, cursor, codex, copilot_cli, openai). Only works with the default summary view.
         #[arg(long, conflicts_with = "view")]
         provider: Option<String>,
-        /// Show cost breakdown by tag key (e.g. --tag ticket_id, --tag activity)
-        #[arg(long)]
+        /// Break down cost by the given tag KEY (e.g. `--tag ticket_id`,
+        /// `--tag activity`, `--tag custom_key`). Unlike `--tickets`
+        /// and `--activities`, which are first-class per-dimension
+        /// views with their own ranking shape, `--tag <KEY>` is the
+        /// escape hatch for any tag key the pipeline emits — including
+        /// custom keys that the CLI doesn't hard-code a flag for. The
+        /// output ranks rows by the tag's VALUES for that key.
+        #[arg(long, value_name = "KEY")]
         tag: Option<String>,
         /// Maximum rows to show in breakdown views (`--projects`,
         /// `--branches`, `--tickets`, `--activities`, `--files`,
@@ -533,7 +539,14 @@ pub enum StatsFormat {
 
 #[derive(Debug, Clone, Copy, ValueEnum, PartialEq)]
 pub enum StatuslineFormat {
-    /// ANSI colors + OSC 8 hyperlinks (for Claude Code statusline)
+    /// ANSI colors + OSC 8 hyperlinks (for Claude Code statusline).
+    /// Accepts `text` as an alias so `--format text` matches the shared
+    /// convention the other CLI surfaces use for their default human-
+    /// readable render.
+    // The `text` alias landed in 8.3.1 as a fresh-user friction fix.
+    // Intentionally kept out of the clap `///` doc comment so the CI
+    // help-cleanliness grep guard stays green.
+    #[value(alias = "text")]
     Claude,
     /// Plain text, no ANSI (for Starship / shell prompts)
     Starship,
@@ -1294,6 +1307,45 @@ mod tests {
                 assert_eq!(activity.as_deref(), Some("bugfix"));
             }
             _ => panic!("expected sessions command"),
+        }
+    }
+
+    /// #485: `budi statusline --format text` should parse as the
+    /// default (Claude) render so a fresh user doesn't have to
+    /// remember that statusline's format vocabulary differs from
+    /// `budi stats` / `budi sessions`. Added via `#[value(alias = "text")]`
+    /// on `StatuslineFormat::Claude`.
+    #[test]
+    fn cli_statusline_accepts_text_as_claude_alias() {
+        let cli = Cli::try_parse_from(["budi", "statusline", "--format", "text"])
+            .expect("budi statusline --format text should parse");
+        match cli.command {
+            Commands::Statusline { format, .. } => {
+                assert_eq!(format, StatuslineFormat::Claude);
+            }
+            _ => panic!("expected statusline command"),
+        }
+
+        // Explicit `--format claude` still parses as Claude (no
+        // regression from the alias addition).
+        let cli = Cli::try_parse_from(["budi", "statusline", "--format", "claude"])
+            .expect("budi statusline --format claude should parse");
+        match cli.command {
+            Commands::Statusline { format, .. } => {
+                assert_eq!(format, StatuslineFormat::Claude);
+            }
+            _ => panic!("expected statusline command"),
+        }
+
+        // Other non-default formats still resolve to their own
+        // variants — alias only applies to the default.
+        let cli = Cli::try_parse_from(["budi", "statusline", "--format", "json"])
+            .expect("budi statusline --format json should parse");
+        match cli.command {
+            Commands::Statusline { format, .. } => {
+                assert_eq!(format, StatuslineFormat::Json);
+            }
+            _ => panic!("expected statusline command"),
         }
     }
 }


### PR DESCRIPTION
## Summary

Bundle U-2 (#491) and U-3 (#485) — both touch CLI surface text and
clap value parsing in \`main.rs\`, so they land together.

## U-3 (#485) — \`budi statusline --format text\`

Pre-fix:

\`\`\`
\$ budi statusline --format text
error: invalid value 'text' for '--format <FORMAT>'
  [possible values: claude, starship, json, custom]
\`\`\`

\`budi stats\` / \`budi sessions\` / \`budi cloud status\` accept \`text\`
as the default; statusline's format vocabulary legitimately differs
because \"text\" doesn't have a single right rendering for a shell
prompt fragment. This PR adds \`text\` as an **alias** for the default
(Claude) variant so a fresh user who reflexively types
\`--format text\` gets the expected render, without widening the
vocabulary.

## U-2 (#491) — \`--tag <KEY>\` help prose

Pre-fix help read:

\`\`\`
--tag <TAG>  Show cost breakdown by tag key (e.g. --tag ticket_id, --tag activity)
\`\`\`

Same shape as \`--tickets\` / \`--activities\`. A fresh reader could
reasonably expect \`--tag\` to be a breakdown view like those two.
Post-fix help is explicit that \`--tag <KEY>\` is the escape-hatch
filter for any tag key the pipeline emits, including custom keys the
CLI doesn't hard-code. Value name renamed from \`<TAG>\` to \`<KEY>\` so
clap error messages and tab-completion echo the clarification.

## Changes

- \`crates/budi-cli/src/main.rs\`:
  - \`StatuslineFormat::Claude\` gains \`#[value(alias = \"text\")]\` and the doc comment explains why.
  - \`--tag\` help rewritten; \`value_name\` → \`\"KEY\"\`.
  - New regression test \`cli_statusline_accepts_text_as_claude_alias\` covers the alias, the explicit \`claude\` variant, and at least one non-aliased format (\`json\`).

## Risks / compatibility notes

- \`--format claude\` still parses as Claude (no regression from the alias). The alias only covers the default; \`starship\` / \`json\` / \`custom\` are unchanged.
- \`--tag\` semantics are unchanged — this is pure help prose.

## Validation

- \`cargo fmt --all --check\` — clean
- \`cargo clippy --workspace --all-targets --locked -- -D warnings\` — clean
- \`cargo test -p budi-cli\` — 159 tests pass, including the new alias regression.
- Manual smoke: \`./target/release/budi statusline --format text\` renders the default statusline; \`./target/release/budi stats --help\` shows the rewritten \`--tag\` prose.

Closes #485
Closes #491
Refs #481