### PR TITLE
fix: eliminate HOME env race in parallel tests (#630)

### DIFF
--- a/crates/budi-cli/src/commands/integrations.rs
+++ b/crates/budi-cli/src/commands/integrations.rs
@@ -965,6 +965,31 @@ fn is_legacy_cursor_hook(entry: &Value) -> bool {
 mod tests {
     use super::*;
 
+    static HOME_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    struct HomeGuard {
+        prev: Option<String>,
+        _lock: std::sync::MutexGuard<'static, ()>,
+    }
+
+    impl HomeGuard {
+        fn new(home: &std::path::Path) -> Self {
+            let lock = HOME_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+            let prev = std::env::var("HOME").ok();
+            unsafe { std::env::set_var("HOME", home) };
+            Self { prev, _lock: lock }
+        }
+    }
+
+    impl Drop for HomeGuard {
+        fn drop(&mut self) {
+            match &self.prev {
+                Some(h) => unsafe { std::env::set_var("HOME", h) },
+                None => unsafe { std::env::remove_var("HOME") },
+            }
+        }
+    }
+
     #[test]
     fn apply_statusline_adds_new_statusline_when_missing() {
         let mut settings = json!({});
@@ -1113,17 +1138,11 @@ mod tests {
         .expect("write v8.3.14 integrations.toml");
 
         // Redirect HOME to the temp dir for the duration of this test.
-        let prev_home = std::env::var("HOME").ok();
-        unsafe { std::env::set_var("HOME", &tmp) };
+        // HomeGuard serializes via Mutex and restores on drop (#630).
+        let _home_guard = HomeGuard::new(&tmp);
 
         let config = budi_core::config::BudiConfig::default();
         let report = refresh_enabled_integrations(&config);
-
-        // Restore HOME before any assertions so a failure doesn't leak.
-        match prev_home {
-            Some(h) => unsafe { std::env::set_var("HOME", h) },
-            None => unsafe { std::env::remove_var("HOME") },
-        }
 
         // Cursor extension warnings are expected on machines without
         // Cursor installed — filter them out; only fail on unexpected ones.

--- a/crates/budi-cli/src/commands/statusline.rs
+++ b/crates/budi-cli/src/commands/statusline.rs
@@ -42,8 +42,11 @@ fn detect_git_branch(dir: &str) -> Option<String> {
 /// renders as `crates/budi-cli`. Falls back to the `~`-normalized path
 /// when it has fewer than two segments.
 fn short_display_path(cwd: &str) -> String {
-    let home = std::env::var("HOME").unwrap_or_default();
-    let normalized = if !home.is_empty() && cwd.starts_with(&home) {
+    short_display_path_with_home(cwd, &std::env::var("HOME").unwrap_or_default())
+}
+
+fn short_display_path_with_home(cwd: &str, home: &str) -> String {
+    let normalized = if !home.is_empty() && cwd.starts_with(home) {
         format!("~{}", &cwd[home.len()..])
     } else {
         cwd.to_string()
@@ -720,25 +723,23 @@ mod tests {
     #[test]
     fn short_display_path_normalizes_home_and_truncates() {
         // #546: path shortening contract for the Claude-format prefix.
-        unsafe { std::env::set_var("HOME", "/Users/alice") };
+        // Uses `short_display_path_with_home` to avoid mutating the
+        // global HOME env var (#630).
+        let home = "/Users/alice";
         assert_eq!(
-            short_display_path("/Users/alice/_projects/budi"),
+            short_display_path_with_home("/Users/alice/_projects/budi", home),
             "_projects/budi",
         );
-        // Deeply nested paths drop to the final two segments so the
-        // prefix doesn't blow out the prompt width budget.
         assert_eq!(
-            short_display_path("/Users/alice/_projects/budi/crates/budi-cli"),
+            short_display_path_with_home("/Users/alice/_projects/budi/crates/budi-cli", home),
             "crates/budi-cli",
         );
-        // Outside HOME: no tilde rewrite, still truncated to last two.
         assert_eq!(
-            short_display_path("/opt/homebrew/Cellar/budi/8.3.5"),
+            short_display_path_with_home("/opt/homebrew/Cellar/budi/8.3.5", home),
             "budi/8.3.5",
         );
-        // Shallow paths (<= 2 segments) render intact after tilde rewrite.
-        assert_eq!(short_display_path("/Users/alice"), "~");
-        assert_eq!(short_display_path("/tmp"), "/tmp");
+        assert_eq!(short_display_path_with_home("/Users/alice", home), "~");
+        assert_eq!(short_display_path_with_home("/tmp", home), "/tmp");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **`short_display_path`** (statusline.rs): extracted `short_display_path_with_home` that accepts the home directory as a parameter, so the test no longer mutates the global `HOME` env var.
- **`e2e_refresh_from_v8_3_14`** (integrations.rs): replaced bare `set_var`/restore with a `HomeGuard` RAII wrapper that holds a `Mutex<()>`, preventing concurrent HOME mutations and guaranteeing restore even on assertion panics.

Combines fix options 2 and 3 from the issue — parameterization where the call chain is shallow, mutex serialization where the production code depends on `home_dir()` through a deep call chain.

Closes #630

## Test plan

- [x] `cargo test --package budi-cli` passes (227 tests)
- [x] Ran full suite 3 times with no flakiness in the previously-affected tests
- [x] `cargo fmt --all` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)