### PR TITLE
feat: add session and message as first-class statusline slots

### DIFF
--- a/crates/budi-cli/src/commands/statusline.rs
+++ b/crates/budi-cli/src/commands/statusline.rs
@@ -161,6 +161,9 @@ fn build_slot_values(data: &Value) -> HashMap<String, String> {
     if let Some(v) = data.get("session_cost").and_then(|v| v.as_f64()) {
         vals.insert("session".to_string(), fmt_cost(v));
     }
+    if let Some(v) = data.get("session_msg_cost").and_then(|v| v.as_f64()) {
+        vals.insert("message".to_string(), fmt_cost(v / 100.0));
+    }
     if let Some(v) = data.get("branch_cost").and_then(|v| v.as_f64()) {
         vals.insert("branch".to_string(), fmt_cost(v));
     }
@@ -405,8 +408,9 @@ pub fn cmd_statusline(format: StatuslineFormat, provider: Option<String>) -> Res
     if let Some(ref p) = effective_provider {
         query_params.push(("provider", p.clone()));
     }
-    let needs_session =
-        needed.contains(&"session".to_string()) || needed.contains(&"health".to_string());
+    let needs_session = needed.contains(&"session".to_string())
+        || needed.contains(&"message".to_string())
+        || needed.contains(&"health".to_string());
     if let Some(ref sid) = session_id
         && needs_session
     {
@@ -885,6 +889,52 @@ mod tests {
         assert_eq!(vals.get("branch").unwrap(), "$12.50");
         assert_eq!(vals.get("provider").unwrap(), "claude_code");
         assert!(!vals.contains_key("session")); // not in response
+    }
+
+    #[test]
+    fn build_slot_values_includes_session_and_message() {
+        let data = json!({
+            "cost_1d": 10.0,
+            "cost_7d": 50.0,
+            "cost_30d": 200.0,
+            "session_cost": 6.23,
+            "session_msg_cost": 8.0,
+        });
+        let vals = build_slot_values(&data);
+        assert_eq!(vals.get("session").unwrap(), "$6.23");
+        assert_eq!(vals.get("message").unwrap(), "$0.08");
+        assert!(!vals.contains_key("health"));
+    }
+
+    #[test]
+    fn build_slot_values_message_absent_without_session_msg_cost() {
+        let data = json!({
+            "cost_1d": 1.0,
+            "cost_7d": 5.0,
+            "cost_30d": 20.0,
+            "session_cost": 1.0,
+        });
+        let vals = build_slot_values(&data);
+        assert!(vals.contains_key("session"));
+        assert!(!vals.contains_key("message"));
+    }
+
+    #[test]
+    fn render_slots_session_and_message() {
+        let mut values = HashMap::new();
+        values.insert("session".to_string(), "$6.23".to_string());
+        values.insert("message".to_string(), "$0.08".to_string());
+        values.insert("1d".to_string(), "$114".to_string());
+
+        let slots = vec![
+            "session".to_string(),
+            "message".to_string(),
+            "1d".to_string(),
+        ];
+        assert_eq!(
+            render_slots(&slots, &values, " · "),
+            "$6.23 session · $0.08 message · $114 1d"
+        );
     }
 
     #[test]

--- a/crates/budi-core/src/config.rs
+++ b/crates/budi-core/src/config.rs
@@ -175,8 +175,8 @@ pub fn load_agents_config() -> Option<AgentsConfig> {
 /// as backward-compatible aliases — they render the same rolling-window
 /// values so existing `~/.config/budi/statusline.toml` files keep working.
 pub const STATUSLINE_SLOTS: &[&str] = &[
-    "1d", "7d", "30d", "today", "week", "month", "session", "branch", "project", "provider",
-    "health",
+    "1d", "7d", "30d", "today", "week", "month", "session", "message", "branch", "project",
+    "provider", "health",
 ];
 
 /// Named presets for common statusline layouts.
@@ -222,7 +222,7 @@ pub struct StatuslineConfig {
     /// Ordered list of data slots to display. Default: ["today", "week", "month"].
     pub slots: Vec<String>,
     /// Optional custom format template. Overrides `slots` and `preset` when set.
-    /// Placeholders: {today}, {week}, {month}, {session}, {branch}, {project}, {provider}, {health}
+    /// Placeholders: {today}, {week}, {month}, {session}, {message}, {branch}, {project}, {provider}, {health}
     pub format: Option<String>,
 }
 
@@ -333,7 +333,7 @@ slots = [\"1d\", \"7d\", \"30d\"]
 # Or build a custom format:
 # format = \"{health} {project} | {session} | {1d} 1d | {7d} 7d\"
 #
-# Available slots: 1d, 7d, 30d, session, branch, project, provider, health
+# Available slots: 1d, 7d, 30d, session, message, branch, project, provider, health
 # Docs: https://github.com/siropkin/budi#status-line
 ";
 


### PR DESCRIPTION
## Summary

Closes #631.

- Adds `message` to `STATUSLINE_SLOTS` and wires it through `build_slot_values()` by reading `session_msg_cost` from the daemon response (converting cents → dollars)
- Both `session` and `message` now work as regular slots in `slots = [...]`, rendered by `render_slots()` — no special render path needed
- Requesting either slot triggers the `session_id` query param so the daemon returns the required data
- Users can now write `slots = ["session", "message", "1d"]` and get `$6.23 session · $0.08 message · $114 1d`

## Test plan

- [x] `cargo test -p budi-cli statusline` — 35 tests pass (3 new)
- [x] `cargo test -p budi-core statusline` — 17 tests pass
- [x] `cargo clippy --all-targets` — clean
- [x] `cargo fmt --all` — no changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)