### PR TITLE
cli: `--format json` consistency on system-state commands

### DIFF
--- a/crates/budi-cli/src/commands/autostart.rs
+++ b/crates/budi-cli/src/commands/autostart.rs
@@ -1,11 +1,20 @@
 use anyhow::Result;
 use budi_core::autostart;
 use budi_core::config;
+use serde::Serialize;
 
+use crate::StatsFormat;
 use crate::daemon;
 
 /// `budi autostart status` — show current autostart state.
-pub fn cmd_autostart_status() -> Result<()> {
+pub fn cmd_autostart_status(format: StatsFormat) -> Result<()> {
+    if matches!(format, StatsFormat::Json) {
+        return cmd_autostart_status_json();
+    }
+    cmd_autostart_status_text()
+}
+
+fn cmd_autostart_status_text() -> Result<()> {
     let mechanism = autostart::service_mechanism();
     let status = autostart::service_status();
     let green = super::ansi("\x1b[32m");
@@ -33,6 +42,56 @@ pub fn cmd_autostart_status() -> Result<()> {
     }
 
     Ok(())
+}
+
+#[derive(Debug, Serialize)]
+struct AutostartStatusJson {
+    installed: bool,
+    running: bool,
+    /// Service file path on disk. `null` on platforms (Windows Task Scheduler)
+    /// where the mechanism doesn't expose a single backing file.
+    service_path: Option<String>,
+    /// Stable platform-keyword tag: `launchd` (macOS), `systemd` (Linux),
+    /// `task_scheduler` (Windows), or `unsupported` on other platforms.
+    platform: &'static str,
+}
+
+fn cmd_autostart_status_json() -> Result<()> {
+    let status = autostart::service_status();
+    let body = AutostartStatusJson {
+        installed: matches!(
+            status,
+            autostart::ServiceStatus::Installed | autostart::ServiceStatus::Running
+        ),
+        running: matches!(status, autostart::ServiceStatus::Running),
+        service_path: autostart::service_file_path().map(|p| p.display().to_string()),
+        platform: autostart_platform_tag(),
+    };
+    super::print_json(&body)?;
+    Ok(())
+}
+
+/// Stable platform keyword for the JSON contract — separate from
+/// `service_mechanism()` (which returns a free-form human label like
+/// `"launchd LaunchAgent"`) so scripted callers can dispatch on a fixed
+/// vocabulary.
+fn autostart_platform_tag() -> &'static str {
+    #[cfg(target_os = "macos")]
+    {
+        "launchd"
+    }
+    #[cfg(target_os = "linux")]
+    {
+        "systemd"
+    }
+    #[cfg(target_os = "windows")]
+    {
+        "task_scheduler"
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+    {
+        "unsupported"
+    }
 }
 
 /// `budi autostart install` — install the autostart service.
@@ -92,4 +151,66 @@ pub fn cmd_autostart_uninstall() -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Lock the keys + value shape of the `--format json` contract so a
+    /// future refactor can't silently rename a field that scripted
+    /// callers grep for.
+    #[test]
+    fn autostart_status_json_locks_schema() {
+        let body = AutostartStatusJson {
+            installed: true,
+            running: true,
+            service_path: Some(
+                "/Users/test/Library/LaunchAgents/dev.getbudi.budi-daemon.plist".to_string(),
+            ),
+            platform: "launchd",
+        };
+        let v = serde_json::to_value(&body).expect("serialise");
+        let obj = v.as_object().expect("object");
+        let mut keys: Vec<&str> = obj.keys().map(String::as_str).collect();
+        keys.sort();
+        assert_eq!(
+            keys,
+            vec!["installed", "platform", "running", "service_path"]
+        );
+        assert!(v["installed"].is_boolean());
+        assert!(v["running"].is_boolean());
+        assert!(v["service_path"].is_string());
+        assert!(v["platform"].is_string());
+    }
+
+    #[test]
+    fn autostart_status_json_emits_null_service_path_when_absent() {
+        // Windows Task Scheduler has no single backing file. The JSON
+        // contract surfaces that as `null`, not as an empty string.
+        let body = AutostartStatusJson {
+            installed: false,
+            running: false,
+            service_path: None,
+            platform: "task_scheduler",
+        };
+        let v = serde_json::to_value(&body).expect("serialise");
+        assert!(v["service_path"].is_null());
+    }
+
+    #[test]
+    fn autostart_platform_tag_is_keyword_only() {
+        // The JSON contract promises a fixed vocabulary; the tag must
+        // be a single word with no spaces (unlike `service_mechanism()`
+        // which returns "launchd LaunchAgent" / "systemd user service").
+        let tag = autostart_platform_tag();
+        assert!(
+            !tag.contains(' '),
+            "autostart_platform_tag must be a single keyword, got {tag:?}"
+        );
+        assert!(matches!(
+            tag,
+            "launchd" | "systemd" | "task_scheduler" | "unsupported"
+        ));
+    }
 }

--- a/crates/budi-cli/src/commands/cloud.rs
+++ b/crates/budi-cli/src/commands/cloud.rs
@@ -601,9 +601,19 @@ pub fn cmd_cloud_status(format: StatsFormat) -> Result<()> {
 /// background tick would — that way a manual reset can never race a
 /// concurrent envelope build that already read the about-to-be-deleted
 /// watermark.
-pub fn cmd_cloud_reset(yes: bool) -> Result<()> {
+pub fn cmd_cloud_reset(yes: bool, format: StatsFormat) -> Result<()> {
     let cfg = load_cloud_config();
     if !confirm_reset(&cfg, yes)? {
+        if matches!(format, StatsFormat::Json) {
+            // No mutation happened. Emit the same shape the success path
+            // would, so scripted callers don't have to special-case the
+            // abort with a separate text-only branch.
+            super::print_json(&CloudResetJson {
+                watermarks_dropped: 0,
+                org: cfg.org_id.clone(),
+            })?;
+            return Ok(());
+        }
         println!("Aborted. Watermarks left unchanged.");
         return Ok(());
     }
@@ -613,9 +623,24 @@ pub fn cmd_cloud_reset(yes: bool) -> Result<()> {
         .cloud_reset()
         .context("failed to reset cloud sync watermarks via the daemon")?;
 
-    let removed = body.get("removed").and_then(Value::as_u64).unwrap_or(0) as usize;
-    render_reset_text(&cfg, removed);
+    let removed = body.get("removed").and_then(Value::as_u64).unwrap_or(0) as u32;
+
+    if matches!(format, StatsFormat::Json) {
+        super::print_json(&CloudResetJson {
+            watermarks_dropped: removed,
+            org: cfg.org_id.clone(),
+        })?;
+        return Ok(());
+    }
+
+    render_reset_text(&cfg, removed as usize);
     Ok(())
+}
+
+#[derive(Debug, serde::Serialize)]
+struct CloudResetJson {
+    watermarks_dropped: u32,
+    org: Option<String>,
 }
 
 fn confirm_reset(cfg: &CloudConfig, yes: bool) -> Result<bool> {
@@ -866,6 +891,35 @@ fn render_status_text(body: &Value) {
 mod tests {
     use super::*;
     use budi_core::config::CloudConfig;
+
+    /// #588: lock the JSON shape for `budi cloud reset --format json`.
+    /// Scripted callers (CI watermark resets, dashboards) depend on
+    /// these field names — a future refactor that renamed
+    /// `watermarks_dropped` would silently break them.
+    #[test]
+    fn cloud_reset_json_locks_schema_with_org() {
+        let body = CloudResetJson {
+            watermarks_dropped: 7,
+            org: Some("acme-org-123".to_string()),
+        };
+        let v = serde_json::to_value(&body).expect("serialise");
+        let mut keys: Vec<&str> = v.as_object().unwrap().keys().map(String::as_str).collect();
+        keys.sort();
+        assert_eq!(keys, vec!["org", "watermarks_dropped"]);
+        assert_eq!(v["watermarks_dropped"], serde_json::json!(7));
+        assert_eq!(v["org"], serde_json::json!("acme-org-123"));
+    }
+
+    #[test]
+    fn cloud_reset_json_serialises_missing_org_as_null() {
+        let body = CloudResetJson {
+            watermarks_dropped: 0,
+            org: None,
+        };
+        let v = serde_json::to_value(&body).expect("serialise");
+        assert!(v["org"].is_null());
+        assert_eq!(v["watermarks_dropped"], serde_json::json!(0));
+    }
 
     #[test]
     fn template_stub_variant_is_disabled_and_carries_placeholder() {

--- a/crates/budi-cli/src/commands/doctor.rs
+++ b/crates/budi-cli/src/commands/doctor.rs
@@ -7,31 +7,49 @@ use budi_core::legacy_proxy;
 use budi_core::provider::Provider;
 use chrono::{DateTime, Local, Utc};
 use rusqlite::{Connection, OptionalExtension, params};
+use serde::Serialize;
 
+use crate::StatsFormat;
 use crate::daemon::{daemon_health, ensure_daemon_running, resolve_daemon_binary};
 
-pub fn cmd_doctor(repo_root: Option<PathBuf>, deep: bool, quiet: bool) -> Result<()> {
+pub fn cmd_doctor(
+    repo_root: Option<PathBuf>,
+    deep: bool,
+    quiet: bool,
+    format: StatsFormat,
+) -> Result<()> {
     let repo_root = super::try_resolve_repo_root(repo_root);
     let config = match &repo_root {
         Some(root) => config::load_or_default(root)?,
         None => config::BudiConfig::default(),
     };
 
+    let json_output = matches!(format, StatsFormat::Json);
+
     let dim = super::ansi("\x1b[90m");
     let reset = super::ansi("\x1b[0m");
 
-    if let Some(ref root) = repo_root {
-        println!("budi doctor - {}", root.display());
-    } else {
-        println!("budi doctor - global mode");
+    if !json_output {
+        if let Some(ref root) = repo_root {
+            println!("budi doctor - {}", root.display());
+        } else {
+            println!("budi doctor - global mode");
+        }
+        println!();
     }
-    println!();
 
     let mut report = DoctorReport::default();
+    // Buffer of every check that ran, in the same order they appear in the
+    // text-mode output. Used to render the `--format json` payload after
+    // the run completes so the JSON shape matches what the operator sees.
+    let mut checks: Vec<CheckResult> = Vec::new();
 
     let daemon = check_daemon_health(repo_root.as_deref(), &config);
-    daemon.result.print_respecting(quiet);
+    if !json_output {
+        daemon.result.print_respecting(quiet);
+    }
     report.record(&daemon.result);
+    checks.push(daemon.result.clone());
 
     if daemon.started_this_run {
         // The daemon seeds tail offsets on startup before the backstop loop
@@ -42,21 +60,33 @@ pub fn cmd_doctor(repo_root: Option<PathBuf>, deep: bool, quiet: bool) -> Result
 
     let db_path = budi_core::analytics::db_path()?;
     let schema = check_schema(&db_path, deep);
-    schema.result.print_respecting(quiet);
+    if !json_output {
+        schema.result.print_respecting(quiet);
+    }
     report.record(&schema.result);
+    checks.push(schema.result.clone());
 
     let proxy_residue = check_legacy_proxy_residue();
-    proxy_residue.print_respecting(quiet);
+    if !json_output {
+        proxy_residue.print_respecting(quiet);
+    }
     report.record(&proxy_residue);
+    checks.push(proxy_residue);
 
     let statusline_check = check_claude_statusline_integration();
-    statusline_check.print_respecting(quiet);
+    if !json_output {
+        statusline_check.print_respecting(quiet);
+    }
     report.record(&statusline_check);
+    checks.push(statusline_check);
 
     if let Some(conn) = schema.conn.as_ref() {
         let legacy_proxy_history = check_legacy_proxy_history(conn);
-        legacy_proxy_history.print_respecting(quiet);
+        if !json_output {
+            legacy_proxy_history.print_respecting(quiet);
+        }
         report.record(&legacy_proxy_history);
+        checks.push(legacy_proxy_history);
     }
 
     let providers = doctor_providers();
@@ -69,21 +99,46 @@ pub fn cmd_doctor(repo_root: Option<PathBuf>, deep: bool, quiet: bool) -> Result
                     .to_string(),
             ),
         );
-        no_providers.print_respecting(quiet);
+        if !json_output {
+            no_providers.print_respecting(quiet);
+        }
         report.record(&no_providers);
+        checks.push(no_providers);
     } else {
         let conn = schema.conn.as_ref();
         for provider in &providers {
             let diag = gather_provider_doctor_data(conn, provider.as_ref());
 
             let tailer = summarize_tailer_health(&diag);
-            tailer.print_respecting(quiet);
+            if !json_output {
+                tailer.print_respecting(quiet);
+            }
             report.record(&tailer);
+            checks.push(tailer);
 
             let visibility = summarize_transcript_visibility(&diag);
-            visibility.print_respecting(quiet);
+            if !json_output {
+                visibility.print_respecting(quiet);
+            }
             report.record(&visibility);
+            checks.push(visibility);
         }
+    }
+
+    if json_output {
+        let body = DoctorJson {
+            all_pass: report.fails == 0 && report.warns == 0,
+            checks: checks.iter().map(CheckResultJson::from).collect(),
+        };
+        super::print_json(&body)?;
+        // Exit code matrix matches text mode: warnings are not failures,
+        // so we only escalate on an actual FAIL row. Use process::exit(2)
+        // (matching `cloud sync --format json`) so callers can branch on
+        // status without parsing stderr.
+        if report.fails > 0 {
+            std::process::exit(2);
+        }
+        return Ok(());
     }
 
     println!();
@@ -108,6 +163,33 @@ pub fn cmd_doctor(repo_root: Option<PathBuf>, deep: bool, quiet: bool) -> Result
         report.fail_count(),
         report.warn_count()
     );
+}
+
+#[derive(Debug, Serialize)]
+struct DoctorJson {
+    all_pass: bool,
+    checks: Vec<CheckResultJson>,
+}
+
+#[derive(Debug, Serialize)]
+struct CheckResultJson {
+    name: String,
+    status: &'static str,
+    detail: String,
+}
+
+impl From<&CheckResult> for CheckResultJson {
+    fn from(value: &CheckResult) -> Self {
+        Self {
+            name: value.label.clone(),
+            status: match value.state {
+                CheckState::Pass => "pass",
+                CheckState::Warn => "warn",
+                CheckState::Fail => "fail",
+            },
+            detail: value.detail.clone(),
+        }
+    }
 }
 
 #[derive(Debug, Default)]
@@ -1065,6 +1147,64 @@ fn parse_rfc3339_utc(raw: &str) -> Option<DateTime<Utc>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// #588: `budi doctor --format json` lock-in. The JSON contract is
+    /// `{checks: [{name, status, detail}], all_pass}` with `status`
+    /// drawn from a fixed vocabulary of `pass | warn | fail`. Scripted
+    /// callers branch on this shape — a future rename would silently
+    /// break them.
+    #[test]
+    fn doctor_json_locks_schema_and_status_vocabulary() {
+        let checks = [
+            CheckResult::pass("daemon health", "responding on http://127.0.0.1:7878"),
+            CheckResult::warn("tailer providers", "no enabled providers", None),
+            CheckResult::fail(
+                "schema",
+                "missing column `tags`",
+                Some("budi db check --fix".into()),
+            ),
+        ];
+        let body = DoctorJson {
+            all_pass: false,
+            checks: checks.iter().map(CheckResultJson::from).collect(),
+        };
+        let v = serde_json::to_value(&body).expect("serialise");
+
+        let mut top_keys: Vec<&str> = v.as_object().unwrap().keys().map(String::as_str).collect();
+        top_keys.sort();
+        assert_eq!(top_keys, vec!["all_pass", "checks"]);
+        assert_eq!(v["all_pass"], serde_json::json!(false));
+
+        let arr = v["checks"].as_array().expect("checks array");
+        assert_eq!(arr.len(), 3);
+        for entry in arr {
+            let mut keys: Vec<&str> = entry
+                .as_object()
+                .unwrap()
+                .keys()
+                .map(String::as_str)
+                .collect();
+            keys.sort();
+            assert_eq!(keys, vec!["detail", "name", "status"]);
+        }
+        assert_eq!(arr[0]["status"], serde_json::json!("pass"));
+        assert_eq!(arr[1]["status"], serde_json::json!("warn"));
+        assert_eq!(arr[2]["status"], serde_json::json!("fail"));
+        // `fix` is intentionally not part of the JSON shape — it's a
+        // text-mode-only operator hint, not part of the wire contract.
+        assert!(arr[2].as_object().unwrap().get("fix").is_none());
+    }
+
+    #[test]
+    fn doctor_json_all_pass_true_when_all_checks_pass() {
+        let checks = [CheckResult::pass("a", "ok"), CheckResult::pass("b", "ok")];
+        let body = DoctorJson {
+            all_pass: true,
+            checks: checks.iter().map(CheckResultJson::from).collect(),
+        };
+        let v = serde_json::to_value(&body).expect("serialise");
+        assert_eq!(v["all_pass"], serde_json::json!(true));
+    }
 
     fn diag(display_name: &'static str) -> ProviderDoctorData {
         ProviderDoctorData {

--- a/crates/budi-cli/src/commands/status.rs
+++ b/crates/budi-cli/src/commands/status.rs
@@ -1,13 +1,22 @@
 use anyhow::Result;
+use serde::Serialize;
 
 use crate::StatsPeriod;
 use crate::client::DaemonClient;
 use crate::commands::stats::{format_cost_cents, format_tokens, period_date_range};
+use crate::{StatsFormat, commands};
 
 use super::ansi;
 
 /// Quick operational overview: daemon and today's cost.
-pub fn cmd_status() -> Result<()> {
+pub fn cmd_status(format: StatsFormat) -> Result<()> {
+    if matches!(format, StatsFormat::Json) {
+        return cmd_status_json();
+    }
+    cmd_status_text()
+}
+
+fn cmd_status_text() -> Result<()> {
     let bold_cyan = ansi("\x1b[1;36m");
     let bold = ansi("\x1b[1m");
     let dim = ansi("\x1b[90m");
@@ -84,4 +93,133 @@ pub fn cmd_status() -> Result<()> {
 
     println!();
     Ok(())
+}
+
+#[derive(Debug, Serialize)]
+struct StatusJson {
+    daemon: DaemonJson,
+    today: Option<TodayJson>,
+}
+
+#[derive(Debug, Serialize)]
+struct DaemonJson {
+    running: bool,
+    version: String,
+    port: u16,
+}
+
+#[derive(Debug, Serialize)]
+struct TodayJson {
+    cost_cents: f64,
+    messages: u64,
+    providers: Vec<String>,
+}
+
+fn cmd_status_json() -> Result<()> {
+    let config = DaemonClient::load_config();
+    let daemon_ok = crate::daemon::daemon_health(&config);
+    let daemon = DaemonJson {
+        running: daemon_ok,
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        port: config.daemon_port,
+    };
+
+    let today = if daemon_ok {
+        match DaemonClient::connect() {
+            Ok(client) => {
+                let (since, _until) = period_date_range(StatsPeriod::Today);
+                let summary = client.summary(since.as_deref(), None, None).ok();
+                let cost = client.cost(since.as_deref(), None, None).ok();
+                let providers = client.providers(since.as_deref(), None).ok();
+
+                match (summary, cost) {
+                    (Some(summary), Some(cost)) => Some(TodayJson {
+                        cost_cents: cost.total_cost * 100.0,
+                        messages: summary.total_messages,
+                        providers: providers
+                            .unwrap_or_default()
+                            .into_iter()
+                            .map(|p| p.provider)
+                            .collect(),
+                    }),
+                    _ => None,
+                }
+            }
+            Err(_) => None,
+        }
+    } else {
+        None
+    };
+
+    commands::print_json(&StatusJson { daemon, today })?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Lock the JSON shape: `{daemon: {running, version, port}, today:
+    /// {cost_cents, messages, providers}}`. Scripted callers — CI gates,
+    /// dashboards, the cloud surface — depend on these names.
+    #[test]
+    fn status_json_locks_schema_with_today_present() {
+        let body = StatusJson {
+            daemon: DaemonJson {
+                running: true,
+                version: "8.3.14".to_string(),
+                port: 7878,
+            },
+            today: Some(TodayJson {
+                cost_cents: 12345.6,
+                messages: 42,
+                providers: vec!["claude_code".to_string(), "cursor".to_string()],
+            }),
+        };
+        let v = serde_json::to_value(&body).expect("serialise");
+        let mut top_keys: Vec<&str> = v.as_object().unwrap().keys().map(String::as_str).collect();
+        top_keys.sort();
+        assert_eq!(top_keys, vec!["daemon", "today"]);
+
+        // Daemon block.
+        let daemon = v["daemon"].as_object().expect("daemon is object");
+        let mut keys: Vec<&str> = daemon.keys().map(String::as_str).collect();
+        keys.sort();
+        assert_eq!(keys, vec!["port", "running", "version"]);
+        assert!(v["daemon"]["running"].is_boolean());
+        assert!(v["daemon"]["version"].is_string());
+        assert!(v["daemon"]["port"].is_number());
+
+        // Today block + the cents-key normalisation contract from #445.
+        let today = v["today"].as_object().expect("today is object");
+        let mut keys: Vec<&str> = today.keys().map(String::as_str).collect();
+        keys.sort();
+        assert_eq!(keys, vec!["cost_cents", "messages", "providers"]);
+        // After commands::print_json runs the cents normaliser the float
+        // would round to an integer; here we serialise without the
+        // helper so the raw float should still pass through. The
+        // round_cents_to_integer test in mod.rs covers that conversion.
+        assert!(v["today"]["cost_cents"].is_number());
+        assert!(v["today"]["messages"].is_u64());
+        assert!(v["today"]["providers"].is_array());
+    }
+
+    #[test]
+    fn status_json_today_is_null_when_daemon_down() {
+        // When the daemon is unreachable we still emit `today` as a
+        // top-level key (so the shape stays stable for `jq .today`),
+        // but as `null` rather than zero-valued so callers can detect
+        // "no data" without false positives.
+        let body = StatusJson {
+            daemon: DaemonJson {
+                running: false,
+                version: "8.3.14".to_string(),
+                port: 7878,
+            },
+            today: None,
+        };
+        let v = serde_json::to_value(&body).expect("serialise");
+        assert!(v["today"].is_null());
+        assert_eq!(v["daemon"]["running"], serde_json::json!(false));
+    }
 }

--- a/crates/budi-cli/src/main.rs
+++ b/crates/budi-cli/src/main.rs
@@ -52,6 +52,9 @@ enum Commands {
         /// gates and for a glance-only human check on a working box.
         #[arg(long, default_value_t = false)]
         quiet: bool,
+        /// Output format: text (default) or json
+        #[arg(short, long, value_enum, default_value_t = StatsFormat::Text)]
+        format: StatsFormat,
         #[arg(long, hide = true)]
         repo_root: Option<PathBuf>,
     },
@@ -167,7 +170,11 @@ Examples:
         format: StatsFormat,
     },
     /// Quick overview: daemon and today's cost (is everything working?)
-    Status,
+    Status {
+        /// Output format: text (default) or json
+        #[arg(short, long, value_enum, default_value_t = StatsFormat::Text)]
+        format: StatsFormat,
+    },
     /// Show AI spending in your shell prompt (reads editor context from stdin when piped)
     ///
     /// Emits the shared provider-scoped status contract. Rolling
@@ -201,9 +208,10 @@ Examples:
     /// Manage the daemon autostart service (launchd / systemd / Task Scheduler)
     #[command(after_help = "\
 Examples:
-  budi autostart status      Check if autostart is installed and running
-  budi autostart install     Install the autostart service
-  budi autostart uninstall   Remove the autostart service")]
+  budi autostart status              Check if autostart is installed and running
+  budi autostart status --format json  JSON output for scripting
+  budi autostart install             Install the autostart service
+  budi autostart uninstall           Remove the autostart service")]
     Autostart {
         #[command(subcommand)]
         action: AutostartAction,
@@ -227,7 +235,8 @@ Examples:
   budi cloud sync --full         Drop watermarks then re-upload everything
   budi cloud sync --full --yes   Same, non-interactive (CI / scripts)
   budi cloud reset               Reset watermarks so next sync re-uploads all
-  budi cloud reset --yes         Same, non-interactive (CI / scripts)")]
+  budi cloud reset --yes         Same, non-interactive (CI / scripts)
+  budi cloud reset --format json JSON output (requires --yes for non-TTY)")]
     Cloud {
         #[command(subcommand)]
         action: CloudAction,
@@ -466,6 +475,9 @@ enum CloudAction {
         /// re-upload on a stray invocation.
         #[arg(long, default_value_t = false)]
         yes: bool,
+        /// Output format: text (default) or json
+        #[arg(short, long, value_enum, default_value_t = StatsFormat::Text)]
+        format: StatsFormat,
     },
 }
 
@@ -495,7 +507,11 @@ enum DbAction {
 #[derive(Debug, Subcommand)]
 enum AutostartAction {
     /// Show whether the autostart service is installed and running
-    Status,
+    Status {
+        /// Output format: text (default) or json
+        #[arg(short, long, value_enum, default_value_t = StatsFormat::Text)]
+        format: StatsFormat,
+    },
     /// Install the autostart service (daemon starts at login)
     Install,
     /// Remove the autostart service
@@ -634,8 +650,9 @@ fn main() -> Result<()> {
         Commands::Doctor {
             deep,
             quiet,
+            format,
             repo_root,
-        } => commands::doctor::cmd_doctor(repo_root, deep, quiet),
+        } => commands::doctor::cmd_doctor(repo_root, deep, quiet, format),
         Commands::Stats(args) => {
             let StatsArgs { view, opts } = args;
             let StatsOpts {
@@ -753,10 +770,10 @@ fn main() -> Result<()> {
                 )
             }
         }
-        Commands::Status => commands::status::cmd_status(),
+        Commands::Status { format } => commands::status::cmd_status(format),
         Commands::Integrations { action } => commands::integrations::cmd_integrations(action),
         Commands::Autostart { action } => match action {
-            AutostartAction::Status => commands::autostart::cmd_autostart_status(),
+            AutostartAction::Status { format } => commands::autostart::cmd_autostart_status(format),
             AutostartAction::Install => commands::autostart::cmd_autostart_install(),
             AutostartAction::Uninstall => commands::autostart::cmd_autostart_uninstall(),
         },
@@ -772,7 +789,7 @@ fn main() -> Result<()> {
             CloudAction::Sync { format, full, yes } => {
                 commands::cloud::cmd_cloud_sync(format, full, yes)
             }
-            CloudAction::Reset { yes } => commands::cloud::cmd_cloud_reset(yes),
+            CloudAction::Reset { yes, format } => commands::cloud::cmd_cloud_reset(yes, format),
         },
         Commands::Pricing(args) => {
             let PricingArgs { view, format } = args;
@@ -1324,8 +1341,11 @@ mod tests {
         let cli = Cli::try_parse_from(["budi", "cloud", "reset"]).expect("budi cloud reset parses");
         match cli.command {
             Commands::Cloud {
-                action: CloudAction::Reset { yes },
-            } => assert!(!yes, "default invocation must be interactive"),
+                action: CloudAction::Reset { yes, format },
+            } => {
+                assert!(!yes, "default invocation must be interactive");
+                assert_eq!(format, StatsFormat::Text);
+            }
             _ => panic!("expected cloud reset command"),
         }
 
@@ -1333,9 +1353,27 @@ mod tests {
             .expect("budi cloud reset --yes parses");
         match cli.command {
             Commands::Cloud {
-                action: CloudAction::Reset { yes },
-            } => assert!(yes, "--yes must skip the confirmation"),
+                action: CloudAction::Reset { yes, format },
+            } => {
+                assert!(yes, "--yes must skip the confirmation");
+                assert_eq!(format, StatsFormat::Text);
+            }
             _ => panic!("expected cloud reset --yes command"),
+        }
+
+        // #588: `--format json` parses on `cloud reset` so scripted
+        // callers (CI gates, dashboards) can emit a stable JSON shape
+        // without scraping the human render.
+        let cli = Cli::try_parse_from(["budi", "cloud", "reset", "--yes", "--format", "json"])
+            .expect("budi cloud reset --yes --format json parses");
+        match cli.command {
+            Commands::Cloud {
+                action: CloudAction::Reset { yes, format },
+            } => {
+                assert!(yes);
+                assert_eq!(format, StatsFormat::Json);
+            }
+            _ => panic!("expected cloud reset --yes --format json command"),
         }
     }
 
@@ -1725,6 +1763,75 @@ mod tests {
                 assert_eq!(format, StatuslineFormat::Json);
             }
             _ => panic!("expected statusline command"),
+        }
+    }
+
+    // #588: every system-state command must accept `--format json` so CI
+    // gates and dashboards can stop scraping the human render. The
+    // following tests lock the clap surface; the per-command JSON shapes
+    // are tested next to their implementations.
+
+    #[test]
+    fn cli_status_accepts_format_json() {
+        let cli = Cli::try_parse_from(["budi", "status"]).expect("budi status parses");
+        match cli.command {
+            Commands::Status { format } => assert_eq!(format, StatsFormat::Text),
+            _ => panic!("expected status command"),
+        }
+        let cli = Cli::try_parse_from(["budi", "status", "--format", "json"])
+            .expect("budi status --format json parses");
+        match cli.command {
+            Commands::Status { format } => assert_eq!(format, StatsFormat::Json),
+            _ => panic!("expected status --format json command"),
+        }
+    }
+
+    #[test]
+    fn cli_doctor_accepts_format_json() {
+        let cli = Cli::try_parse_from(["budi", "doctor"]).expect("budi doctor parses");
+        match cli.command {
+            Commands::Doctor { format, .. } => assert_eq!(format, StatsFormat::Text),
+            _ => panic!("expected doctor command"),
+        }
+        let cli = Cli::try_parse_from(["budi", "doctor", "--format", "json"])
+            .expect("budi doctor --format json parses");
+        match cli.command {
+            Commands::Doctor { format, .. } => assert_eq!(format, StatsFormat::Json),
+            _ => panic!("expected doctor --format json command"),
+        }
+    }
+
+    #[test]
+    fn cli_autostart_status_accepts_format_json() {
+        let cli =
+            Cli::try_parse_from(["budi", "autostart", "status"]).expect("budi autostart status");
+        match cli.command {
+            Commands::Autostart {
+                action: AutostartAction::Status { format },
+            } => assert_eq!(format, StatsFormat::Text),
+            _ => panic!("expected autostart status command"),
+        }
+
+        let cli = Cli::try_parse_from(["budi", "autostart", "status", "--format", "json"])
+            .expect("budi autostart status --format json parses");
+        match cli.command {
+            Commands::Autostart {
+                action: AutostartAction::Status { format },
+            } => assert_eq!(format, StatsFormat::Json),
+            _ => panic!("expected autostart status --format json command"),
+        }
+    }
+
+    #[test]
+    fn cli_cloud_status_accepts_format_json() {
+        // Already shipped pre-#588 — guard regression.
+        let cli = Cli::try_parse_from(["budi", "cloud", "status", "--format", "json"])
+            .expect("budi cloud status --format json parses");
+        match cli.command {
+            Commands::Cloud {
+                action: CloudAction::Status { format },
+            } => assert_eq!(format, StatsFormat::Json),
+            _ => panic!("expected cloud status --format json command"),
         }
     }
 }


### PR DESCRIPTION
Closes #588.

## Summary
- Added `--format <text|json>` to `status`, `doctor`, `autostart status`, `cloud reset`. (`cloud status` already shipped it.)
- Locked the JSON shapes in unit tests so a future refactor can't silently rename a field that scripted callers grep for.
- Exit codes match text mode: success commands exit 0 in both modes; `doctor --format json` exits 2 on any FAIL row (matches the `cloud sync --format json` convention) so CI can branch on status without parsing stderr.

## JSON shapes
- `status` — `{daemon: {running, version, port}, today: {cost_cents, messages, providers}|null}` (`today` is `null` when the daemon is unreachable so callers detect "no data" without false positives)
- `doctor` — `{checks: [{name, status: pass|warn|fail, detail}], all_pass}` (text-mode `fix:` hint is intentionally not in the wire contract)
- `autostart status` — `{installed, running, service_path, platform: launchd|systemd|task_scheduler}` (`service_path` is `null` on Windows Task Scheduler since there's no single backing file)
- `cloud reset` — `{watermarks_dropped, org}` (emitted on the abort path too so scripted callers don't have to special-case the no-mutation branch)

## Test plan
- [x] `cargo test --workspace` (251 tests pass)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Smoke-tested each command end-to-end against a live daemon — output is valid JSON parseable by `jq` / `python -m json.tool`
- [x] `cost_cents` rounds to integer via the existing `print_json` cents normaliser (#445)
- [x] CLI parser tests lock the new flags on the clap surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)