### PR TITLE
cloud-uploader: send readable device label in ingest envelope (#552)

### DIFF
--- a/crates/budi-cli/src/commands/cloud.rs
+++ b/crates/budi-cli/src/commands/cloud.rs
@@ -294,6 +294,12 @@ endpoint = \"https://app.getbudi.dev\"
 {device_id_line}
 {org_id_line}
 
+# Optional human-friendly label shown on the cloud Devices page (#552).
+# When commented out, budi defaults to this machine's OS hostname.
+# Uncomment and set a custom string to override. Set `label = \"\"` if you
+# want to opt out of sharing a readable label entirely.
+# label = \"ivan-mbp\"
+
 [cloud.sync]
 # Background sync interval in seconds. Defaults to 300 (5 minutes).
 interval_seconds = 300

--- a/crates/budi-core/src/cloud_sync.rs
+++ b/crates/budi-core/src/cloud_sync.rs
@@ -26,6 +26,12 @@ pub struct SyncEnvelope {
     pub schema_version: u32,
     pub device_id: String,
     pub org_id: String,
+    /// Human-friendly device label (#552). Populated from
+    /// [`CloudConfig::effective_label`] on every ingest, so a local
+    /// rename propagates without the user having to re-link. Always
+    /// serialized; an empty string is the explicit opt-out contract
+    /// documented on `CloudConfig::label`.
+    pub label: String,
     pub synced_at: String,
     pub payload: SyncPayload,
 }
@@ -502,6 +508,7 @@ pub fn build_sync_envelope(conn: &Connection, config: &CloudConfig) -> Result<Sy
         schema_version: 1,
         device_id,
         org_id,
+        label: config.effective_label(),
         synced_at: chrono::Utc::now().to_rfc3339(),
         payload: SyncPayload {
             daily_rollups,
@@ -837,6 +844,7 @@ mod tests {
                 schema_version: 1,
                 device_id: "dev_test".into(),
                 org_id: "org_test".into(),
+                label: "test-host".into(),
                 synced_at: "2026-04-12T00:00:00Z".into(),
                 payload: SyncPayload {
                     daily_rollups: vec![],
@@ -1069,6 +1077,7 @@ mod tests {
             schema_version: 1,
             device_id: "dev_test".into(),
             org_id: "org_test".into(),
+            label: "ivan-mbp".into(),
             synced_at: "2026-04-12T00:00:00Z".into(),
             payload: SyncPayload {
                 daily_rollups: vec![DailyRollupRecord {
@@ -1094,6 +1103,9 @@ mod tests {
         let json = serde_json::to_value(&envelope).unwrap();
         assert_eq!(json["schema_version"], 1);
         assert_eq!(json["device_id"], "dev_test");
+        // #552: label travels alongside device_id / org_id / synced_at
+        // on the envelope root.
+        assert_eq!(json["label"], "ivan-mbp");
         assert_eq!(
             json["payload"]["daily_rollups"][0]["bucket_day"],
             "2026-04-10"
@@ -1106,6 +1118,68 @@ mod tests {
                 .get("ticket_source")
                 .is_none()
         );
+    }
+
+    /// #552: when `cloud.toml` omits `label`, `effective_label()` falls
+    /// back to the local OS hostname. We don't pin the exact value —
+    /// the test host's hostname is whatever the CI image decided — but
+    /// it must match `get_hostname()` (same source of truth) so a
+    /// hostname change propagates consistently across callers.
+    #[test]
+    fn effective_label_defaults_to_hostname_when_unset() {
+        let config = CloudConfig::default();
+        assert!(config.label.is_none());
+        assert_eq!(
+            config.effective_label(),
+            crate::pipeline::enrichers::get_hostname(),
+        );
+    }
+
+    /// #552: explicit TOML value is sent verbatim, including an empty
+    /// string (documented as the opt-out contract on `CloudConfig::label`).
+    #[test]
+    fn effective_label_sends_explicit_value_verbatim() {
+        let explicit = CloudConfig {
+            label: Some("ivan-mbp".into()),
+            ..CloudConfig::default()
+        };
+        assert_eq!(explicit.effective_label(), "ivan-mbp");
+
+        let opt_out = CloudConfig {
+            label: Some(String::new()),
+            ..CloudConfig::default()
+        };
+        assert_eq!(
+            opt_out.effective_label(),
+            "",
+            "opt-out must send empty label rather than silently \
+             falling back to hostname — otherwise the user can't \
+             actually hide their hostname",
+        );
+    }
+
+    /// Round-trip through `build_sync_envelope` to confirm the label
+    /// lands on the envelope with the same precedence.
+    #[test]
+    fn build_envelope_populates_label_from_config() {
+        let dir = std::env::temp_dir().join("budi-cloud-sync-label-envelope");
+        std::fs::create_dir_all(&dir).ok();
+        let db_path = dir.join("test.db");
+        let _ = std::fs::remove_file(&db_path);
+
+        let conn = crate::analytics::open_db_with_migration(&db_path).unwrap();
+        let config = CloudConfig {
+            enabled: true,
+            api_key: Some("budi_test".into()),
+            device_id: Some("dev_test".into()),
+            org_id: Some("org_test".into()),
+            label: Some("ivan-mbp".into()),
+            ..CloudConfig::default()
+        };
+        let envelope = build_sync_envelope(&conn, &config).unwrap();
+        assert_eq!(envelope.label, "ivan-mbp");
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     // Regression for #333: cloud_sync must produce the same ticket_id as the

--- a/crates/budi-core/src/config.rs
+++ b/crates/budi-core/src/config.rs
@@ -472,6 +472,22 @@ pub struct CloudConfig {
     pub org_id: Option<String>,
     pub endpoint: String,
     pub sync: CloudSyncConfig,
+    /// Human-friendly device label included in every ingest envelope.
+    /// Rendered on the cloud dashboard's Devices page instead of the
+    /// truncated `dev_<id>` we ship by default.
+    ///
+    /// - `None` (TOML key absent) → default to the local OS hostname
+    ///   when the envelope is built.
+    /// - `Some("")` (TOML `label = ""`) → explicit opt-out; the cloud
+    ///   receives an empty label and falls back to whatever it renders
+    ///   for a missing value. Raw hostnames can be PII, so the opt-out
+    ///   path is deliberately surface-level simple (edit one line).
+    /// - `Some("ivan-mbp")` → sent verbatim on every ingest, so a
+    ///   rename propagates without re-linking the device.
+    ///
+    /// See [#552](https://github.com/siropkin/budi/issues/552) for the
+    /// full UX decision and the paired cloud-side persistence ticket.
+    pub label: Option<String>,
 }
 
 impl Default for CloudConfig {
@@ -483,6 +499,7 @@ impl Default for CloudConfig {
             org_id: None,
             endpoint: DEFAULT_CLOUD_ENDPOINT.to_string(),
             sync: CloudSyncConfig::default(),
+            label: None,
         }
     }
 }
@@ -532,6 +549,25 @@ impl CloudConfig {
             }
         }
         self.endpoint.clone()
+    }
+
+    /// Resolve the device label sent with each ingest envelope (#552).
+    ///
+    /// Precedence:
+    /// 1. `label` key present in `cloud.toml` → returned verbatim,
+    ///    including `""` (explicit opt-out — the user chose to share
+    ///    nothing human-readable).
+    /// 2. `label` key absent → the local OS hostname from
+    ///    [`crate::pipeline::enrichers::get_hostname`].
+    ///
+    /// An empty hostname still produces an empty string rather than a
+    /// panic; the cloud dashboard treats empty labels as "fall back to
+    /// whatever default label the server would render otherwise".
+    pub fn effective_label(&self) -> String {
+        if let Some(explicit) = self.label.as_ref() {
+            return explicit.clone();
+        }
+        crate::pipeline::enrichers::get_hostname()
     }
 
     /// Returns true only if cloud sync is configured enough to run:

--- a/crates/budi-core/src/pipeline/enrichers.rs
+++ b/crates/budi-core/src/pipeline/enrichers.rs
@@ -228,7 +228,7 @@ impl IdentityEnricher {
     }
 }
 
-fn get_hostname() -> String {
+pub(crate) fn get_hostname() -> String {
     // Fast paths that avoid spawning a subprocess
     if let Ok(h) = std::env::var("HOSTNAME")
         && !h.is_empty()


### PR DESCRIPTION
## Summary

The cloud Devices page (siropkin/budi-cloud#58) renders a row per linked daemon but has nothing human-friendly to show — the envelope never included a label — so the table falls back to a truncated `dev_<id>`. This PR adds a `label` field to the ingest envelope so the dashboard has something the user chose.

- **Source of truth**: `CloudConfig::label: Option<String>` read from `~/.config/budi/cloud.toml [cloud] label`.
- **Precedence** (`CloudConfig::effective_label`):
  - Key missing → local OS hostname via `pipeline::enrichers::get_hostname` (now `pub(crate)`; same resolver already used for message-level identity tags, so hostname renames propagate consistently).
  - Key present including `label = \"\"` → value sent verbatim. Empty string is the documented opt-out — raw hostnames can be PII, and the opt-out has to be edit-one-line simple.
- **Transport**: `SyncEnvelope.label: String`, set on every `build_sync_envelope` call so a rename propagates on the next ingest tick without re-linking.
- **Discoverability**: `budi cloud init` template gains a commented-out `label` hint so users find the option without grepping the source.

Paired cloud-side ticket siropkin/budi-cloud#60 persists the label on auto-register + subsequent ingests and renders it on `/dashboard/devices`.

## Risks

- **PII in default hostnames.** Default behavior sends whatever `hostname` resolves to. ADR-0083 requires user-controlled defaults for any new ingest field; the opt-out path (`label = \"\"`) is documented on `CloudConfig::label` and in the init template so a privacy-minded user can disable it with one edit. Not emitting a label at all would mean every dashboard row still reads `dev_<id>` — worse UX for the common case.
- **Field always present on the envelope.** Modeled as `String` rather than `Option<String>` because we always populate it (hostname fallback). Server-side (siropkin/budi-cloud#60) must handle empty strings gracefully; the ticket reflects that.
- **Cache-tier impact: none.** Label is a single small string on the envelope root, no pagination or rollup schema change.

## Validation

- `cargo fmt --all --check` — clean
- `cargo clippy --workspace --all-targets --locked -- -D warnings` — clean
- `cargo test --workspace --locked` — all tests pass (176 + 471 + 39 = 686, including three new cases: `effective_label_defaults_to_hostname_when_unset`, `effective_label_sends_explicit_value_verbatim` covering both the verbatim and opt-out branches, and `build_envelope_populates_label_from_config` round-tripping through the full envelope builder; plus the existing `envelope_serializes_to_expected_shape` now asserts the label lands at the JSON root).

Fixes #552.

🤖 Generated with [Claude Code](https://claude.com/claude-code)