### PR TITLE
feat: expose `id_short` in session JSON output (#618)

### DIFF
--- a/crates/budi-cli/src/commands/sessions.rs
+++ b/crates/budi-cli/src/commands/sessions.rs
@@ -29,13 +29,7 @@ struct SessionsEnvelope {
 /// terminal alongside repo + cost columns.
 const MODEL_COL_WIDTH: usize = 28;
 
-/// Short-UUID prefix length rendered by `budi sessions` by default
-/// (#445). `--full-uuid` surfaces the 36-char identifier for scripting
-/// and for `budi sessions <id>` lookup. Eight hex chars is long enough
-/// to remain unambiguous at the < 1M session scale Budi is designed
-/// around; the fresh-user smoke pass showed 36 chars dominating the
-/// visible row width.
-const SHORT_UUID_LEN: usize = 8;
+use budi_core::analytics::SHORT_ID_LEN;
 
 pub fn cmd_sessions(
     period: StatsPeriod,
@@ -476,7 +470,7 @@ fn render_session_id(id: &str, full_uuid: bool) -> String {
     if full_uuid {
         return id.to_string();
     }
-    id.chars().take(SHORT_UUID_LEN).collect()
+    id.chars().take(SHORT_ID_LEN).collect::<String>()
 }
 
 /// Truncate `s` to at most `max` characters (not bytes), appending an
@@ -511,7 +505,7 @@ mod tests {
         let id = "1d027675-4ad0-43b2-b396-88b6ee28f7ba";
         let rendered = render_session_id(id, false);
         assert_eq!(rendered, "1d027675");
-        assert_eq!(rendered.len(), SHORT_UUID_LEN);
+        assert_eq!(rendered.len(), SHORT_ID_LEN);
     }
 
     #[test]
@@ -529,7 +523,7 @@ mod tests {
         let id = "café-1234-5678-abcd";
         let rendered = render_session_id(id, false);
         // Eight chars — `c`, `a`, `f`, `é`, `-`, `1`, `2`, `3`.
-        assert_eq!(rendered.chars().count(), SHORT_UUID_LEN);
+        assert_eq!(rendered.chars().count(), SHORT_ID_LEN);
     }
 
     #[test]

--- a/crates/budi-core/src/analytics/sessions.rs
+++ b/crates/budi-core/src/analytics/sessions.rs
@@ -194,11 +194,22 @@ pub fn session_visibility(conn: &Connection) -> Result<Vec<SessionVisibilityWind
 
 pub const CURSOR_LAG_HINT: &str = "Cursor cost data may lag up to ~10 minutes";
 
+/// Length of the short session-id prefix exposed in both the text view
+/// and the `id_short` JSON field. Eight hex characters gives ~4 billion
+/// combinations — unambiguous at the scale Budi targets.
+pub const SHORT_ID_LEN: usize = 8;
+
+fn short_id(id: &str) -> String {
+    id.chars().take(SHORT_ID_LEN).collect()
+}
+
 /// Session list entry for the Sessions page.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct SessionListEntry {
     #[serde(alias = "session_id")]
     pub id: String,
+    #[serde(default)]
+    pub id_short: String,
     pub started_at: Option<String>,
     pub ended_at: Option<String>,
     pub duration_ms: Option<i64>,
@@ -577,8 +588,10 @@ pub fn session_list_with_filters(
     let mut stmt = conn.prepare(&sql)?;
     let sessions: Vec<SessionListEntry> = stmt
         .query_map(param_refs.as_slice(), |row| {
+            let id: String = row.get(1)?;
             Ok(SessionListEntry {
-                id: row.get(1)?,
+                id_short: short_id(&id),
+                id,
                 started_at: row.get(2)?,
                 ended_at: row.get(3)?,
                 duration_ms: row.get(4)?,
@@ -742,8 +755,10 @@ pub fn session_detail(conn: &Connection, session_id: &str) -> Result<Option<Sess
          FROM session_agg",
         params![session_id],
         |row| {
+            let id: String = row.get(0)?;
             Ok(SessionListEntry {
-                id: row.get(0)?,
+                id_short: short_id(&id),
+                id,
                 started_at: row.get(1)?,
                 ended_at: row.get(2)?,
                 duration_ms: row.get(3)?,


### PR DESCRIPTION
## Summary

- Adds `id_short` (8-char prefix) to `SessionListEntry`, so `budi sessions --format json` and `budi sessions <id> --format json` emit both `id` (full UUID) and `id_short` alongside each other.
- Moves the short-id length constant (`SHORT_ID_LEN`) from the CLI into `budi-core` so both the text renderer and JSON serializer share a single source of truth.
- `#[serde(default)]` on `id_short` ensures backward-compatible deserialization from older daemon responses that lack the field.

Closes #618

## Test plan

- [x] `cargo build` — clean
- [x] `cargo test -p budi-core` — 506 passed
- [x] `cargo test -p budi-cli` — 218 passed
- [ ] Smoke: `budi sessions --format json | jq '.[0] | {id, id_short}'` shows both fields, `id_short` is the first 8 chars of `id`
- [ ] Smoke: `budi sessions latest --format json | jq '{id, id_short}'` — same check

🤖 Generated with [Claude Code](https://claude.com/claude-code)