### PR TITLE
daemon: extend session heal pass with repo/branch + active-session ended_at

### DIFF
--- a/crates/budi-core/src/analytics/mod.rs
+++ b/crates/budi-core/src/analytics/mod.rs
@@ -549,17 +549,30 @@ pub fn ingest_messages_with_sync(
                 "INSERT OR IGNORE INTO sessions (id, provider) VALUES (?1, ?2)",
                 params![sid, provider],
             )?;
-            // Without this, claude_code/codex sessions keep started_at/ended_at
-            // = NULL forever and never reach `fetch_session_summaries`, so
-            // `session_summaries` on cloud goes silently empty (#569). COALESCE
-            // is a no-op for cursor rows already populated by their composer
-            // header repair pass.
+            // Without this, claude_code/codex sessions keep started_at/ended_at/
+            // repo_id/git_branch = NULL forever (#569 / #577) and never reach
+            // `fetch_session_summaries`, so `session_summaries` on cloud goes
+            // silently empty. `started_at` is immutable so COALESCE preserves
+            // any pre-set value; `ended_at` must keep advancing for in-flight
+            // sessions so we always recompute MAX(messages.timestamp) (#578 —
+            // pre-fix `COALESCE(ended_at, MAX)` froze it at the first tick's
+            // MAX, leaving every active session rendered as `<1m` on cloud).
             tx.execute(
                 "UPDATE sessions SET
                     started_at = COALESCE(started_at,
                         (SELECT MIN(timestamp) FROM messages WHERE session_id = ?1)),
-                    ended_at = COALESCE(ended_at,
-                        (SELECT MAX(timestamp) FROM messages WHERE session_id = ?1))
+                    ended_at =
+                        (SELECT MAX(timestamp) FROM messages WHERE session_id = ?1),
+                    repo_id = COALESCE(NULLIF(sessions.repo_id, ''),
+                        (SELECT m.repo_id FROM messages m
+                          WHERE m.session_id = ?1
+                            AND m.repo_id IS NOT NULL AND m.repo_id <> ''
+                          ORDER BY m.timestamp DESC LIMIT 1)),
+                    git_branch = COALESCE(NULLIF(sessions.git_branch, ''),
+                        (SELECT m.git_branch FROM messages m
+                          WHERE m.session_id = ?1
+                            AND m.git_branch IS NOT NULL AND m.git_branch <> ''
+                          ORDER BY m.timestamp DESC LIMIT 1))
                  WHERE id = ?1",
                 params![sid],
             )?;

--- a/crates/budi-core/src/analytics/tests.rs
+++ b/crates/budi-core/src/analytics/tests.rs
@@ -6340,7 +6340,10 @@ fn backfill_repo_and_branch_from_messages() {
             |row| Ok((row.get(0)?, row.get(1)?)),
         )
         .unwrap();
-    assert_eq!(cx_repo.as_deref(), Some("github.com/siropkin/codex-experiments"));
+    assert_eq!(
+        cx_repo.as_deref(),
+        Some("github.com/siropkin/codex-experiments")
+    );
     assert_eq!(cx_branch.as_deref(), Some("master"));
 
     // Idempotent.
@@ -6384,6 +6387,9 @@ fn backfill_preserves_already_populated_repo_and_branch() {
             |row| Ok((row.get(0)?, row.get(1)?)),
         )
         .unwrap();
-    assert_eq!(repo.as_deref(), Some("github.com/example/authoritative-repo"));
+    assert_eq!(
+        repo.as_deref(),
+        Some("github.com/example/authoritative-repo")
+    );
     assert_eq!(branch.as_deref(), Some("authoritative-branch"));
 }

--- a/crates/budi-core/src/analytics/tests.rs
+++ b/crates/budi-core/src/analytics/tests.rs
@@ -6200,11 +6200,13 @@ fn migration_backfills_session_timestamps_from_messages() {
     assert_eq!(again, 0);
 }
 
-/// #569: the repair pass must not clobber an already-populated value
-/// (e.g. cursor's composer-header repair sets a more accurate start time
-/// than the first ingested message). COALESCE keeps the existing value.
+/// #569 / #578: `started_at` is immutable so the repair pass must not
+/// clobber an already-populated value (e.g. cursor's composer-header
+/// repair). `ended_at` *does* advance to MAX(messages.timestamp) — pre-#578
+/// the heal froze it at the first tick's MAX so every active session was
+/// rendered as `<1m` on the cloud.
 #[test]
-fn backfill_does_not_overwrite_existing_session_timestamps() {
+fn backfill_preserves_started_at_but_advances_ended_at() {
     let conn = test_db();
     conn.execute(
         "INSERT INTO sessions (id, provider, started_at, ended_at)
@@ -6212,9 +6214,10 @@ fn backfill_does_not_overwrite_existing_session_timestamps() {
         [],
     )
     .unwrap();
-    // Messages span a wider window — the repair must NOT widen the
-    // session window since cursor's repair already chose authoritative
-    // values from composer headers.
+    // Messages span a wider window. `started_at` must stay at '08' (cursor
+    // chose this from composer headers and it's older than MIN(timestamp));
+    // `ended_at` must advance to '10' so cloud Sessions doesn't freeze the
+    // duration at first-tick MAX.
     conn.execute(
         "INSERT INTO messages (id, session_id, role, timestamp, provider)
          VALUES ('m-1', 's-cursor', 'user', '2026-04-26T07:00:00+00:00', 'cursor'),
@@ -6224,7 +6227,7 @@ fn backfill_does_not_overwrite_existing_session_timestamps() {
     .unwrap();
 
     let healed = crate::migration::backfill_session_timestamps_from_messages(&conn).unwrap();
-    assert_eq!(healed, 0);
+    assert_eq!(healed, 1);
 
     let (start, end): (Option<String>, Option<String>) = conn
         .query_row(
@@ -6234,5 +6237,153 @@ fn backfill_does_not_overwrite_existing_session_timestamps() {
         )
         .unwrap();
     assert_eq!(start.as_deref(), Some("2026-04-26T08:00:00+00:00"));
-    assert_eq!(end.as_deref(), Some("2026-04-26T09:00:00+00:00"));
+    assert_eq!(end.as_deref(), Some("2026-04-26T10:00:00+00:00"));
+
+    // Idempotent: a second run does not re-touch the row now that
+    // ended_at == MAX(messages.timestamp).
+    let again = crate::migration::backfill_session_timestamps_from_messages(&conn).unwrap();
+    assert_eq!(again, 0);
+}
+
+/// #578: regression guard. Pre-fix `COALESCE(ended_at, MAX)` froze ended_at
+/// at the first tick's MAX, so every active session showed `<1m` on the
+/// cloud. Post-fix, fresh messages arriving for a session whose `ended_at`
+/// was already populated must extend it to the new MAX(timestamp).
+#[test]
+fn backfill_advances_ended_at_for_active_session() {
+    let conn = test_db();
+    // Simulate the state right after the first ingest tick: started_at and
+    // ended_at both populated with the first observed message timestamp.
+    conn.execute(
+        "INSERT INTO sessions (id, provider, started_at, ended_at)
+         VALUES ('s-active', 'claude_code',
+                 '2026-04-30T02:37:07+00:00',
+                 '2026-04-30T02:37:08+00:00')",
+        [],
+    )
+    .unwrap();
+    // 30 minutes later, more messages have streamed in.
+    conn.execute(
+        "INSERT INTO messages (id, session_id, role, timestamp, provider)
+         VALUES ('m-1', 's-active', 'user', '2026-04-30T02:37:07+00:00', 'claude_code'),
+                ('m-2', 's-active', 'assistant', '2026-04-30T02:37:08+00:00', 'claude_code'),
+                ('m-3', 's-active', 'assistant', '2026-04-30T03:11:44+00:00', 'claude_code')",
+        [],
+    )
+    .unwrap();
+
+    let healed = crate::migration::backfill_session_timestamps_from_messages(&conn).unwrap();
+    assert_eq!(healed, 1);
+
+    let (start, end): (Option<String>, Option<String>) = conn
+        .query_row(
+            "SELECT started_at, ended_at FROM sessions WHERE id = 's-active'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    // started_at preserved (immutable).
+    assert_eq!(start.as_deref(), Some("2026-04-30T02:37:07+00:00"));
+    // ended_at advanced to the new MAX.
+    assert_eq!(end.as_deref(), Some("2026-04-30T03:11:44+00:00"));
+
+    // Idempotent now that ended_at == MAX.
+    let again = crate::migration::backfill_session_timestamps_from_messages(&conn).unwrap();
+    assert_eq!(again, 0);
+}
+
+/// #577: the repair pass backfills `repo_id` / `git_branch` from the
+/// linked messages so the cloud Sessions table can render a real repo /
+/// branch instead of `(unknown)` / `-`. Pre-#577 the heal pass only
+/// touched `started_at` / `ended_at`, leaving every claude_code / codex
+/// session row's repo and branch NULL.
+#[test]
+fn backfill_repo_and_branch_from_messages() {
+    let conn = test_db();
+    conn.execute(
+        "INSERT INTO sessions (id, provider) VALUES ('s-cc', 'claude_code'),
+                                                    ('s-cx', 'codex')",
+        [],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO messages (id, session_id, role, timestamp, provider, repo_id, git_branch)
+         VALUES ('m-cc-1', 's-cc', 'user', '2026-04-30T09:00:00+00:00', 'claude_code',
+                  'github.com/siropkin/budi', 'main'),
+                ('m-cc-2', 's-cc', 'assistant', '2026-04-30T09:30:00+00:00', 'claude_code',
+                  'github.com/siropkin/budi', 'fix-577'),
+                ('m-cx-1', 's-cx', 'user', '2026-04-30T10:00:00+00:00', 'codex',
+                  'github.com/siropkin/codex-experiments', 'master')",
+        [],
+    )
+    .unwrap();
+
+    let healed = crate::migration::backfill_session_timestamps_from_messages(&conn).unwrap();
+    assert_eq!(healed, 2);
+
+    // claude_code session: most-recent message wins for branch (so a
+    // mid-session branch switch is reflected).
+    let (cc_repo, cc_branch): (Option<String>, Option<String>) = conn
+        .query_row(
+            "SELECT repo_id, git_branch FROM sessions WHERE id = 's-cc'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(cc_repo.as_deref(), Some("github.com/siropkin/budi"));
+    assert_eq!(cc_branch.as_deref(), Some("fix-577"));
+
+    let (cx_repo, cx_branch): (Option<String>, Option<String>) = conn
+        .query_row(
+            "SELECT repo_id, git_branch FROM sessions WHERE id = 's-cx'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(cx_repo.as_deref(), Some("github.com/siropkin/codex-experiments"));
+    assert_eq!(cx_branch.as_deref(), Some("master"));
+
+    // Idempotent.
+    let again = crate::migration::backfill_session_timestamps_from_messages(&conn).unwrap();
+    assert_eq!(again, 0);
+}
+
+/// #577: a session row with `repo_id` / `git_branch` already populated
+/// (e.g. by a future provider-authoritative writer) is preserved by the
+/// heal — COALESCE / NULLIF only fills holes.
+#[test]
+fn backfill_preserves_already_populated_repo_and_branch() {
+    let conn = test_db();
+    conn.execute(
+        "INSERT INTO sessions (id, provider, started_at, ended_at, repo_id, git_branch)
+         VALUES ('s-set', 'claude_code',
+                 '2026-04-30T09:00:00+00:00',
+                 '2026-04-30T09:30:00+00:00',
+                 'github.com/example/authoritative-repo',
+                 'authoritative-branch')",
+        [],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO messages (id, session_id, role, timestamp, provider, repo_id, git_branch)
+         VALUES ('m-1', 's-set', 'user', '2026-04-30T09:00:00+00:00', 'claude_code',
+                  'github.com/example/some-other-repo', 'some-other-branch'),
+                ('m-2', 's-set', 'assistant', '2026-04-30T09:30:00+00:00', 'claude_code',
+                  'github.com/example/some-other-repo', 'some-other-branch')",
+        [],
+    )
+    .unwrap();
+
+    let healed = crate::migration::backfill_session_timestamps_from_messages(&conn).unwrap();
+    assert_eq!(healed, 0);
+
+    let (repo, branch): (Option<String>, Option<String>) = conn
+        .query_row(
+            "SELECT repo_id, git_branch FROM sessions WHERE id = 's-set'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(repo.as_deref(), Some("github.com/example/authoritative-repo"));
+    assert_eq!(branch.as_deref(), Some("authoritative-branch"));
 }

--- a/crates/budi-core/src/migration.rs
+++ b/crates/budi-core/src/migration.rs
@@ -909,27 +909,63 @@ fn backfill_non_repo_ids_to_null(conn: &Connection) -> Result<usize> {
     Ok(total)
 }
 
-/// #569: heal `sessions` rows whose `started_at`/`ended_at` are NULL but whose
-/// `messages` table has data for them.
+/// #569 / #578 / #577: heal `sessions` rows whose `started_at`, `ended_at`,
+/// `repo_id`, or `git_branch` are stale or missing but whose `messages` table
+/// has data for them.
 ///
 /// Pre-fix, the message ingest path inserted stub session rows with only
-/// `(id, provider)`, leaving timestamps NULL. `cloud_sync::fetch_session_summaries`
-/// requires `started_at` to be NOT NULL, so those sessions never reached the
-/// cloud. This pass fills both columns from `MIN(timestamp)`/`MAX(timestamp)`
-/// of the linked messages.
+/// `(id, provider)`, leaving timestamps and repo/branch NULL.
+/// `cloud_sync::fetch_session_summaries` requires `started_at` to be NOT NULL,
+/// so those sessions never reached the cloud. This pass fills the four
+/// derivable columns from the linked messages.
 ///
-/// Idempotent — the COALESCE leaves already-populated values alone, and the
-/// EXISTS clause skips sessions with no messages so the predicate is empty
-/// after one full run.
+/// `started_at` is immutable (the session's first observed message), so it
+/// uses `COALESCE` to preserve any already-set value (e.g. one written by a
+/// future provider-authoritative path). `ended_at` is the session's *last*
+/// observed message and must keep advancing as new messages stream in for
+/// in-flight sessions — `COALESCE` would freeze it at the first ingest tick's
+/// MAX (#578), so this pass always recomputes MAX(messages.timestamp) for any
+/// session whose stored `ended_at` is older. `repo_id` and `git_branch`
+/// (#577) likewise live on every message row; we backfill them from the
+/// session's most-recent message so a branch switch mid-session is reflected.
+///
+/// The WHERE predicate is empty after one full sweep on a stable DB — so
+/// steady-state cost stays the same as the v8.3.11 heal.
 pub fn backfill_session_timestamps_from_messages(conn: &Connection) -> Result<usize> {
     let count = conn.execute(
         "UPDATE sessions SET
             started_at = COALESCE(started_at,
                 (SELECT MIN(timestamp) FROM messages WHERE session_id = sessions.id)),
-            ended_at = COALESCE(ended_at,
-                (SELECT MAX(timestamp) FROM messages WHERE session_id = sessions.id))
-         WHERE (started_at IS NULL OR ended_at IS NULL)
-           AND EXISTS (SELECT 1 FROM messages WHERE session_id = sessions.id)",
+            ended_at =
+                (SELECT MAX(timestamp) FROM messages WHERE session_id = sessions.id),
+            repo_id = COALESCE(NULLIF(sessions.repo_id, ''),
+                (SELECT m.repo_id FROM messages m
+                  WHERE m.session_id = sessions.id
+                    AND m.repo_id IS NOT NULL AND m.repo_id <> ''
+                  ORDER BY m.timestamp DESC LIMIT 1)),
+            git_branch = COALESCE(NULLIF(sessions.git_branch, ''),
+                (SELECT m.git_branch FROM messages m
+                  WHERE m.session_id = sessions.id
+                    AND m.git_branch IS NOT NULL AND m.git_branch <> ''
+                  ORDER BY m.timestamp DESC LIMIT 1))
+         WHERE EXISTS (SELECT 1 FROM messages WHERE session_id = sessions.id)
+           AND (
+                started_at IS NULL
+                OR ended_at IS NULL
+                OR ended_at < (SELECT MAX(timestamp) FROM messages WHERE session_id = sessions.id)
+                OR (
+                    (sessions.repo_id IS NULL OR sessions.repo_id = '')
+                    AND EXISTS (SELECT 1 FROM messages m
+                                WHERE m.session_id = sessions.id
+                                  AND m.repo_id IS NOT NULL AND m.repo_id <> '')
+                )
+                OR (
+                    (sessions.git_branch IS NULL OR sessions.git_branch = '')
+                    AND EXISTS (SELECT 1 FROM messages m
+                                WHERE m.session_id = sessions.id
+                                  AND m.git_branch IS NOT NULL AND m.git_branch <> '')
+                )
+           )",
         [],
     )?;
     Ok(count)


### PR DESCRIPTION
## Summary

Two follow-ups to #569 / PR #570 surfaced during v8.3.12 release validation. Both live in the same heal-pass query in two places (`analytics/mod.rs` per-batch + `migration::backfill_session_timestamps_from_messages` post-tick + boot).

- **Closes #577** — claude_code (992/992) and codex (67/67) sessions had `sessions.repo_id` / `sessions.git_branch` NULL even though the underlying `messages` rows carry both. Cloud `/dashboard/sessions` rendered every row as `(unknown) / -`. Heal pass now backfills both columns from the latest-message-per-session (so a mid-session branch switch is reflected).
- **Closes #578** — `ended_at = COALESCE(ended_at, MAX)` froze the column at the first ingest tick's MAX, so any session still in flight stayed at the timestamp of message #3 forever. Cloud rendered every active session as `<1m`. Real evidence: session ba1e53ac… had `ended_at = 02:37:08` while messages spanned 02:37:07 → 03:11:44 (270 rows, 34 minutes). Heal pass now always recomputes `MAX(messages.timestamp)` for any session whose stored `ended_at` lags. `started_at` keeps `COALESCE` since it's immutable.

WHERE clause tightened so the heal stays idempotent on a stable DB — repo/branch holes are only counted when the matching messages actually carry repo/branch.

## Files

- `crates/budi-core/src/analytics/mod.rs` — per-batch heal in `analytics::sync`.
- `crates/budi-core/src/migration.rs` — `backfill_session_timestamps_from_messages` (runs post-sync-tick + on boot via `reconcile_schema`).
- `crates/budi-core/src/analytics/tests.rs` — pinned the new behavior:
  - `backfill_preserves_started_at_but_advances_ended_at` — renamed from `backfill_does_not_overwrite_existing_session_timestamps`. `started_at` preserved, `ended_at` advances to MAX.
  - `backfill_advances_ended_at_for_active_session` — **explicit #578 regression guard**: session rows with first-tick frozen `ended_at` get advanced to MAX as new messages arrive.
  - `backfill_repo_and_branch_from_messages` — claude_code + codex hydration, latest-message branch wins.
  - `backfill_preserves_already_populated_repo_and_branch` — authoritative session-row repo/branch is not clobbered.

## Test plan

- [x] `cargo test -p budi-core --lib backfill` — 7 / 7 ✓
- [x] `cargo test -p budi-core --lib analytics` — 155 / 155 ✓
- [x] `cargo clippy --workspace --all-targets` — clean
- [ ] Live verification on the maintainer DB after v8.3.13 ships:
  - `sqlite3 analytics.db "SELECT provider, SUM(repo_id IS NOT NULL AND repo_id <> '') AS with_repo FROM sessions GROUP BY provider"` shows non-zero `with_repo` for claude_code / codex.
  - The current active session's `ended_at` advances on the next sync tick instead of staying frozen at the first-tick value.
  - Cloud `/dashboard/sessions` renders real repo / branch and a real duration for active sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)