### PR TITLE
cli: convert `stats` view flags to subcommands (#589)

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,11 +147,11 @@ budi db import
 ```bash
 budi status                  # daemon health + today's cost
 budi stats                   # cost and token summary
-budi stats --projects        # repos ranked by cost
-budi stats --branches        # branches ranked by cost
-budi stats --tickets         # tickets ranked by cost
-budi stats --models          # model breakdown
-budi stats --files           # files ranked by cost
+budi stats projects          # repos ranked by cost
+budi stats branches          # branches ranked by cost
+budi stats tickets           # tickets ranked by cost
+budi stats models            # model breakdown
+budi stats files             # files ranked by cost
 budi sessions                # recent sessions with cost and health
 budi sessions <id>           # session detail: cost, models, health, tags
 budi vitals                  # session health for the latest session
@@ -271,21 +271,21 @@ budi db import --format json       # JSON output with per-agent file/message bre
 ```bash
 budi status                        # quick overview: daemon and today's cost
 budi stats                         # usage summary with cost breakdown
-budi stats --models                # model usage breakdown
-budi stats --projects              # repos ranked by cost
-budi stats --projects --include-non-repo  # also show per-folder detail for non-repo work
-budi stats --branches              # branches ranked by cost
-budi stats --branch <name>         # cost for a specific branch
-budi stats --tickets               # tickets ranked by cost
-budi stats --ticket <id>           # cost for a specific ticket, with per-branch breakdown
-budi stats --activities            # activities ranked by cost (bugfix, refactor, …)
-budi stats --activity <name>       # cost for a specific activity, with per-branch breakdown
-budi stats --files                 # files ranked by cost (repo-relative paths only)
-budi stats --file <path>           # cost for a specific file, with per-branch + per-ticket breakdown
+budi stats models                  # model usage breakdown
+budi stats projects                # repos ranked by cost
+budi stats projects --include-non-repo  # also show per-folder detail for non-repo work
+budi stats branches                # branches ranked by cost
+budi stats branch <name>           # cost for a specific branch
+budi stats tickets                 # tickets ranked by cost
+budi stats ticket <id>             # cost for a specific ticket, with per-branch breakdown
+budi stats activities              # activities ranked by cost (bugfix, refactor, …)
+budi stats activity <name>         # cost for a specific activity, with per-branch breakdown
+budi stats files                   # files ranked by cost (repo-relative paths only)
+budi stats file <path>             # cost for a specific file, with per-branch + per-ticket breakdown
 budi stats --provider codex        # filter stats to a single provider
-budi stats --tag ticket_id         # cost per ticket value (raw tag view)
-budi stats --tag ticket_prefix     # cost per team prefix
-budi stats --files --limit 0       # show every row (default limit is 30)
+budi stats tag ticket_id           # cost per ticket value (raw tag view)
+budi stats tag ticket_prefix       # cost per team prefix
+budi stats files --limit 0         # show every row (default limit is 30)
 budi sessions                      # list recent sessions with cost and health
 budi sessions --ticket <id>        # sessions tagged with a ticket
 budi sessions --activity <name>    # sessions tagged with an activity

--- a/SOUL.md
+++ b/SOUL.md
@@ -201,7 +201,7 @@ CLI, daemon, and dashboard tell the same story (see ADR-0082 and
      earlier NULL-branch rows in the same session.
   3. **`Unassigned` repo + empty branch** — last-resort fallback. Rows in
      this state fold into the `(untagged)` DB bucket and render as
-     `(no branch)` in `budi stats --branches` (#450).
+     `(no branch)` in `budi stats branches` (#450).
 
   A detached HEAD (`gitBranch == "HEAD"`) is normalized to empty so that
   worktrees, mid-rebase sessions, and CI runs do not pollute the branches
@@ -233,9 +233,9 @@ CLI, daemon, and dashboard tell the same story (see ADR-0082 and
   models (suppressed from default output behind `--include-pending`).
 
   Surfaces:
-  - `budi stats --tickets` — list ranked by cost, with a `(no ticket)`
+  - `budi stats tickets` — list ranked by cost, with a `(no ticket)`
     bucket and a `src=…` column showing the dominant `ticket_source`.
-  - `budi stats --ticket <ID>` — detail view with per-branch breakdown
+  - `budi stats ticket <ID>` — detail view with per-branch breakdown
     and a `Source` row. Legacy rows without a `ticket_source` sibling
     tag default to `branch` (the legacy pipeline producer) so older
     DBs stay readable without a reindex.
@@ -270,11 +270,11 @@ CLI, daemon, and dashboard tell the same story (see ADR-0082 and
   value wins, ties broken alphabetically), falling back to `rule` /
   `medium` only when an activity has no companion tags yet (legacy data).
   Surfaces:
-  - `budi stats --activities` — list ranked by cost, with an
+  - `budi stats activities` — list ranked by cost, with an
     `(unclassified)` bucket (#450) for messages that never matched a
     classification rule (short prompts, slash commands, metadata-only
     messages).
-  - `budi stats --activity <NAME>` — detail view with per-branch
+  - `budi stats activity <NAME>` — detail view with per-branch
     breakdown, plus `source` and `confidence` labels.
   - `budi sessions --activity <NAME>` — sessions tagged with the
     activity, mirroring `--ticket`.
@@ -309,12 +309,12 @@ CLI, daemon, and dashboard tell the same story (see ADR-0082 and
   queryable the same way as `ticket_source` / `activity_source`.
 
   Surfaces:
-  - `budi stats --files` — files ranked by cost, with a `(no file tag)`
+  - `budi stats files` — files ranked by cost, with a `(no file tag)`
     bucket (#450) and a `src=…` column showing the dominant source.
     Long paths are middle-ellipsis truncated (configurable via
-    `--label-width N`); full paths stay available via `--file <PATH>`
+    `--label-width N`); full paths stay available via `budi stats file <PATH>`
     and `--format json`.
-  - `budi stats --file <PATH>` — detail view with per-branch **and**
+  - `budi stats file <PATH>` — detail view with per-branch **and**
     per-ticket breakdowns, so you can see which tickets charged cost
     to a particular file.
   - `GET /analytics/files` and `/analytics/files/{*path}` mirror the
@@ -453,7 +453,7 @@ Key points:
 - **cost_confidence**: determines `~` prefix in dashboard for non-exact costs
 - **Source of truth vs derived**: `messages` remains canonical; rollup tables are derived caches maintained incrementally via SQLite triggers during ingest/update/delete
 - **Session context propagation**: git_branch/repo_id flow from user -> assistant messages within a session
-- **Repository identity**: `repo_id` is `Some("host/owner/repo")` only when the cwd is inside a git repo with a remote origin. Non-repo work (scratch dirs, `~/Desktop`, brew-tap checkouts, local-only repos without upstream) persists `repo_id = NULL` and rolls up into a single `(no repository)` bucket in `budi stats --projects`. An idempotent one-shot backfill on startup rewrites any pre-8.3 bare-folder-name values (`Desktop`, `ivan.seredkin`, …) to NULL; `--include-non-repo` opts back into the per-folder detail.
+- **Repository identity**: `repo_id` is `Some("host/owner/repo")` only when the cwd is inside a git repo with a remote origin. Non-repo work (scratch dirs, `~/Desktop`, brew-tap checkouts, local-only repos without upstream) persists `repo_id = NULL` and rolls up into a single `(no repository)` bucket in `budi stats projects`. An idempotent one-shot backfill on startup rewrites any pre-8.3 bare-folder-name values (`Desktop`, `ivan.seredkin`, …) to NULL; `--include-non-repo` opts back into the per-folder detail.
 - **Progressive sync**: files processed newest-first so dashboard shows recent data quickly
 - **Historical import**: `budi db import` = full history backfill, `budi db import --force` = clear all data and re-ingest from scratch. `budi db <verb>` is the only surface — the pre-8.2.1 bare verbs (`budi migrate` / `budi repair` / `budi import`) were removed in 8.3.
 - **Legacy proxy residue (upgrade only)**: live traffic no longer flows through a proxy. The only remaining proxy-related code scans for 8.0/8.1 residue in shell profiles and agent configs, reports retained `proxy_estimated` history honestly, and lets users remove managed blocks via `budi init --cleanup` (consent-first) or `budi uninstall` (managed cleanup parity).

--- a/crates/budi-cli/src/commands/pricing.rs
+++ b/crates/budi-cli/src/commands/pricing.rs
@@ -41,7 +41,7 @@ pub fn cmd_pricing_status(format: StatsFormat, refresh: bool) -> Result<()> {
         // #443 acceptance: JSON consumers see the Budi display-name
         // alias overlay alongside the LiteLLM pricing status. The
         // overlay answers "how does a raw provider model id map to
-        // the canonical `budi stats --models` display name?" without
+        // the canonical `budi stats models` display name?" without
         // having to dump the whole 3k-entry LiteLLM manifest.
         let aliases = json_alias_catalogue();
         let combined = if let Some(r) = &refresh_body {

--- a/crates/budi-cli/src/commands/stats.rs
+++ b/crates/budi-cli/src/commands/stats.rs
@@ -10,8 +10,8 @@ use super::ansi;
 
 // ─── Shared Breakdown Rendering (#449) ───────────────────────────────────────
 //
-// Every `budi stats` breakdown view (`--projects / --branches / --tickets /
-// --activities / --files / --models / --tag`) ships through the same bar
+// Every `budi stats` breakdown view (`projects / branches / tickets /
+// activities / files / models / tag`) ships through the same bar
 // renderer, header shape, and footer so the visual signal never drifts. The
 // contract, nailed down by #449:
 //
@@ -1028,7 +1028,7 @@ fn cmd_stats_branch_detail(
         None => {
             println!("  No data found for branch '{}'.", branch);
             println!("  Tip: run `budi db import` first if you haven't imported data yet.");
-            println!("  Run `budi stats --branches` to see available branches.");
+            println!("  Run `budi stats branches` to see available branches.");
         }
     }
 
@@ -1230,7 +1230,7 @@ fn cmd_stats_ticket_detail(
         None => {
             println!("  No data found for ticket '{}'.", ticket);
             println!("  Tip: run `budi db import` first if you haven't imported data yet.");
-            println!("  Run `budi stats --tickets` to see available tickets.");
+            println!("  Run `budi stats tickets` to see available tickets.");
         }
     }
 
@@ -1438,7 +1438,7 @@ fn cmd_stats_activity_detail(
         None => {
             println!("  No data found for activity '{}'.", activity);
             println!("  Tip: run `budi db import` first if you haven't imported data yet.");
-            println!("  Run `budi stats --activities` to see available activities.");
+            println!("  Run `budi stats activities` to see available activities.");
         }
     }
 
@@ -1682,7 +1682,7 @@ fn cmd_stats_file_detail(
         None => {
             println!("  No data found for file '{}'.", file_path);
             println!("  Tip: run `budi db import` first if you haven't imported data yet.");
-            println!("  Run `budi stats --files` to see available files.");
+            println!("  Run `budi stats files` to see available files.");
         }
     }
 
@@ -2670,7 +2670,7 @@ mod tests {
 
     #[test]
     fn breakdown_row_snapshot_models_view() {
-        // Snapshot baseline for `budi stats --models` row layout
+        // Snapshot baseline for `budi stats models` row layout
         // (#449 acceptance). One row at the top of the scale, one
         // tiny but non-zero row, one $0 row — the three cases the
         // ticket's Reproduction section calls out as bug triggers.
@@ -2727,7 +2727,7 @@ mod tests {
 
     #[test]
     fn breakdown_row_snapshot_tickets_view() {
-        // Golden snapshot for `budi stats --tickets` — pinned so the
+        // Golden snapshot for `budi stats tickets` — pinned so the
         // bar/cost order cannot silently flip back to the pre-#449
         // layout (cost-before-bar).
         let label_w = 24usize;
@@ -2789,7 +2789,7 @@ mod tests {
 
     #[test]
     fn breakdown_row_snapshot_activities_view() {
-        // Golden snapshot for `budi stats --activities`. Preserves the
+        // Golden snapshot for `budi stats activities`. Preserves the
         // `conf=…` in-row legend (addressed more fully by #450) while
         // pinning the #449 layout contract.
         let label_w = 18usize;
@@ -2833,7 +2833,7 @@ mod tests {
 
     #[test]
     fn breakdown_row_snapshot_tag_view() {
-        // Golden snapshot for `budi stats --tag <key>` — the layout
+        // Golden snapshot for `budi stats tag <key>` — the layout
         // every other breakdown now mirrors. Kept as the canonical
         // shape so a future refactor that regresses one view will
         // fail a targeted test.

--- a/crates/budi-cli/src/main.rs
+++ b/crates/budi-cli/src/main.rs
@@ -17,7 +17,7 @@ const HEALTH_TIMEOUT_SECS: u64 = 3;
 #[command(about = "budi — AI cost analytics. Know where your tokens and money go.")]
 #[command(version)]
 #[command(
-    after_help = "Get started:\n  budi init\n\nCommon commands:\n  budi stats              Show today's cost summary\n  budi stats --models     Cost breakdown by model\n  budi stats --branches   Cost breakdown by branch\n  budi sessions           List recent sessions with cost and vitals\n  budi sessions <id>      Session detail: cost, models, vitals, tags\n  budi vitals             Session health vitals for the most recent session\n  budi status             Quick check: daemon and today's spend\n  budi doctor             Full diagnostic: daemon, tailer, schema, transcript visibility\n  budi cloud status       Cloud sync readiness and last-synced-at\n  budi cloud sync         Push queued local data to the cloud now\n  budi autostart status   Check daemon autostart service\n  budi db import          Import historical transcripts from disk\n  budi db import --force  Re-ingest all data from scratch (use after upgrades)\n  budi db repair          Repair schema drift and run migration\n  budi db migrate         Run database migration explicitly\n\nMore info: https://github.com/siropkin/budi"
+    after_help = "Get started:\n  budi init\n\nCommon commands:\n  budi stats              Show today's cost summary\n  budi stats models       Cost breakdown by model\n  budi stats branches     Cost breakdown by branch\n  budi sessions           List recent sessions with cost and vitals\n  budi sessions <id>      Session detail: cost, models, vitals, tags\n  budi vitals             Session health vitals for the most recent session\n  budi status             Quick check: daemon and today's spend\n  budi doctor             Full diagnostic: daemon, tailer, schema, transcript visibility\n  budi cloud status       Cloud sync readiness and last-synced-at\n  budi cloud sync         Push queued local data to the cloud now\n  budi autostart status   Check daemon autostart service\n  budi db import          Import historical transcripts from disk\n  budi db import --force  Re-ingest all data from scratch (use after upgrades)\n  budi db repair          Repair schema drift and run migration\n  budi db migrate         Run database migration explicitly\n\nMore info: https://github.com/siropkin/budi"
 )]
 struct Cli {
     #[command(subcommand)]
@@ -55,128 +55,26 @@ enum Commands {
         #[arg(long, hide = true)]
         repo_root: Option<PathBuf>,
     },
-    /// Show usage analytics (only one view flag at a time: --projects, --branches, --branch, --tickets, --ticket, --activities, --activity, --files, --file, --models, or --tag)
-    #[command(
-        group(clap::ArgGroup::new("view").multiple(false).args(["projects", "branches", "branch", "tickets", "ticket", "activities", "activity", "files", "file", "models", "tag"])),
-        after_help = "\
+    /// Show usage analytics. Bare `budi stats` prints today's summary; subcommands drill into specific views.
+    #[command(after_help = "\
 Examples:
   budi stats                       Today's cost summary (default)
   budi stats -p week               This week's summary
-  budi stats -p month --models     Model breakdown for the month
-  budi stats -p 7d                 Last 7 days (rolling window)
-  budi stats -p 2w                 Last 2 weeks (rolling window)
-  budi stats -p 1m                 Last 1 month (rolling, calendar months)
-  budi stats --branches            Branches ranked by cost (today)
-  budi stats --branch main         Cost details for a specific branch
-  budi stats --branch main --repo github.com/acme/app
-  budi stats --tickets             Tickets ranked by cost (today)
-  budi stats --ticket ENG-123      Cost details for a specific ticket
-  budi stats --ticket ENG-123 --repo github.com/acme/app
-  budi stats --activities          Activities ranked by cost (today)
-  budi stats --activity bugfix     Cost details for a specific activity
-  budi stats --files               Files ranked by cost (today)
-  budi stats --file src/main.rs    Cost details for a specific file
-  budi stats --projects -p all     All-time project costs
-  budi stats --tag activity        Raw cost breakdown by the activity tag
-  budi stats --provider cursor     Filter to Cursor only
-  budi stats --format json         JSON output for scripting"
-    )]
-    Stats {
-        /// Time period to show (today, week, month, all, or relative like 1d, 7d, 1m)
-        #[arg(long, short, default_value = "today")]
-        period: StatsPeriod,
-        /// Show repositories ranked by cost
-        #[arg(long, default_value_t = false)]
-        projects: bool,
-        /// Show branches ranked by cost
-        #[arg(long, default_value_t = false)]
-        branches: bool,
-        /// Show cost for a specific branch
-        #[arg(long)]
-        branch: Option<String>,
-        /// Show tickets ranked by cost (sourced from the `ticket_id` tag).
-        /// Mirrors `--branches` so ticket attribution is a first-class CLI
-        /// dimension alongside branches and repos.
-        #[arg(long, default_value_t = false)]
-        tickets: bool,
-        /// Show cost details for a specific ticket id (e.g. ENG-123).
-        /// Mirrors `--branch <NAME>` and includes a per-branch breakdown
-        /// of where the ticket was worked on.
-        #[arg(long, value_name = "ID")]
-        ticket: Option<String>,
-        /// Show activities ranked by cost (sourced from the `activity` tag
-        /// emitted by the prompt classifier). Mirrors `--tickets` so
-        /// activity attribution is a first-class CLI dimension.
-        #[arg(long, default_value_t = false)]
-        activities: bool,
-        /// Show cost details for a specific activity (e.g. `bugfix`,
-        /// `refactor`). Mirrors `--ticket <ID>` and includes a per-branch
-        /// breakdown so you can see where each kind of work was done.
-        #[arg(long, value_name = "NAME")]
-        activity: Option<String>,
-        /// Show files ranked by cost (sourced from the `file_path` tag
-        /// emitted by the pipeline when tool-call arguments point at a
-        /// file inside the repo root). Mirrors `--tickets` / `--activities`
-        /// so file-level attribution is a first-class CLI dimension.
-        #[arg(long, default_value_t = false)]
-        files: bool,
-        /// Show cost details for a specific file (repo-relative path,
-        /// forward-slashed, inside the repo root). Mirrors `--ticket <ID>`
-        /// and includes per-branch and per-ticket breakdowns so you can see
-        /// which tickets touched the file.
-        #[arg(long, value_name = "PATH")]
-        file: Option<String>,
-        /// Optional repository filter for --branch, --ticket, --activity,
-        /// or --file (recommended when names repeat across repos).
-        #[arg(long)]
-        repo: Option<String>,
-        /// Show model usage breakdown
-        #[arg(long, default_value_t = false)]
-        models: bool,
-        /// Filter by provider (e.g. claude_code, cursor, codex, copilot_cli, openai). Only works with the default summary view.
-        #[arg(long, conflicts_with = "view")]
-        provider: Option<String>,
-        /// Break down cost by the given tag KEY (e.g. `--tag ticket_id`,
-        /// `--tag activity`, `--tag custom_key`). Unlike `--tickets`
-        /// and `--activities`, which are first-class per-dimension
-        /// views with their own ranking shape, `--tag <KEY>` is the
-        /// escape hatch for any tag key the pipeline emits — including
-        /// custom keys that the CLI doesn't hard-code a flag for. The
-        /// output ranks rows by the tag's VALUES for that key.
-        #[arg(long, value_name = "KEY")]
-        tag: Option<String>,
-        /// Maximum rows to show in breakdown views (`--projects`,
-        /// `--branches`, `--tickets`, `--activities`, `--files`,
-        /// `--models`, `--tag`). `0` = no cap (show every matching row).
-        /// Truncated rows collapse into an `(other N: $X)` aggregate so
-        /// the Total footer always reconciles to the cent.
-        #[arg(long, default_value_t = 30)]
-        limit: usize,
-        /// Maximum characters for labels and label-like extra columns
-        /// (branch / file path / ticket id) in breakdown views. Values
-        /// longer than this truncate with a middle ellipsis (`…`). The
-        /// default balances readability on an 80-col terminal with the
-        /// natural length of file paths.
-        #[arg(long, default_value_t = 40)]
-        label_width: usize,
-        /// Include zero-cost `(model not yet attributed)` rows in
-        /// `--models` output. By default, Cursor-lag transient rows
-        /// that carry no backing cost are collapsed into a
-        /// suppressed-count footnote; pass `--include-pending` to
-        /// see them as their own row. Rows with real Cursor-Auto
-        /// cost always render regardless of this flag.
-        #[arg(long, default_value_t = false)]
-        include_pending: bool,
-        /// Break out the `(no repository)` bucket in `--projects` into a
-        /// per-folder breakdown keyed on the cwd basename. Off by
-        /// default so the main Repositories table stays clean of
-        /// `Desktop` / `~` / scratch-dir rows.
-        #[arg(long, default_value_t = false)]
-        include_non_repo: bool,
-        /// Output format: text (default) or json
-        #[arg(short, long, value_enum, default_value_t = StatsFormat::Text)]
-        format: StatsFormat,
-    },
+  budi stats projects -p all       All-time project costs
+  budi stats branches              Branches ranked by cost (today)
+  budi stats branch main           Cost details for a specific branch
+  budi stats branch main --repo github.com/acme/app
+  budi stats tickets               Tickets ranked by cost (today)
+  budi stats ticket ENG-123        Cost details for a specific ticket
+  budi stats activities            Activities ranked by cost (today)
+  budi stats activity bugfix       Cost details for a specific activity
+  budi stats files                 Files ranked by cost (today)
+  budi stats file src/main.rs      Cost details for a specific file
+  budi stats models                Model usage breakdown
+  budi stats tag activity          Raw cost breakdown by the activity tag
+  budi stats --provider cursor     Filter summary to Cursor only
+  budi stats --format json         JSON output for scripting")]
+    Stats(StatsArgs),
     /// Update budi to the latest version
     Update {
         /// Skip confirmation prompt
@@ -343,6 +241,103 @@ Examples:
     Pricing {
         #[command(subcommand)]
         action: PricingAction,
+    },
+}
+
+/// Top-level args for `budi stats`. Bare invocation (no subcommand) renders
+/// the default summary scoped by `--period` / `--provider` / `--format`.
+/// Subcommands drill into a specific view; their flags are global so they
+/// parse equivalently before or after the subcommand name.
+#[derive(Debug, clap::Args)]
+pub struct StatsArgs {
+    #[command(subcommand)]
+    pub view: Option<StatsView>,
+    #[command(flatten)]
+    pub opts: StatsOpts,
+}
+
+/// Shared output / filter knobs for every `budi stats` view. Every flag is
+/// `global = true` so it parses at any depth (`budi stats -p week projects`
+/// and `budi stats projects -p week` are equivalent).
+#[derive(Debug, clap::Args)]
+pub struct StatsOpts {
+    /// Time period to show (today, week, month, all, or relative like 1d, 7d, 1m)
+    #[arg(long, short, default_value = "today", global = true)]
+    pub period: StatsPeriod,
+    /// Optional repository filter for `branch`, `ticket`, `activity`, or
+    /// `file` detail views (recommended when names repeat across repos).
+    #[arg(long, global = true)]
+    pub repo: Option<String>,
+    /// Filter by provider (e.g. claude_code, cursor, codex, copilot_cli, openai). Only meaningful for the default summary view.
+    #[arg(long, global = true)]
+    pub provider: Option<String>,
+    /// Maximum rows in breakdown views (`projects`, `branches`, `tickets`,
+    /// `activities`, `files`, `models`, `tag`). `0` = no cap. Truncated
+    /// rows collapse into an `(other N: $X)` aggregate so the Total
+    /// footer always reconciles to the cent.
+    #[arg(long, default_value_t = 30, global = true)]
+    pub limit: usize,
+    /// Maximum characters for labels and label-like extra columns in
+    /// breakdown views. Values longer than this truncate with a middle
+    /// ellipsis (`…`).
+    #[arg(long, default_value_t = 40, global = true)]
+    pub label_width: usize,
+    /// Include zero-cost `(model not yet attributed)` rows in the
+    /// `models` view. By default Cursor-lag transient rows are collapsed
+    /// into a suppressed-count footnote.
+    #[arg(long, default_value_t = false, global = true)]
+    pub include_pending: bool,
+    /// Break out the `(no repository)` bucket in `projects` into a
+    /// per-folder breakdown keyed on the cwd basename.
+    #[arg(long, default_value_t = false, global = true)]
+    pub include_non_repo: bool,
+    /// Output format: text (default) or json
+    #[arg(short, long, value_enum, default_value_t = StatsFormat::Text, global = true)]
+    pub format: StatsFormat,
+}
+
+/// Drill-in views for `budi stats`. Each variant maps to one of the
+/// pre-8.3.14 mutually-exclusive view flags. Singular variants take an
+/// argument (the specific entity to drill into); plural variants render
+/// a ranked breakdown.
+#[derive(Debug, Subcommand)]
+pub enum StatsView {
+    /// Repositories ranked by cost
+    Projects,
+    /// Branches ranked by cost
+    Branches,
+    /// Cost details for a specific branch
+    Branch {
+        /// Branch name (e.g. `main`)
+        name: String,
+    },
+    /// Tickets ranked by cost
+    Tickets,
+    /// Cost details for a specific ticket
+    Ticket {
+        /// Ticket id (e.g. ENG-123)
+        id: String,
+    },
+    /// Activities ranked by cost
+    Activities,
+    /// Cost details for a specific activity
+    Activity {
+        /// Activity name (e.g. `bugfix`, `refactor`)
+        name: String,
+    },
+    /// Files ranked by cost
+    Files,
+    /// Cost details for a specific file
+    File {
+        /// Repo-relative file path (forward-slashed, inside the repo root)
+        path: String,
+    },
+    /// Cost breakdown by model
+    Models,
+    /// Raw cost breakdown by tag KEY (escape hatch for custom tag keys)
+    Tag {
+        /// Tag key (e.g. `ticket_id`, `activity`, or any custom key)
+        key: String,
     },
 }
 
@@ -627,28 +622,48 @@ fn main() -> Result<()> {
             quiet,
             repo_root,
         } => commands::doctor::cmd_doctor(repo_root, deep, quiet),
-        Commands::Stats {
-            period,
-            projects,
-            branches,
-            branch,
-            tickets,
-            ticket,
-            activities,
-            activity,
-            files,
-            file,
-            repo,
-            models,
-            provider,
-            tag,
-            limit,
-            label_width,
-            include_pending,
-            include_non_repo,
-            format,
-        } => {
+        Commands::Stats(args) => {
+            let StatsArgs { view, opts } = args;
+            let StatsOpts {
+                period,
+                repo,
+                provider,
+                limit,
+                label_width,
+                include_pending,
+                include_non_repo,
+                format,
+            } = opts;
             let json_output = matches!(format, StatsFormat::Json);
+            // Translate the new subcommand shape to the existing
+            // `cmd_stats` dispatch — the helper still drives the
+            // per-view rendering, we just project `view` back into the
+            // legacy boolean / Option arguments it expects.
+            let mut projects = false;
+            let mut branches = false;
+            let mut branch: Option<String> = None;
+            let mut tickets = false;
+            let mut ticket: Option<String> = None;
+            let mut activities = false;
+            let mut activity: Option<String> = None;
+            let mut files = false;
+            let mut file: Option<String> = None;
+            let mut models = false;
+            let mut tag: Option<String> = None;
+            match view {
+                None => {}
+                Some(StatsView::Projects) => projects = true,
+                Some(StatsView::Branches) => branches = true,
+                Some(StatsView::Branch { name }) => branch = Some(name),
+                Some(StatsView::Tickets) => tickets = true,
+                Some(StatsView::Ticket { id }) => ticket = Some(id),
+                Some(StatsView::Activities) => activities = true,
+                Some(StatsView::Activity { name }) => activity = Some(name),
+                Some(StatsView::Files) => files = true,
+                Some(StatsView::File { path }) => file = Some(path),
+                Some(StatsView::Models) => models = true,
+                Some(StatsView::Tag { key }) => tag = Some(key),
+            }
             commands::stats::cmd_stats(
                 period,
                 projects,
@@ -912,47 +927,58 @@ mod tests {
     }
 
     #[test]
-    fn cli_parses_stats_tickets_flag() {
+    fn cli_parses_stats_tickets_subcommand() {
         let cli =
-            Cli::try_parse_from(["budi", "stats", "--tickets"]).expect("budi stats --tickets");
+            Cli::try_parse_from(["budi", "stats", "tickets"]).expect("budi stats tickets parses");
         match cli.command {
-            Commands::Stats {
-                tickets, ticket, ..
-            } => {
-                assert!(tickets);
-                assert!(ticket.is_none());
+            Commands::Stats(args) => {
+                assert!(matches!(args.view, Some(StatsView::Tickets)));
             }
             _ => panic!("expected stats command"),
         }
     }
 
     #[test]
-    fn cli_parses_stats_ticket_value_flag() {
-        let cli = Cli::try_parse_from(["budi", "stats", "--ticket", "PAVA-2057"])
-            .expect("budi stats --ticket PAVA-2057");
+    fn cli_parses_stats_ticket_subcommand() {
+        let cli = Cli::try_parse_from(["budi", "stats", "ticket", "PAVA-2057"])
+            .expect("budi stats ticket PAVA-2057 parses");
         match cli.command {
-            Commands::Stats {
-                tickets, ticket, ..
-            } => {
-                assert!(!tickets);
-                assert_eq!(ticket.as_deref(), Some("PAVA-2057"));
-            }
+            Commands::Stats(args) => match args.view {
+                Some(StatsView::Ticket { id }) => assert_eq!(id, "PAVA-2057"),
+                other => panic!("expected ticket variant, got {:?}", other),
+            },
             _ => panic!("expected stats command"),
         }
     }
 
     #[test]
-    fn cli_stats_view_flags_are_mutually_exclusive() {
-        // --tickets vs --ticket
-        assert!(Cli::try_parse_from(["budi", "stats", "--tickets", "--ticket", "X-1"]).is_err());
-        // --tickets vs --branches
-        assert!(Cli::try_parse_from(["budi", "stats", "--tickets", "--branches"]).is_err());
-        // --ticket vs --branch
-        assert!(
-            Cli::try_parse_from(["budi", "stats", "--ticket", "X-1", "--branch", "main"]).is_err()
-        );
-        // --tickets vs --models
-        assert!(Cli::try_parse_from(["budi", "stats", "--tickets", "--models"]).is_err());
+    fn cli_stats_legacy_view_flags_are_rejected() {
+        // #589: the 11 mutually-exclusive view flags (--projects /
+        // --branches / --branch / --tickets / --ticket / --activities /
+        // --activity / --files / --file / --models / --tag) were removed
+        // in favor of subcommands. Regression guard so they don't quietly
+        // come back.
+        assert!(Cli::try_parse_from(["budi", "stats", "--tickets"]).is_err());
+        assert!(Cli::try_parse_from(["budi", "stats", "--ticket", "X-1"]).is_err());
+        assert!(Cli::try_parse_from(["budi", "stats", "--branches"]).is_err());
+        assert!(Cli::try_parse_from(["budi", "stats", "--branch", "main"]).is_err());
+        assert!(Cli::try_parse_from(["budi", "stats", "--activities"]).is_err());
+        assert!(Cli::try_parse_from(["budi", "stats", "--activity", "bugfix"]).is_err());
+        assert!(Cli::try_parse_from(["budi", "stats", "--files"]).is_err());
+        assert!(Cli::try_parse_from(["budi", "stats", "--file", "x.rs"]).is_err());
+        assert!(Cli::try_parse_from(["budi", "stats", "--models"]).is_err());
+        assert!(Cli::try_parse_from(["budi", "stats", "--projects"]).is_err());
+        assert!(Cli::try_parse_from(["budi", "stats", "--tag", "ticket_id"]).is_err());
+    }
+
+    #[test]
+    fn cli_stats_subcommands_are_mutually_exclusive_by_construction() {
+        // With clap subcommands, only one drill-in view can be selected
+        // per invocation by definition. Passing two subcommand names back
+        // to back parses the first as the view and the second as a
+        // positional / unknown argument, which clap rejects.
+        assert!(Cli::try_parse_from(["budi", "stats", "tickets", "branches"]).is_err());
+        assert!(Cli::try_parse_from(["budi", "stats", "models", "files"]).is_err());
     }
 
     #[test]
@@ -960,16 +986,19 @@ mod tests {
         let cli = Cli::try_parse_from([
             "budi",
             "stats",
-            "--ticket",
+            "ticket",
             "PAVA-2057",
             "--repo",
             "siropkin/budi",
         ])
-        .expect("budi stats --ticket --repo");
+        .expect("budi stats ticket --repo parses");
         match cli.command {
-            Commands::Stats { ticket, repo, .. } => {
-                assert_eq!(ticket.as_deref(), Some("PAVA-2057"));
-                assert_eq!(repo.as_deref(), Some("siropkin/budi"));
+            Commands::Stats(args) => {
+                match args.view {
+                    Some(StatsView::Ticket { id }) => assert_eq!(id, "PAVA-2057"),
+                    other => panic!("expected ticket variant, got {:?}", other),
+                }
+                assert_eq!(args.opts.repo.as_deref(), Some("siropkin/budi"));
             }
             _ => panic!("expected stats command"),
         }
@@ -988,58 +1017,28 @@ mod tests {
     }
 
     #[test]
-    fn cli_parses_stats_activities_flag() {
-        let cli = Cli::try_parse_from(["budi", "stats", "--activities"])
-            .expect("budi stats --activities parses");
+    fn cli_parses_stats_activities_subcommand() {
+        let cli = Cli::try_parse_from(["budi", "stats", "activities"])
+            .expect("budi stats activities parses");
         match cli.command {
-            Commands::Stats {
-                activities,
-                activity,
-                ..
-            } => {
-                assert!(activities);
-                assert!(activity.is_none());
+            Commands::Stats(args) => {
+                assert!(matches!(args.view, Some(StatsView::Activities)));
             }
             _ => panic!("expected stats command"),
         }
     }
 
     #[test]
-    fn cli_parses_stats_activity_value_flag() {
-        let cli = Cli::try_parse_from(["budi", "stats", "--activity", "bugfix"])
-            .expect("budi stats --activity bugfix parses");
+    fn cli_parses_stats_activity_subcommand() {
+        let cli = Cli::try_parse_from(["budi", "stats", "activity", "bugfix"])
+            .expect("budi stats activity bugfix parses");
         match cli.command {
-            Commands::Stats {
-                activities,
-                activity,
-                ..
-            } => {
-                assert!(!activities);
-                assert_eq!(activity.as_deref(), Some("bugfix"));
-            }
+            Commands::Stats(args) => match args.view {
+                Some(StatsView::Activity { name }) => assert_eq!(name, "bugfix"),
+                other => panic!("expected activity variant, got {:?}", other),
+            },
             _ => panic!("expected stats command"),
         }
-    }
-
-    #[test]
-    fn cli_stats_activity_is_mutually_exclusive_with_other_views() {
-        // --activities vs --tickets / --branches / --activity / --models
-        assert!(
-            Cli::try_parse_from(["budi", "stats", "--activities", "--tickets"]).is_err(),
-            "--activities and --tickets must be mutually exclusive"
-        );
-        assert!(
-            Cli::try_parse_from(["budi", "stats", "--activities", "--branches"]).is_err(),
-            "--activities and --branches must be mutually exclusive"
-        );
-        assert!(
-            Cli::try_parse_from(["budi", "stats", "--activities", "--activity", "bugfix"]).is_err(),
-            "--activities and --activity must be mutually exclusive"
-        );
-        assert!(
-            Cli::try_parse_from(["budi", "stats", "--activity", "bugfix", "--models"]).is_err(),
-            "--activity and --models must be mutually exclusive"
-        );
     }
 
     #[test]
@@ -1047,66 +1046,48 @@ mod tests {
         let cli = Cli::try_parse_from([
             "budi",
             "stats",
-            "--activity",
+            "activity",
             "bugfix",
             "--repo",
             "siropkin/budi",
         ])
-        .expect("budi stats --activity --repo parses");
+        .expect("budi stats activity --repo parses");
         match cli.command {
-            Commands::Stats { activity, repo, .. } => {
-                assert_eq!(activity.as_deref(), Some("bugfix"));
-                assert_eq!(repo.as_deref(), Some("siropkin/budi"));
+            Commands::Stats(args) => {
+                match args.view {
+                    Some(StatsView::Activity { name }) => assert_eq!(name, "bugfix"),
+                    other => panic!("expected activity variant, got {:?}", other),
+                }
+                assert_eq!(args.opts.repo.as_deref(), Some("siropkin/budi"));
             }
             _ => panic!("expected stats command"),
         }
     }
 
     #[test]
-    fn cli_parses_stats_files_flag() {
-        let cli =
-            Cli::try_parse_from(["budi", "stats", "--files"]).expect("budi stats --files parses");
+    fn cli_parses_stats_files_subcommand() {
+        let cli = Cli::try_parse_from(["budi", "stats", "files"]).expect("budi stats files parses");
         match cli.command {
-            Commands::Stats { files, file, .. } => {
-                assert!(files);
-                assert!(file.is_none());
+            Commands::Stats(args) => {
+                assert!(matches!(args.view, Some(StatsView::Files)));
             }
             _ => panic!("expected stats command"),
         }
     }
 
     #[test]
-    fn cli_parses_stats_file_value_flag() {
-        let cli = Cli::try_parse_from(["budi", "stats", "--file", "crates/budi-core/src/lib.rs"])
-            .expect("budi stats --file <path> parses");
+    fn cli_parses_stats_file_subcommand() {
+        let cli = Cli::try_parse_from(["budi", "stats", "file", "crates/budi-core/src/lib.rs"])
+            .expect("budi stats file <path> parses");
         match cli.command {
-            Commands::Stats { files, file, .. } => {
-                assert!(!files);
-                assert_eq!(file.as_deref(), Some("crates/budi-core/src/lib.rs"));
-            }
+            Commands::Stats(args) => match args.view {
+                Some(StatsView::File { path }) => {
+                    assert_eq!(path, "crates/budi-core/src/lib.rs")
+                }
+                other => panic!("expected file variant, got {:?}", other),
+            },
             _ => panic!("expected stats command"),
         }
-    }
-
-    #[test]
-    fn cli_stats_file_is_mutually_exclusive_with_other_views() {
-        // --files vs --tickets / --branches / --file / --models etc.
-        assert!(
-            Cli::try_parse_from(["budi", "stats", "--files", "--tickets"]).is_err(),
-            "--files and --tickets must be mutually exclusive"
-        );
-        assert!(
-            Cli::try_parse_from(["budi", "stats", "--files", "--activities"]).is_err(),
-            "--files and --activities must be mutually exclusive"
-        );
-        assert!(
-            Cli::try_parse_from(["budi", "stats", "--files", "--file", "x.rs"]).is_err(),
-            "--files and --file must be mutually exclusive"
-        );
-        assert!(
-            Cli::try_parse_from(["budi", "stats", "--file", "x.rs", "--models"]).is_err(),
-            "--file and --models must be mutually exclusive"
-        );
     }
 
     #[test]
@@ -1114,16 +1095,133 @@ mod tests {
         let cli = Cli::try_parse_from([
             "budi",
             "stats",
-            "--file",
+            "file",
             "src/main.rs",
             "--repo",
             "siropkin/budi",
         ])
-        .expect("budi stats --file --repo parses");
+        .expect("budi stats file --repo parses");
         match cli.command {
-            Commands::Stats { file, repo, .. } => {
-                assert_eq!(file.as_deref(), Some("src/main.rs"));
-                assert_eq!(repo.as_deref(), Some("siropkin/budi"));
+            Commands::Stats(args) => {
+                match args.view {
+                    Some(StatsView::File { path }) => assert_eq!(path, "src/main.rs"),
+                    other => panic!("expected file variant, got {:?}", other),
+                }
+                assert_eq!(args.opts.repo.as_deref(), Some("siropkin/budi"));
+            }
+            _ => panic!("expected stats command"),
+        }
+    }
+
+    #[test]
+    fn cli_stats_global_flags_parse_after_subcommand() {
+        // Regression guard: shared flags marked `global = true` must
+        // parse equivalently before or after the subcommand name. The
+        // typical user reach is `budi stats projects -p week` (after).
+        let cli = Cli::try_parse_from(["budi", "stats", "projects", "-p", "week"])
+            .expect("budi stats projects -p week should parse");
+        match cli.command {
+            Commands::Stats(args) => {
+                assert!(matches!(args.view, Some(StatsView::Projects)));
+                assert_eq!(args.opts.period, StatsPeriod::Week);
+            }
+            _ => panic!("expected stats command"),
+        }
+
+        // `budi stats branches --limit 5 --format json` exercises three
+        // shared knobs at once on a breakdown view.
+        let cli = Cli::try_parse_from([
+            "budi", "stats", "branches", "--limit", "5", "--format", "json",
+        ])
+        .expect("budi stats branches with shared opts should parse");
+        match cli.command {
+            Commands::Stats(args) => {
+                assert!(matches!(args.view, Some(StatsView::Branches)));
+                assert_eq!(args.opts.limit, 5);
+                assert_eq!(args.opts.format, StatsFormat::Json);
+            }
+            _ => panic!("expected stats command"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_stats_models_subcommand() {
+        let cli =
+            Cli::try_parse_from(["budi", "stats", "models"]).expect("budi stats models parses");
+        match cli.command {
+            Commands::Stats(args) => assert!(matches!(args.view, Some(StatsView::Models))),
+            _ => panic!("expected stats command"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_stats_projects_subcommand() {
+        let cli = Cli::try_parse_from(["budi", "stats", "projects", "-p", "all"])
+            .expect("budi stats projects -p all parses");
+        match cli.command {
+            Commands::Stats(args) => {
+                assert!(matches!(args.view, Some(StatsView::Projects)));
+                assert_eq!(args.opts.period, StatsPeriod::All);
+            }
+            _ => panic!("expected stats command"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_stats_branches_subcommand() {
+        let cli =
+            Cli::try_parse_from(["budi", "stats", "branches"]).expect("budi stats branches parses");
+        match cli.command {
+            Commands::Stats(args) => assert!(matches!(args.view, Some(StatsView::Branches))),
+            _ => panic!("expected stats command"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_stats_branch_subcommand() {
+        let cli = Cli::try_parse_from(["budi", "stats", "branch", "main"])
+            .expect("budi stats branch main parses");
+        match cli.command {
+            Commands::Stats(args) => match args.view {
+                Some(StatsView::Branch { name }) => assert_eq!(name, "main"),
+                other => panic!("expected branch variant, got {:?}", other),
+            },
+            _ => panic!("expected stats command"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_stats_tag_subcommand() {
+        let cli = Cli::try_parse_from(["budi", "stats", "tag", "activity"])
+            .expect("budi stats tag activity parses");
+        match cli.command {
+            Commands::Stats(args) => match args.view {
+                Some(StatsView::Tag { key }) => assert_eq!(key, "activity"),
+                other => panic!("expected tag variant, got {:?}", other),
+            },
+            _ => panic!("expected stats command"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_bare_stats() {
+        // No subcommand → default summary view. Shared opts still parse
+        // at the top level.
+        let cli = Cli::try_parse_from(["budi", "stats"]).expect("bare budi stats parses");
+        match cli.command {
+            Commands::Stats(args) => {
+                assert!(args.view.is_none());
+                assert_eq!(args.opts.period, StatsPeriod::Today);
+            }
+            _ => panic!("expected stats command"),
+        }
+
+        let cli = Cli::try_parse_from(["budi", "stats", "--provider", "cursor"])
+            .expect("budi stats --provider cursor parses");
+        match cli.command {
+            Commands::Stats(args) => {
+                assert!(args.view.is_none());
+                assert_eq!(args.opts.provider.as_deref(), Some("cursor"));
             }
             _ => panic!("expected stats command"),
         }
@@ -1453,21 +1551,21 @@ mod tests {
         let cli = Cli::try_parse_from(["budi", "stats", "-p", "7d"])
             .expect("budi stats -p 7d should parse");
         match cli.command {
-            Commands::Stats { period, .. } => assert_eq!(period, StatsPeriod::Days(7)),
+            Commands::Stats(args) => assert_eq!(args.opts.period, StatsPeriod::Days(7)),
             _ => panic!("expected stats command"),
         }
 
         let cli = Cli::try_parse_from(["budi", "stats", "--period", "2w"])
             .expect("budi stats --period 2w should parse");
         match cli.command {
-            Commands::Stats { period, .. } => assert_eq!(period, StatsPeriod::Weeks(2)),
+            Commands::Stats(args) => assert_eq!(args.opts.period, StatsPeriod::Weeks(2)),
             _ => panic!("expected stats command"),
         }
 
         let cli = Cli::try_parse_from(["budi", "stats", "-p", "1m"])
             .expect("budi stats -p 1m should parse");
         match cli.command {
-            Commands::Stats { period, .. } => assert_eq!(period, StatsPeriod::Months(1)),
+            Commands::Stats(args) => assert_eq!(args.opts.period, StatsPeriod::Months(1)),
             _ => panic!("expected stats command"),
         }
 


### PR DESCRIPTION
## Summary

Closes #589.

Replaces the 11 mutually-exclusive `budi stats` view flags with clap subcommands. Shared options live in a single `StatsOpts` struct and are marked `global = true`, so `-p week` and `--format json` parse the same way before or after the subcommand name.

```
# Before
budi stats --tickets
budi stats --ticket ENG-123 --repo siropkin/budi
budi stats --activities
budi stats --activity bugfix
budi stats --files
budi stats --models -p week
budi stats --tag activity

# After
budi stats tickets
budi stats ticket ENG-123 --repo siropkin/budi
budi stats activities
budi stats activity bugfix
budi stats files
budi stats models -p week
budi stats tag activity
```

Bare `budi stats` (no subcommand) is unchanged — still renders today's summary, still respects `--provider` / `--format` / `-p`.

The 11 legacy flags are **removed entirely** (no users, safe to break); a regression guard test (`cli_stats_legacy_view_flags_are_rejected`) ensures they don't sneak back in.

## Notable changes

- New `StatsArgs` / `StatsView` / `StatsOpts` types in `crates/budi-cli/src/main.rs`
- Dispatch in `main()` projects the new subcommand shape back into the existing `cmd_stats(...)` signature so the per-view rendering helpers in `commands/stats.rs` are untouched
- README, SOUL.md, and in-tip text (`Run \`budi stats branches\` to see available branches.`) updated to the subcommand form
- `budi stats --help` shrinks from a wall of 11 mutually-exclusive flags to a clean subcommand list; each subcommand has its own focused `--help`

## Test plan

- [x] `cargo build -p budi-cli` clean
- [x] `cargo clippy -p budi-cli --all-targets -- -D warnings` clean
- [x] `cargo fmt -p budi-cli --check` clean
- [x] `cargo test -p budi-cli` — 191 passed, 0 failed
- [x] Smoke-tested live: `budi stats projects -p week`, `budi stats ticket ENG-123 --repo siropkin/budi`, `budi stats branches --limit 5 --format json`
- [x] Verified bare `budi stats` and `budi stats --provider cursor --format json` still work
- [x] Verified `budi stats --tickets` (and the other 10 legacy flags) now error with clap unknown-flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)