### PR TITLE
cli: split `pricing status` and `pricing sync` (drop `status --refresh`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,9 +299,9 @@ budi vitals --session <id>         # health vitals for a specific session
 ```bash
 budi doctor                        # check health: daemon, tailer, schema, transcript visibility
 budi doctor --deep                 # run full SQLite integrity_check (slower)
-budi pricing status                # pricing manifest source, version, fetched-at, model count
-budi pricing status --refresh      # trigger an immediate LiteLLM manifest refresh
-budi pricing status --json         # same data in JSON
+budi pricing                       # pricing manifest source, version, fetched-at, model count (read-only)
+budi pricing sync                  # fetch the latest LiteLLM manifest into the local cache
+budi pricing --format json         # same data in JSON
 budi cloud init                    # generate ~/.config/budi/cloud.toml from a commented template
 budi cloud init --api-key KEY      # write the key + enable sync in one step
 budi cloud status                  # cloud sync readiness + last-synced-at + queued records

--- a/SOUL.md
+++ b/SOUL.md
@@ -496,7 +496,7 @@ Key points:
 - `crates/budi-cli/src/commands/status.rs` — `budi status` quick overview (daemon, today's cost, first-run hints).
 - `crates/budi-cli/src/commands/statusline.rs` — Statusline rendering (default quiet rolling `1d` / `7d` / `30d`, provider-scoped; `coach` / `full` opt-in variants).
 - `crates/budi-cli/src/commands/cloud.rs` — `budi cloud sync` / `budi cloud status` / `budi cloud init` (text + JSON; exit code 2 on non-ok sync).
-- `crates/budi-cli/src/commands/pricing.rs` — `budi pricing status [--json] [--refresh]`.
+- `crates/budi-cli/src/commands/pricing.rs` — `budi pricing` / `budi pricing status` (read-only) + `budi pricing sync` (network refresh; mirrors `cloud sync`). Both accept `--format json`.
 <!-- budi-cursor and budi-cloud live in their own repos: siropkin/budi-cursor, siropkin/budi-cloud -->
 
 ## Dev notes

--- a/crates/budi-cli/src/commands/pricing.rs
+++ b/crates/budi-cli/src/commands/pricing.rs
@@ -1,4 +1,4 @@
-//! `budi pricing` subcommand — manifest status + manual refresh.
+//! `budi pricing` subcommand — manifest status (read-only) and sync (network).
 //!
 //! Surfaces what [`budi_core::pricing::current_state`] knows about the
 //! in-memory pricing manifest: which layer is authoritative (disk cache
@@ -7,13 +7,15 @@
 //! model ids seen in transcripts that aren't in the manifest yet (those
 //! get `cost_cents = 0` until a refresh resolves them, ADR-0091 §2).
 //!
-//! The `--refresh` flag triggers an immediate manifest fetch via
+//! `pricing sync` triggers an immediate manifest fetch via
 //! `POST /pricing/refresh` and then prints the post-refresh status. This
-//! is the only user-facing way to skip the 24 h worker cadence.
+//! is the only user-facing way to skip the 24 h worker cadence; in 8.3.14
+//! it replaces the pre-existing `pricing status --refresh` flag, mirroring
+//! the `cloud sync` direction-tagged verb shape (#584).
 //!
 //! Output format matches the `budi cloud status` contract: `--format
 //! text` is the default, `--format json` emits the daemon payload
-//! verbatim for scripting. Exit code is `2` on refresh failure so CI
+//! verbatim for scripting. Exit code is `2` on `sync` failure so CI
 //! scripts can branch on status without parsing the body.
 
 use anyhow::Result;
@@ -25,16 +27,9 @@ use crate::client::DaemonClient;
 
 use super::{ansi, format_cost};
 
-/// `budi pricing status [--json] [--refresh]`
-pub fn cmd_pricing_status(format: StatsFormat, refresh: bool) -> Result<()> {
+/// `budi pricing` (bare) and `budi pricing status` — read-only manifest state.
+pub fn cmd_pricing_status(format: StatsFormat) -> Result<()> {
     let client = DaemonClient::connect()?;
-
-    let refresh_body = if refresh {
-        Some(client.pricing_refresh()?)
-    } else {
-        None
-    };
-
     let status = client.pricing_status()?;
 
     if matches!(format, StatsFormat::Json) {
@@ -44,26 +39,50 @@ pub fn cmd_pricing_status(format: StatsFormat, refresh: bool) -> Result<()> {
         // the canonical `budi stats models` display name?" without
         // having to dump the whole 3k-entry LiteLLM manifest.
         let aliases = json_alias_catalogue();
-        let combined = if let Some(r) = &refresh_body {
-            serde_json::json!({ "refresh": r, "status": status, "aliases": aliases })
-        } else {
-            serde_json::json!({ "status": status, "aliases": aliases })
-        };
+        let combined = serde_json::json!({ "status": status, "aliases": aliases });
         super::print_json(&combined)?;
-        if let Some(r) = refresh_body.as_ref()
-            && r.get("ok").and_then(Value::as_bool) != Some(true)
-        {
+        return Ok(());
+    }
+
+    render_status_text(&status);
+    render_alias_map_text();
+    Ok(())
+}
+
+/// `budi pricing sync` — fetch the latest LiteLLM manifest, then show state.
+///
+/// 8.3.14 (#584) split this off the pre-existing `pricing status --refresh`
+/// flag so the only network-touching verb in the namespace lives behind its
+/// own subcommand, matching the `cloud sync` shape. Exit code is `2` on
+/// refresh failure so CI scripts can branch on status without parsing the
+/// body.
+pub fn cmd_pricing_sync(format: StatsFormat) -> Result<()> {
+    let client = DaemonClient::connect()?;
+    let refresh_body = client.pricing_refresh()?;
+    let status = client.pricing_status()?;
+    let ok = refresh_body
+        .get("ok")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+
+    if matches!(format, StatsFormat::Json) {
+        let aliases = json_alias_catalogue();
+        let combined = serde_json::json!({
+            "refresh": refresh_body,
+            "status": status,
+            "aliases": aliases,
+        });
+        super::print_json(&combined)?;
+        if !ok {
             std::process::exit(2);
         }
         return Ok(());
     }
 
-    if let Some(r) = &refresh_body {
-        render_refresh_text(r);
-        if r.get("ok").and_then(Value::as_bool) != Some(true) {
-            render_status_text(&status);
-            std::process::exit(2);
-        }
+    render_refresh_text(&refresh_body);
+    if !ok {
+        render_status_text(&status);
+        std::process::exit(2);
     }
     render_status_text(&status);
     render_alias_map_text();

--- a/crates/budi-cli/src/main.rs
+++ b/crates/budi-cli/src/main.rs
@@ -1447,8 +1447,8 @@ mod tests {
             _ => panic!("expected pricing command"),
         }
 
-        let cli = Cli::try_parse_from(["budi", "pricing", "status"])
-            .expect("budi pricing status parses");
+        let cli =
+            Cli::try_parse_from(["budi", "pricing", "status"]).expect("budi pricing status parses");
         match cli.command {
             Commands::Pricing(args) => assert!(matches!(args.view, Some(PricingView::Status))),
             _ => panic!("expected pricing status command"),

--- a/crates/budi-cli/src/main.rs
+++ b/crates/budi-cli/src/main.rs
@@ -232,16 +232,21 @@ Examples:
         #[command(subcommand)]
         action: CloudAction,
     },
-    /// Pricing manifest: view status, trigger a manual refresh
+    /// Pricing manifest: view status (read-only) or sync from upstream (network)
+    ///
+    /// Bare `budi pricing` defaults to the read-only `pricing status` view.
+    /// `pricing sync` is the network-touching verb that fetches the latest
+    /// LiteLLM manifest, mirroring the `cloud sync` shape on the cloud
+    /// namespace — both are direction-tagged data movements, both come
+    /// with `--format json` for scripted use.
     #[command(after_help = "\
 Examples:
-  budi pricing status              Show current manifest layer, version, and unknown models
-  budi pricing status --refresh    Fetch the latest LiteLLM manifest before showing status
-  budi pricing status --format json  JSON output for scripting")]
-    Pricing {
-        #[command(subcommand)]
-        action: PricingAction,
-    },
+  budi pricing                     Show current manifest layer, version, and unknown models (read-only)
+  budi pricing status              Same as bare `budi pricing` (long form)
+  budi pricing sync                Fetch the latest LiteLLM manifest into the local cache
+  budi pricing --format json       JSON output for scripting
+  budi pricing sync --format json  JSON output (exit code 2 on refresh failure)")]
+    Pricing(PricingArgs),
 }
 
 /// Top-level args for `budi stats`. Bare invocation (no subcommand) renders
@@ -341,17 +346,26 @@ pub enum StatsView {
     },
 }
 
+/// Top-level args for `budi pricing`. Bare invocation (no subcommand) renders
+/// the read-only manifest status — same output as the explicit `pricing status`.
+/// `pricing sync` is the only network-touching verb in this namespace; it
+/// replaces the pre-8.3.14 `pricing status --refresh` flag (the lone
+/// side-effecting flag in the entire CLI that hid behind a read-only verb).
+#[derive(Debug, clap::Args)]
+pub struct PricingArgs {
+    #[command(subcommand)]
+    pub view: Option<PricingView>,
+    /// Output format: text (default) or json
+    #[arg(short, long, value_enum, default_value_t = StatsFormat::Text, global = true)]
+    pub format: StatsFormat,
+}
+
 #[derive(Debug, Subcommand)]
-enum PricingAction {
-    /// Show manifest layer, version, known model count, and unknown models
-    Status {
-        /// Output format: text (default) or json
-        #[arg(short, long, value_enum, default_value_t = StatsFormat::Text)]
-        format: StatsFormat,
-        /// Trigger an immediate manifest refresh before showing status
-        #[arg(long, default_value_t = false)]
-        refresh: bool,
-    },
+pub enum PricingView {
+    /// Read-only: show manifest layer, version, known model count, unknown models
+    Status,
+    /// Network: fetch the latest LiteLLM manifest into the local cache, then show state
+    Sync,
 }
 
 #[derive(Debug, Subcommand)]
@@ -760,11 +774,13 @@ fn main() -> Result<()> {
             }
             CloudAction::Reset { yes } => commands::cloud::cmd_cloud_reset(yes),
         },
-        Commands::Pricing { action } => match action {
-            PricingAction::Status { format, refresh } => {
-                commands::pricing::cmd_pricing_status(format, refresh)
+        Commands::Pricing(args) => {
+            let PricingArgs { view, format } = args;
+            match view {
+                None | Some(PricingView::Status) => commands::pricing::cmd_pricing_status(format),
+                Some(PricingView::Sync) => commands::pricing::cmd_pricing_sync(format),
             }
-        },
+        }
     }
 }
 
@@ -1414,6 +1430,72 @@ mod tests {
             }
             _ => panic!("expected cloud init command"),
         }
+    }
+
+    #[test]
+    fn cli_parses_pricing_subcommands() {
+        // #584: split `pricing status --refresh` (the lone read-only-shaped
+        // verb that hid a network call) into `pricing status` (read-only)
+        // and `pricing sync` (network), with bare `budi pricing` defaulting
+        // to the read-only view.
+        let cli = Cli::try_parse_from(["budi", "pricing"]).expect("bare budi pricing parses");
+        match cli.command {
+            Commands::Pricing(args) => {
+                assert!(args.view.is_none(), "bare invocation has no view");
+                assert!(matches!(args.format, StatsFormat::Text));
+            }
+            _ => panic!("expected pricing command"),
+        }
+
+        let cli = Cli::try_parse_from(["budi", "pricing", "status"])
+            .expect("budi pricing status parses");
+        match cli.command {
+            Commands::Pricing(args) => assert!(matches!(args.view, Some(PricingView::Status))),
+            _ => panic!("expected pricing status command"),
+        }
+
+        let cli =
+            Cli::try_parse_from(["budi", "pricing", "sync"]).expect("budi pricing sync parses");
+        match cli.command {
+            Commands::Pricing(args) => assert!(matches!(args.view, Some(PricingView::Sync))),
+            _ => panic!("expected pricing sync command"),
+        }
+
+        let cli = Cli::try_parse_from(["budi", "pricing", "--format", "json"])
+            .expect("budi pricing --format json parses");
+        match cli.command {
+            Commands::Pricing(args) => {
+                assert!(args.view.is_none());
+                assert!(matches!(args.format, StatsFormat::Json));
+            }
+            _ => panic!("expected pricing command"),
+        }
+
+        let cli = Cli::try_parse_from(["budi", "pricing", "sync", "--format", "json"])
+            .expect("budi pricing sync --format json parses");
+        match cli.command {
+            Commands::Pricing(args) => {
+                assert!(matches!(args.view, Some(PricingView::Sync)));
+                assert!(matches!(args.format, StatsFormat::Json));
+            }
+            _ => panic!("expected pricing sync command"),
+        }
+    }
+
+    #[test]
+    fn cli_rejects_legacy_pricing_refresh_flag() {
+        // #584: `--refresh` was the only flag in the entire CLI that
+        // performed a network call from a read-only-shaped verb. It is
+        // dropped entirely (no users, safe to break per the ticket); the
+        // replacement is `budi pricing sync`.
+        assert!(
+            Cli::try_parse_from(["budi", "pricing", "status", "--refresh"]).is_err(),
+            "`pricing status --refresh` must hard-fail; use `pricing sync` instead",
+        );
+        assert!(
+            Cli::try_parse_from(["budi", "pricing", "--refresh"]).is_err(),
+            "bare `pricing --refresh` must hard-fail; use `pricing sync` instead",
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #584.

`pricing status --refresh` was the only flag in the entire CLI that did a network call from a read-only-shaped verb. Split into clean read-only and network verbs — `pricing sync` mirrors the `cloud sync` direction-tagged shape on the cloud namespace.

```
budi pricing               # read-only state (alias / short for `pricing status`)
budi pricing status        # read-only state (long form, kept for symmetry)
budi pricing sync          # NETWORK: fetch latest LiteLLM manifest, then show
budi pricing --format json
budi pricing sync --format json    # exit code 2 on failure (unchanged)
```

`pricing status --refresh` is removed entirely (no users, safe to break per the ticket). The migration target is `budi pricing sync`; clap rejects the legacy flag with its standard unknown-flag error.

## Test plan

- [x] `budi pricing` (no flags) renders the same human output as today's `pricing status` (read-only path is unchanged behaviour-wise).
- [x] `budi pricing sync` makes the network call, writes the cache, then renders the post-fetch state.
- [x] `budi pricing sync --format json` emits the structured `{refresh, status, aliases}` shape and exits `2` on `ok=false`.
- [x] `budi pricing status --refresh` hard-fails with clap's unknown-flag error (regression test).
- [x] CLI parser tests cover bare / `status` / `sync` / `--format json` paths.
- [x] `cargo test --workspace` — 727 tests pass.
- [x] `cargo clippy -p budi-cli --all-targets -- -D warnings` clean.

## Docs sweep

- `README.md` examples updated (read-only `budi pricing` + `budi pricing sync` + `budi pricing --format json`).
- `SOUL.md` file map entry for `crates/budi-cli/src/commands/pricing.rs` updated to reflect the split.
- Module docstring on `commands/pricing.rs` rewritten around the split with the `cloud sync` mirroring rationale.

The `siropkin/getbudi.dev` landing-site sweep noted in the ticket comment (`src/pages/index.astro` line 56 + line 836) lives in a separate repo and will need its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)