### PR TITLE
cli: `budi cloud sync --full` (drop watermarks + sync in one call)

### DIFF
--- a/crates/budi-cli/src/commands/cloud.rs
+++ b/crates/budi-cli/src/commands/cloud.rs
@@ -502,8 +502,35 @@ fn describe_source(src: IdentitySource) -> &'static str {
 }
 
 /// `budi cloud sync` — flush the pending cloud queue now.
-pub fn cmd_cloud_sync(format: StatsFormat) -> Result<()> {
+///
+/// #583: `--full` folds `cloud reset && cloud sync` into one verb. The
+/// watermarks are dropped via the same `POST /cloud/reset` path the
+/// standalone `budi cloud reset` uses (so the daemon's `cloud_syncing`
+/// busy flag still serializes the reset against any concurrent envelope
+/// build) and then the regular sync runs. Cloud-side dedup keeps the
+/// re-upload safe even when records overlap with rows the cloud
+/// already has.
+pub fn cmd_cloud_sync(format: StatsFormat, full: bool, yes: bool) -> Result<()> {
     let client = DaemonClient::connect()?;
+
+    let reset_removed = if full {
+        let cfg = load_cloud_config();
+        if !confirm_reset(&cfg, yes)? {
+            println!("Aborted. Watermarks left unchanged.");
+            return Ok(());
+        }
+        let reset_body = client
+            .cloud_reset()
+            .context("failed to reset cloud sync watermarks via the daemon")?;
+        let removed = reset_body
+            .get("removed")
+            .and_then(Value::as_u64)
+            .unwrap_or(0) as usize;
+        Some(removed)
+    } else {
+        None
+    };
+
     let body = client.cloud_sync()?;
 
     if matches!(format, StatsFormat::Json) {
@@ -515,11 +542,37 @@ pub fn cmd_cloud_sync(format: StatsFormat) -> Result<()> {
         return Ok(());
     }
 
+    if let Some(removed) = reset_removed {
+        render_full_reset_preamble(removed);
+    }
     render_sync_text(&body);
     if body.get("ok").and_then(Value::as_bool) != Some(true) {
         std::process::exit(2);
     }
     Ok(())
+}
+
+/// #583: tiny prefix block printed in `--full` mode so users see the
+/// reset step landed before the regular sync output. Stays quiet when
+/// nothing was dropped (matches the `cloud reset` no-op render).
+fn render_full_reset_preamble(removed: usize) {
+    let green = ansi("\x1b[32m");
+    let yellow = ansi("\x1b[33m");
+    let dim = ansi("\x1b[90m");
+    let bold = ansi("\x1b[1m");
+    let reset = ansi("\x1b[0m");
+
+    println!();
+    if removed == 0 {
+        println!(
+            "  {yellow}!{reset} {bold}No cloud sync watermarks were set.{reset} Re-uploading from scratch."
+        );
+    } else {
+        println!(
+            "  {green}✓{reset} {bold}Dropped cloud sync watermarks{reset}  {dim}({removed} sentinel row{}){reset}",
+            if removed == 1 { "" } else { "s" },
+        );
+    }
 }
 
 /// `budi cloud status` — report cloud sync readiness and last-synced-at.

--- a/crates/budi-cli/src/main.rs
+++ b/crates/budi-cli/src/main.rs
@@ -426,9 +426,9 @@ enum CloudAction {
     ///
     /// `--full` drops the local cloud-sync watermarks before the push so the
     /// next sync re-uploads every rollup + session summary. Equivalent to
-    /// running `budi cloud reset && budi cloud sync` in one step (#583). The
-    /// re-upload is safe — cloud-side dedup (ADR-0083 §6) collapses any
-    /// records that overlap with what the cloud already has.
+    /// running `budi cloud reset && budi cloud sync` in one step. The
+    /// re-upload is safe — cloud-side dedup collapses any records that
+    /// overlap with what the cloud already has.
     Sync {
         /// Output format: text (default) or json
         #[arg(short, long, value_enum, default_value_t = StatsFormat::Text)]

--- a/crates/budi-cli/src/main.rs
+++ b/crates/budi-cli/src/main.rs
@@ -326,6 +326,8 @@ Examples:
   budi cloud status              Show cloud sync readiness and last sync
   budi cloud sync                Push queued local data to the cloud now
   budi cloud sync --format json  JSON output (exit code 2 on failure)
+  budi cloud sync --full         Drop watermarks then re-upload everything
+  budi cloud sync --full --yes   Same, non-interactive (CI / scripts)
   budi cloud reset               Reset watermarks so next sync re-uploads all
   budi cloud reset --yes         Same, non-interactive (CI / scripts)")]
     Cloud {
@@ -421,10 +423,26 @@ enum CloudAction {
         format: StatsFormat,
     },
     /// Push queued local data (daily rollups, session summaries) to the cloud now
+    ///
+    /// `--full` drops the local cloud-sync watermarks before the push so the
+    /// next sync re-uploads every rollup + session summary. Equivalent to
+    /// running `budi cloud reset && budi cloud sync` in one step (#583). The
+    /// re-upload is safe — cloud-side dedup (ADR-0083 §6) collapses any
+    /// records that overlap with what the cloud already has.
     Sync {
         /// Output format: text (default) or json
         #[arg(short, long, value_enum, default_value_t = StatsFormat::Text)]
         format: StatsFormat,
+        /// Drop the cloud-sync watermarks before pushing so the next sync
+        /// re-uploads everything. Equivalent to `cloud reset && cloud sync`.
+        #[arg(long, default_value_t = false)]
+        full: bool,
+        /// Skip the interactive confirmation that `--full` would otherwise
+        /// show. Required for non-TTY callers (CI, scripts) — otherwise the
+        /// prompt aborts to avoid a silent re-upload on a stray invocation.
+        /// Ignored unless `--full` is set.
+        #[arg(long, default_value_t = false)]
+        yes: bool,
     },
     /// Drop the cloud sync watermarks so the next sync re-uploads everything
     ///
@@ -722,7 +740,9 @@ fn main() -> Result<()> {
                 org_id,
             } => commands::cloud::cmd_cloud_init(api_key, force, yes, device_id, org_id),
             CloudAction::Status { format } => commands::cloud::cmd_cloud_status(format),
-            CloudAction::Sync { format } => commands::cloud::cmd_cloud_sync(format),
+            CloudAction::Sync { format, full, yes } => {
+                commands::cloud::cmd_cloud_sync(format, full, yes)
+            }
             CloudAction::Reset { yes } => commands::cloud::cmd_cloud_reset(yes),
         },
         Commands::Pricing { action } => match action {
@@ -1114,8 +1134,12 @@ mod tests {
         let cli = Cli::try_parse_from(["budi", "cloud", "sync"]).expect("budi cloud sync parses");
         match cli.command {
             Commands::Cloud {
-                action: CloudAction::Sync { format },
-            } => assert!(matches!(format, StatsFormat::Text)),
+                action: CloudAction::Sync { format, full, yes },
+            } => {
+                assert!(matches!(format, StatsFormat::Text));
+                assert!(!full, "default invocation must not drop watermarks");
+                assert!(!yes, "default invocation must be interactive");
+            }
             _ => panic!("expected cloud sync command"),
         }
 
@@ -1126,6 +1150,54 @@ mod tests {
                 action: CloudAction::Status { format },
             } => assert!(matches!(format, StatsFormat::Json)),
             _ => panic!("expected cloud status command"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_cloud_sync_full() {
+        // #583: `--full` folds the prior `cloud reset && cloud sync`
+        // two-step into a single verb. `--yes` is the non-interactive
+        // escape hatch CI / scripts need so the confirmation prompt
+        // isn't a hard block.
+        let cli = Cli::try_parse_from(["budi", "cloud", "sync", "--full"])
+            .expect("budi cloud sync --full parses");
+        match cli.command {
+            Commands::Cloud {
+                action: CloudAction::Sync { full, yes, .. },
+            } => {
+                assert!(full, "--full must request a watermark drop");
+                assert!(!yes, "--full alone must keep the confirmation prompt");
+            }
+            _ => panic!("expected cloud sync --full command"),
+        }
+
+        let cli = Cli::try_parse_from(["budi", "cloud", "sync", "--full", "--yes"])
+            .expect("budi cloud sync --full --yes parses");
+        match cli.command {
+            Commands::Cloud {
+                action: CloudAction::Sync { full, yes, .. },
+            } => {
+                assert!(full);
+                assert!(yes, "--yes must skip the confirmation");
+            }
+            _ => panic!("expected cloud sync --full --yes command"),
+        }
+
+        let cli = Cli::try_parse_from(["budi", "cloud", "sync", "--full", "--format", "json"])
+            .expect("budi cloud sync --full --format json parses");
+        match cli.command {
+            Commands::Cloud {
+                action:
+                    CloudAction::Sync {
+                        full,
+                        format,
+                        yes: _,
+                    },
+            } => {
+                assert!(full);
+                assert!(matches!(format, StatsFormat::Json));
+            }
+            _ => panic!("expected cloud sync --full --format json command"),
         }
     }
 


### PR DESCRIPTION
Closes #583.

## Summary

- Add `--full` flag to `budi cloud sync` that drops the local cloud-sync watermarks before pushing, so the next sync re-uploads every rollup + session summary.
- Add `--yes` flag to `budi cloud sync` to skip the confirmation prompt that `--full` would otherwise show (required for CI / non-TTY callers).
- Keep `budi cloud reset` as a separate verb for the rare "drop watermarks but don't immediately re-upload" case.

Equivalent to today's `budi cloud reset --yes && budi cloud sync` two-step, folded into one call. Re-uses the same `POST /cloud/reset` path the standalone reset verb uses, so the daemon's `cloud_syncing` busy flag still serializes the reset against any concurrent envelope build. Cloud-side dedup (ADR-0083 §6) keeps the re-upload safe even when records overlap.

## Test plan

- [x] `cargo build -p budi-cli` clean
- [x] `cargo test -p budi-cli` — all 185 tests pass, including new `cli_parses_cloud_sync_full`
- [x] `cargo clippy -p budi-cli` clean
- [x] `budi cloud sync --help` renders the new flags with clear copy
- [x] `budi cloud --help` examples block lists `--full` and `--full --yes`
- [x] CLI parsing: `cloud sync` (default), `cloud sync --full`, `cloud sync --full --yes`, `cloud sync --full --format json` all parse correctly

Idempotence ("running `cloud sync --full` twice in a row uploads everything once, then nothing on the second invocation") is covered by the existing `reset_cloud_watermarks_drops_sentinel_rows` core test plus the existing watermark-repopulation logic in `sync_tick_report` — `--full` is a thin wrapper that invokes the same two daemon endpoints back-to-back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)