### PR TITLE
fix: `budi stats activities` reports no attribution despite tagged sessions (#616)

### DIFF
--- a/crates/budi-core/src/analytics/mod.rs
+++ b/crates/budi-core/src/analytics/mod.rs
@@ -540,7 +540,7 @@ pub fn ingest_messages_with_sync(
             {
                 seen_sessions.insert((sid.clone(), msg.provider.clone()));
                 if let Some(ref cat) = msg.prompt_category {
-                    session_categories.entry(sid).or_insert_with(|| cat.clone());
+                    session_categories.insert(sid, cat.clone());
                 }
             }
         }
@@ -579,8 +579,7 @@ pub fn ingest_messages_with_sync(
         }
         for (sid, category) in &session_categories {
             tx.execute(
-                "UPDATE sessions SET prompt_category = ?2
-                 WHERE id = ?1 AND (prompt_category IS NULL OR prompt_category = '')",
+                "UPDATE sessions SET prompt_category = ?2 WHERE id = ?1",
                 params![sid, category],
             )?;
         }

--- a/crates/budi-core/src/analytics/sync.rs
+++ b/crates/budi-core/src/analytics/sync.rs
@@ -319,6 +319,13 @@ fn sync_with_max_age<F: FnMut(&SyncProgress)>(
             tracing::info!("Backfilled ticket_id tags on {tickets_backfilled} messages");
         }
 
+        let activities_backfilled = backfill_activity_tags(conn);
+        if activities_backfilled > 0 {
+            tracing::info!(
+                "Backfilled activity tags on {activities_backfilled} messages (#616)"
+            );
+        }
+
         let removed_legacy_auto_tags = cleanup_legacy_auto_tags(conn);
         if removed_legacy_auto_tags > 0 {
             tracing::info!(
@@ -490,6 +497,82 @@ fn backfill_ticket_tags(conn: &mut Connection) -> usize {
             }
             count += 1;
         }
+    }
+
+    if tx.commit().is_err() {
+        return 0;
+    }
+    count
+}
+
+/// Backfill `activity` / `activity_source` / `activity_confidence` tags for
+/// assistant messages that were ingested without them.
+///
+/// Root cause (#616): the live tailer processes user and assistant messages
+/// in separate batches (the user entry is written to JSONL before Claude
+/// responds). `propagate_session_context` inside `Pipeline::process` can
+/// only propagate `prompt_category` from user → assistant within a single
+/// batch, so an assistant arriving in a later batch never inherits the
+/// classification and never receives an activity tag.
+///
+/// Fix: after each sync cycle, find recent assistant messages without an
+/// activity tag whose session carries a `prompt_category` (set when the
+/// user message was ingested) and insert the missing tags. The session-
+/// level classification is the best available signal when per-message
+/// prompt text is not stored in the database.
+fn backfill_activity_tags(conn: &mut Connection) -> usize {
+    let rows: Vec<(String, String)> = {
+        let mut stmt = match conn.prepare(
+            "SELECT m.id, s.prompt_category
+             FROM messages m
+             JOIN sessions s ON s.id = m.session_id
+             WHERE m.role = 'assistant'
+               AND m.timestamp >= datetime('now', '-90 days')
+               AND s.prompt_category IS NOT NULL AND s.prompt_category != ''
+               AND NOT EXISTS (
+                 SELECT 1 FROM tags t
+                 WHERE t.message_id = m.id AND t.key = 'activity'
+               )
+             LIMIT 10000",
+        ) {
+            Ok(s) => s,
+            Err(_) => return 0,
+        };
+        stmt.query_map([], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })
+        .ok()
+        .map(|iter| iter.filter_map(|r| r.ok()).collect())
+        .unwrap_or_default()
+    };
+
+    if rows.is_empty() {
+        return 0;
+    }
+
+    let tx = match conn.transaction() {
+        Ok(t) => t,
+        Err(_) => return 0,
+    };
+
+    let mut count = 0usize;
+    for (uuid, category) in &rows {
+        if let Err(e) = tx.execute(
+            "INSERT OR IGNORE INTO tags (message_id, key, value) VALUES (?1, 'activity', ?2)",
+            rusqlite::params![uuid, category],
+        ) {
+            tracing::warn!("backfill_activity_tags: activity insert failed for {uuid}: {e}");
+            continue;
+        }
+        let _ = tx.execute(
+            "INSERT OR IGNORE INTO tags (message_id, key, value) VALUES (?1, 'activity_source', 'rule')",
+            rusqlite::params![uuid],
+        );
+        let _ = tx.execute(
+            "INSERT OR IGNORE INTO tags (message_id, key, value) VALUES (?1, 'activity_confidence', 'medium')",
+            rusqlite::params![uuid],
+        );
+        count += 1;
     }
 
     if tx.commit().is_err() {
@@ -751,8 +834,8 @@ fn truncate_title(text: &str, max_len: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        ProviderSyncStats, SyncProgress, SyncReport, first_legacy_proxy_message_timestamp,
-        read_transcript_tail,
+        ProviderSyncStats, SyncProgress, SyncReport, backfill_activity_tags,
+        first_legacy_proxy_message_timestamp, read_transcript_tail,
     };
 
     fn temp_file_path(test_name: &str) -> std::path::PathBuf {
@@ -867,5 +950,120 @@ mod tests {
 
         let ts = first_legacy_proxy_message_timestamp(&conn).expect("timestamp exists");
         assert_eq!(ts.to_rfc3339(), "2026-04-10T09:00:00+00:00");
+    }
+
+    #[test]
+    fn backfill_activity_tags_fills_from_session_category() {
+        let mut conn = rusqlite::Connection::open_in_memory().expect("open in-memory db");
+        crate::migration::migrate(&conn).expect("migrate schema");
+
+        conn.execute(
+            "INSERT INTO sessions (id, provider, prompt_category)
+             VALUES ('s1', 'claude_code', 'bugfix')",
+            [],
+        )
+        .expect("insert session");
+
+        conn.execute(
+            "INSERT INTO messages
+             (id, session_id, role, timestamp, model, provider,
+              input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
+              cost_cents, cost_confidence)
+             VALUES
+             ('a1', 's1', 'assistant', datetime('now'), 'claude-opus-4-6', 'claude_code',
+              100, 50, 0, 0, 5.0, 'exact')",
+            [],
+        )
+        .expect("insert assistant message");
+
+        let count = backfill_activity_tags(&mut conn);
+        assert_eq!(count, 1, "should backfill exactly one message");
+
+        let tags: Vec<(String, String)> = conn
+            .prepare("SELECT key, value FROM tags WHERE message_id = 'a1' ORDER BY key")
+            .unwrap()
+            .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+            .unwrap()
+            .filter_map(|r| r.ok())
+            .collect();
+
+        assert_eq!(
+            tags,
+            vec![
+                ("activity".to_string(), "bugfix".to_string()),
+                ("activity_confidence".to_string(), "medium".to_string()),
+                ("activity_source".to_string(), "rule".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn backfill_activity_tags_skips_already_tagged() {
+        let mut conn = rusqlite::Connection::open_in_memory().expect("open in-memory db");
+        crate::migration::migrate(&conn).expect("migrate schema");
+
+        conn.execute(
+            "INSERT INTO sessions (id, provider, prompt_category)
+             VALUES ('s1', 'claude_code', 'bugfix')",
+            [],
+        )
+        .expect("insert session");
+
+        conn.execute(
+            "INSERT INTO messages
+             (id, session_id, role, timestamp, model, provider,
+              input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
+              cost_cents, cost_confidence)
+             VALUES
+             ('a1', 's1', 'assistant', datetime('now'), 'claude-opus-4-6', 'claude_code',
+              100, 50, 0, 0, 5.0, 'exact')",
+            [],
+        )
+        .expect("insert assistant message");
+
+        conn.execute(
+            "INSERT INTO tags (message_id, key, value) VALUES ('a1', 'activity', 'feature')",
+            [],
+        )
+        .expect("insert existing activity tag");
+
+        let count = backfill_activity_tags(&mut conn);
+        assert_eq!(count, 0, "should not backfill already-tagged message");
+
+        let activity: String = conn
+            .query_row(
+                "SELECT value FROM tags WHERE message_id = 'a1' AND key = 'activity'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(activity, "feature", "original tag should be preserved");
+    }
+
+    #[test]
+    fn backfill_activity_tags_skips_sessions_without_category() {
+        let mut conn = rusqlite::Connection::open_in_memory().expect("open in-memory db");
+        crate::migration::migrate(&conn).expect("migrate schema");
+
+        conn.execute(
+            "INSERT INTO sessions (id, provider) VALUES ('s1', 'claude_code')",
+            [],
+        )
+        .expect("insert session without prompt_category");
+
+        conn.execute(
+            "INSERT INTO messages
+             (id, session_id, role, timestamp, model, provider,
+              input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
+              cost_cents, cost_confidence)
+             VALUES
+             ('a1', 's1', 'assistant', datetime('now'), 'claude-opus-4-6', 'claude_code',
+              100, 50, 0, 0, 5.0, 'exact')",
+            [],
+        )
+        .expect("insert assistant message");
+
+        let count = backfill_activity_tags(&mut conn);
+        assert_eq!(count, 0, "should not backfill when session has no category");
     }
 }

--- a/crates/budi-core/src/analytics/sync.rs
+++ b/crates/budi-core/src/analytics/sync.rs
@@ -321,9 +321,7 @@ fn sync_with_max_age<F: FnMut(&SyncProgress)>(
 
         let activities_backfilled = backfill_activity_tags(conn);
         if activities_backfilled > 0 {
-            tracing::info!(
-                "Backfilled activity tags on {activities_backfilled} messages (#616)"
-            );
+            tracing::info!("Backfilled activity tags on {activities_backfilled} messages (#616)");
         }
 
         let removed_legacy_auto_tags = cleanup_legacy_auto_tags(conn);

--- a/crates/budi-core/src/analytics/tests.rs
+++ b/crates/budi-core/src/analytics/tests.rs
@@ -6462,3 +6462,96 @@ fn status_snapshot_empty_window() {
     assert_eq!(snap.cost.total_cost, 0.0);
     assert!(snap.providers.is_empty());
 }
+
+#[test]
+fn session_prompt_category_tracks_latest_value() {
+    let mut conn = test_db();
+
+    let u1 = ParsedMessage {
+        uuid: "u1".to_string(),
+        session_id: Some("s1".to_string()),
+        timestamp: "2026-03-14T18:13:42Z".parse().unwrap(),
+        cwd: None,
+        role: "user".to_string(),
+        model: None,
+        input_tokens: 0,
+        output_tokens: 0,
+        cache_creation_tokens: 0,
+        cache_read_tokens: 0,
+        git_branch: None,
+        repo_id: None,
+        provider: "claude_code".to_string(),
+        cost_cents: None,
+        session_title: None,
+        parent_uuid: None,
+        user_name: None,
+        machine_name: None,
+        cost_confidence: "n/a".to_string(),
+        pricing_source: None,
+        request_id: None,
+        speed: None,
+        cache_creation_1h_tokens: 0,
+        web_search_requests: 0,
+        prompt_category: Some("bugfix".to_string()),
+        prompt_category_source: None,
+        prompt_category_confidence: None,
+        tool_names: Vec::new(),
+        tool_use_ids: Vec::new(),
+        tool_files: Vec::new(),
+        tool_outcomes: Vec::new(),
+    };
+    ingest_messages(&mut conn, &[u1], Some(&[Vec::new()])).unwrap();
+
+    let cat: String = conn
+        .query_row(
+            "SELECT prompt_category FROM sessions WHERE id = 's1'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(cat, "bugfix");
+
+    let u2 = ParsedMessage {
+        uuid: "u2".to_string(),
+        session_id: Some("s1".to_string()),
+        timestamp: "2026-03-14T18:14:00Z".parse().unwrap(),
+        cwd: None,
+        role: "user".to_string(),
+        model: None,
+        input_tokens: 0,
+        output_tokens: 0,
+        cache_creation_tokens: 0,
+        cache_read_tokens: 0,
+        git_branch: None,
+        repo_id: None,
+        provider: "claude_code".to_string(),
+        cost_cents: None,
+        session_title: None,
+        parent_uuid: None,
+        user_name: None,
+        machine_name: None,
+        cost_confidence: "n/a".to_string(),
+        pricing_source: None,
+        request_id: None,
+        speed: None,
+        cache_creation_1h_tokens: 0,
+        web_search_requests: 0,
+        prompt_category: Some("feature".to_string()),
+        prompt_category_source: None,
+        prompt_category_confidence: None,
+        tool_names: Vec::new(),
+        tool_use_ids: Vec::new(),
+        tool_files: Vec::new(),
+        tool_outcomes: Vec::new(),
+    };
+    ingest_messages(&mut conn, &[u2], Some(&[Vec::new()])).unwrap();
+
+    let cat: String = conn
+        .query_row(
+            "SELECT prompt_category FROM sessions WHERE id = 's1'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(cat, "feature", "session should track the latest prompt_category");
+}

--- a/crates/budi-core/src/analytics/tests.rs
+++ b/crates/budi-core/src/analytics/tests.rs
@@ -6553,5 +6553,8 @@ fn session_prompt_category_tracks_latest_value() {
             |row| row.get(0),
         )
         .unwrap();
-    assert_eq!(cat, "feature", "session should track the latest prompt_category");
+    assert_eq!(
+        cat, "feature",
+        "session should track the latest prompt_category"
+    );
 }


### PR DESCRIPTION
## Summary

- **Root cause**: The live tailer processes user and assistant messages in separate batches (500ms debounce vs seconds of Claude response time). `propagate_session_context` can only propagate `prompt_category` from user → assistant within a single `Pipeline::process()` call, so assistant messages arriving in a later batch never inherit the classification and never receive activity tags.
- **Fix**: Add `backfill_activity_tags()` post-ingest step that finds recent assistant messages without activity tags whose session carries a `prompt_category` and inserts the missing `activity`/`activity_source`/`activity_confidence` tag triplet. Runs every sync cycle, same pattern as `backfill_ticket_tags`.
- **Session tracking improvement**: Track the latest `prompt_category` per session (not just the first) so the backfill uses the most recent classification when the user changes topics mid-session.

## Test plan

- [x] `backfill_activity_tags_fills_from_session_category` — backfill inserts all three tags from session category
- [x] `backfill_activity_tags_skips_already_tagged` — existing activity tags are preserved
- [x] `backfill_activity_tags_skips_sessions_without_category` — no-op when session lacks classification
- [x] `session_prompt_category_tracks_latest_value` — session updates to latest category on re-ingest
- [x] Full test suite: 506 budi-core + 45 CLI/daemon tests pass

Closes #616

🤖 Generated with [Claude Code](https://claude.com/claude-code)