### PR TITLE
daemon: backfill sessions.started_at/ended_at from messages (#569)

### DIFF
--- a/crates/budi-core/src/analytics/mod.rs
+++ b/crates/budi-core/src/analytics/mod.rs
@@ -549,6 +549,20 @@ pub fn ingest_messages_with_sync(
                 "INSERT OR IGNORE INTO sessions (id, provider) VALUES (?1, ?2)",
                 params![sid, provider],
             )?;
+            // Without this, claude_code/codex sessions keep started_at/ended_at
+            // = NULL forever and never reach `fetch_session_summaries`, so
+            // `session_summaries` on cloud goes silently empty (#569). COALESCE
+            // is a no-op for cursor rows already populated by their composer
+            // header repair pass.
+            tx.execute(
+                "UPDATE sessions SET
+                    started_at = COALESCE(started_at,
+                        (SELECT MIN(timestamp) FROM messages WHERE session_id = ?1)),
+                    ended_at = COALESCE(ended_at,
+                        (SELECT MAX(timestamp) FROM messages WHERE session_id = ?1))
+                 WHERE id = ?1",
+                params![sid],
+            )?;
         }
         for (sid, category) in &session_categories {
             tx.execute(

--- a/crates/budi-core/src/analytics/sync.rs
+++ b/crates/budi-core/src/analytics/sync.rs
@@ -326,6 +326,19 @@ fn sync_with_max_age<F: FnMut(&SyncProgress)>(
             );
         }
 
+        // Heal sessions that older code paths inserted with NULL
+        // started_at/ended_at — without this they never reach
+        // `fetch_session_summaries` and the cloud's `session_summaries`
+        // stays silently empty (#569). Runs before title backfill since
+        // titles filter on `started_at`.
+        match crate::migration::backfill_session_timestamps_from_messages(conn) {
+            Ok(healed) if healed > 0 => {
+                tracing::info!("Backfilled started_at/ended_at on {healed} sessions (#569)");
+            }
+            Ok(_) => {}
+            Err(e) => tracing::warn!("Session timestamp backfill failed: {e}"),
+        }
+
         // Backfill session titles from provider-specific sources.
         let titles_backfilled = backfill_session_titles(conn);
         if titles_backfilled > 0 {

--- a/crates/budi-core/src/analytics/tests.rs
+++ b/crates/budi-core/src/analytics/tests.rs
@@ -6172,8 +6172,7 @@ fn migration_backfills_session_timestamps_from_messages() {
     )
     .unwrap();
 
-    let healed =
-        crate::migration::backfill_session_timestamps_from_messages(&conn).unwrap();
+    let healed = crate::migration::backfill_session_timestamps_from_messages(&conn).unwrap();
     assert_eq!(healed, 2);
 
     let (cc_start, cc_end): (Option<String>, Option<String>) = conn
@@ -6197,8 +6196,7 @@ fn migration_backfills_session_timestamps_from_messages() {
     assert_eq!(cx_end.as_deref(), Some("2026-04-29T12:00:00+00:00"));
 
     // Idempotent: subsequent run touches nothing.
-    let again =
-        crate::migration::backfill_session_timestamps_from_messages(&conn).unwrap();
+    let again = crate::migration::backfill_session_timestamps_from_messages(&conn).unwrap();
     assert_eq!(again, 0);
 }
 
@@ -6225,8 +6223,7 @@ fn backfill_does_not_overwrite_existing_session_timestamps() {
     )
     .unwrap();
 
-    let healed =
-        crate::migration::backfill_session_timestamps_from_messages(&conn).unwrap();
+    let healed = crate::migration::backfill_session_timestamps_from_messages(&conn).unwrap();
     assert_eq!(healed, 0);
 
     let (start, end): (Option<String>, Option<String>) = conn

--- a/crates/budi-core/src/analytics/tests.rs
+++ b/crates/budi-core/src/analytics/tests.rs
@@ -6087,3 +6087,155 @@ fn resolve_session_id_covers_full_prefix_empty_and_ambiguous() {
         "empty prefix must not silently return a random session, got {msg:?}",
     );
 }
+
+/// #569: a fresh ingest path for non-cursor providers (claude_code, codex)
+/// must populate `sessions.started_at` / `sessions.ended_at` so that
+/// `cloud_sync::fetch_session_summaries` can pick up the row. Pre-fix, the
+/// stub session row was inserted with only `(id, provider)` and the cloud
+/// sync predicate `started_at IS NOT NULL` filtered it out forever.
+#[test]
+fn ingest_populates_session_timestamps_for_claude_code() {
+    let mut conn = test_db();
+    let mut early = assistant_msg("cc-1", "s-cc-569", 1.0);
+    early.timestamp = "2026-04-28T09:00:00Z".parse().unwrap();
+    let mut late = assistant_msg("cc-2", "s-cc-569", 2.0);
+    late.timestamp = "2026-04-28T10:30:00Z".parse().unwrap();
+
+    ingest_messages(&mut conn, &[early, late], None).unwrap();
+
+    let (started, ended): (Option<String>, Option<String>) = conn
+        .query_row(
+            "SELECT started_at, ended_at FROM sessions WHERE id = 's-cc-569'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(started.as_deref(), Some("2026-04-28T09:00:00+00:00"));
+    assert_eq!(ended.as_deref(), Some("2026-04-28T10:30:00+00:00"));
+}
+
+/// #569: a session whose row was inserted with NULL timestamps by older
+/// code must get healed when fresh messages for the same session arrive.
+/// COALESCE means we fill the holes without overwriting a value that some
+/// other source (e.g. cursor's composer-header repair) already set.
+#[test]
+fn ingest_heals_stranded_session_when_new_message_arrives() {
+    let mut conn = test_db();
+    // Simulate the legacy stub-only row: just (id, provider).
+    conn.execute(
+        "INSERT INTO sessions (id, provider) VALUES ('s-stranded', 'claude_code')",
+        [],
+    )
+    .unwrap();
+
+    let mut msg = assistant_msg("strand-1", "s-stranded", 1.0);
+    msg.timestamp = "2026-04-28T09:00:00Z".parse().unwrap();
+    ingest_messages(&mut conn, &[msg], None).unwrap();
+
+    let (started, ended): (Option<String>, Option<String>) = conn
+        .query_row(
+            "SELECT started_at, ended_at FROM sessions WHERE id = 's-stranded'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(started.as_deref(), Some("2026-04-28T09:00:00+00:00"));
+    assert_eq!(ended.as_deref(), Some("2026-04-28T09:00:00+00:00"));
+}
+
+/// #569: the standalone repair pass heals legacy stranded sessions even
+/// when no new messages for them arrive. This is the workhorse for user
+/// DBs that already accumulated thousands of NULL-timestamp rows.
+#[test]
+fn migration_backfills_session_timestamps_from_messages() {
+    let conn = test_db();
+    // Two stranded sessions with messages already in place but no
+    // timestamps on the session rows (older bug).
+    conn.execute(
+        "INSERT INTO sessions (id, provider) VALUES ('s-cc', 'claude_code')",
+        [],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO sessions (id, provider) VALUES ('s-codex', 'codex')",
+        [],
+    )
+    .unwrap();
+    // Insert messages directly so the per-batch ingest backfill can't
+    // mask the test — we want to prove the repair pass alone heals these.
+    conn.execute(
+        "INSERT INTO messages (id, session_id, role, timestamp, provider)
+         VALUES ('m-cc-1', 's-cc', 'assistant', '2026-04-28T09:00:00+00:00', 'claude_code'),
+                ('m-cc-2', 's-cc', 'assistant', '2026-04-28T11:00:00+00:00', 'claude_code'),
+                ('m-cx-1', 's-codex', 'user', '2026-04-29T12:00:00+00:00', 'codex')",
+        [],
+    )
+    .unwrap();
+
+    let healed =
+        crate::migration::backfill_session_timestamps_from_messages(&conn).unwrap();
+    assert_eq!(healed, 2);
+
+    let (cc_start, cc_end): (Option<String>, Option<String>) = conn
+        .query_row(
+            "SELECT started_at, ended_at FROM sessions WHERE id = 's-cc'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(cc_start.as_deref(), Some("2026-04-28T09:00:00+00:00"));
+    assert_eq!(cc_end.as_deref(), Some("2026-04-28T11:00:00+00:00"));
+
+    let (cx_start, cx_end): (Option<String>, Option<String>) = conn
+        .query_row(
+            "SELECT started_at, ended_at FROM sessions WHERE id = 's-codex'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(cx_start.as_deref(), Some("2026-04-29T12:00:00+00:00"));
+    assert_eq!(cx_end.as_deref(), Some("2026-04-29T12:00:00+00:00"));
+
+    // Idempotent: subsequent run touches nothing.
+    let again =
+        crate::migration::backfill_session_timestamps_from_messages(&conn).unwrap();
+    assert_eq!(again, 0);
+}
+
+/// #569: the repair pass must not clobber an already-populated value
+/// (e.g. cursor's composer-header repair sets a more accurate start time
+/// than the first ingested message). COALESCE keeps the existing value.
+#[test]
+fn backfill_does_not_overwrite_existing_session_timestamps() {
+    let conn = test_db();
+    conn.execute(
+        "INSERT INTO sessions (id, provider, started_at, ended_at)
+         VALUES ('s-cursor', 'cursor', '2026-04-26T08:00:00+00:00', '2026-04-26T09:00:00+00:00')",
+        [],
+    )
+    .unwrap();
+    // Messages span a wider window — the repair must NOT widen the
+    // session window since cursor's repair already chose authoritative
+    // values from composer headers.
+    conn.execute(
+        "INSERT INTO messages (id, session_id, role, timestamp, provider)
+         VALUES ('m-1', 's-cursor', 'user', '2026-04-26T07:00:00+00:00', 'cursor'),
+                ('m-2', 's-cursor', 'assistant', '2026-04-26T10:00:00+00:00', 'cursor')",
+        [],
+    )
+    .unwrap();
+
+    let healed =
+        crate::migration::backfill_session_timestamps_from_messages(&conn).unwrap();
+    assert_eq!(healed, 0);
+
+    let (start, end): (Option<String>, Option<String>) = conn
+        .query_row(
+            "SELECT started_at, ended_at FROM sessions WHERE id = 's-cursor'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(start.as_deref(), Some("2026-04-26T08:00:00+00:00"));
+    assert_eq!(end.as_deref(), Some("2026-04-26T09:00:00+00:00"));
+}

--- a/crates/budi-core/src/migration.rs
+++ b/crates/budi-core/src/migration.rs
@@ -909,6 +909,32 @@ fn backfill_non_repo_ids_to_null(conn: &Connection) -> Result<usize> {
     Ok(total)
 }
 
+/// #569: heal `sessions` rows whose `started_at`/`ended_at` are NULL but whose
+/// `messages` table has data for them.
+///
+/// Pre-fix, the message ingest path inserted stub session rows with only
+/// `(id, provider)`, leaving timestamps NULL. `cloud_sync::fetch_session_summaries`
+/// requires `started_at` to be NOT NULL, so those sessions never reached the
+/// cloud. This pass fills both columns from `MIN(timestamp)`/`MAX(timestamp)`
+/// of the linked messages.
+///
+/// Idempotent — the COALESCE leaves already-populated values alone, and the
+/// EXISTS clause skips sessions with no messages so the predicate is empty
+/// after one full run.
+pub fn backfill_session_timestamps_from_messages(conn: &Connection) -> Result<usize> {
+    let count = conn.execute(
+        "UPDATE sessions SET
+            started_at = COALESCE(started_at,
+                (SELECT MIN(timestamp) FROM messages WHERE session_id = sessions.id)),
+            ended_at = COALESCE(ended_at,
+                (SELECT MAX(timestamp) FROM messages WHERE session_id = sessions.id))
+         WHERE (started_at IS NULL OR ended_at IS NULL)
+           AND EXISTS (SELECT 1 FROM messages WHERE session_id = sessions.id)",
+        [],
+    )?;
+    Ok(count)
+}
+
 fn create_indexes(conn: &Connection) -> Result<()> {
     conn.execute_batch(
         "
@@ -1153,6 +1179,17 @@ fn reconcile_schema(conn: &Connection) -> Result<SchemaReconcileReport> {
         // `messages.repo_id` in bulk. Cheaper than firing per-row
         // UPDATE triggers across a large history.
         backfill_rollup_tables(conn)?;
+    }
+
+    // #569: heal sessions that were inserted with NULL timestamps by the
+    // pre-fix message ingest path. Without this, claude_code/codex
+    // sessions stranded in user DBs never make it to the cloud.
+    let healed_timestamps = backfill_session_timestamps_from_messages(conn)?;
+    if healed_timestamps > 0 {
+        tracing::info!(
+            rows = healed_timestamps,
+            "Backfilled started_at/ended_at on sessions from messages (#569)"
+        );
     }
 
     let added_indexes = missing_reconcile_indexes(conn)?;


### PR DESCRIPTION
## Summary

Fixes #569 — claude_code/codex sessions never reached cloud sync because the ingest path inserted session rows with only `(id, provider)`, leaving `started_at`/`ended_at` NULL. `cloud_sync::fetch_session_summaries` requires `started_at` NOT NULL, so those sessions were silently filtered out forever while `daily_rollups` kept flowing on the dashboard.

## Fix (three idempotent layers)

- **Per-batch ingest** (`analytics/mod.rs`) — after `INSERT OR IGNORE INTO sessions`, COALESCE-fill `started_at`/`ended_at` from `MIN(timestamp)`/`MAX(timestamp)` of `messages` for that session id. New sessions get timestamps atomically; stranded sessions get topped up the moment any fresh message for them arrives.
- **Standalone repair pass** (`migration::backfill_session_timestamps_from_messages`) — one UPDATE that heals every stranded session with messages, called after each ingest tick in `analytics::sync` (before `backfill_session_titles`, which filters on `started_at`).
- **Migration** (`reconcile_schema`) — same repair runs once on boot so user DBs with thousands of stranded rows (e.g. ~1050 in the reporter's DB) get healed without waiting for fresh ingest on every stranded session.

COALESCE means cursor's authoritative composer-header timestamps are preserved when both passes run.

## Tests

Added 4 tests in `analytics::tests`:
- `ingest_populates_session_timestamps_for_claude_code` — fresh ingest path now populates timestamps for non-cursor providers.
- `ingest_heals_stranded_session_when_new_message_arrives` — pre-existing stub row gets healed when a new message arrives.
- `migration_backfills_session_timestamps_from_messages` — standalone repair heals stranded rows for `claude_code` and `codex`, idempotent on re-run.
- `backfill_does_not_overwrite_existing_session_timestamps` — COALESCE preserves cursor's authoritative timestamps.

## Test plan

- [x] `cargo test -p budi-core --lib` (480 passed)
- [x] `cargo clippy -p budi-core --all-targets` (clean)
- [x] `cargo build --workspace`
- [ ] Verify on real DB: `sqlite3 ~/.local/share/budi/analytics.db "SELECT provider, COUNT(*), COUNT(started_at) FROM sessions GROUP BY provider"` — `started_at` count should equal total count for all providers after one daemon tick on 8.3.11.
- [ ] Verify `/dashboard/sessions?days=1` populates after the next sync tick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)