### PR TITLE
init: auto-import historical transcripts so budi has data immediately (#548)

### DIFF
--- a/crates/budi-cli/src/commands/init.rs
+++ b/crates/budi-cli/src/commands/init.rs
@@ -59,6 +59,24 @@ pub fn cmd_init(cleanup: bool, yes: bool, no_integrations: bool, no_daemon: bool
         install_default_integrations(&config);
     }
 
+    // #548: auto-import historical transcripts so `budi stats` has
+    // data immediately after setup. `cmd_import(false, false)` is
+    // idempotent (ingest skips already-seen message ids via the
+    // per-path offset table), so this is safe to run on every
+    // `budi init` — first install walks the full history, repeat
+    // inits become fast no-ops. Skipped under `--no-daemon` because
+    // the import routes through `/sync/*` on the daemon we didn't
+    // start. Import failure is warn-only — init stays successful.
+    if !no_daemon {
+        println!();
+        if let Err(e) = super::import::cmd_import(false, false) {
+            let yellow = super::ansi("\x1b[33m");
+            let reset = super::ansi("\x1b[0m");
+            eprintln!("{yellow}  Warning:{reset} historical import failed: {e:#}");
+            eprintln!("  Run `budi db import` to retry.");
+        }
+    }
+
     let bold_cyan = super::ansi("\x1b[1;36m");
     let dim = super::ansi("\x1b[90m");
     let reset = super::ansi("\x1b[0m");


### PR DESCRIPTION
## Summary

First-user feedback: "how to run history import with budi? i thought we do it with budi init" + "i would say auto import, too many initial command then".

Before: after `budi init`, `budi stats` showed $0.00 because the tailer only ingests new transcript activity — historical data on disk stayed invisible until the user ran `budi db import` as a separate step that init's output didn't mention.

After: `cmd_init` calls `cmd_import(false, false)` immediately after the integrations install and before the final "budi initialized" banner. Existing sync path is idempotent (per-path offset table skips already-seen messages by id), so this is safe to run on every init — first install walks the full history, repeat inits become fast no-ops that confirm "0 new messages".

## Risks

- **Init takes longer on first install.** Typical first run ingests the full Claude Code + Cursor + Codex transcript history — can be minutes on a machine with heavy historical use. Mitigated by the existing `budi db import` progress feed (per-agent polling at 2 s) so the user doesn't think init is hung.
- **Import failure is warn-only.** Init exit code stays 0 even if the import fails, with a pointer to retry. Matches the pattern of other best-effort subsystems (cloud device_id seeding, integrations install).
- **Skipped under `--no-daemon`.** The import routes through `/sync/*` on the daemon we didn't start. Documented in the new comment block.

## Validation

- `cargo fmt --all --check` — clean
- `cargo clippy --workspace --all-targets --locked -- -D warnings` — clean
- `cargo test --workspace --locked` — all 170 + 464 + 39 = 673 tests pass
- Manual smoke on maintainer machine: repeat `budi init` completes in a few seconds, surfaces per-agent "0 new messages" reconciliation, then the "budi initialized" banner fires as before.

Fixes #548.

🤖 Generated with [Claude Code](https://claude.com/claude-code)