### PR TITLE
init: seed `statusline.toml` so users can customize the statusline (#600)

### DIFF
--- a/crates/budi-cli/src/commands/integrations.rs
+++ b/crates/budi-cli/src/commands/integrations.rs
@@ -375,6 +375,13 @@ fn install_claude_settings(
         }
         if let Some(preset) = statusline_preset {
             set_statusline_preset(preset)?;
+        } else {
+            // #600: when no preset is passed (the `budi init` path), drop a
+            // template `statusline.toml` so users have a real file to edit.
+            // README docs the file as the source of truth; without seeding
+            // a fresh install has nothing to discover. Idempotent — repeat
+            // installs leave user edits byte-stable.
+            seed_statusline_toml()?;
         }
     }
 
@@ -438,6 +445,29 @@ pub(crate) fn apply_statusline(settings: &mut Value) -> Result<StatuslineApply> 
         "padding": 0
     });
     Ok(StatuslineApply::Changed)
+}
+
+/// Idempotently seed `~/.config/budi/statusline.toml` with the default
+/// `cost` preset and commented examples. Called on the no-preset path
+/// (i.e. `budi init`) so users have a real file to edit.
+///
+/// Prints a single confirmation line on first generation. Stays quiet
+/// on repeat runs so `budi init` doesn't nag once the user already has
+/// (and possibly customized) the file.
+fn seed_statusline_toml() -> Result<()> {
+    match config::seed_statusline_config_if_needed()? {
+        config::SeedStatuslineOutcome::Generated => {
+            let path = config::statusline_config_path()?;
+            let dim = super::ansi("\x1b[90m");
+            let reset = super::ansi("\x1b[0m");
+            println!(
+                "  Status line: {} {dim}(cost preset — edit to customize){reset}",
+                path.display()
+            );
+        }
+        config::SeedStatuslineOutcome::AlreadySet => {}
+    }
+    Ok(())
 }
 
 pub fn set_statusline_preset(preset: StatuslinePreset) -> Result<()> {

--- a/crates/budi-core/src/config.rs
+++ b/crates/budi-core/src/config.rs
@@ -305,6 +305,65 @@ pub fn load_statusline_config() -> StatuslineConfig {
     toml::from_str(&raw).unwrap_or_default()
 }
 
+/// Outcome of a call to [`seed_statusline_config_if_needed`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SeedStatuslineOutcome {
+    /// Wrote a fresh `statusline.toml` with the quiet `cost` preset and
+    /// commented examples for `coach` / `full` / custom formats.
+    Generated,
+    /// File already exists — no-op so user edits aren't clobbered.
+    AlreadySet,
+}
+
+/// Default seeded contents for `~/.config/budi/statusline.toml`.
+///
+/// Mirrors the default `StatuslineConfig` (`slots = ["1d", "7d", "30d"]`)
+/// so a `cat ~/.config/budi/statusline.toml` after `budi init` shows
+/// users *exactly* what's running, plus the discoverability comments
+/// for the `coach` / `full` presets and the custom-format escape hatch.
+pub const STATUSLINE_TOML_TEMPLATE: &str = "\
+# budi statusline configuration.
+# Active layout: rolling 1d / 7d / 30d cost (the quiet default).
+slots = [\"1d\", \"7d\", \"30d\"]
+
+# Try a different preset:
+# preset = \"coach\"  # session cost + health vitals + tip
+# preset = \"full\"   # session + health + 1d
+#
+# Or build a custom format:
+# format = \"{health} {project} | {session} | {1d} 1d | {7d} 7d\"
+#
+# Available slots: 1d, 7d, 30d, session, branch, project, provider, health
+# Docs: https://github.com/siropkin/budi#status-line
+";
+
+/// Idempotently seed `~/.config/budi/statusline.toml` with the default
+/// `cost` preset and commented examples for the other presets.
+///
+/// `budi init` calls this after installing the Claude Code statusline so
+/// users have a real file to edit (#600). Without it, the README told
+/// users to customize via `~/.config/budi/statusline.toml` but the file
+/// only existed once they passed `--statusline-preset`, leaving fresh
+/// installs with nothing to discover.
+///
+/// Idempotent: returns `AlreadySet` on every call after the first
+/// without touching the file (preserves user edits). Caller is
+/// responsible for the `~/.claude` / `--no-integrations` install gates;
+/// we only own the create-if-missing rule for the file itself.
+pub fn seed_statusline_config_if_needed() -> Result<SeedStatuslineOutcome> {
+    let path = statusline_config_path()?;
+    if path.exists() {
+        return Ok(SeedStatuslineOutcome::AlreadySet);
+    }
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("Failed to create {}", parent.display()))?;
+    }
+    fs::write(&path, STATUSLINE_TOML_TEMPLATE)
+        .with_context(|| format!("Failed to write {}", path.display()))?;
+    Ok(SeedStatuslineOutcome::Generated)
+}
+
 /// A single tag rule from `~/.config/budi/tags.toml`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TagRule {

--- a/scripts/e2e/test_600_init_seeds_statusline_toml.sh
+++ b/scripts/e2e/test_600_init_seeds_statusline_toml.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# End-to-end regression for issue #600: verify `budi init` seeds
+# `~/.config/budi/statusline.toml` so users can actually customize the
+# statusline. Pre-fix, the file only existed when `--statusline-preset`
+# was passed explicitly, leaving a fresh install with nothing to edit
+# despite the README pointing users at the file.
+#
+# Acceptance contract pinned:
+# - Fresh `budi init` on a system with `~/.claude` produces
+#   `~/.config/budi/statusline.toml` with the default-cost-preset
+#   template content.
+# - Repeat `budi init` does not overwrite an existing user-edited file
+#   (asserted byte-stable).
+# - `budi init --no-integrations` does not produce the file.
+# - `budi init` on a system without `~/.claude` does not produce the
+#   file (same gate as the statusline install itself).
+set -euo pipefail
+
+export NO_COLOR="${NO_COLOR:-1}"
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BUDI="$ROOT/target/release/budi"
+
+if [[ ! -x "$BUDI" ]]; then
+  echo "error: release binary not built. run \`cargo build --release\` first." >&2
+  exit 2
+fi
+
+TMPDIR_ROOT="$(mktemp -d -t budi-e2e-600-XXXXXX)"
+export HOME="$TMPDIR_ROOT"
+export BUDI_HOME="$HOME/.local/share/budi"
+
+cleanup() {
+  local status=$?
+  if [[ "${KEEP_TMP:-0}" == "1" ]]; then
+    echo "[e2e] leaving tmp: $TMPDIR_ROOT"
+  else
+    rm -rf "$TMPDIR_ROOT"
+  fi
+  exit $status
+}
+trap cleanup EXIT INT TERM
+
+echo "[e2e] HOME=$HOME"
+
+STATUSLINE_TOML="$HOME/.config/budi/statusline.toml"
+
+# Scenario 1: ~/.claude absent — init must not create the statusline
+# file because the statusline install itself is gated on Claude Code
+# being present. Mirrors the gate from `install_default_integrations`.
+echo "[e2e] scenario 1: ~/.claude absent — init does not seed statusline.toml"
+rm -rf "$HOME/.claude" "$HOME/.config"
+"$BUDI" init --no-daemon >"$TMPDIR_ROOT/init-1.log" 2>&1 || {
+  cat "$TMPDIR_ROOT/init-1.log" >&2
+  echo "[e2e] FAIL: init in scenario 1 failed" >&2
+  exit 1
+}
+if [[ -e "$STATUSLINE_TOML" ]]; then
+  echo "[e2e] FAIL: init seeded $STATUSLINE_TOML when ~/.claude was absent" >&2
+  cat "$STATUSLINE_TOML" >&2
+  exit 1
+fi
+echo "[e2e] OK: scenario 1 — statusline.toml not seeded without ~/.claude"
+
+# Scenario 2: ~/.claude present, no prior config — init must seed
+# `~/.config/budi/statusline.toml` with the cost preset template and
+# the discoverability comments for `coach` / `full` / custom format.
+echo "[e2e] scenario 2: ~/.claude present — init seeds statusline.toml"
+rm -rf "$HOME/.config"
+mkdir -p "$HOME/.claude"
+"$BUDI" init --no-daemon >"$TMPDIR_ROOT/init-2.log" 2>&1 || {
+  cat "$TMPDIR_ROOT/init-2.log" >&2
+  echo "[e2e] FAIL: init in scenario 2 failed" >&2
+  exit 1
+}
+if [[ ! -f "$STATUSLINE_TOML" ]]; then
+  echo "[e2e] FAIL: expected $STATUSLINE_TOML to exist after init" >&2
+  cat "$TMPDIR_ROOT/init-2.log" >&2
+  exit 1
+fi
+# Pin the active layout line — this is what the user sees first when
+# they `cat` the file. Shifts in this string are user-visible drift.
+if ! grep -qE '^slots = \["1d", "7d", "30d"\]$' "$STATUSLINE_TOML"; then
+  echo "[e2e] FAIL: $STATUSLINE_TOML missing default slots line" >&2
+  cat "$STATUSLINE_TOML" >&2
+  exit 1
+fi
+# Pin the discoverability comments so users hunting for `coach` / `full`
+# can find them in the same place the README points at.
+for marker in 'preset = "coach"' 'preset = "full"' 'format = ' 'Available slots:'; do
+  if ! grep -qF "$marker" "$STATUSLINE_TOML"; then
+    echo "[e2e] FAIL: $STATUSLINE_TOML missing marker: $marker" >&2
+    cat "$STATUSLINE_TOML" >&2
+    exit 1
+  fi
+done
+# Pin the one-line confirmation in init output (init.rs prints this
+# after the seed runs). Without it, the user can't tell what just
+# happened. NO_COLOR=1 is set above, so no ANSI codes leak in.
+if ! grep -qF "$STATUSLINE_TOML" "$TMPDIR_ROOT/init-2.log"; then
+  echo "[e2e] FAIL: init did not print statusline.toml path in confirmation" >&2
+  cat "$TMPDIR_ROOT/init-2.log" >&2
+  exit 1
+fi
+if ! grep -qF "cost preset — edit to customize" "$TMPDIR_ROOT/init-2.log"; then
+  echo "[e2e] FAIL: init did not print the (cost preset — edit to customize) hint" >&2
+  cat "$TMPDIR_ROOT/init-2.log" >&2
+  exit 1
+fi
+echo "[e2e] OK: scenario 2 — statusline.toml seeded with template + confirmation printed"
+
+# Scenario 2b: repeat init — must not clobber user edits. Simulate a
+# user customization first, then run init again and assert byte-stable.
+echo "[e2e] scenario 2b: repeat init must be byte-stable on user-edited file"
+USER_EDIT='# my edit
+slots = ["session", "branch"]
+'
+printf '%s' "$USER_EDIT" >"$STATUSLINE_TOML"
+SHA_BEFORE="$(shasum -a 256 "$STATUSLINE_TOML" | awk '{print $1}')"
+"$BUDI" init --no-daemon >"$TMPDIR_ROOT/init-2b.log" 2>&1 || {
+  cat "$TMPDIR_ROOT/init-2b.log" >&2
+  echo "[e2e] FAIL: repeat init in scenario 2b failed" >&2
+  exit 1
+}
+SHA_AFTER="$(shasum -a 256 "$STATUSLINE_TOML" | awk '{print $1}')"
+if [[ "$SHA_BEFORE" != "$SHA_AFTER" ]]; then
+  echo "[e2e] FAIL: repeat init clobbered user-edited statusline.toml" >&2
+  echo "  before: $SHA_BEFORE" >&2
+  echo "  after:  $SHA_AFTER" >&2
+  cat "$STATUSLINE_TOML" >&2
+  exit 1
+fi
+# The confirmation line should *not* fire on the repeat run — that
+# would nag the user every `budi init` after the first.
+if grep -qF "cost preset — edit to customize" "$TMPDIR_ROOT/init-2b.log"; then
+  echo "[e2e] FAIL: repeat init re-printed the seeding hint" >&2
+  cat "$TMPDIR_ROOT/init-2b.log" >&2
+  exit 1
+fi
+echo "[e2e] OK: scenario 2b — repeat init byte-stable, no nag"
+
+# Scenario 3: --no-integrations must skip the seed entirely. Even with
+# ~/.claude present, the user opted out of integrations, so there's no
+# statusline being installed and therefore no file to seed.
+echo "[e2e] scenario 3: --no-integrations does not seed statusline.toml"
+TMPDIR_ROOT2="$(mktemp -d -t budi-e2e-600b-XXXXXX)"
+OLD_HOME="$HOME"
+export HOME="$TMPDIR_ROOT2"
+export BUDI_HOME="$HOME/.local/share/budi"
+mkdir -p "$HOME/.claude"
+"$BUDI" init --no-daemon --no-integrations >"$TMPDIR_ROOT2/init-3.log" 2>&1 || {
+  cat "$TMPDIR_ROOT2/init-3.log" >&2
+  echo "[e2e] FAIL: --no-integrations init failed" >&2
+  rm -rf "$TMPDIR_ROOT2"
+  exit 1
+}
+if [[ -e "$HOME/.config/budi/statusline.toml" ]]; then
+  echo "[e2e] FAIL: --no-integrations seeded statusline.toml anyway" >&2
+  cat "$HOME/.config/budi/statusline.toml" >&2
+  rm -rf "$TMPDIR_ROOT2"
+  exit 1
+fi
+rm -rf "$TMPDIR_ROOT2"
+export HOME="$OLD_HOME"
+export BUDI_HOME="$HOME/.local/share/budi"
+echo "[e2e] OK: scenario 3 — --no-integrations leaves statusline.toml absent"
+
+echo "[e2e] PASS"


### PR DESCRIPTION
Closes #600.

## Summary

- `budi init` now seeds `~/.config/budi/statusline.toml` with the active `cost` preset and commented examples for `coach` / `full` / custom-format. The README documents this file as the customization surface; pre-fix it didn't exist after a fresh init, so users had nothing to discover.
- Idempotent: repeat init runs leave user-edited files byte-stable.
- Gated: not seeded when `~/.claude` is absent (the statusline itself isn't installed) or when `--no-integrations` is passed.

## Files

- `crates/budi-core/src/config.rs` — `seed_statusline_config_if_needed()` + `STATUSLINE_TOML_TEMPLATE` constant.
- `crates/budi-cli/src/commands/integrations.rs` — wired into `install_claude_settings` on the no-preset path; prints a single confirmation line on first generation.
- `scripts/e2e/test_600_init_seeds_statusline_toml.sh` — covers all four acceptance scenarios.

## Test plan

- [x] `cargo build --release` — clean
- [x] `cargo clippy --release --all-targets -- -D warnings` — clean
- [x] `cargo test -p budi-core --release config::` — all pass
- [x] `bash scripts/e2e/test_600_init_seeds_statusline_toml.sh` — all 4 scenarios pass
- [x] `bash scripts/e2e/test_454_init_installs_statusline.sh` — still passes (no regression on the existing statusline install path)
- [x] Negative-path verification: stashed the fix, ran the new e2e — scenario 2 fails as expected. Restored fix, e2e passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)