### PR TITLE
fix: add health_state to session detail JSON output

### DIFF
--- a/crates/budi-cli/src/commands/sessions.rs
+++ b/crates/budi-cli/src/commands/sessions.rs
@@ -214,6 +214,10 @@ pub fn cmd_session_detail(session_id: &str, json_output: bool) -> Result<()> {
         if let Some(map) = obj.as_object_mut() {
             map.insert("tags".to_string(), serde_json::to_value(&tags)?);
             if let Some(h) = health {
+                map.insert(
+                    "health_state".to_string(),
+                    serde_json::Value::String(h.state.clone()),
+                );
                 map.insert("health".to_string(), serde_json::to_value(&h)?);
             }
         }


### PR DESCRIPTION
## Summary

- Adds `health_state` (string) alongside the existing `health` (object) in `budi sessions latest --format json` output
- Makes the detail view consistent with the list view (`budi sessions --format json`), which already emits `health_state`
- Non-breaking change (Option 2 from #629): existing `health` field is preserved

Closes #629

## Test plan

- [x] `cargo check` — compiles cleanly
- [x] `cargo fmt --all` — no formatting issues
- [x] `cargo clippy` — no warnings
- [x] `cargo test` — all tests pass (1 pre-existing flaky test unrelated to this change)
- [ ] Manual: run `budi sessions --format json` and `budi sessions latest --format json`, verify both contain `health_state` as a string field

🤖 Generated with [Claude Code](https://claude.com/claude-code)