### PR TITLE
feat: remove preset / render_coach machinery and emoji

### DIFF
--- a/crates/budi-cli/src/commands/init.rs
+++ b/crates/budi-cli/src/commands/init.rs
@@ -174,7 +174,7 @@ fn install_default_integrations(config: &config::BudiConfig) {
         .map(|p| p.exists())
         .unwrap_or(false);
 
-    let report = super::integrations::install_selected(config, &selected, None);
+    let report = super::integrations::install_selected(config, &selected);
 
     let mut prefs = super::integrations::load_preferences();
     prefs

--- a/crates/budi-cli/src/commands/integrations.rs
+++ b/crates/budi-cli/src/commands/integrations.rs
@@ -47,30 +47,10 @@ impl IntegrationComponent {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum, Serialize, Deserialize)]
-#[clap(rename_all = "kebab-case")]
-#[serde(rename_all = "kebab-case")]
-pub enum StatuslinePreset {
-    Coach,
-    Cost,
-    Full,
-}
-
-impl StatuslinePreset {
-    fn as_str(self) -> &'static str {
-        match self {
-            Self::Coach => "coach",
-            Self::Cost => "cost",
-            Self::Full => "full",
-        }
-    }
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(default)]
 pub struct IntegrationPreferences {
     pub enabled: BTreeSet<IntegrationComponent>,
-    pub statusline_preset: Option<StatuslinePreset>,
 }
 
 #[derive(Debug, Default)]
@@ -108,12 +88,7 @@ pub fn cmd_integrations(action: crate::IntegrationAction) -> Result<()> {
             println!("Install later with `budi integrations install --with <name>`");
             Ok(())
         }
-        crate::IntegrationAction::Install {
-            with,
-            all,
-            statusline_preset,
-            yes,
-        } => {
+        crate::IntegrationAction::Install { with, all, yes } => {
             let mut selected = if all {
                 all_components()
             } else if !with.is_empty() {
@@ -130,12 +105,6 @@ pub fn cmd_integrations(action: crate::IntegrationAction) -> Result<()> {
                 }
                 return Ok(());
             }
-
-            // Default statusline is the quiet `1d` / `7d` / `30d` cost view
-            // (ADR-0088 §4). `coach` / `full` remain opt-in advanced variants
-            // documented in the README — we no longer prompt for a preset
-            // during onboarding so the default path stays simple.
-            let preset = statusline_preset;
 
             if !yes && io::stdin().is_terminal() {
                 println!("Will install:");
@@ -154,7 +123,7 @@ pub fn cmd_integrations(action: crate::IntegrationAction) -> Result<()> {
                 }
             }
 
-            let mut report = install_selected(&cfg, &selected, preset);
+            let mut report = install_selected(&cfg, &selected);
             report.warnings.extend(removed_surface_notes);
             let mut prefs = load_preferences();
             prefs
@@ -162,9 +131,6 @@ pub fn cmd_integrations(action: crate::IntegrationAction) -> Result<()> {
                 .retain(|component| !component.is_removed_surface());
             for component in &selected {
                 prefs.enabled.insert(*component);
-            }
-            if preset.is_some() {
-                prefs.statusline_preset = preset;
             }
             let _ = save_preferences(&prefs);
 
@@ -276,7 +242,6 @@ pub fn infer_preferences_from_system(config: &config::BudiConfig) -> Integration
 pub fn install_selected(
     config: &config::BudiConfig,
     selected: &BTreeSet<IntegrationComponent>,
-    statusline_preset: Option<StatuslinePreset>,
 ) -> InstallReport {
     let mut filtered_selected = selected.clone();
     let mut report = InstallReport::default();
@@ -292,9 +257,7 @@ pub fn install_selected(
         || filtered_selected.contains(&IntegrationComponent::ClaudeCodeOtel)
         || filtered_selected.contains(&IntegrationComponent::ClaudeCodeStatusline);
 
-    if uses_claude_settings
-        && let Err(e) = install_claude_settings(config, &filtered_selected, statusline_preset)
-    {
+    if uses_claude_settings && let Err(e) = install_claude_settings(config, &filtered_selected) {
         let yellow = super::ansi("\x1b[33m");
         let reset = super::ansi("\x1b[0m");
         eprintln!("{yellow}  Warning:{reset} Claude Code setup failed: {e}");
@@ -391,13 +354,12 @@ pub fn refresh_enabled_integrations(config: &config::BudiConfig) -> InstallRepor
     if prefs.enabled.is_empty() {
         return InstallReport::default();
     }
-    install_selected(config, &prefs.enabled, prefs.statusline_preset)
+    install_selected(config, &prefs.enabled)
 }
 
 fn install_claude_settings(
     config: &config::BudiConfig,
     selected: &BTreeSet<IntegrationComponent>,
-    statusline_preset: Option<StatuslinePreset>,
 ) -> Result<()> {
     let home = budi_core::config::home_dir()?;
     let settings_path = home.join(super::statusline::CLAUDE_USER_SETTINGS);
@@ -432,16 +394,7 @@ fn install_claude_settings(
                 );
             }
         }
-        if let Some(preset) = statusline_preset {
-            set_statusline_preset(preset)?;
-        } else {
-            // #600: when no preset is passed (the `budi init` path), drop a
-            // template `statusline.toml` so users have a real file to edit.
-            // README docs the file as the source of truth; without seeding
-            // a fresh install has nothing to discover. Idempotent — repeat
-            // installs leave user edits byte-stable.
-            seed_statusline_toml()?;
-        }
+        seed_statusline_toml()?;
     }
 
     if selected.contains(&IntegrationComponent::ClaudeCodeHooks) && apply_cc_hooks(&mut settings) {
@@ -507,8 +460,8 @@ pub(crate) fn apply_statusline(settings: &mut Value) -> Result<StatuslineApply> 
 }
 
 /// Idempotently seed `~/.config/budi/statusline.toml` with the default
-/// `cost` preset and commented examples. Called on the no-preset path
-/// (i.e. `budi init`) so users have a real file to edit.
+/// slot layout and commented examples. Called during `budi init` so
+/// users have a real file to edit.
 ///
 /// Prints a single confirmation line on first generation. Stays quiet
 /// on repeat runs so `budi init` doesn't nag once the user already has
@@ -520,31 +473,12 @@ fn seed_statusline_toml() -> Result<()> {
             let dim = super::ansi("\x1b[90m");
             let reset = super::ansi("\x1b[0m");
             println!(
-                "  Status line: {} {dim}(cost preset — edit to customize){reset}",
+                "  Status line: {} {dim}(edit to customize){reset}",
                 path.display()
             );
         }
         config::SeedStatuslineOutcome::AlreadySet => {}
     }
-    Ok(())
-}
-
-pub fn set_statusline_preset(preset: StatuslinePreset) -> Result<()> {
-    let path = config::statusline_config_path()?;
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent)
-            .with_context(|| format!("Failed to create {}", parent.display()))?;
-    }
-    let mut sl_cfg = config::load_statusline_config();
-    sl_cfg.preset = Some(preset.as_str().to_string());
-    sl_cfg.format = None;
-    let raw = toml::to_string_pretty(&sl_cfg)?;
-    fs::write(&path, raw).with_context(|| format!("Failed writing {}", path.display()))?;
-    println!(
-        "  Status line: preset set to `{}` in {}",
-        preset.as_str(),
-        path.display()
-    );
     Ok(())
 }
 

--- a/crates/budi-cli/src/commands/statusline.rs
+++ b/crates/budi-cli/src/commands/statusline.rs
@@ -214,47 +214,6 @@ fn render_slots(slots: &[String], values: &HashMap<String, String>, sep: &str) -
     }
 }
 
-/// Session-aware rendering for coach/full presets.
-///
-/// Session view: `📊 budi · $0.03 msg · $1.24 session · {extra}`
-/// Falls back to period view when no session data is available.
-///
-/// `budi_label` is pre-formatted (may include ANSI/OSC 8 for Claude format).
-fn render_coach(
-    data: &Value,
-    extra_slots: &[(&str, &HashMap<String, String>)],
-    ansi: bool,
-    budi_label: &str,
-) -> Option<String> {
-    let _state = data.get("health_state")?.as_str()?;
-
-    let (dim, reset) = if ansi {
-        ("\x1b[90m", "\x1b[0m")
-    } else {
-        ("", "")
-    };
-
-    let session_cost = data.get("session_cost").and_then(|v| v.as_f64())?;
-
-    let mut parts: Vec<String> = vec![format!("📊 {budi_label}")];
-
-    // Last message cost (if available)
-    if let Some(msg_cost) = data.get("last_message_cost").and_then(|v| v.as_f64()) {
-        parts.push(format!("{} msg", fmt_cost(msg_cost)));
-    }
-
-    parts.push(format!("{} session", fmt_cost(session_cost)));
-
-    for (slot_name, values) in extra_slots {
-        if let Some(v) = values.get(*slot_name) {
-            parts.push(format!("{v} {slot_name}"));
-        }
-    }
-
-    let sep = format!(" {dim}·{reset} ");
-    Some(parts.join(&sep))
-}
-
 /// Legacy custom-template tokens whose values silently shifted from calendar
 /// to rolling semantics in 8.2 (ADR-0088 §4). Users with a custom
 /// `statusline.toml` referencing these keep rendering, but the underlying
@@ -471,15 +430,7 @@ pub fn cmd_statusline(format: StatuslineFormat, provider: Option<String>) -> Res
         .unwrap_or_else(|| json!({}));
 
     let values = build_slot_values(&statusline_data);
-    let has_health = statusline_data.get("health_state").is_some();
-
-    // Extra slots for coach rendering (slots beyond session+health, e.g. "today" in "full" preset)
     let effective = sl_config.effective_slots();
-    let extra: Vec<(&str, &HashMap<String, String>)> = effective
-        .iter()
-        .filter(|s| *s != "session" && *s != "health")
-        .map(|s| (s.as_str(), &values))
-        .collect();
 
     let cloud_base = budi_core::config::DEFAULT_CLOUD_ENDPOINT;
     let budi_url = if session_id.is_some() {
@@ -490,31 +441,18 @@ pub fn cmd_statusline(format: StatuslineFormat, provider: Option<String>) -> Res
 
     match format {
         StatuslineFormat::Json => {
-            // #445 item 4: surface integer cents so downstream
-            // consumers (Cursor extension, cloud dashboard, starship
-            // templates) never see 10-digit fractional-cent floats.
             let _ = super::print_json_compact(&statusline_data);
         }
         StatuslineFormat::Custom => {
             if let Some(ref template) = sl_config.format {
                 nudge_legacy_statusline_tokens(template);
                 println!("{}", render_template(template, &values));
-            } else if has_health {
-                let line = render_coach(&statusline_data, &extra, false, "budi")
-                    .unwrap_or_else(|| render_slots(&effective, &values, " · "));
-                println!("{line}");
             } else {
                 println!("{}", render_slots(&effective, &values, " · "));
             }
         }
         StatuslineFormat::Starship => {
-            let line = if has_health {
-                render_coach(&statusline_data, &extra, false, "budi")
-                    .unwrap_or_else(|| render_slots(&effective, &values, " · "))
-            } else {
-                render_slots(&effective, &values, " · ")
-            };
-            println!("{line}");
+            println!("{}", render_slots(&effective, &values, " · "));
         }
         StatuslineFormat::Claude => {
             let budi_link = format!(
@@ -548,17 +486,8 @@ pub fn cmd_statusline(format: StatuslineFormat, provider: Option<String>) -> Res
                 format!("{budi_link} {dim}·{reset} {joined}")
             };
 
-            let body = if has_health {
-                render_coach(&statusline_data, &extra, true, &budi_link)
-                    .unwrap_or_else(|| render_cost_line(&effective))
-            } else {
-                render_cost_line(&effective)
-            };
+            let body = render_cost_line(&effective);
 
-            // #546: prepend Claude-Code-default-equivalent context
-            // (model · short_cwd · branch) so installing
-            // `statusLine.command = "budi statusline"` doesn't
-            // subtract information from the user's prompt footer.
             match render_context_prefix(
                 model_name.as_deref(),
                 short_cwd.as_deref(),

--- a/crates/budi-cli/src/main.rs
+++ b/crates/budi-cli/src/main.rs
@@ -8,7 +8,7 @@ mod client;
 mod commands;
 mod daemon;
 
-use crate::commands::integrations::{IntegrationComponent, StatuslinePreset};
+use crate::commands::integrations::IntegrationComponent;
 
 const HEALTH_TIMEOUT_SECS: u64 = 3;
 
@@ -376,9 +376,6 @@ enum IntegrationAction {
         /// Install every available integration
         #[arg(long, default_value_t = false)]
         all: bool,
-        /// Statusline preset for Claude Code status line (coach=session health, cost=period)
-        #[arg(long, value_enum)]
-        statusline_preset: Option<StatuslinePreset>,
         /// Skip prompts and use defaults
         #[arg(long, default_value_t = false)]
         yes: bool,

--- a/crates/budi-core/src/config.rs
+++ b/crates/budi-core/src/config.rs
@@ -179,17 +179,6 @@ pub const STATUSLINE_SLOTS: &[&str] = &[
     "provider", "health",
 ];
 
-/// Named presets for common statusline layouts.
-///
-/// Default is `cost` (rolling `1d` / `7d` / `30d`). `coach` and `full` are
-/// advanced variants documented in the README; they are not in the default
-/// install path per ADR-0088 §4.
-pub const STATUSLINE_PRESETS: &[(&str, &[&str])] = &[
-    ("cost", &["1d", "7d", "30d"]),
-    ("coach", &["session", "health"]),
-    ("full", &["session", "health", "1d"]),
-];
-
 /// Normalize a legacy slot name to its canonical form.
 /// Maps calendar-window aliases (`today` / `week` / `month`) to their rolling
 /// equivalents (`1d` / `7d` / `30d`). Returns the input unchanged for all
@@ -208,21 +197,20 @@ pub fn normalize_statusline_slot(slot: &str) -> &str {
 /// Loaded from `~/.config/budi/statusline.toml`.
 /// Example:
 /// ```toml
-/// preset = "coach"
-/// # Or customize directly:
-/// # slots = ["today", "week", "month", "branch"]
-/// # format = "{today} | {week} | {month}"
+/// slots = ["session", "message", "1d"]
+/// # Or use a custom format:
+/// # format = "{session} | {1d} 1d | {7d} 7d"
 /// ```
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct StatuslineConfig {
-    /// Named preset: "cost" (today/week/month), "coach" (session+health), "full" (session+health+today).
-    /// When set, overrides `slots`. Ignored if `format` is set.
-    pub preset: Option<String>,
-    /// Ordered list of data slots to display. Default: ["today", "week", "month"].
+    /// Deprecated: silently mapped to equivalent `slots` array for migration.
+    #[serde(default, skip_serializing)]
+    preset: Option<String>,
+    /// Ordered list of data slots to display. Default: ["1d", "7d", "30d"].
     pub slots: Vec<String>,
-    /// Optional custom format template. Overrides `slots` and `preset` when set.
-    /// Placeholders: {today}, {week}, {month}, {session}, {message}, {branch}, {project}, {provider}, {health}
+    /// Optional custom format template. Overrides `slots` when set.
+    /// Placeholders: {1d}, {7d}, {30d}, {session}, {message}, {branch}, {project}, {provider}, {health}
     pub format: Option<String>,
 }
 
@@ -237,16 +225,22 @@ impl Default for StatuslineConfig {
 }
 
 impl StatuslineConfig {
-    /// Resolve the effective slots list, considering preset → slots → format priority.
+    /// Resolve the effective slots list.
+    /// Legacy `preset` values are silently mapped to their equivalent slots.
     /// Legacy slot aliases (`today` / `week` / `month`) are normalized to
     /// their canonical rolling-window names (`1d` / `7d` / `30d`).
     pub fn effective_slots(&self) -> Vec<String> {
-        let raw = if let Some(ref preset_name) = self.preset
-            && let Some((_, preset_slots)) = STATUSLINE_PRESETS
-                .iter()
-                .find(|(name, _)| *name == preset_name.as_str())
-        {
-            preset_slots.iter().map(|s| s.to_string()).collect()
+        let raw = if let Some(ref preset_name) = self.preset {
+            match preset_name.as_str() {
+                "cost" => vec!["1d".to_string(), "7d".to_string(), "30d".to_string()],
+                "coach" => vec!["session".to_string(), "health".to_string()],
+                "full" => vec![
+                    "session".to_string(),
+                    "health".to_string(),
+                    "1d".to_string(),
+                ],
+                _ => self.slots.clone(),
+            }
         } else {
             self.slots.clone()
         };
@@ -255,7 +249,7 @@ impl StatuslineConfig {
             .collect()
     }
 
-    /// Resolve which slots are needed (from format template, preset, or explicit slots list).
+    /// Resolve which slots are needed (from format template or effective slots list).
     /// Legacy slot aliases (`today` / `week` / `month`) are normalized to
     /// their canonical rolling-window names (`1d` / `7d` / `30d`).
     pub fn required_slots(&self) -> Vec<String> {
@@ -308,8 +302,8 @@ pub fn load_statusline_config() -> StatuslineConfig {
 /// Outcome of a call to [`seed_statusline_config_if_needed`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SeedStatuslineOutcome {
-    /// Wrote a fresh `statusline.toml` with the quiet `cost` preset and
-    /// commented examples for `coach` / `full` / custom formats.
+    /// Wrote a fresh `statusline.toml` with the default slot layout and
+    /// commented examples for common combinations and custom formats.
     Generated,
     /// File already exists — no-op so user edits aren't clobbered.
     AlreadySet,
@@ -319,16 +313,17 @@ pub enum SeedStatuslineOutcome {
 ///
 /// Mirrors the default `StatuslineConfig` (`slots = ["1d", "7d", "30d"]`)
 /// so a `cat ~/.config/budi/statusline.toml` after `budi init` shows
-/// users *exactly* what's running, plus the discoverability comments
-/// for the `coach` / `full` presets and the custom-format escape hatch.
+/// users *exactly* what's running, plus discoverability comments
+/// for common slot combinations and the custom-format escape hatch.
 pub const STATUSLINE_TOML_TEMPLATE: &str = "\
 # budi statusline configuration.
 # Active layout: rolling 1d / 7d / 30d cost (the quiet default).
 slots = [\"1d\", \"7d\", \"30d\"]
 
-# Try a different preset:
-# preset = \"coach\"  # session cost + health vitals + tip
-# preset = \"full\"   # session + health + 1d
+# Example slot combinations:
+# slots = [\"session\", \"health\"]            # session cost + health vitals
+# slots = [\"session\", \"health\", \"1d\"]      # session + health + 1d
+# slots = [\"session\", \"message\", \"1d\"]     # session + per-message + 1d
 #
 # Or build a custom format:
 # format = \"{health} {project} | {session} | {1d} 1d | {7d} 7d\"
@@ -338,13 +333,10 @@ slots = [\"1d\", \"7d\", \"30d\"]
 ";
 
 /// Idempotently seed `~/.config/budi/statusline.toml` with the default
-/// `cost` preset and commented examples for the other presets.
+/// slot layout and commented examples for other combinations.
 ///
 /// `budi init` calls this after installing the Claude Code statusline so
-/// users have a real file to edit (#600). Without it, the README told
-/// users to customize via `~/.config/budi/statusline.toml` but the file
-/// only existed once they passed `--statusline-preset`, leaving fresh
-/// installs with nothing to discover.
+/// users have a real file to edit (#600).
 ///
 /// Idempotent: returns `AlreadySet` on every call after the first
 /// without touching the file (preserves user edits). Caller is
@@ -1033,23 +1025,27 @@ mod tests {
     }
 
     #[test]
-    fn statusline_preset_overrides_slots() {
-        let config = StatuslineConfig {
-            preset: Some("coach".to_string()),
-            slots: vec!["1d".to_string()],
-            format: None,
-        };
+    fn statusline_legacy_preset_coach_migrates_to_slots() {
+        let config: StatuslineConfig = toml::from_str(r#"preset = "coach""#).unwrap();
         assert_eq!(config.effective_slots(), vec!["session", "health"]);
         assert_eq!(config.required_slots(), vec!["session", "health"]);
     }
 
     #[test]
-    fn statusline_format_overrides_preset() {
-        let config = StatuslineConfig {
-            preset: Some("coach".to_string()),
-            slots: vec![],
-            format: Some("{1d} | {7d}".to_string()),
-        };
+    fn statusline_legacy_preset_full_migrates_to_slots() {
+        let config: StatuslineConfig = toml::from_str(r#"preset = "full""#).unwrap();
+        assert_eq!(config.effective_slots(), vec!["session", "health", "1d"]);
+    }
+
+    #[test]
+    fn statusline_format_overrides_legacy_preset() {
+        let config: StatuslineConfig = toml::from_str(
+            r#"
+preset = "coach"
+format = "{1d} | {7d}"
+"#,
+        )
+        .unwrap();
         assert_eq!(config.required_slots(), vec!["1d", "7d"]);
     }
 
@@ -1092,12 +1088,8 @@ format = "{1d} | {7d} | {branch}"
     }
 
     #[test]
-    fn statusline_cost_preset_uses_rolling_windows() {
-        let config = StatuslineConfig {
-            preset: Some("cost".to_string()),
-            slots: vec![],
-            format: None,
-        };
+    fn statusline_legacy_preset_cost_migrates_to_rolling_windows() {
+        let config: StatuslineConfig = toml::from_str(r#"preset = "cost""#).unwrap();
         assert_eq!(config.effective_slots(), vec!["1d", "7d", "30d"]);
     }
 

--- a/crates/budi-daemon/src/routes/hooks.rs
+++ b/crates/budi-daemon/src/routes/hooks.rs
@@ -77,30 +77,10 @@ impl IntegrationInstallComponent {
     }
 }
 
-#[derive(Debug, Clone, Copy, serde::Deserialize)]
-#[serde(rename_all = "kebab-case")]
-pub enum IntegrationStatuslinePreset {
-    Coach,
-    Cost,
-    Full,
-}
-
-impl IntegrationStatuslinePreset {
-    fn as_cli_arg(self) -> &'static str {
-        match self {
-            Self::Coach => "coach",
-            Self::Cost => "cost",
-            Self::Full => "full",
-        }
-    }
-}
-
 #[derive(Debug, serde::Deserialize)]
 pub struct InstallIntegrationsRequest {
     #[serde(default)]
     pub components: Vec<IntegrationInstallComponent>,
-    #[serde(default)]
-    pub statusline_preset: Option<IntegrationStatuslinePreset>,
 }
 
 #[derive(Debug, serde::Serialize)]
@@ -397,11 +377,6 @@ pub async fn admin_install_integrations(
         args.push("--with".to_string());
         args.push(component.as_cli_arg().to_string());
     }
-    if let Some(preset) = req.statusline_preset {
-        args.push("--statusline-preset".to_string());
-        args.push(preset.as_cli_arg().to_string());
-    }
-
     let budi_bin_for_run = budi_bin.clone();
     let args_for_run = args.clone();
     let output = tokio::task::spawn_blocking(move || {


### PR DESCRIPTION
## Summary

Closes #632

- **Removed `render_coach()`** — all slots now render uniformly through `render_slots()`, eliminating the dual rendering path
- **Removed `preset` field** from `StatuslineConfig` public API, `StatuslinePreset` enum, `--statusline-preset` CLI arg, and daemon `IntegrationStatuslinePreset`
- **Removed the 📊 emoji** — statusline renders uniformly without injecting emojis
- **Updated the seeded `statusline.toml`** template to show example slot combinations instead of preset names
- **Migration**: existing `statusline.toml` files with `preset = "coach"/"cost"/"full"` are silently mapped to equivalent `slots` arrays via a private `#[serde(skip_serializing)]` field

## Test plan

- [x] `cargo build` — compiles cleanly
- [x] `cargo test` — all 275 tests pass
- [x] `cargo clippy` — no warnings
- [x] Legacy preset migration tests: `statusline_legacy_preset_coach_migrates_to_slots`, `statusline_legacy_preset_full_migrates_to_slots`, `statusline_legacy_preset_cost_migrates_to_rolling_windows`
- [ ] Manual: verify `budi statusline` renders without emoji or coach formatting
- [ ] Manual: verify existing `statusline.toml` with `preset = "coach"` still works (maps to `["session", "health"]`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)