### PR TITLE
ci: replace cargo-deny-action with direct cargo install (#536)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,11 +227,17 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      # #536: EmbarkStudios/cargo-deny-action@v2.0.17 was failing on every
+      # PR with `failed to get 'FETCH_HEAD' metadata` — the action's internal
+      # gix-based advisory-db cache didn't exist on fresh runners and
+      # couldn't be bootstrapped. Install cargo-deny directly via cargo
+      # instead; its own advisory-db fetch handles the `~/.cargo/advisory-db`
+      # path correctly (same path cargo-audit uses in the rust-checks job).
+      - name: Install cargo-deny
+        run: cargo install cargo-deny --locked
+
       - name: Run cargo-deny
-        uses: EmbarkStudios/cargo-deny-action@91bf2b620e09e18d6eb78b92e7861937469acedb # v2.0.17
-        with:
-          command: check
-          arguments: --all-features
+        run: cargo deny --all-features check
 
   ci-success:
     if: always()


### PR DESCRIPTION
## Summary

`EmbarkStudios/cargo-deny-action@v2.0.17` was failing on every PR (including #535) with `failed to get 'FETCH_HEAD' metadata` — the action's internal gix-based advisory-db cache couldn't bootstrap its directory layout on fresh runners. v2.0.17 is the latest tag, so bumping wasn't an option.

Install `cargo-deny` directly via `cargo install --locked` and invoke `cargo deny --all-features check` as a regular shell step. cargo-deny manages its own advisory-db in `~/.cargo/advisory-db` — the same path cargo-audit uses in the `rust-checks` job, which has been working reliably.

Fixes #536.

## Risks

- Build time: installing cargo-deny from source adds ~30-60s versus the pre-built action. One-time cost; acceptable for a non-blocking job.
- `continue-on-error: true` kept as-is — job is still advisory until we've observed one clean cycle. Once stable, follow-up can promote it to a required status check (called out in #536 acceptance).
- `deny.toml` config unchanged; `cargo deny --all-features check` is the same invocation the action was passing (`command: check`, `arguments: --all-features`).

## Validation

- Local: `cargo deny --all-features check` on main reports `advisories ok, bans ok, licenses ok, sources ok` against `deny.toml`.
- CI: will verify on this PR that the `supply-chain` job turns green. If it does, #536 acceptance step 1 is done; follow-up can drop `continue-on-error`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)