### PR TITLE
release: prep v8.3.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,70 @@
 # Changelog
 
+## 8.3.17 — 2026-05-05
+
+8.3.17 is a quality-of-life release that fixes five user-facing bugs and
+adds two test-coverage backstops for fixes that landed in 8.3.16.
+Headline: **`budi stats activities` no longer silently drops attribution**
+when assistant messages arrive in a later tailer batch than the user
+messages that classify them. The rest closes out JSON output gaps
+(`sessions --format json` truncation envelope, `id_short`), a
+`budi status` / `budi stats` cost divergence window, inconsistent
+`--provider` validation across commands, and a `budi doctor` display
+bug that masked daemon outages behind a green PASS.
+
+### Fixed
+
+- **`budi stats activities` no longer drops attribution (#616 / PR #622)** —
+  the live tailer processes user and assistant messages in separate
+  batches (500 ms debounce). `propagate_session_context` only propagated
+  `prompt_category` from user → assistant within a single
+  `Pipeline::process()` call, so assistant messages arriving in a later
+  batch never inherited the classification and never received activity
+  tags. Fix: deferred propagation across batch boundaries.
+- **`budi status` Today cost no longer lags `budi stats` (#619 / PR #621)** —
+  `status` read a cached aggregate while `stats` queried live SQL,
+  creating a visible divergence window of seconds after each ingest.
+  New `/analytics/status_snapshot` daemon endpoint queries summary,
+  cost, and providers from a single DB connection, guaranteeing a
+  consistent point-in-time snapshot.
+- **`budi statusline --provider <unknown>` now validates (#615 / PR #620)** —
+  `statusline` silently returned zero cost for unknown providers while
+  `stats` rejected them with a helpful list. Centralized provider
+  parsing so both commands validate against the canonical provider set.
+- **`budi sessions --format json` truncation envelope (#617 / PR #623)** —
+  JSON output now wraps sessions in an envelope with `returned_count`,
+  `truncated`, `limit`, and `window` fields so consumers can tell
+  whether they hit the cap.
+- **`budi doctor` auto-recovery display (#612 / PR #627)** —
+  when `doctor` auto-starts a dead daemon, text output now shows
+  supervisor state (e.g. `supervisor: launchd LaunchAgent: installed
+  (not running)`) alongside the gap duration, instead of masking the
+  outage behind a green PASS.
+
+### Added
+
+- **`id_short` in session JSON output (#618 / PR #624)** —
+  `budi sessions --format json` and `budi sessions <id> --format json`
+  now emit both `id` (full UUID) and `id_short` (8-char prefix).
+
+### Tests
+
+- **macOS launchctl kickstart regression guards (#611 / PR #625)** —
+  extracted `launchctl_kickstart_target()` helper from
+  `try_launchctl_kickstart()` for testability; added unit tests pinning
+  the expected kickstart target format.
+- **Upgrade-path integration refresh e2e (#613 / PR #626)** —
+  simulates upgrading from a v8.3.14 `integrations.toml` (missing the
+  `/budi` skill component) and verifies that `refresh_enabled_integrations`
+  creates `statusline.toml`, `SKILL.md` with canonical bytes, and
+  persists the expanded component set.
+
+### Non-blocking, carried forward
+
+- **Cloud Overview cost / token totals diverge from local CLI** (#10) — presentation-layer aggregation difference, not data loss.
+- **RC-4 Part B** (#504) — Cursor Usage API auth root-cause; Part A shipped with `v8.3.1`.
+- **ADR-0090 supersede** — pending one release cycle of live validation on the now-working `cursorDiskKV` bubbles path before the Usage API §1 surface can be retired.
+
 ## 8.3.16 — 2026-05-01
 
 8.3.16 is a same-day patch release on top of 8.3.15 that closes three

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,7 +175,7 @@ dependencies = [
 
 [[package]]
 name = "budi-cli"
-version = "8.3.16"
+version = "8.3.17"
 dependencies = [
  "anyhow",
  "budi-core",
@@ -195,7 +195,7 @@ dependencies = [
 
 [[package]]
 name = "budi-core"
-version = "8.3.16"
+version = "8.3.17"
 dependencies = [
  "anyhow",
  "chrono",
@@ -211,7 +211,7 @@ dependencies = [
 
 [[package]]
 name = "budi-daemon"
-version = "8.3.16"
+version = "8.3.17"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "8.3.16"
+version = "8.3.17"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"


### PR DESCRIPTION
## Summary

- Bump workspace version from 8.3.16 → 8.3.17
- Add CHANGELOG entry documenting the 8.3.17 milestone (7 issues, 8 PRs)

### Milestone contents

| # | Type | Title |
|---|------|-------|
| #615 | fix | `budi statusline --provider <unknown>` validates against canonical set |
| #616 | fix | `budi stats activities` attribution across tailer batches |
| #617 | fix | `budi sessions --format json` truncation envelope |
| #618 | feat | `id_short` in session JSON output |
| #619 | fix | `budi status` Today cost lag via single-connection snapshot |
| #611 | test | macOS launchctl kickstart regression guards |
| #612 | fix | `budi doctor` auto-recovery display |
| #613 | test | upgrade-path integration refresh e2e |

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace` — 227 passed
- [ ] CI pipeline (ubuntu + macOS + windows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)