### PR TITLE
daemon: log cloud-uploader state at startup (#540)

### DIFF
--- a/crates/budi-core/src/config.rs
+++ b/crates/budi-core/src/config.rs
@@ -550,6 +550,33 @@ impl CloudConfig {
     pub fn is_api_key_stub(&self) -> bool {
         self.api_key.as_deref() == Some(CLOUD_API_KEY_STUB)
     }
+
+    /// #540: short, stable snake_case reason tag for the "uploader
+    /// disabled" daemon startup log line. Returns `None` when the
+    /// config IS ready to run (caller should log the "configured" line
+    /// instead). Precedence mirrors `budi cloud status`: the
+    /// `enabled` flag is the coarsest gate, then api_key presence /
+    /// staleness, then the identity pair. This string is logged
+    /// verbatim as a structured field — do not change wording without
+    /// updating any external log grep consumers.
+    pub fn disabled_reason(&self) -> Option<&'static str> {
+        if !self.effective_enabled() {
+            return Some("cloud.enabled=false");
+        }
+        if self.effective_api_key().is_none() {
+            return Some("missing api_key");
+        }
+        if self.is_api_key_stub() {
+            return Some("api_key is placeholder");
+        }
+        if self.device_id.is_none() {
+            return Some("missing device_id");
+        }
+        if self.org_id.is_none() {
+            return Some("missing org_id");
+        }
+        None
+    }
 }
 
 /// Path to the cloud config file.
@@ -1117,6 +1144,37 @@ retry_max_seconds = 120
             !config.is_api_key_stub(),
             "stub detection is exact-match so accidental padding surfaces as a real (broken) key"
         );
+    }
+
+    #[test]
+    fn cloud_config_disabled_reason_walks_precedence() {
+        // #540: reason tag taxonomy — same order `budi cloud status`
+        // surfaces missing fields, so the daemon startup log and the
+        // CLI status command agree on "what's blocking cloud sync".
+        let mut config = CloudConfig::default();
+        // Default (enabled=false, everything None): coarsest gate fires first.
+        assert_eq!(config.disabled_reason(), Some("cloud.enabled=false"));
+
+        config.enabled = true;
+        // Enabled but no api_key at all.
+        assert_eq!(config.disabled_reason(), Some("missing api_key"));
+
+        config.api_key = Some(CLOUD_API_KEY_STUB.to_string());
+        // Placeholder distinguished from truly-missing.
+        assert_eq!(config.disabled_reason(), Some("api_key is placeholder"));
+
+        config.api_key = Some("budi_real".to_string());
+        // Real key, but no device_id.
+        assert_eq!(config.disabled_reason(), Some("missing device_id"));
+
+        config.device_id = Some("dev_test".to_string());
+        // device_id set, but no org_id.
+        assert_eq!(config.disabled_reason(), Some("missing org_id"));
+
+        config.org_id = Some("org_test".to_string());
+        // Everything populated: no disabled reason — caller should log "configured".
+        assert_eq!(config.disabled_reason(), None);
+        assert!(config.is_ready());
     }
 
     #[test]

--- a/crates/budi-daemon/src/main.rs
+++ b/crates/budi-daemon/src/main.rs
@@ -330,25 +330,34 @@ async fn main() -> Result<()> {
     }
 
     // --- Start cloud sync worker if configured ---
+    //
+    // #540: always emit exactly one INFO line from this block at boot
+    // so operators can grep `daemon.log` for `cloud uploader` and see
+    // current state regardless of whether the uploader is running.
+    // When disabled for any reason, the `reason=...` field matches the
+    // taxonomy in `CloudConfig::disabled_reason`.
     {
         let cloud_config = budi_core::config::load_cloud_config();
-        if cloud_config.is_ready() {
-            if let Ok(db_path) = analytics::db_path() {
-                tracing::info!(
-                    endpoint = %cloud_config.effective_endpoint(),
-                    interval_s = cloud_config.sync.interval_seconds,
-                    "Starting cloud sync worker"
-                );
-                tokio::spawn(workers::cloud_sync::run(
-                    db_path,
-                    cloud_config,
-                    cloud_syncing.clone(),
-                ));
+        match cloud_config.disabled_reason() {
+            None => {
+                if let Ok(db_path) = analytics::db_path() {
+                    tracing::info!(
+                        endpoint = %cloud_config.effective_endpoint(),
+                        device_id = %log_id_prefix(cloud_config.device_id.as_deref()),
+                        org_id = %log_id_prefix(cloud_config.org_id.as_deref()),
+                        interval_s = cloud_config.sync.interval_seconds,
+                        "cloud uploader configured"
+                    );
+                    tokio::spawn(workers::cloud_sync::run(
+                        db_path,
+                        cloud_config,
+                        cloud_syncing.clone(),
+                    ));
+                }
             }
-        } else if cloud_config.effective_enabled() {
-            tracing::warn!(
-                "Cloud sync enabled but not fully configured (missing api_key, device_id, or org_id)"
-            );
+            Some(reason) => {
+                tracing::info!(reason, "cloud uploader disabled");
+            }
         }
     }
 
@@ -404,6 +413,28 @@ const SHUTDOWN_DRAIN_TIMEOUT: std::time::Duration = std::time::Duration::from_se
 /// here — `std::process::exit(0)` below ends it along with the rest of
 /// the runtime. If we want to drain in-flight HTTP requests on the same
 /// signal, that is a larger refactor tracked outside this ticket.
+/// #540: abbreviate a `device_id` / `org_id` for the daemon startup log
+/// line. Full values are stored in `cloud.toml` and aren't secret, but
+/// long opaque UUIDs / org slugs clutter the log. Prints the first 8
+/// chars followed by `…` when the value is longer than that; returns
+/// `"(missing)"` for `None` (shouldn't appear for a ready config, but
+/// defensive so the log line never blows up).
+fn log_id_prefix(value: Option<&str>) -> String {
+    match value {
+        None => "(missing)".to_string(),
+        Some(v) => {
+            // Unicode-safe truncation: step 8 chars, not 8 bytes.
+            let mut it = v.chars();
+            let head: String = (&mut it).take(8).collect();
+            if it.next().is_some() {
+                format!("{head}…")
+            } else {
+                head
+            }
+        }
+    }
+}
+
 fn install_shutdown_listener(
     tailer_shutdown: std::sync::Arc<std::sync::atomic::AtomicBool>,
     tailer_handle: Option<tokio::task::JoinHandle<()>>,
@@ -621,6 +652,30 @@ mod tests {
             cloud_syncing: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
             sync_progress: std::sync::Arc::new(std::sync::Mutex::new(None)),
         })
+    }
+
+    #[test]
+    fn log_id_prefix_abbreviates_long_ids_and_preserves_short_ones() {
+        // #540: the daemon startup log prints device_id / org_id
+        // abbreviated so operators can eyeball "am I on the right
+        // device?" without full opaque UUIDs cluttering the log.
+        assert_eq!(
+            log_id_prefix(Some("7b322df1-3bcd-4e72-9e2a-0b2f3c4d5e6f")),
+            "7b322df1…"
+        );
+        // Short values (shorter than the 8-char abbreviation
+        // threshold) render intact — no trailing ellipsis.
+        assert_eq!(log_id_prefix(Some("short")), "short");
+        // Exactly-8-char values don't grow an ellipsis — there's
+        // nothing hidden.
+        assert_eq!(log_id_prefix(Some("exactly8")), "exactly8");
+        // None → explicit "(missing)" sentinel. Should not fire in
+        // production (the configured branch only runs for
+        // `is_ready` configs), but keeps the log line stable if it
+        // ever does.
+        assert_eq!(log_id_prefix(None), "(missing)");
+        // Unicode: the truncation is char-boundary-safe.
+        assert_eq!(log_id_prefix(Some("✨org_aaabbbccc")), "✨org_aaa…");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Before: daemon silently skipped the uploader spawn when `cloud.enabled=false`, when `api_key` was still the stub, or when `device_id`/`org_id` were missing. A reader tailing `daemon.log` saw only ingest / pricing lines and had to cross-check `cloud.toml` to confirm the uploader wasn't running.

After: the cloud-startup block always emits exactly one INFO line, regardless of enabled state.

- **Ready**: `INFO cloud uploader configured endpoint=... device_id=... org_id=... interval_s=300`
- **Not ready**: `INFO cloud uploader disabled reason="<tag>"` where `<tag>` is one of the structured tags from a new `CloudConfig::disabled_reason()`:
  - `cloud.enabled=false`
  - `missing api_key`
  - `api_key is placeholder`
  - `missing device_id`
  - `missing org_id`

The reason taxonomy mirrors the precedence `budi cloud status` already uses, so grepping `daemon.log` gives the same answer as running the CLI.

## Risks

- Log line text is new — grep consumers (if any) need to be aware. The strings are the stable ones already documented in the ticket; do-not-change-without-updating-consumers comment added on `disabled_reason`.
- `api_key` never logged — only the boolean shape "placeholder vs. real vs. missing" surfaces. Full `device_id` / `org_id` also not logged — abbreviated to the first 8 chars plus `…` via a new `log_id_prefix` helper.
- Tracing level: the warn-level message for "enabled but not configured" was demoted to INFO. Rationale: the whole purpose is a grep-able state-of-cloud line at boot; elevating partially-configured to WARN made it indistinguishable from actual runtime problems.

## Validation

- `cargo fmt --all --check` — clean
- `cargo clippy --workspace --all-targets --locked -- -D warnings` — clean
- `cargo test --workspace --locked` — all pass, including 2 new tests:
  - `cloud_config_disabled_reason_walks_precedence` in budi-core
  - `log_id_prefix_abbreviates_long_ids_and_preserves_short_ones` in budi-daemon

Fixes #540.

🤖 Generated with [Claude Code](https://claude.com/claude-code)