### PR TITLE
update: run brew update before brew upgrade (#517)

### DIFF
--- a/crates/budi-cli/src/commands/update.rs
+++ b/crates/budi-cli/src/commands/update.rs
@@ -220,6 +220,28 @@ fn fetch_latest_release_tag() -> Result<String> {
 }
 
 fn run_brew_upgrade() -> Result<()> {
+    // #517: run `brew update --quiet` before `brew upgrade budi` so the
+    // tap's `formula.jws.json` is refreshed. Without this pre-flight,
+    // `brew upgrade` hits the local stale tap index right after a new
+    // homebrew-budi release cuts and exits with a confusing
+    // "already installed" warning, leaving the user on the old version
+    // even though a newer one just published. Observed during the
+    // 8.3.1 post-tag smoke — first `budi update --yes` reported
+    // "Warning: siropkin/budi/budi 8.3.0 already installed", a second
+    // invocation a minute later succeeded because the background
+    // auto-update refreshed the tap between runs.
+    //
+    // `--quiet` suppresses the line-noise so `budi update`'s output
+    // stays readable. Any refresh failure (network dropped mid-fetch,
+    // etc.) is non-fatal — fall through to `brew upgrade`, which will
+    // either succeed against a cached index or surface its own error.
+    let _ = Command::new("brew")
+        .args(["update", "--quiet"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .status();
+
     let status = Command::new("brew")
         .args(["upgrade", "budi"])
         .stdin(Stdio::inherit())


### PR DESCRIPTION
## Summary

Pre-fix \`run_brew_upgrade\` in \`budi update\` called \`brew upgrade budi\` directly, relying on Homebrew's background auto-update to refresh the tap index. That's a race: when \`budi update\` is invoked within minutes of a new \`homebrew-budi\` auto-bump, the tap's \`formula.jws.json\` is often still stale and \`brew upgrade\` reports \"Warning: siropkin/budi/budi 8.3.0 already installed\" on the old version. Observed during the v8.3.1 post-tag smoke — first invocation mis-fired, second invocation succeeded after auto-update ran asynchronously.

## Fix

Run \`brew update --quiet\` before \`brew upgrade budi\`. \`--quiet\` keeps the line-noise suppressed. A refresh failure is non-fatal — fall through to \`brew upgrade\`.

## Risks / compatibility notes

- One extra subprocess invocation per \`budi update\` run. \`brew update\` on a warm tap is typically <1s.
- No behavior change on non-Homebrew installs (the standalone path doesn't touch brew).

## Validation

- \`cargo fmt --all --check\` / \`cargo clippy --workspace --all-targets --locked -- -D warnings\` — clean.
- \`cargo test --workspace --locked\` — all tests pass.

Closes #517