### PR TITLE
init: seed cloud.device_id + actionable error for missing org_id (#521)

### DIFF
--- a/crates/budi-cli/src/commands/cloud.rs
+++ b/crates/budi-cli/src/commands/cloud.rs
@@ -103,10 +103,17 @@ api_key = \"{api_key}\"
 # self-hosted ingester.
 endpoint = \"https://app.getbudi.dev\"
 
-# Optional. Only prompts, code, and responses are stripped before upload —
-# these two fields identify which device and workspace the daily rollups
-# belong to on the dashboard. `budi init` seeds them automatically on a
-# real enable, but you can set them explicitly for multi-machine setups.
+# These two fields identify which device and workspace the daily rollups
+# belong to on the dashboard.
+#
+# `device_id` is auto-seeded by `budi init` (UUID v4) once `enabled = true`
+# and `api_key` is non-stub. You can also set it explicitly for multi-
+# machine setups — any stable non-empty string works.
+#
+# `org_id` must be copied by hand from the Settings page at
+# https://app.getbudi.dev/dashboard/settings — `budi init` does not
+# reach out to the dashboard to discover it. `budi cloud sync` refuses
+# to run until both fields are present (see `budi cloud status`).
 # device_id = \"your-device-id\"
 # org_id = \"your-org-id\"
 

--- a/crates/budi-cli/src/commands/init.rs
+++ b/crates/budi-cli/src/commands/init.rs
@@ -45,6 +45,16 @@ pub fn cmd_init(cleanup: bool, yes: bool, no_integrations: bool, no_daemon: bool
         print_autostart_status(&config);
     }
 
+    // #521: auto-seed `device_id` in `~/.config/budi/cloud.toml` when
+    // cloud sync is opted in but the field is still commented out.
+    // Matches the template comment's long-standing promise that
+    // `budi init` seeds these values on a real enable. Prints a
+    // single-line status so the user sees whether the seeding just
+    // happened, already existed, or was skipped because cloud is off.
+    // `org_id` is NOT auto-generated (it has to come from the dashboard
+    // Settings page); we nudge the user separately when it's missing.
+    announce_cloud_device_id_seeding();
+
     if !no_integrations {
         install_default_integrations(&config);
     }
@@ -66,6 +76,58 @@ pub fn cmd_init(cleanup: bool, yes: bool, no_integrations: bool, no_daemon: bool
     );
 
     Ok(())
+}
+
+/// #521: seed `cloud.device_id` into `~/.config/budi/cloud.toml` when
+/// the user has opted into cloud sync but the field is still the
+/// commented template line. Pre-8.3.2 the template promised that
+/// `budi init` would do this but the seeding logic was never wired up;
+/// users were left with `budi cloud status = enabled but not fully
+/// configured` after following the documented flow.
+///
+/// On `Generated`, print a short confirmation + a nudge to set
+/// `org_id` (which the dashboard Settings page exposes). On
+/// `AlreadySet`, stay silent — subsequent `budi init` runs should not
+/// nag. On `Skipped`, stay silent — cloud sync isn't opted in, so
+/// the user hasn't asked budi to touch `cloud.toml`. Failures print a
+/// warning but do NOT abort the overall `budi init`, because the rest
+/// of init (daemon / autostart / integrations) is independent.
+fn announce_cloud_device_id_seeding() {
+    let dim = super::ansi("\x1b[90m");
+    let green = super::ansi("\x1b[32m");
+    let yellow = super::ansi("\x1b[33m");
+    let reset = super::ansi("\x1b[0m");
+    match budi_core::config::seed_cloud_device_id_if_needed() {
+        Ok(budi_core::config::SeedDeviceIdOutcome::Generated(id)) => {
+            // Surface the first 8 chars of the UUID so an operator
+            // with two devices can tell them apart in the dashboard
+            // without having to open the TOML.
+            let short = id.split('-').next().unwrap_or(&id);
+            println!(
+                "  {green}✓{reset} Cloud device_id seeded ({short}…) in ~/.config/budi/cloud.toml"
+            );
+            // Nudge for org_id if it's still missing. Checking via
+            // `load_cloud_config` keeps this one read-only pass; the
+            // file was just mutated above, so the re-load is
+            // intentional.
+            let cfg = budi_core::config::load_cloud_config();
+            if cfg.org_id.is_none() {
+                println!(
+                    "  {yellow}!{reset} Set {dim}org_id{reset} in ~/.config/budi/cloud.toml {dim}(copy from Settings page at https://app.getbudi.dev/dashboard/settings){reset}"
+                );
+            }
+        }
+        Ok(budi_core::config::SeedDeviceIdOutcome::AlreadySet) => {
+            // Quiet — user has already completed setup, no nag.
+        }
+        Ok(budi_core::config::SeedDeviceIdOutcome::Skipped) => {
+            // Quiet — no cloud.toml or cloud isn't enabled. Fresh users
+            // who haven't run `budi cloud init` see nothing.
+        }
+        Err(e) => {
+            eprintln!("  {yellow}!{reset} Could not seed cloud.device_id: {e:#}");
+        }
+    }
 }
 
 /// Install the default recommended integrations (Claude Code statusline,

--- a/crates/budi-core/src/config.rs
+++ b/crates/budi-core/src/config.rs
@@ -568,6 +568,129 @@ pub fn cloud_config_exists() -> bool {
         .unwrap_or(false)
 }
 
+/// Outcome of a call to [`seed_cloud_device_id_if_needed`]. Surfaced to
+/// the CLI so `budi init` can log exactly what happened (generated /
+/// already set / skipped because cloud is disabled).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SeedDeviceIdOutcome {
+    /// `cloud.toml` didn't exist, cloud was disabled, or the api_key is
+    /// still the stub. No seeding attempted. The CLI shouldn't nag the
+    /// user — they haven't opted into cloud yet.
+    Skipped,
+    /// `device_id` was already present in the config file. No-op.
+    AlreadySet,
+    /// Generated a fresh UUID v4 and wrote it into the commented
+    /// `# device_id = ...` slot. Returns the generated id so the CLI
+    /// can log it for operator visibility.
+    Generated(String),
+}
+
+/// If the on-disk cloud config has `enabled = true` + a non-stub
+/// `api_key` + no `device_id`, generate a fresh UUID v4 and write it
+/// into the `device_id` line. Preserves all other content (comments,
+/// formatting, other fields) by doing a targeted string edit rather
+/// than a serde round-trip that would drop comments.
+///
+/// Idempotent: returns `AlreadySet` on the second call without
+/// touching the file. Returns `Skipped` whenever cloud sync isn't
+/// configured enough to matter — fresh installs that never opted
+/// into cloud never see a `cloud.toml` modification.
+///
+/// `org_id` is NOT auto-generated; it has to come from the dashboard
+/// Settings page. The CLI render step nudges users to that value
+/// separately.
+///
+/// See #521 for context.
+pub fn seed_cloud_device_id_if_needed() -> Result<SeedDeviceIdOutcome> {
+    let path = cloud_config_path()?;
+    if !path.exists() {
+        return Ok(SeedDeviceIdOutcome::Skipped);
+    }
+
+    // Re-read the raw file for string-level editing (parser drops comments).
+    let raw = fs::read_to_string(&path)
+        .with_context(|| format!("read cloud config at {}", path.display()))?;
+
+    // Parse the struct to check gating conditions (enabled + real api_key).
+    let config = load_cloud_config();
+    if !config.effective_enabled() {
+        return Ok(SeedDeviceIdOutcome::Skipped);
+    }
+    let api_key = match config.effective_api_key() {
+        Some(k) if !k.is_empty() && k != CLOUD_API_KEY_STUB => k,
+        _ => return Ok(SeedDeviceIdOutcome::Skipped),
+    };
+    let _ = api_key; // used only for the gate
+
+    if config.device_id.is_some() {
+        return Ok(SeedDeviceIdOutcome::AlreadySet);
+    }
+
+    // Generate a fresh UUID v4. `uuid` is already a workspace dep.
+    let new_device_id = uuid::Uuid::new_v4().to_string();
+
+    // Surgical string edit: replace the commented template line. The
+    // template writes exactly `# device_id = "your-device-id"`; match
+    // that verbatim, fall back to appending a fresh `device_id` line
+    // under `[cloud]` when the commented template line is absent (e.g.
+    // the user hand-removed it).
+    let commented = "# device_id = \"your-device-id\"";
+    let uncommented = format!("device_id = \"{new_device_id}\"");
+
+    let new_raw = if raw.contains(commented) {
+        raw.replacen(commented, &uncommented, 1)
+    } else {
+        // Fallback: append the field under the `[cloud]` section. Walk
+        // the raw lines to find the first `[cloud]` header line and
+        // insert after the `api_key` line (so the field lives inside
+        // the `[cloud]` table, not accidentally in `[cloud.sync]`).
+        match find_insertion_line_for_device_id(&raw) {
+            Some(idx) => {
+                let mut lines: Vec<String> = raw.lines().map(str::to_string).collect();
+                lines.insert(idx, uncommented.clone());
+                // Preserve the trailing newline of the original file.
+                let mut joined = lines.join("\n");
+                if raw.ends_with('\n') {
+                    joined.push('\n');
+                }
+                joined
+            }
+            None => {
+                // Truly foreign structure — don't rewrite; let the
+                // user hand-edit. Surface as skipped so the CLI
+                // doesn't claim a generation that didn't happen.
+                return Ok(SeedDeviceIdOutcome::Skipped);
+            }
+        }
+    };
+
+    fs::write(&path, new_raw)
+        .with_context(|| format!("write cloud config at {}", path.display()))?;
+
+    Ok(SeedDeviceIdOutcome::Generated(new_device_id))
+}
+
+/// Locate the line index in `raw` where a fresh `device_id = "..."`
+/// line should be inserted when the commented template slot is
+/// missing. Returns the line immediately after the last `api_key = ...`
+/// line inside the `[cloud]` section (before any `[cloud.sync]` or
+/// other table), or `None` if no such anchor is found.
+fn find_insertion_line_for_device_id(raw: &str) -> Option<usize> {
+    let mut in_cloud_section = false;
+    let mut last_api_key_line: Option<usize> = None;
+    for (i, line) in raw.lines().enumerate() {
+        let trimmed = line.trim();
+        if trimmed.starts_with('[') {
+            in_cloud_section = trimmed == "[cloud]";
+            continue;
+        }
+        if in_cloud_section && trimmed.starts_with("api_key") {
+            last_api_key_line = Some(i + 1);
+        }
+    }
+    last_api_key_line
+}
+
 /// Load cloud config. Returns default (disabled) if the file does not exist.
 pub fn load_cloud_config() -> CloudConfig {
     let path = match cloud_config_path() {
@@ -1014,5 +1137,52 @@ api_key = "budi_test"
         assert_eq!(config.api_key.as_deref(), Some("budi_test"));
         assert_eq!(config.endpoint, "https://app.getbudi.dev");
         assert_eq!(config.sync.interval_seconds, 300);
+    }
+
+    /// #521: locate the insertion line for a fresh `device_id` when the
+    /// commented-template slot has been removed by a hand-edit. The
+    /// helper is a pure string pass — no file I/O — so we can unit-
+    /// test every branch without touching `~/.config`.
+    #[test]
+    fn find_insertion_line_for_device_id_anchors_after_api_key() {
+        let raw = r#"# comment
+[cloud]
+enabled = true
+api_key = "budi_real"
+endpoint = "https://app.getbudi.dev"
+
+[cloud.sync]
+interval_seconds = 300
+"#;
+        let idx = find_insertion_line_for_device_id(raw).expect("should find an anchor");
+        // The line after `api_key = "budi_real"` is line index 3 (0-based),
+        // so insertion index is 4.
+        let lines: Vec<&str> = raw.lines().collect();
+        assert_eq!(lines[idx - 1], "api_key = \"budi_real\"");
+    }
+
+    #[test]
+    fn find_insertion_line_for_device_id_returns_none_without_cloud_section() {
+        let raw = r#"# something else
+[unrelated]
+foo = "bar"
+"#;
+        assert!(find_insertion_line_for_device_id(raw).is_none());
+    }
+
+    #[test]
+    fn find_insertion_line_for_device_id_skips_cloud_sync_section() {
+        // `api_key` inside `[cloud.sync]` (unlikely but possible) must
+        // NOT be treated as the anchor — we want the `[cloud]` table's
+        // api_key.
+        let raw = r#"[cloud]
+enabled = true
+
+[cloud.sync]
+api_key = "wrong_table"
+"#;
+        // No `api_key` exists in the `[cloud]` section itself, so the
+        // helper returns None rather than anchoring inside `[cloud.sync]`.
+        assert!(find_insertion_line_for_device_id(raw).is_none());
     }
 }

--- a/crates/budi-daemon/src/routes/cloud.rs
+++ b/crates/budi-daemon/src/routes/cloud.rs
@@ -71,11 +71,13 @@ pub async fn cloud_sync(
         )));
     }
     if !cfg.is_ready() {
-        return Ok(Json(not_ready_body(
-            RESULT_NOT_CONFIGURED,
-            &cfg,
-            "Cloud sync is not fully configured. Ensure api_key, device_id, and org_id are set in ~/.config/budi/cloud.toml.",
-        )));
+        // #521: spell out which field is missing and where to find its
+        // value so a fresh user can complete the flow without reading
+        // the ADR. Pre-fix the operator saw a generic "ensure api_key,
+        // device_id, and org_id are set" line that listed every
+        // possible gap.
+        let missing = missing_fields_message(&cfg);
+        return Ok(Json(not_ready_body(RESULT_NOT_CONFIGURED, &cfg, &missing)));
     }
 
     if state
@@ -120,6 +122,50 @@ fn not_ready_body(result: &str, cfg: &CloudConfig, message: &str) -> Value {
         "rollups_attempted": 0,
         "sessions_attempted": 0,
     })
+}
+
+/// #521: enumerate which `[cloud]` fields are still missing and
+/// point each missing field at the concrete action the operator
+/// needs to take. Returned as a single user-facing line so both
+/// `/cloud/status` and `/cloud/sync` surface the same prose.
+fn missing_fields_message(cfg: &CloudConfig) -> String {
+    let mut problems: Vec<String> = Vec::new();
+    if cfg.effective_api_key().is_none() {
+        problems
+            .push("`api_key` — paste from https://app.getbudi.dev/dashboard/settings".to_string());
+    } else if cfg
+        .effective_api_key()
+        .as_deref()
+        .map(|k| k == config::CLOUD_API_KEY_STUB)
+        .unwrap_or(false)
+    {
+        problems.push(
+            "`api_key` — still the placeholder; paste your real key from https://app.getbudi.dev/dashboard/settings"
+                .to_string(),
+        );
+    }
+    if cfg.device_id.is_none() {
+        problems.push(
+            "`device_id` — run `budi init` to auto-generate a UUID, or set any stable string"
+                .to_string(),
+        );
+    }
+    if cfg.org_id.is_none() {
+        problems.push(
+            "`org_id` — copy from the Organization panel at https://app.getbudi.dev/dashboard/settings"
+                .to_string(),
+        );
+    }
+    if problems.is_empty() {
+        // Defensive: `is_ready()` was false so something must be missing
+        // — fall back to a generic line rather than returning an empty
+        // string that would read as no-message.
+        return "Cloud sync is not fully configured. Check ~/.config/budi/cloud.toml.".to_string();
+    }
+    format!(
+        "Cloud sync is not fully configured. Missing:\n  - {}\nAfter editing ~/.config/budi/cloud.toml, re-run `budi cloud status`.",
+        problems.join("\n  - ")
+    )
 }
 
 fn report_to_json(report: SyncTickReport) -> Value {


### PR DESCRIPTION
## Summary

Pre-fix the documented fresh-user cloud-connect flow dead-ended
at step 2 of the \`budi cloud init --api-key\` → \`budi init\` →
\`budi cloud status\` loop:

\`\`\`
\$ budi cloud status
  ! State: enabled but not fully configured
\$ budi cloud sync
  ! Cloud sync is not fully configured. Ensure api_key, device_id,
    and org_id are set in ~/.config/budi/cloud.toml.
\`\`\`

\`budi init\` had NO cloud-config handling despite the template
comment promising \"\`budi init\` seeds them automatically on a real
enable.\" Surfaced during v8.3.1's post-tag cloud-UI audit.

## Changes

1. **\`seed_cloud_device_id_if_needed\`** in \`budi-core::config\`
   generates a fresh UUID v4 and uncomments the template's
   \`# device_id = ...\` slot when cloud is opted-in with a real
   \`api_key\` and \`device_id\` is still None. Surgical string-edit
   preserves every comment / layout line. Idempotent.
2. **\`cmd_init\`** calls the seeder on every run, prints \`✓ Cloud
   device_id seeded (<uuid-prefix>…)\` plus a nudge if \`org_id\` is
   still missing. Quiet on repeat runs.
3. **Template comment** in \`budi cloud init\` rewritten so it no
   longer lies — spells out that \`device_id\` is auto-seeded by
   \`budi init\` and \`org_id\` must be copied by hand from
   \`https://app.getbudi.dev/dashboard/settings\`.
4. **Daemon \`/cloud/sync\` + \`/cloud/status\`** now emit a per-field
   missing-fields message via a new \`missing_fields_message\` helper
   — pre-fix every operator saw the same generic \"ensure api_key,
   device_id, and org_id are set\" line regardless of which one was
   actually missing.

## Risks / compatibility notes

- **No new network calls.** \`org_id\` is NOT auto-discovered via an
  API request — that would need a new endpoint on \`siropkin/budi-cloud\`
  (tracked there separately). Keeping this PR inside the local-only
  contract.
- **Idempotent seeding**: the seeder returns \`AlreadySet\` on every
  call after the first, so repeat \`budi init\` runs don't touch the
  file.
- **String-level edit** over \`toml\` round-trip is deliberate —
  preserves comments, field order, and trailing newlines. The
  alternative (parse → round-trip via \`toml::to_string\`) would
  destroy the heavily-commented template immediately.
- **Template comment change is forwards-compatible**: old
  \`cloud.toml\` files with the pre-fix comment still work — the
  seeder edits the \`# device_id = \"your-device-id\"\` line directly,
  which is unchanged from the old template.

## Validation

- \`cargo fmt --all --check\` — clean
- \`cargo clippy --workspace --all-targets --locked -- -D warnings\` — clean
- \`cargo test --workspace --locked\` — all tests pass including three new ones pinning the string-editor branches.

Closes #521