### PR TITLE
cloud: `budi cloud reset` re-uploads everything after the cloud loses it (#564)

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,7 @@ budi cloud init                    # generate ~/.config/budi/cloud.toml from a c
 budi cloud init --api-key KEY      # write the key + enable sync in one step
 budi cloud status                  # cloud sync readiness + last-synced-at + queued records
 budi cloud sync                    # push queued local rollups to the cloud now
+budi cloud reset                   # reset watermarks so the next sync re-uploads everything (org switch / data wipe)
 budi autostart status              # check daemon autostart service
 budi autostart install             # install the autostart service
 budi autostart uninstall           # remove the autostart service

--- a/crates/budi-cli/src/client.rs
+++ b/crates/budi-cli/src/client.rs
@@ -376,6 +376,22 @@ impl DaemonClient {
         Ok(resp.json()?)
     }
 
+    /// `POST /cloud/reset` — drop the cloud-sync watermarks so the next
+    /// sync re-uploads every local rollup + session summary (#564).
+    ///
+    /// Returns the same `{ok, result, removed, message}` shape on success
+    /// and a 409 `busy` error when the worker / a manual sync are mid-flight.
+    pub fn cloud_reset(&self) -> Result<Value> {
+        let resp = self
+            .client
+            .post(format!("{}/cloud/reset", self.base_url))
+            .timeout(std::time::Duration::from_secs(30))
+            .send()
+            .map_err(describe_send_error)?;
+        let resp = check_response(resp)?;
+        Ok(resp.json()?)
+    }
+
     /// `GET /cloud/status` — read cloud sync readiness and watermarks.
     /// Never blocks on the network; the daemon only reads local state.
     pub fn cloud_status(&self) -> Result<Value> {

--- a/crates/budi-cli/src/commands/cloud.rs
+++ b/crates/budi-cli/src/commands/cloud.rs
@@ -536,6 +536,102 @@ pub fn cmd_cloud_status(format: StatsFormat) -> Result<()> {
     Ok(())
 }
 
+/// #564: `budi cloud reset` — drop the local cloud-sync watermarks so the
+/// next sync re-uploads every rollup + session summary in
+/// `message_rollups_daily` / `sessions`. The user-visible escape hatch
+/// after the cloud loses historical rows (org switch, device_id rotation,
+/// cloud-side wipe). Cloud-side dedup (ADR-0083 §6) keeps the re-upload
+/// safe even when records overlap with what the cloud already has.
+///
+/// Routes through the daemon's `POST /cloud/reset` so SQLite stays
+/// daemon-owned and the reset takes the same `cloud_syncing` busy flag a
+/// background tick would — that way a manual reset can never race a
+/// concurrent envelope build that already read the about-to-be-deleted
+/// watermark.
+pub fn cmd_cloud_reset(yes: bool) -> Result<()> {
+    let cfg = load_cloud_config();
+    if !confirm_reset(&cfg, yes)? {
+        println!("Aborted. Watermarks left unchanged.");
+        return Ok(());
+    }
+
+    let client = DaemonClient::connect()?;
+    let body = client
+        .cloud_reset()
+        .context("failed to reset cloud sync watermarks via the daemon")?;
+
+    let removed = body
+        .get("removed")
+        .and_then(Value::as_u64)
+        .unwrap_or(0) as usize;
+    render_reset_text(&cfg, removed);
+    Ok(())
+}
+
+fn confirm_reset(cfg: &CloudConfig, yes: bool) -> Result<bool> {
+    if yes {
+        return Ok(true);
+    }
+    if !io::stdin().is_terminal() {
+        return Err(anyhow!(
+            "`budi cloud reset` requires confirmation. Re-run with --yes to skip the prompt (required for non-interactive shells)."
+        ));
+    }
+    print!(
+        "This will reset the cloud sync watermarks for {}.\nThe next `budi cloud sync` will re-upload all local rollups and session summaries to the cloud.\nContinue? [y/N] ",
+        describe_reset_target(cfg),
+    );
+    io::stdout().flush().ok();
+    let mut answer = String::new();
+    if io::stdin().read_line(&mut answer).is_err() {
+        return Ok(false);
+    }
+    Ok(matches!(
+        answer.trim().to_ascii_lowercase().as_str(),
+        "y" | "yes"
+    ))
+}
+
+/// Phrase the prompt + post-reset line so the user sees which org they
+/// are about to re-upload to. Falls back to a generic phrase when
+/// `cloud.toml` is missing or partial — `budi cloud reset` still works
+/// in those cases (the watermarks live in SQLite, independent of the
+/// TOML), but we don't want to print `org ""`.
+fn describe_reset_target(cfg: &CloudConfig) -> String {
+    match cfg.org_id.as_deref() {
+        Some(id) if !id.is_empty() => format!("org \"{id}\""),
+        _ => "the configured cloud endpoint".to_string(),
+    }
+}
+
+fn render_reset_text(cfg: &CloudConfig, removed: usize) {
+    let green = ansi("\x1b[32m");
+    let yellow = ansi("\x1b[33m");
+    let dim = ansi("\x1b[90m");
+    let bold = ansi("\x1b[1m");
+    let reset = ansi("\x1b[0m");
+
+    println!();
+    if removed == 0 {
+        println!(
+            "  {yellow}!{reset} {bold}No cloud sync watermarks were set.{reset} The next `budi cloud sync` already starts from scratch."
+        );
+    } else {
+        println!(
+            "  {green}✓{reset} {bold}Cloud sync watermarks reset for {}.{reset}",
+            describe_reset_target(cfg),
+        );
+        println!(
+            "    {dim}removed{reset}    {removed} sentinel row{}",
+            if removed == 1 { "" } else { "s" },
+        );
+    }
+    println!(
+        "    {dim}next step{reset}  run {bold}budi cloud sync{reset} to push everything now, or wait for the next interval tick"
+    );
+    println!();
+}
+
 fn render_sync_text(body: &Value) {
     let green = ansi("\x1b[32m");
     let red = ansi("\x1b[31m");
@@ -932,5 +1028,34 @@ mod tests {
         let err = rotation_aware_already_exists_error(&path, &cfg).to_string();
         assert!(err.contains("--force"));
         assert!(!err.contains("org \"\""));
+    }
+
+    #[test]
+    fn describe_reset_target_names_org_when_present() {
+        // #564: the reset prompt and post-reset line both name the
+        // currently-linked org so the user can sanity-check what
+        // they are about to re-upload to.
+        let cfg = config_with_org(Some("org_xEvtA"));
+        assert_eq!(describe_reset_target(&cfg), "org \"org_xEvtA\"");
+    }
+
+    #[test]
+    fn describe_reset_target_falls_back_when_org_id_missing() {
+        // #564: a partial / malformed `cloud.toml` shouldn't print a
+        // quoted empty string. The reset path still works (watermarks
+        // live in SQLite, independent of the TOML), so we just print a
+        // generic phrase.
+        let cfg = config_with_org(None);
+        assert_eq!(
+            describe_reset_target(&cfg),
+            "the configured cloud endpoint",
+        );
+
+        let empty = config_with_org(Some(""));
+        assert_eq!(
+            describe_reset_target(&empty),
+            "the configured cloud endpoint",
+            "empty org_id should not produce \"\" in the message",
+        );
     }
 }

--- a/crates/budi-cli/src/commands/cloud.rs
+++ b/crates/budi-cli/src/commands/cloud.rs
@@ -560,10 +560,7 @@ pub fn cmd_cloud_reset(yes: bool) -> Result<()> {
         .cloud_reset()
         .context("failed to reset cloud sync watermarks via the daemon")?;
 
-    let removed = body
-        .get("removed")
-        .and_then(Value::as_u64)
-        .unwrap_or(0) as usize;
+    let removed = body.get("removed").and_then(Value::as_u64).unwrap_or(0) as usize;
     render_reset_text(&cfg, removed);
     Ok(())
 }
@@ -1046,10 +1043,7 @@ mod tests {
         // live in SQLite, independent of the TOML), so we just print a
         // generic phrase.
         let cfg = config_with_org(None);
-        assert_eq!(
-            describe_reset_target(&cfg),
-            "the configured cloud endpoint",
-        );
+        assert_eq!(describe_reset_target(&cfg), "the configured cloud endpoint",);
 
         let empty = config_with_org(Some(""));
         assert_eq!(

--- a/crates/budi-cli/src/main.rs
+++ b/crates/budi-cli/src/main.rs
@@ -1135,8 +1135,7 @@ mod tests {
         // interactive (yes=false). `--yes` is the non-interactive
         // escape hatch CI / scripts need so the prompt isn't a
         // hard block.
-        let cli =
-            Cli::try_parse_from(["budi", "cloud", "reset"]).expect("budi cloud reset parses");
+        let cli = Cli::try_parse_from(["budi", "cloud", "reset"]).expect("budi cloud reset parses");
         match cli.command {
             Commands::Cloud {
                 action: CloudAction::Reset { yes },

--- a/crates/budi-cli/src/main.rs
+++ b/crates/budi-cli/src/main.rs
@@ -325,7 +325,9 @@ Examples:
   budi cloud init --api-key KEY  Write the key and enable sync in one step
   budi cloud status              Show cloud sync readiness and last sync
   budi cloud sync                Push queued local data to the cloud now
-  budi cloud sync --format json  JSON output (exit code 2 on failure)")]
+  budi cloud sync --format json  JSON output (exit code 2 on failure)
+  budi cloud reset               Reset watermarks so next sync re-uploads all
+  budi cloud reset --yes         Same, non-interactive (CI / scripts)")]
     Cloud {
         #[command(subcommand)]
         action: CloudAction,
@@ -423,6 +425,20 @@ enum CloudAction {
         /// Output format: text (default) or json
         #[arg(short, long, value_enum, default_value_t = StatsFormat::Text)]
         format: StatsFormat,
+    },
+    /// Drop the cloud sync watermarks so the next sync re-uploads everything
+    ///
+    /// Useful after switching orgs, rotating an api_key, or recovering from a
+    /// cloud-side data wipe — the daemon's local watermark is org-blind and
+    /// keeps the cloud "ahead" of where it actually is until the watermark is
+    /// reset (#564). Cloud-side dedup means the re-upload is safe even if some
+    /// records overlap with rows the cloud already has.
+    Reset {
+        /// Skip the interactive confirmation. Required for non-TTY callers
+        /// (CI, scripts) — otherwise the prompt aborts to avoid a silent
+        /// re-upload on a stray invocation.
+        #[arg(long, default_value_t = false)]
+        yes: bool,
     },
 }
 
@@ -707,6 +723,7 @@ fn main() -> Result<()> {
             } => commands::cloud::cmd_cloud_init(api_key, force, yes, device_id, org_id),
             CloudAction::Status { format } => commands::cloud::cmd_cloud_status(format),
             CloudAction::Sync { format } => commands::cloud::cmd_cloud_sync(format),
+            CloudAction::Reset { yes } => commands::cloud::cmd_cloud_reset(yes),
         },
         Commands::Pricing { action } => match action {
             PricingAction::Status { format, refresh } => {
@@ -1109,6 +1126,31 @@ mod tests {
                 action: CloudAction::Status { format },
             } => assert!(matches!(format, StatsFormat::Json)),
             _ => panic!("expected cloud status command"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_cloud_reset() {
+        // #564: bare `budi cloud reset` parses and defaults to
+        // interactive (yes=false). `--yes` is the non-interactive
+        // escape hatch CI / scripts need so the prompt isn't a
+        // hard block.
+        let cli =
+            Cli::try_parse_from(["budi", "cloud", "reset"]).expect("budi cloud reset parses");
+        match cli.command {
+            Commands::Cloud {
+                action: CloudAction::Reset { yes },
+            } => assert!(!yes, "default invocation must be interactive"),
+            _ => panic!("expected cloud reset command"),
+        }
+
+        let cli = Cli::try_parse_from(["budi", "cloud", "reset", "--yes"])
+            .expect("budi cloud reset --yes parses");
+        match cli.command {
+            Commands::Cloud {
+                action: CloudAction::Reset { yes },
+            } => assert!(yes, "--yes must skip the confirmation"),
+            _ => panic!("expected cloud reset --yes command"),
         }
     }
 

--- a/crates/budi-core/src/cloud_sync.rs
+++ b/crates/budi-core/src/cloud_sync.rs
@@ -167,6 +167,29 @@ pub fn set_session_watermark(conn: &Connection, timestamp: &str) -> Result<()> {
     Ok(())
 }
 
+/// #564: drop the three cloud-sync sentinel rows so the next push falls
+/// into the no-watermark path of `fetch_daily_rollups` /
+/// `fetch_session_summaries` and re-uploads everything from
+/// `message_rollups_daily` + `sessions`. Used by `budi cloud reset` after
+/// the cloud loses historical rows (org switch, device_id rotation,
+/// cloud-side wipe). Cloud-side dedup (ADR-0083 §6) makes the re-upload
+/// safe even when records overlap with what the cloud already has.
+///
+/// Returns the number of sentinel rows that were removed (0..=3) so the
+/// caller can decide whether to print "watermarks reset" vs "no watermarks
+/// to reset".
+pub fn reset_cloud_watermarks(conn: &Connection) -> Result<usize> {
+    let removed = conn.execute(
+        "DELETE FROM sync_state WHERE file_path IN (?1, ?2, ?3)",
+        params![
+            CLOUD_SYNC_WATERMARK_KEY,
+            format!("{CLOUD_SYNC_WATERMARK_KEY}_value"),
+            CLOUD_SYNC_SESSION_WATERMARK_KEY,
+        ],
+    )?;
+    Ok(removed)
+}
+
 /// Snapshot of the cloud sync state for reporting via `budi cloud status`.
 ///
 /// Captures configuration readiness, the last successful sync watermarks, and
@@ -879,6 +902,71 @@ mod tests {
         assert_eq!(
             get_session_watermark(&conn).unwrap().as_deref(),
             Some("2026-04-10T10:00:00Z")
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn reset_cloud_watermarks_drops_sentinel_rows() {
+        // #564: dropping the three sentinel rows must move the daemon
+        // back to the no-watermark path so the next sync re-sends every
+        // local rollup + session summary. After reset, getters return
+        // None — the same shape a fresh install reports.
+        let dir = std::env::temp_dir().join("budi-cloud-sync-test-reset");
+        std::fs::create_dir_all(&dir).ok();
+        let db_path = dir.join("test.db");
+        let _ = std::fs::remove_file(&db_path);
+
+        let conn = crate::analytics::open_db_with_migration(&db_path).unwrap();
+        set_cloud_watermark(&conn, "2026-04-10").unwrap();
+        set_session_watermark(&conn, "2026-04-10T10:00:00Z").unwrap();
+
+        let removed = reset_cloud_watermarks(&conn).unwrap();
+        assert_eq!(
+            removed, 3,
+            "all three sentinels (rollup-completed, rollup-value, session) must be removed",
+        );
+        assert!(get_cloud_watermark_value(&conn).unwrap().is_none());
+        assert!(get_session_watermark(&conn).unwrap().is_none());
+
+        // Idempotent: a second reset is a no-op (returns 0 rows
+        // removed). Lets the CLI render the right "nothing to reset"
+        // line without an extra existence check.
+        let removed_again = reset_cloud_watermarks(&conn).unwrap();
+        assert_eq!(removed_again, 0);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn reset_cloud_watermarks_leaves_unrelated_rows_alone() {
+        // The DELETE must be scoped to the cloud sentinels — never
+        // touch ingestion offsets / tail offsets / completion markers
+        // that share `sync_state`. A regression here would silently
+        // re-import every JSONL transcript on the next tick.
+        let dir = std::env::temp_dir().join("budi-cloud-sync-test-reset-scope");
+        std::fs::create_dir_all(&dir).ok();
+        let db_path = dir.join("test.db");
+        let _ = std::fs::remove_file(&db_path);
+
+        let conn = crate::analytics::open_db_with_migration(&db_path).unwrap();
+        crate::analytics::set_sync_offset(&conn, "/tmp/transcript.jsonl", 4096).unwrap();
+        crate::analytics::mark_sync_completed(&conn).unwrap();
+        set_cloud_watermark(&conn, "2026-04-10").unwrap();
+
+        reset_cloud_watermarks(&conn).unwrap();
+
+        // Ingestion offset survives.
+        assert_eq!(
+            crate::analytics::get_sync_offset(&conn, "/tmp/transcript.jsonl").unwrap(),
+            4096,
+        );
+        // Sync-completion marker survives.
+        assert!(
+            crate::analytics::last_sync_completed_at(&conn)
+                .unwrap()
+                .is_some(),
         );
 
         let _ = std::fs::remove_dir_all(&dir);

--- a/crates/budi-daemon/src/main.rs
+++ b/crates/budi-daemon/src/main.rs
@@ -69,6 +69,7 @@ fn build_router(app_state: AppState) -> Router {
         .route("/sync/all", post(h::analytics_history))
         .route("/sync/reset", post(h::analytics_sync_reset))
         .route("/cloud/sync", post(c::cloud_sync))
+        .route("/cloud/reset", post(c::cloud_reset))
         .route("/pricing/refresh", post(p::pricing_refresh))
         .route("/admin/providers", get(a::analytics_registered_providers))
         .route("/admin/schema", get(a::analytics_schema_version))

--- a/crates/budi-daemon/src/routes/cloud.rs
+++ b/crates/budi-daemon/src/routes/cloud.rs
@@ -112,6 +112,69 @@ pub async fn cloud_sync(
     Ok(Json(report_to_json(report)))
 }
 
+/// `POST /cloud/reset` — drop the cloud-sync watermarks so the next
+/// sync re-uploads every local rollup + session summary (#564).
+///
+/// User-driven escape hatch for org switches, device_id rotations, and
+/// cloud-side data wipes that leave the daemon's incremental watermark
+/// "ahead" of where the cloud actually is. Cloud-side dedup
+/// (ADR-0083 §6) keeps the re-upload safe even when records overlap
+/// with rows the cloud already has.
+///
+/// This route is loopback-protected (see `build_router` in `main.rs`)
+/// because it mutates `sync_state`. We grab the same `cloud_syncing`
+/// busy flag as `/cloud/sync` so a manual reset can never race a
+/// background tick that already built an envelope against the
+/// soon-to-be-deleted watermark — that would push under the old
+/// watermark, then the reset would land, then the next tick would
+/// re-push everything anyway. Holding the flag keeps the sequencing
+/// honest. Returns 409 when the worker (or another `cloud sync`) is
+/// already running so the operator can re-run after it finishes.
+pub async fn cloud_reset(
+    State(state): State<AppState>,
+) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+    if state
+        .cloud_syncing
+        .compare_exchange(
+            false,
+            true,
+            std::sync::atomic::Ordering::SeqCst,
+            std::sync::atomic::Ordering::SeqCst,
+        )
+        .is_err()
+    {
+        return Err((
+            StatusCode::CONFLICT,
+            Json(json!({
+                "ok": false,
+                "error": "cloud sync already running — wait for it to finish, then re-run `budi cloud reset`",
+                "result": "busy"
+            })),
+        ));
+    }
+
+    let flag = state.cloud_syncing.clone();
+    let removed = tokio::task::spawn_blocking(move || -> anyhow::Result<usize> {
+        let _guard = CloudBusyFlagGuard::new(flag);
+        let db_path = analytics::db_path()?;
+        let conn = analytics::open_db(&db_path)?;
+        cloud_sync::reset_cloud_watermarks(&conn)
+    })
+    .await
+    .map_err(|e| super::internal_error(anyhow::anyhow!("cloud reset task panicked: {e}")))?
+    .map_err(super::internal_error)?;
+
+    let cfg = config::load_cloud_config();
+    Ok(Json(json!({
+        "ok": true,
+        "result": "reset",
+        "endpoint": cfg.effective_endpoint(),
+        "org_id": cfg.org_id,
+        "removed": removed,
+        "message": "Cloud sync watermarks reset. Run `budi cloud sync` to push everything now, or wait for the next interval tick.",
+    })))
+}
+
 fn not_ready_body(result: &str, cfg: &CloudConfig, message: &str) -> Value {
     json!({
         "ok": false,


### PR DESCRIPTION
## Summary

- Adds `budi cloud reset` — drops the three cloud-sync watermarks in `sync_state` (`__budi_cloud_sync__`, `__budi_cloud_sync___value`, `__budi_cloud_sync_sessions__`) so the next `budi cloud sync` falls into the no-watermark path and re-uploads every local rollup + session summary. Cloud-side dedup (ADR-0083 §6) keeps the re-upload safe even when records overlap with rows the cloud already has.
- Adds a daemon `POST /cloud/reset` route (loopback-protected, takes the same `cloud_syncing` busy flag as `/cloud/sync` so a manual reset can't race a concurrent envelope build).
- Adds `reset_cloud_watermarks(&Connection) -> usize` in `budi-core::cloud_sync` (idempotent; returns the number of sentinel rows it removed).

## Why

After an org switch / device_id rotation / cloud-side data wipe (#564, plus the pattern called out in #559 and #560), the daemon's local watermark stays "ahead" of where the cloud actually is — so the next sync only pushes today's bucket and historical rollups never re-upload. Pre-fix, the only workaround was a hand-written `sqlite3 ... DELETE FROM sync_state ...` against the analytics database while the daemon was stopped.

This is the third leg of the "after an org switch on the cloud, my daemon is in a weird state" theme:
- #559 — `cloud init` UX after key rotation (shipped 8.3.9).
- #560 — daemon cache stale api_key after `cloud.toml` rewrite (shipped 8.3.9).
- #564 (this PR) — local watermark is org-blind; the cloud loses the data on an org switch and the daemon never re-sends it.

## UX

Interactive (default) — names the linked org so the user can sanity-check before re-uploading:
```
$ budi cloud reset
This will reset the cloud sync watermarks for org "org_xEvtA".
The next `budi cloud sync` will re-upload all local rollups and session summaries to the cloud.
Continue? [y/N]
```

Non-interactive (CI / scripts):
```
$ budi cloud reset --yes
  ✓ Cloud sync watermarks reset for org "org_xEvtA".
    removed    3 sentinel rows
    next step  run budi cloud sync to push everything now, or wait for the next interval tick
```

Non-TTY without `--yes` errors out cleanly so a stray invocation can't silently re-upload.

## Test plan
- [x] `cargo test --workspace` (all 700+ tests pass)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] New unit tests:
  - `reset_cloud_watermarks_drops_sentinel_rows` — drops all three, idempotent on a second call.
  - `reset_cloud_watermarks_leaves_unrelated_rows_alone` — ingestion offsets / `__budi_sync_completed__` survive (regression guard against accidentally re-importing every transcript).
  - `cli_parses_cloud_reset` — bare and `--yes` forms parse.
  - `describe_reset_target_*` — prompt copy names the org when present, falls back cleanly when missing.
- [ ] Manual smoke: simulate the org-switch scenario (set a watermark via SQL, run `budi cloud reset --yes`, confirm `budi cloud sync` then sends every row).

🤖 Generated with [Claude Code](https://claude.com/claude-code)