### PR TITLE
daemon: session-health route resolves short UUID prefixes (#496)

### DIFF
--- a/crates/budi-core/src/analytics/tests.rs
+++ b/crates/budi-core/src/analytics/tests.rs
@@ -5946,3 +5946,63 @@ fn unknown_provider_filter_yields_zero_messages_and_zero_cost() {
     .unwrap();
     assert_eq!(cost.total_cost, 0.0);
 }
+
+// ─── #496 D-3: short-UUID prefix resolver contract ──────────────────────────
+
+#[test]
+fn resolve_session_id_covers_full_prefix_empty_and_ambiguous() {
+    // Ticket acceptance: full-uuid hit, short-prefix unique hit,
+    // short-prefix multi-hit (ambiguous), short-prefix no-hit. Every
+    // future `--session <ID>` surface inherits these four paths via
+    // `budi_core::analytics::resolve_session_id`, which is the shared
+    // resolver the daemon's `resolve_sid` helper wraps.
+    let mut conn = test_db();
+    let session_full = "670b9539-aaaa-bbbb-cccc-111122223333";
+    // One other session sharing a 4-char prefix with the full id so
+    // `670b9539` resolves uniquely, `670b` is ambiguous, and
+    // `deadbeef` matches nothing.
+    let session_alt = "670bdead-1111-2222-3333-444455556677";
+    // Seed two assistant rows — one per session. ingest_messages also
+    // seeds the `sessions` table via the pipeline-independent path we
+    // rely on for resolve_session_id's subquery.
+    let mut m1 = assistant_msg("s-d3-1", session_full, 1.0);
+    m1.cwd = Some("/tmp/d3-full".to_string());
+    let mut m2 = assistant_msg("s-d3-2", session_alt, 1.0);
+    m2.cwd = Some("/tmp/d3-alt".to_string());
+    ingest_messages(&mut conn, &[m1, m2], None).unwrap();
+
+    // Full UUID hit.
+    let full_hit = resolve_session_id(&conn, session_full).unwrap();
+    assert_eq!(full_hit.as_deref(), Some(session_full));
+
+    // Short-prefix unique hit — the 8-char prefix `670b9539` only
+    // matches `session_full`.
+    let short_hit = resolve_session_id(&conn, "670b9539").unwrap();
+    assert_eq!(short_hit.as_deref(), Some(session_full));
+
+    // Short-prefix multi-hit — `670b` matches both seeded sessions.
+    let ambig = resolve_session_id(&conn, "670b").unwrap_err();
+    let msg = format!("{ambig:#}");
+    assert!(
+        msg.contains("ambiguous session prefix"),
+        "ambiguous prefix should surface as an error, got {msg:?}",
+    );
+
+    // Short-prefix no-hit.
+    let miss = resolve_session_id(&conn, "deadbeef").unwrap();
+    assert!(
+        miss.is_none(),
+        "no-match prefix should return Ok(None), got {miss:?}",
+    );
+
+    // Empty prefix: `LIKE '' || '%'` matches every row, so both
+    // seeded sessions surface and the resolver correctly flags it as
+    // ambiguous. Worth pinning since the daemon route now passes the
+    // raw query-string value through without trimming.
+    let empty = resolve_session_id(&conn, "").unwrap_err();
+    let msg = format!("{empty:#}");
+    assert!(
+        msg.contains("ambiguous session prefix"),
+        "empty prefix must not silently return a random session, got {msg:?}",
+    );
+}

--- a/crates/budi-daemon/src/routes/analytics.rs
+++ b/crates/budi-daemon/src/routes/analytics.rs
@@ -1128,10 +1128,19 @@ pub struct SessionHealthParams {
 pub async fn analytics_session_health(
     Query(params): Query<SessionHealthParams>,
 ) -> Result<Json<analytics::SessionHealth>, (StatusCode, Json<serde_json::Value>)> {
+    // #496 (D-3): resolve an 8-char session prefix (or any prefix) the
+    // same way `GET /analytics/sessions/{id}` does so `budi vitals
+    // --session <short-uuid>` accepts the same id a user copied out of
+    // `budi sessions`. Pre-fix the prefix flowed through unresolved and
+    // `LEFT JOIN` matched zero rows → silent INSUFFICIENT DATA.
+    let sid = match params.session_id {
+        Some(ref s) if !s.is_empty() => Some(resolve_sid(s.clone()).await?),
+        _ => None,
+    };
     let result = tokio::task::spawn_blocking(move || {
         let db_path = analytics::db_path()?;
         let conn = analytics::open_db(&db_path)?;
-        analytics::session_health(&conn, params.session_id.as_deref())
+        analytics::session_health(&conn, sid.as_deref())
     })
     .await
     .map_err(|e| internal_error(anyhow::anyhow!("{e}")))?


### PR DESCRIPTION
## Summary

Pre-fix:

\`\`\`
\$ budi sessions
   ...
   670b9539  claude_code  42  \$1.23  ...

\$ budi vitals --session 670b9539
⚪ Session Health: INSUFFICIENT DATA
  0 messages · \$0.00 total
  Not enough session data yet to assess
\`\`\`

The 8-char prefix \`670b9539\` resolves for \`budi sessions <id>\` (which
canonicalizes against \`sessions.id\`) but \`budi vitals --session
<id>\` silently returns INSUFFICIENT DATA because the
\`/analytics/session-health\` route did an exact-match join.

The shared prefix resolver \`budi_core::analytics::resolve_session_id\`
already lives in the core crate (that's where \`GET /analytics/sessions/{id}\`
picks up short-UUID support). The daemon's \`resolve_sid\` helper in
\`routes/analytics.rs\` wraps it with 404 / 500 HTTP-error semantics.
This PR wires the helper into the session-health route, which is
literally a three-line change.

## Behavior matrix (post-fix)

| Input | Before | After |
|---|---|---|
| Full UUID | OK | OK (regression guard) |
| Unique short prefix | INSUFFICIENT DATA | Renders vitals for the matched session |
| Ambiguous short prefix | INSUFFICIENT DATA | 500 \"ambiguous session prefix '<X>'\" |
| No-match short prefix | INSUFFICIENT DATA | 404 \"session '<X>' not found\" |
| Missing / empty \`session_id\` | Most-recent session | Most-recent session (unchanged) |

## Changes

- \`crates/budi-daemon/src/routes/analytics.rs::analytics_session_health\`: resolve the \`session_id\` query parameter via the shared \`resolve_sid\` helper before calling \`analytics::session_health\`. Empty / missing still falls through to the most-recent-session path.
- New test \`resolve_session_id_covers_full_prefix_empty_and_ambiguous\` in \`budi-core/src/analytics/tests.rs\` pins all four cases from #496's acceptance list plus the empty-prefix edge.

## Risks / compatibility notes

- CLI-side behavior gains the short-UUID path; existing callers that
  pass full UUIDs see no change.
- Ambiguous prefixes now surface as daemon errors (500) instead of
  silent \"no data\". Matches the pre-existing \`GET
  /analytics/sessions/{id}\` behavior for the same class of input; no
  new error shape.
- The Cursor extension and the statusline surface use
  \`/analytics/statusline\`, not \`/analytics/session-health\` — this PR
  doesn't touch their code path.

## Validation

- \`cargo fmt --all --check\` — clean
- \`cargo clippy --workspace --all-targets --locked -- -D warnings\` — clean
- \`cargo test --workspace --locked\` — all tests pass, including the new resolver test.

Closes #496
Refs #481
Refs #445