### PR TITLE
cost: add other_cost so summary sub-line reconciles to top line (#520)

### DIFF
--- a/crates/budi-cli/src/commands/stats.rs
+++ b/crates/budi-cli/src/commands/stats.rs
@@ -692,17 +692,38 @@ fn format_summary(
     // Cost-component sub-line — unconditional (#451). Reads $0.00 in
     // each cell when the window has no spend, so the shape stays
     // identical to a populated summary. Uses the same fixed-decimal
-    // formatter as the top-line so the four components always sum to
-    // the top-line value on the rendered screen.
-    writeln!(
-        out,
-        "  {dim}  input {}  output {}  cache write {}  cache read {}{reset}",
-        format_cost_cents_fixed(est.input_cost * 100.0),
-        format_cost_cents_fixed(est.output_cost * 100.0),
-        format_cost_cents_fixed(est.cache_write_cost * 100.0),
-        format_cost_cents_fixed(est.cache_read_cost * 100.0),
-    )
-    .unwrap();
+    // formatter as the top-line so the four base components always
+    // sum to the top-line value on the rendered screen.
+    //
+    // #520: if `other_cost` is non-zero — typically Cursor fast-mode,
+    // thinking-token cost, or web-search fees that are in
+    // `total_cost` (via `SUM(cost_cents)` at ingest) but absent from
+    // the four base token×rate components — render a fifth `other`
+    // cell so the sub-line visually reconciles to the top-line.
+    // Silently omitted when the residual is zero (typical for a
+    // Claude-only window) to keep the sub-line readable.
+    if est.other_cost > 0.0 {
+        writeln!(
+            out,
+            "  {dim}  input {}  output {}  cache write {}  cache read {}  other {}{reset}",
+            format_cost_cents_fixed(est.input_cost * 100.0),
+            format_cost_cents_fixed(est.output_cost * 100.0),
+            format_cost_cents_fixed(est.cache_write_cost * 100.0),
+            format_cost_cents_fixed(est.cache_read_cost * 100.0),
+            format_cost_cents_fixed(est.other_cost * 100.0),
+        )
+        .unwrap();
+    } else {
+        writeln!(
+            out,
+            "  {dim}  input {}  output {}  cache write {}  cache read {}{reset}",
+            format_cost_cents_fixed(est.input_cost * 100.0),
+            format_cost_cents_fixed(est.output_cost * 100.0),
+            format_cost_cents_fixed(est.cache_write_cost * 100.0),
+            format_cost_cents_fixed(est.cache_read_cost * 100.0),
+        )
+        .unwrap();
+    }
     // Cache-savings line — unconditional (#451). $0.00 when no cache
     // hits accumulated; skipping it in 8.2 made `today` look
     // structurally different from `1d` whenever cache savings happened
@@ -2872,6 +2893,7 @@ mod tests {
             output_cost: 20.82,
             cache_write_cost: 27.48,
             cache_read_cost: 65.94,
+            other_cost: 0.0,
             cache_savings,
         }
     }
@@ -3304,6 +3326,7 @@ mod tests {
             output_cost: 19.92,
             cache_write_cost: 32.36,
             cache_read_cost: 74.08,
+            other_cost: 0.0,
             cache_savings: 0.0,
         };
         let providers = vec![fixture_provider(
@@ -3344,6 +3367,85 @@ mod tests {
                 assert!(
                     !line.contains("K") && !line.contains("M"),
                     "top-line `Est. cost` must not humanize: {line:?}",
+                );
+            }
+        }
+    }
+
+    /// #520: when `other_cost > 0`, the summary sub-line grows a
+    /// fifth `other $N.NN` cell so the four base components + `other`
+    /// sum to the top line. Fresh Claude-only windows (other_cost=0)
+    /// keep the pre-8.3.2 four-cell sub-line so the surface stays
+    /// uncluttered.
+    #[test]
+    fn summary_renders_other_cost_cell_when_nonzero() {
+        let summary = fixture_summary();
+        // Seed the 2026-04-22 audit's actual 30d numbers: top-line
+        // \$3,915.47, components sum \$3,800.47, other = \$115.00.
+        let est = budi_core::cost::CostEstimate {
+            total_cost: 3_915.47,
+            input_cost: 995.38,
+            output_cost: 316.65,
+            cache_write_cost: 703.15,
+            cache_read_cost: 1_785.29,
+            other_cost: 115.00,
+            cache_savings: 0.0,
+        };
+        let providers = vec![fixture_provider(
+            "claude_code",
+            "Claude Code",
+            262,
+            391_547.0,
+        )];
+        let palette = SummaryPalette::plain();
+        let rendered = format_summary(
+            StatsPeriod::Today,
+            None,
+            &summary,
+            &est,
+            &providers,
+            &palette,
+        );
+        assert!(
+            rendered.contains("other $115.00"),
+            "other cell must render when non-zero:\n{rendered}",
+        );
+        assert!(
+            rendered.contains("Est. cost    $3,915.47"),
+            "top-line cost precision must carry thousands sep + cents:\n{rendered}",
+        );
+    }
+
+    #[test]
+    fn summary_omits_other_cost_cell_when_zero() {
+        let summary = fixture_summary();
+        let est = budi_core::cost::CostEstimate {
+            total_cost: 7.50,
+            input_cost: 5.00,
+            output_cost: 2.50,
+            cache_write_cost: 0.0,
+            cache_read_cost: 0.0,
+            other_cost: 0.0,
+            cache_savings: 0.0,
+        };
+        let providers = vec![fixture_provider("claude_code", "Claude Code", 10, 750.0)];
+        let palette = SummaryPalette::plain();
+        let rendered = format_summary(
+            StatsPeriod::Today,
+            None,
+            &summary,
+            &est,
+            &providers,
+            &palette,
+        );
+        // The "other" label only appears inside the summary block
+        // when `other_cost > 0`; a zero window keeps the pre-8.3.2
+        // four-cell shape.
+        for line in rendered.lines() {
+            if line.contains("input ") && line.contains("output ") {
+                assert!(
+                    !line.contains("other"),
+                    "sub-line should not contain `other` when other_cost == 0: {line:?}",
                 );
             }
         }

--- a/crates/budi-core/src/cost.rs
+++ b/crates/budi-core/src/cost.rs
@@ -6,6 +6,17 @@ use rusqlite::Connection;
 use crate::analytics::{DimensionFilters, UNTAGGED_DIMENSION};
 
 /// Estimated cost breakdown.
+///
+/// #520 (8.3.2): `total_cost` is `SUM(cost_cents)` from `messages`
+/// (the authoritative cost stored at ingest time by `CostEnricher`,
+/// which may include thinking tokens, fast-mode multipliers, and web-
+/// search fees). The four per-component fields (`input_cost` /
+/// `output_cost` / `cache_write_cost` / `cache_read_cost`) are re-
+/// derived from base token sums × current manifest pricing and cover
+/// only those four buckets. When Cursor fast-mode or thinking-token
+/// cost contributes to a session, the four components can sum to less
+/// than `total_cost`. `other_cost` captures that gap so the summary
+/// view visibly reconciles.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct CostEstimate {
     pub total_cost: f64,
@@ -13,6 +24,13 @@ pub struct CostEstimate {
     pub output_cost: f64,
     pub cache_write_cost: f64,
     pub cache_read_cost: f64,
+    /// #520: residual cost present in `total_cost` but not captured by
+    /// the four base-token components above. Non-zero when Cursor
+    /// fast-mode, thinking tokens, or web-search fees contributed to
+    /// the aggregate. Defaults to 0 for back-compat; callers that pre-
+    /// 8.3.2 ignored this field see no behavior change.
+    #[serde(default)]
+    pub other_cost: f64,
     pub cache_savings: f64,
 }
 
@@ -177,6 +195,7 @@ pub fn estimate_cost_with_filters(
         output_cost: 0.0,
         cache_write_cost: 0.0,
         cache_read_cost: 0.0,
+        other_cost: 0.0,
         cache_savings: 0.0,
     };
 
@@ -214,6 +233,19 @@ pub fn estimate_cost_with_filters(
     total.cache_write_cost = (total.cache_write_cost * 100.0).round() / 100.0;
     total.cache_read_cost = (total.cache_read_cost * 100.0).round() / 100.0;
     total.cache_savings = (total.cache_savings * 100.0).round() / 100.0;
+
+    // #520: the four per-component fields sum from base-token × rate,
+    // while `total_cost` is `SUM(cost_cents)` from ingest (which can
+    // include thinking / fast-mode / web-search contributions).
+    // Compute `other_cost` as the residual so the summary view
+    // visually reconciles. Clamp to >= 0 — a negative residual would
+    // mean the four components over-counted vs the stored total,
+    // which shouldn't happen but guards against a future pricing
+    // drift surfacing as a confusing "other -$N" row on screen.
+    let components_sum =
+        total.input_cost + total.output_cost + total.cache_write_cost + total.cache_read_cost;
+    let other = total.total_cost - components_sum;
+    total.other_cost = ((other * 100.0).round() / 100.0).max(0.0);
 
     Ok(total)
 }
@@ -525,5 +557,82 @@ mod tests {
             cost.total_cost > 0.0,
             "sub-cent messages should not be lost"
         );
+    }
+
+    /// #520: when `cost_cents` at ingest exceeds the sum of the four
+    /// base-token components (e.g. Cursor fast-mode, thinking tokens,
+    /// web-search fees), `other_cost` captures the residual so the
+    /// summary render sums back to the top line.
+    #[test]
+    fn cost_other_component_captures_residual_above_base_tokens() {
+        let conn = setup_db();
+        // Seed a row whose stored `cost_cents` (1000 ¢ = $10.00) is
+        // higher than the pure base-token × manifest-rate recomputation.
+        // For `claude-opus-4-6`: 1M input × $5/M = $5.00, 100K output ×
+        // $25/M = $2.50 → components sum $7.50. The extra $2.50 is the
+        // "other" bucket — thinking/fast-mode/web-search in real data.
+        conn.execute(
+            "INSERT INTO messages (id, role, timestamp, model, input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens, cost_cents)
+             VALUES (?1, 'assistant', '2026-03-21T00:00:00Z', 'claude-opus-4-6', ?2, ?3, 0, 0, ?4)",
+            params!["msg1", 1_000_000i64, 100_000i64, 1000.0],
+        ).unwrap();
+        let cost = estimate_cost_filtered(&conn, None, None, None).unwrap();
+        assert_eq!(cost.total_cost, 10.0);
+        assert_eq!(cost.input_cost, 5.0);
+        assert_eq!(cost.output_cost, 2.5);
+        assert_eq!(cost.cache_write_cost, 0.0);
+        assert_eq!(cost.cache_read_cost, 0.0);
+        assert_eq!(cost.other_cost, 2.5);
+        // Reconciliation: four components + other == total.
+        let sum = cost.input_cost
+            + cost.output_cost
+            + cost.cache_write_cost
+            + cost.cache_read_cost
+            + cost.other_cost;
+        assert!(
+            (sum - cost.total_cost).abs() < 0.005,
+            "sub-line must reconcile to top line: sum={sum}, total={}",
+            cost.total_cost,
+        );
+    }
+
+    /// #520: when the four base-token components already equal the
+    /// stored total, `other_cost` is 0 so the render suppresses the
+    /// "other" cell and the sub-line reads as pre-8.3.2.
+    #[test]
+    fn cost_other_component_is_zero_when_no_residual() {
+        let conn = setup_db();
+        // `claude-opus-4-6`: 1M input × $5/M + 100K output × $25/M = $7.50.
+        // Stored `cost_cents` matches the recomputation exactly, so
+        // `other_cost` should be zero.
+        conn.execute(
+            "INSERT INTO messages (id, role, timestamp, model, input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens, cost_cents)
+             VALUES (?1, 'assistant', '2026-03-21T00:00:00Z', 'claude-opus-4-6', ?2, ?3, 0, 0, ?4)",
+            params!["msg1", 1_000_000i64, 100_000i64, 750.0],
+        ).unwrap();
+        let cost = estimate_cost_filtered(&conn, None, None, None).unwrap();
+        assert_eq!(cost.total_cost, 7.5);
+        assert_eq!(cost.other_cost, 0.0);
+    }
+
+    /// #520 defensive: a negative residual (components > total — only
+    /// possible under an incoherent pricing state) clamps to 0 so the
+    /// render never shows a confusing "other -$N" cell. The stored
+    /// `total_cost` remains the authoritative number.
+    #[test]
+    fn cost_other_component_clamps_negative_residual_to_zero() {
+        let conn = setup_db();
+        // Under-stored cost_cents vs token × rate. The recomputation
+        // says ~$7.50 for the four base components, but we persist
+        // only $5.00 at ingest time — `other_cost` should clamp at 0
+        // rather than flip negative.
+        conn.execute(
+            "INSERT INTO messages (id, role, timestamp, model, input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens, cost_cents)
+             VALUES (?1, 'assistant', '2026-03-21T00:00:00Z', 'claude-opus-4-6', ?2, ?3, 0, 0, ?4)",
+            params!["msg1", 1_000_000i64, 100_000i64, 500.0],
+        ).unwrap();
+        let cost = estimate_cost_filtered(&conn, None, None, None).unwrap();
+        assert_eq!(cost.total_cost, 5.0);
+        assert_eq!(cost.other_cost, 0.0);
     }
 }


### PR DESCRIPTION
## Summary

Pre-fix \`budi stats -p 30d\` on the maintainer's machine showed:

\`\`\`
Est. cost    \$3,915.47
  input \$995.38  output \$316.65  cache write \$703.15  cache read \$1,785.29
\`\`\`

Sum of the four sub-line values = \$3,800.47. Delta: **\$115.00**. Not a rounding artifact.

## Root cause

\`CostEstimate.total_cost\` is \`SUM(cost_cents)\` from \`messages\` (the authoritative ingest-time cost; includes thinking tokens, Cursor fast-mode, web-search fees). The four per-component fields (\`input_cost / output_cost / cache_write_cost / cache_read_cost\`) are re-derived from base-token sums × manifest pricing — only four buckets. The \$115 gap is real Cursor fast-mode / thinking / web-search cost that lives in \`total_cost\` but is absent from any of the four components.

## Fix

Add \`other_cost: f64\` to \`CostEstimate\`. Compute as residual \`(total_cost − (input + output + cache_write + cache_read)).max(0.0)\`. The summary render grows a fifth \`other \$N.NN\` cell when it's non-zero; keeps the pre-8.3.2 four-cell layout when zero.

\`#[serde(default)]\` on the field keeps pre-8.3.2 JSON bodies deserializing cleanly.

## Validation

- \`cargo fmt --all --check\` / \`cargo clippy --workspace --all-targets --locked -- -D warnings\` — clean.
- \`cargo test --workspace --locked\` — 5 new tests pin the residual math, reconciliation, clamp behavior, and the summary render branches for both non-zero and zero cases.

## Risks / compatibility notes

- Wire-level addition — old JSON consumers unchanged. Older CLIs reading a newer daemon's response see the extra field and drop it on deserialize (`#[serde(default)]`).
- Summary text render gains a fifth cell only when \`other_cost > 0\` — Claude-only windows keep the familiar four-cell shape.
- No SQL change. \`total_cost\` remains authoritative.

Closes #520