### PR TITLE
release: prep v8.3.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,48 @@
 # Changelog
 
+## 8.3.18 — 2026-05-05
+
+8.3.18 adds first-class `session` and `message` statusline slots, cleans
+up legacy rendering machinery, and fixes two consistency bugs.
+Headline: **statusline slots are now fully composable** — `session` and
+`message` work like any other slot (`1d`, `7d`, `30d`), and the old
+`preset` / `render_coach` codepath with its hard-coded 📊 emoji is gone.
+
+### Added
+
+- **`session` and `message` as first-class statusline slots (#631 / PR #635)** —
+  users can now place `session` and `message` in their `slots` array
+  like any rolling-window slot. `session` shows current-session cost;
+  `message` shows last-message cost. Both read from the daemon response
+  and convert cents → dollars through the standard slot pipeline.
+
+### Changed
+
+- **Remove `preset` / `render_coach` machinery and 📊 emoji (#632 / PR #636)** —
+  the statusline had two rendering paths: normal slots and a special
+  `render_coach()` codepath triggered by `preset = "coach"`. This
+  created dead code, config confusion, and a hard-coded emoji.
+  All presets now expand to regular slot arrays at config load time;
+  `render_coach` and the 📊 prefix are removed.
+
+### Fixed
+
+- **`budi sessions latest --format json` `health_state` consistency (#629 / PR #633)** —
+  the list view (`budi sessions --format json`) emitted `health_state`
+  (a string) while the detail view (`budi sessions latest --format json`)
+  only emitted `health` (an object). The detail view now includes both
+  fields for consistency.
+- **Flaky `e2e_refresh_from_v8_3_14` test under parallel execution (#630 / PR #634)** —
+  the test temporarily overrode the `HOME` environment variable, which
+  raced with other tests sharing the process-wide env. Fix: isolated
+  the HOME override to eliminate the race condition.
+
+### Non-blocking, carried forward
+
+- **Cloud Overview cost / token totals diverge from local CLI** (#10) — presentation-layer aggregation difference, not data loss.
+- **RC-4 Part B** (#504) — Cursor Usage API auth root-cause; Part A shipped with `v8.3.1`.
+- **ADR-0090 supersede** — pending one release cycle of live validation on the now-working `cursorDiskKV` bubbles path before the Usage API §1 surface can be retired.
+
 ## 8.3.17 — 2026-05-05
 
 8.3.17 is a quality-of-life release that fixes five user-facing bugs and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,7 +175,7 @@ dependencies = [
 
 [[package]]
 name = "budi-cli"
-version = "8.3.17"
+version = "8.3.18"
 dependencies = [
  "anyhow",
  "budi-core",
@@ -195,7 +195,7 @@ dependencies = [
 
 [[package]]
 name = "budi-core"
-version = "8.3.17"
+version = "8.3.18"
 dependencies = [
  "anyhow",
  "chrono",
@@ -211,7 +211,7 @@ dependencies = [
 
 [[package]]
 name = "budi-daemon"
-version = "8.3.17"
+version = "8.3.18"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "8.3.17"
+version = "8.3.18"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"


### PR DESCRIPTION
## Summary

- Bump workspace version to 8.3.18
- Add changelog entry covering 4 issues: `session`/`message` first-class statusline slots (#631), `preset`/`render_coach` removal (#632), `health_state` JSON consistency (#629), HOME env race fix (#630)

## Test plan

- [ ] CI passes (fmt, clippy, tests)
- [ ] Merge → tag `v8.3.18` → release pipeline builds assets + updates Homebrew tap
- [ ] `brew upgrade budi` installs 8.3.18
- [ ] Smoke test: `budi --version`, `budi status`, `budi statusline` with `session`/`message` slots

🤖 Generated with [Claude Code](https://claude.com/claude-code)