### PR TITLE
update: restart daemon against installed version after brew upgrade (#529)

### DIFF
--- a/crates/budi-cli/src/commands/update.rs
+++ b/crates/budi-cli/src/commands/update.rs
@@ -11,7 +11,7 @@ use reqwest::blocking::Client;
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 
-use crate::daemon::{ensure_daemon_running, ensure_daemon_running_with_binary};
+use crate::daemon::{ensure_daemon_running, restart_daemon_for_version_upgrade};
 
 const RELEASES_LATEST_URL: &str = "https://api.github.com/repos/siropkin/budi/releases/latest";
 const RELEASE_DOWNLOAD_BASE: &str = "https://github.com/siropkin/budi/releases/download";
@@ -178,7 +178,16 @@ pub fn cmd_update(yes: bool, version: Option<String>) -> Result<()> {
         None
     };
     println!("Restarting daemon...");
-    let _ = ensure_daemon_running_with_binary(repo_root.as_deref(), &config, daemon_override);
+    // #529: use the version-aware restart path so the daemon is
+    // explicitly killed + respawned when `/health.version` doesn't
+    // match the version we just installed. The generic
+    // `ensure_daemon_running_with_binary` compares against
+    // `env!("CARGO_PKG_VERSION")` of the running CLI — which during
+    // `budi update` is still the PRE-install process, so a pre-
+    // install daemon matches and no restart fires. `latest` is the
+    // version we just put on disk; that's the true respawn target.
+    let _ =
+        restart_daemon_for_version_upgrade(repo_root.as_deref(), &config, daemon_override, &latest);
 
     // Verify installed version.
     let verification_bin = prepared.as_ref().map(|p| p.budi_dst.as_path());

--- a/crates/budi-cli/src/daemon.rs
+++ b/crates/budi-cli/src/daemon.rs
@@ -136,7 +136,14 @@ fn daemon_port_conflict_hint(port: u16) -> String {
 
 /// Check if the running daemon reports the same version as this CLI binary.
 fn daemon_version_matches(config: &BudiConfig) -> bool {
-    let cli_version = env!("CARGO_PKG_VERSION");
+    daemon_version_equals(config, env!("CARGO_PKG_VERSION"))
+}
+
+/// Return true if the running daemon's `/health.version` equals `expected`.
+/// Used by the CLI-general restart path (running CLI's own version) and by
+/// `budi update`'s post-install restart (the version just installed on disk,
+/// which may differ from the currently-running CLI process's version).
+fn daemon_version_equals(config: &BudiConfig, expected: &str) -> bool {
     let Ok(client) = daemon_client_with_timeout(Duration::from_secs(HEALTH_TIMEOUT_SECS)) else {
         return false;
     };
@@ -148,10 +155,46 @@ fn daemon_version_matches(config: &BudiConfig) -> bool {
         return false;
     };
     match json.get("version").and_then(|v| v.as_str()) {
-        Some(daemon_version) => daemon_version == cli_version,
+        Some(daemon_version) => daemon_version == expected,
         // Old daemons don't report version — treat as mismatch
         None => false,
     }
+}
+
+/// #529: post-install restart used by `budi update`.
+///
+/// `ensure_daemon_running_with_binary` compares the daemon's version against
+/// the CURRENTLY-RUNNING CLI's `env!("CARGO_PKG_VERSION")`. During
+/// `budi update`, that's the PRE-install CLI — so the daemon's pre-install
+/// version matches and the respawn path is never taken, leaving `/health`
+/// reporting the old version until the next `budi init` / `budi doctor`.
+///
+/// This helper takes the just-installed `expected` version as an explicit
+/// argument so the update flow compares the daemon against the NEW binary
+/// rather than the running process. If `/health.version` doesn't match,
+/// it kills every `budi-daemon` process, waits for the port to release,
+/// and hands off to `ensure_daemon_running_with_binary` to spawn the new
+/// one.
+///
+/// No-op when the daemon already reports the expected version (the brew /
+/// launchd respawn already picked up the new binary on its own).
+pub fn restart_daemon_for_version_upgrade(
+    repo_root: Option<&Path>,
+    config: &BudiConfig,
+    daemon_bin_override: Option<&Path>,
+    expected: &str,
+) -> Result<()> {
+    if daemon_health(config) && daemon_version_equals(config, expected) {
+        return Ok(());
+    }
+    // Kill any daemon (running old version, unhealthy, or absent — `kill` is
+    // idempotent on an empty set of pids).
+    kill_all_daemons();
+    if !wait_for_port_release(config, 40, Duration::from_millis(150)) {
+        force_kill_all_daemons();
+        let _ = wait_for_port_release(config, 20, Duration::from_millis(150));
+    }
+    ensure_daemon_running_with_binary(repo_root, config, daemon_bin_override)
 }
 
 fn wait_for_daemon_health(


### PR DESCRIPTION
## Summary

`budi update` previously called `ensure_daemon_running_with_binary`, which compares `/health.version` against the RUNNING CLI's `env!("CARGO_PKG_VERSION")`. During `budi update` the running CLI is still the PRE-install process, so the pre-install daemon matches and no restart fires — `/health` keeps reporting the old version until the next `budi init` / `budi doctor` happens to respawn it.

New `restart_daemon_for_version_upgrade(expected)` takes the version we just installed on disk as an explicit argument, compares `/health` against that, and kills + respawns when they don't match. `daemon_version_matches` now delegates to a shared `daemon_version_equals(expected)` helper so both entry points share the same health-probe logic.

Surfaced during the 8.3.1 → 8.3.2 post-tag smoke: `brew upgrade budi` bumped the tap correctly but `/health.version` stayed on 8.3.1 until a follow-up `budi init` restarted the daemon. Fixes #529.

## Risks

- Kill-and-respawn on every update where `/health.version` differs from the just-installed binary. Expected — that's the intent.
- `kill_all_daemons` is idempotent on an empty set of pids, so a pre-update daemon in a crashed/absent state is handled the same way.
- The daemon-version comparison is string-equal; if the launchd / brew respawn already picked up the new binary before this path runs, the early-return keeps the behavior a no-op.
- Bootstrap-paradox acknowledged: an 8.3.2 → 8.3.3 update will hit this fix, but an 8.3.1 → 8.3.2 update won't — that one is already shipped.

## Validation

- `cargo fmt --all --check` — clean
- `cargo clippy --workspace --all-targets --locked -- -D warnings` — clean
- `cargo test --workspace --locked` — all pass

Manual smoke deferred to the next update (8.3.2 → 8.3.3) — that's the first release that contains this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)