### PR TITLE
docs: README pass for 8.3.14-era surface drift (#601)

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ budi db import               # import historical transcripts (one-time backfill)
 budi update                  # update to latest release
 ```
 
-All commands support `--period today|week|month|all` and `--format json`. See the [full CLI reference](#full-cli-reference) below.
+Data commands accept `--period today|week|month|all` (or relative like `7d`, `2w`, `1m`) and `--format json` for scripting. See the [full CLI reference](#full-cli-reference) below.
 
 ## Status line
 
@@ -295,13 +295,17 @@ budi sessions latest               # detail + vitals for the most recent session
 ```bash
 budi doctor                        # check health: daemon, tailer, schema, transcript visibility
 budi doctor --deep                 # run full SQLite integrity_check (slower)
+budi doctor --format json          # JSON output for scripting
 budi pricing                       # pricing manifest source, version, fetched-at, model count (read-only)
+budi pricing status                # same as bare `budi pricing` (long form)
 budi pricing sync                  # fetch the latest LiteLLM manifest into the local cache
 budi pricing --format json         # same data in JSON
 budi cloud init                    # generate ~/.config/budi/cloud.toml from a commented template
 budi cloud init --api-key KEY      # write the key + enable sync in one step
 budi cloud status                  # cloud sync readiness + last-synced-at + queued records
 budi cloud sync                    # push queued local rollups to the cloud now
+budi cloud sync --full             # drop watermarks then re-upload everything (cloud reset && cloud sync in one step)
+budi cloud sync --full --yes       # same, non-interactive (CI / scripts)
 budi cloud reset                   # reset watermarks so the next sync re-uploads everything (org switch / data wipe)
 budi autostart status              # check daemon autostart service
 budi autostart install             # install the autostart service
@@ -319,7 +323,7 @@ budi uninstall                     # remove status line, config, and data
 budi uninstall --keep-data         # uninstall but keep analytics database
 ```
 
-All data commands support `--period today|week|month|all` and `--format json`.
+Data views accept `--period today|week|month|all` (or relative like `7d`, `2w`, `1m`) and `--format json` for scripting. Side-effecting commands (`init`, `update`, `uninstall`, `db check`, `cloud init`, `integrations install`) do not take `--format json`.
 
 </details>
 


### PR DESCRIPTION
## Summary

Audit pass on `README.md` for drift after 8.3.14. Three new verbs that landed in the binary were missing from the CLI reference, and two prose claims overstated which commands accept `--period` / `--format json`.

**Added to the Full CLI reference:**
- `budi pricing status` — long form of bare `budi pricing` (#584 split)
- `budi cloud sync --full` / `--full --yes` — combined `cloud reset && cloud sync` (#583)
- `budi doctor --format json` — JSON output (#588 consistency pass)

**Tightened wording:**
- "All commands support `--period` and `--format json`" → "Data commands accept …" (the prior wording was directly above a code block that included `budi update`, which takes neither flag)
- Same fix on the closing line of the Full CLI reference, with an explicit list of the side-effecting verbs that don't accept `--format json` (`init`, `update`, `uninstall`, `db check`, `cloud init`, `integrations install`)

**Verified clean (no change needed):**
- No `budi vitals` / `budi health` / `budi migrate` / `budi repair` / `init --cleanup` recommended-command hits in `README.md` or `SOUL.md` (the only matches in `SOUL.md` are historical "removed in 8.3.x" notes with the right issue refs)
- Sessions section uses `vitals` / `health` as data nouns, not verbs
- Status line section already references `~/.config/budi/statusline.toml` (seeded by #605)
- Troubleshooting `budi integrations list` / `--with claude-code-statusline` commands resolve against the current binary
- In-binary `--help` (`crates/budi-cli/src/main.rs` after_help) already advertises pricing / cloud / stats subcommands correctly — no source changes needed

**Out of scope (per ticket):**
- ADR updates (immutable history)
- Section restructuring / new content

Closes #601

## Test plan

- [x] `grep -nE 'budi (vitals|health|migrate|repair)\b' README.md SOUL.md` → only the SOUL.md historical-removal notes remain
- [x] `grep -nE 'init.*--cleanup' README.md SOUL.md` → no hits
- [x] `cargo build --bin budi` then `budi pricing --help` / `budi cloud --help` / `budi stats --help` → in-binary examples match README

🤖 Generated with [Claude Code](https://claude.com/claude-code)