### PR TITLE
fix: validate `budi statusline --provider` against canonical set (#615)

### DIFF
--- a/crates/budi-cli/src/commands/mod.rs
+++ b/crates/budi-cli/src/commands/mod.rs
@@ -212,6 +212,39 @@ pub fn format_cost(dollars: f64) -> String {
     }
 }
 
+/// Resolve a user-supplied `--provider` value to its canonical DB name.
+///
+/// Centralized so every command that takes `--provider` shares one
+/// contract: unknown values error with a helpful list, and aliases
+/// (`copilot` → `copilot_cli`, `anthropic` → `claude_code`) resolve to
+/// the canonical form used in SQLite. Prompt-style commands that want to
+/// stay quiet on a typo can map this error to a soft fallback themselves
+/// (#615).
+pub fn normalize_provider(input: &str) -> Result<String> {
+    const KNOWN_PROVIDERS: &[&str] = &["claude_code", "cursor", "codex", "copilot_cli", "openai"];
+
+    if KNOWN_PROVIDERS.contains(&input) {
+        return Ok(input.to_string());
+    }
+
+    match input {
+        "copilot" => Ok("copilot_cli".to_string()),
+        "anthropic" => Ok("claude_code".to_string()),
+        _ => {
+            let all: Vec<&str> = KNOWN_PROVIDERS
+                .iter()
+                .copied()
+                .chain(["copilot", "anthropic"])
+                .collect();
+            anyhow::bail!(
+                "Unknown provider '{}'. Available providers: {}",
+                input,
+                all.join(", ")
+            );
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -312,6 +345,47 @@ mod tests {
         let before = v.clone();
         round_cents_to_integer(&mut v);
         assert_eq!(v, before);
+    }
+
+    // --- normalize_provider (#615) -----------------------------------
+
+    #[test]
+    fn normalize_provider_accepts_canonical_names() {
+        // Every canonical name routed through the shared helper round-
+        // trips unchanged so callers can pass the result straight to the
+        // SQL `provider` column.
+        for name in ["claude_code", "cursor", "codex", "copilot_cli", "openai"] {
+            assert_eq!(normalize_provider(name).unwrap(), name);
+        }
+    }
+
+    #[test]
+    fn normalize_provider_resolves_user_aliases() {
+        assert_eq!(normalize_provider("copilot").unwrap(), "copilot_cli");
+        assert_eq!(normalize_provider("anthropic").unwrap(), "claude_code");
+    }
+
+    #[test]
+    fn normalize_provider_rejects_unknown_with_helpful_list() {
+        // #615: unknown values must error consistently for every command
+        // that takes `--provider` (currently `budi stats` and
+        // `budi statusline`). The error mentions the unknown value AND
+        // every accepted name so users can fix typos in shell configs
+        // without re-reading the docs.
+        let err = normalize_provider("doesnotexist").expect_err("must error");
+        let msg = err.to_string();
+        assert!(msg.contains("doesnotexist"), "error: {msg}");
+        for expected in [
+            "claude_code",
+            "cursor",
+            "codex",
+            "copilot_cli",
+            "openai",
+            "copilot",
+            "anthropic",
+        ] {
+            assert!(msg.contains(expected), "error '{msg}' missing '{expected}'");
+        }
     }
 
     #[test]

--- a/crates/budi-cli/src/commands/stats.rs
+++ b/crates/budi-cli/src/commands/stats.rs
@@ -6,7 +6,7 @@ use chrono::{Local, Months, NaiveDate, TimeZone};
 use crate::StatsPeriod;
 use crate::client::DaemonClient;
 
-use super::ansi;
+use super::{ansi, normalize_provider};
 
 // ─── Shared Breakdown Rendering (#449) ───────────────────────────────────────
 //
@@ -2206,35 +2206,6 @@ fn display_dimension(view: BreakdownView, value: &str) -> String {
         view.untagged_label().to_string()
     } else {
         value.to_string()
-    }
-}
-
-/// Resolve a user-supplied provider name to its canonical DB value.
-///
-/// Canonical names: `claude_code`, `cursor`, `codex`, `copilot_cli`, `openai`.
-/// Accepted aliases: `copilot` → `copilot_cli`, `anthropic` → `claude_code`.
-fn normalize_provider(input: &str) -> Result<String> {
-    const KNOWN_PROVIDERS: &[&str] = &["claude_code", "cursor", "codex", "copilot_cli", "openai"];
-
-    if KNOWN_PROVIDERS.contains(&input) {
-        return Ok(input.to_string());
-    }
-
-    match input {
-        "copilot" => Ok("copilot_cli".to_string()),
-        "anthropic" => Ok("claude_code".to_string()),
-        _ => {
-            let all: Vec<&str> = KNOWN_PROVIDERS
-                .iter()
-                .copied()
-                .chain(["copilot", "anthropic"])
-                .collect();
-            anyhow::bail!(
-                "Unknown provider '{}'. Available providers: {}",
-                input,
-                all.join(", ")
-            );
-        }
     }
 }
 

--- a/crates/budi-cli/src/commands/statusline.rs
+++ b/crates/budi-cli/src/commands/statusline.rs
@@ -16,6 +16,7 @@ use crate::daemon::daemon_client_with_timeout;
 pub const CLAUDE_USER_SETTINGS: &str = ".claude/settings.json";
 
 use super::format_cost as fmt_cost;
+use super::normalize_provider;
 
 /// Detect the current git branch from a directory.
 fn detect_git_branch(dir: &str) -> Option<String> {
@@ -322,6 +323,14 @@ fn nudge_legacy_statusline_tokens_inner(
 }
 
 pub fn cmd_statusline(format: StatuslineFormat, provider: Option<String>) -> Result<()> {
+    // #615: validate --provider up front against the same canonical set
+    // as `budi stats` so an unknown value errors with a helpful list
+    // instead of silently rendering $0.00. Aliases (`copilot`,
+    // `anthropic`) resolve to their canonical form here too.
+    let provider = provider
+        .map(|p| normalize_provider(&p))
+        .transpose()?;
+
     let stdin_json = if io::stdin().is_terminal() {
         None
     } else {
@@ -1063,5 +1072,23 @@ mod tests {
         assert!(!out.is_empty());
         assert!(marker.exists());
         let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn cmd_statusline_rejects_unknown_provider_before_io() {
+        // #615: an unknown `--provider` value must error with the same
+        // helpful list `budi stats --provider <unknown>` produces, not
+        // fall through and render a silent zero. The validation runs
+        // before any daemon I/O so the test is hermetic — no fixture
+        // daemon required.
+        let err = cmd_statusline(
+            crate::StatuslineFormat::Json,
+            Some("doesnotexist".to_string()),
+        )
+        .expect_err("unknown provider must error");
+        let msg = err.to_string();
+        assert!(msg.contains("doesnotexist"), "error: {msg}");
+        assert!(msg.contains("Available providers"), "error: {msg}");
+        assert!(msg.contains("claude_code"), "error: {msg}");
     }
 }

--- a/crates/budi-cli/src/commands/statusline.rs
+++ b/crates/budi-cli/src/commands/statusline.rs
@@ -327,9 +327,7 @@ pub fn cmd_statusline(format: StatuslineFormat, provider: Option<String>) -> Res
     // as `budi stats` so an unknown value errors with a helpful list
     // instead of silently rendering $0.00. Aliases (`copilot`,
     // `anthropic`) resolve to their canonical form here too.
-    let provider = provider
-        .map(|p| normalize_provider(&p))
-        .transpose()?;
+    let provider = provider.map(|p| normalize_provider(&p)).transpose()?;
 
     let stdin_json = if io::stdin().is_terminal() {
         None


### PR DESCRIPTION
## Summary

Closes #615.

`budi statusline --provider doesnotexist` used to fall through and render a silent zero, while `budi stats --provider doesnotexist` errored with a helpful list — same flag, two contracts.

- Lifted `normalize_provider` from `commands/stats.rs` into `commands/mod.rs` so every command that takes `--provider` shares one gate.
- `cmd_statusline` now calls it up front, before any daemon I/O. Aliases (`copilot` → `copilot_cli`, `anthropic` → `claude_code`) keep working.

```
$ budi statusline --format json --provider doesnotexist
Error: Unknown provider 'doesnotexist'. Available providers: claude_code, cursor, codex, copilot_cli, openai, copilot, anthropic
# exit 1
```

## Test plan

- [x] `cargo test -p budi-cli` — 215 passing, including new `normalize_provider_*` and `cmd_statusline_rejects_unknown_provider_before_io` cases.
- [x] `cargo clippy -p budi-cli -- -D warnings` clean.
- [x] Manual smoke: unknown provider errors with the canonical list; `--provider cursor` round-trips; `--provider copilot` resolves to `copilot_cli`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)