### PR TITLE
ci: fix release wait-on-check race when ci-success hasn't registered

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,14 +25,27 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
+      # fountainhead/action-wait-for-check treats a missing check as "wait" rather
+      # than "exit immediately", which avoids the race where ci-success hasn't
+      # registered yet on a fresh tag push (see issue #573).
       - name: Wait for CI workflow
-        uses: lewagon/wait-on-check-action@ccfb013c15c8afb7bf2b7c028fb74dc5a068cccc # v1.3.4
+        id: wait-ci
+        uses: fountainhead/action-wait-for-check@5a908a24814494009c4bb27c242ea38c93c593be # v1.2.0
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ github.sha }}
-          check-name: ci-success
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 15
-          allowed-conclusions: success
+          checkName: ci-success
+          timeoutSeconds: 1500
+          intervalSeconds: 15
+
+      - name: Verify ci-success conclusion
+        run: |
+          conclusion='${{ steps.wait-ci.outputs.conclusion }}'
+          echo "ci-success conclusion: ${conclusion}"
+          if [[ "${conclusion}" != "success" ]]; then
+            echo "::error::ci-success did not succeed (conclusion=${conclusion})"
+            exit 1
+          fi
 
   verify_tag_version:
     name: Verify tag matches Cargo version


### PR DESCRIPTION
## Summary
- Closes #573
- Replace `lewagon/wait-on-check-action` with `fountainhead/action-wait-for-check` in the release workflow's `ci-check` gate. The new action treats a not-yet-registered check as "keep polling" rather than "exit immediately", which avoids the race where `ci-success` hasn't appeared yet on a fresh tag push.
- `fountainhead/action-wait-for-check` only reports the result via an output (`conclusion`), so add a follow-up step that fails the job when the conclusion is anything other than `success`.
- Pinned to commit SHA for `v1.2.0` (`5a908a2`), matching the existing convention in this workflow.

## Why this fixes #573
The previous action queried check-runs for the SHA, filtered by `check-name: ci-success`, found no match because `ci-success` (which depends on `rust-checks` / `windows-build` / `macos-build` / `supply-chain`) hadn't been registered yet, and exited with "The requested check was never run against this ref". The new action polls until a completed check named `ci-success` appears, then returns its conclusion — so it correctly waits for the umbrella check to land instead of bailing on a transient empty result.

## Test plan
- [ ] Cut the next release tag (e.g. v8.3.12 prep) and push it without manually waiting for `main` CI to go green; confirm `Verify CI passed` waits and then proceeds when `ci-success` completes.
- [ ] Force a CI failure on `main` and verify the release workflow's verify step exits 1 with the conclusion echoed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)