### PR TITLE
pricing: tag zero-token rows as 'unpriced:no_tokens' (#533)

### DIFF
--- a/SOUL.md
+++ b/SOUL.md
@@ -147,7 +147,7 @@ filesystem poke on every render.
 ### Database (SQLite, WAL mode, schema v1)
 
 Core tables:
-- **messages** - Single cost entity. One row per API call. All token/cost data lives here. Fields: id, session_id, role, model, provider, timestamp, input/output/cache tokens, cost_cents, cost_confidence, pricing_source (8.3+, [ADR-0091](docs/adr/0091-model-pricing-manifest-source-of-truth.md); one of `manifest:vNNN` / `backfilled:vNNN` / `embedded:vBUILD` / `legacy:pre-manifest` / `unknown`), git_branch, repo_id, cwd, request_id
+- **messages** - Single cost entity. One row per API call. All token/cost data lives here. Fields: id, session_id, role, model, provider, timestamp, input/output/cache tokens, cost_cents, cost_confidence, pricing_source (8.3+, [ADR-0091](docs/adr/0091-model-pricing-manifest-source-of-truth.md); one of `manifest:vNNN` / `backfilled:vNNN` / `embedded:vBUILD` / `legacy:pre-manifest` / `unknown` / `upstream:api` (Cursor Usage API rows) / `unpriced:no_tokens` (zero-token rows — user messages, tool results; 8.3.4+)), git_branch, repo_id, cwd, request_id
 - **sessions** - Lifecycle context (start/end, duration, mode, title) without mixing cost concerns. One row per conversation. Primary key field: id
 - **tags** - Flexible key-value pairs per message (repo, ticket_id, activity, user, etc.) using message_id FK to messages(id)
 - **sync_state** - Tracks incremental ingestion progress per file for progressive sync. Also stores cloud sync watermarks (`__budi_cloud_sync__` keys) for idempotent cloud uploads

--- a/crates/budi-core/src/pipeline/enrichers.rs
+++ b/crates/budi-core/src/pipeline/enrichers.rs
@@ -401,6 +401,24 @@ impl Enricher for CostEnricher {
             msg.uuid
         );
 
+        // #533: tag rows that will never have a priceable token cost —
+        // user messages, tool results, any `role != "assistant"` row, and
+        // assistant rows that made it here with zero tokens and no cost
+        // (e.g. ingested from a JSONL that emits a stub-shaped event).
+        // Without this, they fall through to the `messages.pricing_source`
+        // DEFAULT `"legacy:pre-manifest"`, which ADR-0091 §4 reserves for
+        // genuinely pre-migration rows. `"unpriced:no_tokens"` is the
+        // absence-of-provenance sentinel for this class.
+        if msg.pricing_source.is_none()
+            && msg.cost_cents.is_none()
+            && msg.input_tokens == 0
+            && msg.output_tokens == 0
+            && msg.cache_creation_tokens == 0
+            && msg.cache_read_tokens == 0
+        {
+            msg.pricing_source = Some(crate::pricing::COLUMN_VALUE_UNPRICED_NO_TOKENS.to_string());
+        }
+
         if let Some(ref speed) = msg.speed
             && speed != "standard"
         {
@@ -547,6 +565,50 @@ mod tests {
         msg.role = "user".to_string();
         enricher.enrich(&mut msg);
         assert!(msg.cost_cents.is_none());
+    }
+
+    #[test]
+    fn cost_enricher_tags_user_messages_as_unpriced_no_tokens() {
+        // #533: user-role rows with no tokens must land with
+        // `pricing_source = "unpriced:no_tokens"` instead of falling
+        // through to the DB `DEFAULT 'legacy:pre-manifest'`, which
+        // ADR-0091 §4 reserves for genuinely pre-migration rows.
+        let mut enricher = CostEnricher;
+        let mut msg = test_msg();
+        msg.role = "user".to_string();
+        msg.input_tokens = 0;
+        msg.output_tokens = 0;
+        msg.cache_creation_tokens = 0;
+        msg.cache_read_tokens = 0;
+        enricher.enrich(&mut msg);
+        assert!(msg.cost_cents.is_none());
+        assert_eq!(
+            msg.pricing_source.as_deref(),
+            Some(crate::pricing::COLUMN_VALUE_UNPRICED_NO_TOKENS),
+        );
+    }
+
+    #[test]
+    fn cost_enricher_assistant_with_tokens_keeps_manifest_provenance() {
+        // Regression guard for #533: priced assistant rows still get the
+        // manifest provenance and never collapse to `"unpriced:no_tokens"`.
+        let mut enricher = CostEnricher;
+        let mut msg = test_msg();
+        msg.role = "assistant".to_string();
+        msg.model = Some("claude-opus-4-6".to_string());
+        msg.input_tokens = 1_000_000;
+        msg.output_tokens = 100_000;
+        enricher.enrich(&mut msg);
+        assert!(msg.cost_cents.is_some());
+        let src = msg.pricing_source.as_deref().expect("provenance set");
+        assert_ne!(src, crate::pricing::COLUMN_VALUE_UNPRICED_NO_TOKENS);
+        assert_ne!(src, crate::pricing::COLUMN_VALUE_LEGACY);
+        // Real provenance: `embedded:v*` or `manifest:v*` depending on
+        // whether a manifest refresh has landed in this test process.
+        assert!(
+            src.starts_with("embedded:v") || src.starts_with("manifest:v"),
+            "unexpected provenance: {src}",
+        );
     }
 
     #[test]

--- a/crates/budi-core/src/pricing/mod.rs
+++ b/crates/budi-core/src/pricing/mod.rs
@@ -58,8 +58,8 @@ use crate::provider::ModelPricing;
 /// | `EmbeddedBaseline`    | `embedded:vBUILD`     |
 /// | `LegacyPreManifest`   | `legacy:pre-manifest` |
 ///
-/// Two further column literals (`"unknown"` and `"upstream:api"`) are
-/// intentionally *not* variants of this enum:
+/// Three further column literals (`"unknown"`, `"upstream:api"`,
+/// `"unpriced:no_tokens"`) are intentionally *not* variants of this enum:
 /// - `"unknown"` is the absence of a source, produced when
 ///   [`lookup`] returns [`PricingOutcome::Unknown`]. Callers serialize
 ///   that literal directly.
@@ -67,8 +67,13 @@ use crate::provider::ModelPricing;
 ///   whose `cost_cents` came from Cursor's Usage API (not from our
 ///   manifest). See [ADR-0091] §1 commentary on `cost_confidence =
 ///   "exact"` rows and the decision note in #376.
+/// - `"unpriced:no_tokens"` is written by `CostEnricher` for rows that
+///   will never have a priceable token cost — user messages, tool-result
+///   messages, or any row ingested with zero tokens. Prevents these
+///   rows from falling through to the DB's `"legacy:pre-manifest"`
+///   DEFAULT, which is reserved for genuinely pre-migration rows (#533).
 ///
-/// `parse_column` returns `None` for both literals so callers handle
+/// `parse_column` returns `None` for all three literals so callers handle
 /// them explicitly rather than via a silent fallback.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
@@ -90,6 +95,14 @@ pub const COLUMN_VALUE_UPSTREAM_API: &str = "upstream:api";
 /// Column literal written by the schema migration for pre-manifest rows.
 pub const COLUMN_VALUE_LEGACY: &str = "legacy:pre-manifest";
 
+/// Column literal for rows that will never have a priceable token cost — user
+/// messages, tool-result messages, any row ingested with zero tokens. Written
+/// by `CostEnricher` so these rows don't fall through to the DB's
+/// `"legacy:pre-manifest"` DEFAULT, which is reserved for genuinely
+/// pre-migration rows (#533). Not a [`PricingSource`] variant — follows the
+/// same sentinel-literal pattern as `"unknown"` / `"upstream:api"`.
+pub const COLUMN_VALUE_UNPRICED_NO_TOKENS: &str = "unpriced:no_tokens";
+
 impl PricingSource {
     /// Serialize to the exact string stored in `messages.pricing_source`.
     pub fn as_column_value(&self) -> String {
@@ -102,12 +115,16 @@ impl PricingSource {
     }
 
     /// Parse `messages.pricing_source` back into a variant, or `None` for
-    /// the literal `"unknown"` / `"upstream:api"` / anything malformed.
+    /// the literals `"unknown"` / `"upstream:api"` / `"unpriced:no_tokens"`,
+    /// or anything malformed.
     pub fn parse_column(value: &str) -> Option<Self> {
         if value == COLUMN_VALUE_LEGACY {
             return Some(PricingSource::LegacyPreManifest);
         }
-        if value == COLUMN_VALUE_UNKNOWN || value == COLUMN_VALUE_UPSTREAM_API {
+        if value == COLUMN_VALUE_UNKNOWN
+            || value == COLUMN_VALUE_UPSTREAM_API
+            || value == COLUMN_VALUE_UNPRICED_NO_TOKENS
+        {
             return None;
         }
         // All other valid shapes are `<prefix>:v<rest>`. Colon is ASCII (1
@@ -1345,9 +1362,15 @@ mod pricing_tests {
             PricingSource::parse_column(&embedded),
             Some(PricingSource::EmbeddedBaseline)
         );
-        // Unknown + upstream:api round-trip to None (not variants).
+        // Unknown + upstream:api + unpriced:no_tokens round-trip to None
+        // (sentinel literals, not enum variants).
         assert_eq!(PricingSource::parse_column(COLUMN_VALUE_UNKNOWN), None);
         assert_eq!(PricingSource::parse_column(COLUMN_VALUE_UPSTREAM_API), None);
+        // #533: new sentinel for zero-token / user-role rows.
+        assert_eq!(
+            PricingSource::parse_column(COLUMN_VALUE_UNPRICED_NO_TOKENS),
+            None,
+        );
         assert_eq!(PricingSource::parse_column("garbage"), None);
     }
 


### PR DESCRIPTION
## Summary

Every user-role message and zero-token row was landing with `pricing_source = "legacy:pre-manifest"` because `CostEnricher::enrich` only sets provenance for `role == "assistant"`. Non-assistant rows kept `msg.pricing_source = None` and fell through to the DB's `DEFAULT 'legacy:pre-manifest'` — a label ADR-0091 §4 reserves for genuinely pre-migration rows. Surfaced during v8.3.3 post-tag investigation (#531 comment).

- Add `pub const COLUMN_VALUE_UNPRICED_NO_TOKENS: &str = "unpriced:no_tokens"` alongside the existing `"unknown"` / `"upstream:api"` sentinels (NOT a `PricingSource` variant — ADR-0091 §4 locks the enum shape; the sentinel-literal pattern already exists).
- `parse_column` returns `None` for the new literal, same as the others.
- `CostEnricher::enrich` tags any row that still has `pricing_source = None && cost_cents = None` with zero tokens in every lane.
- SOUL.md updated to list the new literal.

## Risks

- **No DB-level change, no migration.** DEFAULT stays `'legacy:pre-manifest'` — the new label is only applied by the enricher pipeline. If a writer bypasses the enricher (shouldn't happen in normal flow), the row still gets the DB default.
- **No backfill.** ADR-0091 §5 Rule C is explicit: `legacy:pre-manifest` rows are never automatically touched. Existing mislabeled rows stay as-is; the fix only applies to rows ingested by 8.3.4+.
- **Downstream callers**: `rewrite_unknown` backfill in `pricing/mod.rs:684` filters on `pricing_source = 'unknown'` — unaffected. Cloud sync doesn't filter on `pricing_source`. No breaking reads.
- **`PricingSource::parse_column("unpriced:no_tokens") → None`** — matches existing `"unknown"` / `"upstream:api"` behavior; any caller already handling those three is correct for the new literal too.

## Validation

- `cargo fmt --all --check` — clean
- `cargo clippy --workspace --all-targets --locked -- -D warnings` — clean
- `cargo test --workspace --locked` — all pass (including 3 new tests: `cost_enricher_tags_user_messages_as_unpriced_no_tokens`, `cost_enricher_assistant_with_tokens_keeps_manifest_provenance`, and expanded `pricing_source_roundtrips`)

Fixes #533.

🤖 Generated with [Claude Code](https://claude.com/claude-code)