### PR TITLE
feat(statusline): add --slots flag and auto-resolve session without stdin (#639)

### DIFF
--- a/crates/budi-cli/src/commands/statusline.rs
+++ b/crates/budi-cli/src/commands/statusline.rs
@@ -280,7 +280,27 @@ fn nudge_legacy_statusline_tokens_inner(
     }
 }
 
-pub fn cmd_statusline(format: StatuslineFormat, provider: Option<String>) -> Result<()> {
+/// Parse a comma-separated `--slots` value into a normalized list.
+///
+/// Splits on commas, trims whitespace, drops empty entries, and routes
+/// each name through [`config::normalize_statusline_slot`] so the legacy
+/// `today` / `week` / `month` aliases resolve to `1d` / `7d` / `30d`
+/// before they reach the daemon query builder. Unknown slot names are
+/// kept as-is — they'll silently render nothing via `render_slots`'s
+/// missing-key fallback rather than failing the whole prompt.
+fn parse_slots_arg(raw: &str) -> Vec<String> {
+    raw.split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(|s| config::normalize_statusline_slot(s).to_string())
+        .collect()
+}
+
+pub fn cmd_statusline(
+    format: StatuslineFormat,
+    provider: Option<String>,
+    slots: Option<String>,
+) -> Result<()> {
     // #615: validate --provider up front against the same canonical set
     // as `budi stats` so an unknown value errors with a helpful list
     // instead of silently rendering $0.00. Aliases (`copilot`,
@@ -311,7 +331,7 @@ pub fn cmd_statusline(format: StatuslineFormat, provider: Option<String>) -> Res
                 .map(|p| p.display().to_string())
         });
 
-    let session_id = stdin_json.as_ref().and_then(|v| {
+    let mut session_id = stdin_json.as_ref().and_then(|v| {
         v.get("session_id")
             .and_then(|s| s.as_str())
             .map(String::from)
@@ -325,7 +345,18 @@ pub fn cmd_statusline(format: StatuslineFormat, provider: Option<String>) -> Res
     let base = cfg.daemon_base_url();
 
     // Load statusline config (for Claude/Custom formats, and to determine needed query params)
-    let sl_config = config::load_statusline_config();
+    let mut sl_config = config::load_statusline_config();
+    // #639: `--slots` overrides the on-disk config for this invocation.
+    // Drop any preset/custom-format that would otherwise win and replace
+    // the slot list with the parsed args. Empty input (no real slots
+    // after trimming) keeps the on-disk config intact rather than
+    // silently rendering nothing.
+    if let Some(ref raw) = slots {
+        let parsed = parse_slots_arg(raw);
+        if !parsed.is_empty() {
+            sl_config = config::StatuslineConfig::with_slots(parsed);
+        }
+    }
     let needed = sl_config.required_slots();
 
     // #546: always detect branch for the Claude format so the CC-default-
@@ -355,17 +386,15 @@ pub fn cmd_statusline(format: StatuslineFormat, provider: Option<String>) -> Res
         _ => None,
     });
 
-    // Build query params for the daemon
+    let needs_session =
+        needed.contains(&"session".to_string()) || needed.contains(&"message".to_string());
+
+    // Build query params for the daemon. Session id is appended later
+    // (after the daemon client exists) so we can fall back to the
+    // daemon's `current` resolver when stdin didn't carry one (#639).
     let mut query_params: Vec<(&str, String)> = Vec::new();
     if let Some(ref p) = effective_provider {
         query_params.push(("provider", p.clone()));
-    }
-    let needs_session =
-        needed.contains(&"session".to_string()) || needed.contains(&"message".to_string());
-    if let Some(ref sid) = session_id
-        && needs_session
-    {
-        query_params.push(("session_id", sid.clone()));
     }
     if let Some(ref b) = branch {
         query_params.push(("branch", b.clone()));
@@ -411,6 +440,42 @@ pub fn cmd_statusline(format: StatuslineFormat, provider: Option<String>) -> Res
         }
         return Ok(());
     };
+
+    // #639: when stdin didn't carry a `session_id` (manual TTY
+    // invocation, custom statusline drivers, etc.) but the active slot
+    // layout needs one, ask the daemon to resolve the current session
+    // for our cwd. Mirrors `budi sessions current` so coach/full
+    // presets keep working outside the Claude Code stdin envelope.
+    // Errors are swallowed — a prompt-hot path falls through to the
+    // legacy "no session" render rather than failing the prompt.
+    if needs_session && session_id.is_none() {
+        let resolve_url = format!("{}/analytics/sessions/resolve", base);
+        let mut params: Vec<(&str, &str)> = vec![("token", "current")];
+        if let Some(c) = cwd.as_deref() {
+            params.push(("cwd", c));
+        }
+        if let Some(sid) = client
+            .get(&resolve_url)
+            .query(&params)
+            .send()
+            .ok()
+            .filter(|r| r.status().is_success())
+            .and_then(|r| r.json::<Value>().ok())
+            .and_then(|v| {
+                v.get("session_id")
+                    .and_then(|s| s.as_str())
+                    .map(String::from)
+            })
+        {
+            session_id = Some(sid);
+        }
+    }
+    if let Some(ref sid) = session_id
+        && needs_session
+    {
+        query_params.push(("session_id", sid.clone()));
+    }
+
     let statusline_url = format!("{}/analytics/statusline", base);
     let statusline_data: Value = client
         .get(&statusline_url)
@@ -1044,6 +1109,44 @@ mod tests {
     }
 
     #[test]
+    fn parse_slots_arg_strips_whitespace_and_normalizes() {
+        // #639: `--slots` accepts the raw user string. Trim each entry,
+        // drop empties (so trailing commas don't render `""` slots) and
+        // normalize legacy aliases to their rolling-window form so the
+        // override matches the canonical vocabulary.
+        assert_eq!(
+            parse_slots_arg("session,message"),
+            vec!["session".to_string(), "message".to_string()]
+        );
+        assert_eq!(
+            parse_slots_arg(" session , message "),
+            vec!["session".to_string(), "message".to_string()]
+        );
+        assert_eq!(
+            parse_slots_arg("today,week,month"),
+            vec!["1d".to_string(), "7d".to_string(), "30d".to_string()]
+        );
+        assert_eq!(parse_slots_arg(",, 1d ,, ,"), vec!["1d".to_string()]);
+        assert!(parse_slots_arg("").is_empty());
+    }
+
+    #[test]
+    fn slots_override_replaces_config_preset() {
+        // #639: a `--slots` override must clear the on-disk preset and
+        // custom format so the user gets exactly what they asked for,
+        // not a merge of CLI + TOML.
+        let parsed = parse_slots_arg("session,message");
+        let cfg = config::StatuslineConfig::with_slots(parsed);
+        assert_eq!(
+            cfg.effective_slots(),
+            vec!["session".to_string(), "message".to_string()]
+        );
+        // No custom format leaks through, so render_slots — not
+        // render_template — is what runs.
+        assert!(cfg.format.is_none());
+    }
+
+    #[test]
     fn cmd_statusline_rejects_unknown_provider_before_io() {
         // #615: an unknown `--provider` value must error with the same
         // helpful list `budi stats --provider <unknown>` produces, not
@@ -1053,6 +1156,7 @@ mod tests {
         let err = cmd_statusline(
             crate::StatuslineFormat::Json,
             Some("doesnotexist".to_string()),
+            None,
         )
         .expect_err("unknown provider must error");
         let msg = err.to_string();

--- a/crates/budi-cli/src/main.rs
+++ b/crates/budi-cli/src/main.rs
@@ -173,6 +173,7 @@ Examples:
   budi statusline                              Default quiet output scoped to the Claude Code surface
   budi statusline --format json                Emit the shared status contract (JSON)
   budi statusline --format json --provider cursor   Consume the same shape for the Cursor surface
+  budi statusline --slots session,message      Override config slots from the command line
   budi statusline --install                    Install budi into the Claude Code status line")]
     Statusline {
         /// Install the status line in ~/.claude/settings.json
@@ -186,6 +187,12 @@ Examples:
         /// Claude Code statusline never shows blended multi-provider totals.
         #[arg(long)]
         provider: Option<String>,
+        /// Comma-separated slot list (e.g. `session,message`). Overrides
+        /// `~/.config/budi/statusline.toml` slots/preset/format for this
+        /// invocation. Known slots: 1d, 7d, 30d, session, message, branch,
+        /// project, provider (legacy: today, week, month).
+        #[arg(long, value_name = "SLOTS")]
+        slots: Option<String>,
     },
     /// Manage optional integrations (install later, list current status)
     Integrations {
@@ -726,11 +733,12 @@ fn main() -> Result<()> {
             install,
             format,
             provider,
+            slots,
         } => {
             if install {
                 commands::statusline::cmd_statusline_install()
             } else {
-                commands::statusline::cmd_statusline(format, provider)
+                commands::statusline::cmd_statusline(format, provider, slots)
             }
         }
         Commands::Sessions {
@@ -1785,6 +1793,32 @@ mod tests {
         match cli.command {
             Commands::Statusline { format, .. } => {
                 assert_eq!(format, StatuslineFormat::Json);
+            }
+            _ => panic!("expected statusline command"),
+        }
+    }
+
+    /// #639: `budi statusline --slots <list>` must parse and surface the
+    /// raw value to the command handler. The handler is responsible for
+    /// trimming/normalizing — this test only locks the clap surface so
+    /// the flag isn't accidentally renamed or dropped.
+    #[test]
+    fn cli_statusline_accepts_slots_flag() {
+        let cli = Cli::try_parse_from(["budi", "statusline", "--slots", "session,message"])
+            .expect("budi statusline --slots session,message should parse");
+        match cli.command {
+            Commands::Statusline { slots, .. } => {
+                assert_eq!(slots.as_deref(), Some("session,message"));
+            }
+            _ => panic!("expected statusline command"),
+        }
+
+        // Default: no `--slots` → None (config file wins).
+        let cli = Cli::try_parse_from(["budi", "statusline"])
+            .expect("budi statusline should parse without --slots");
+        match cli.command {
+            Commands::Statusline { slots, .. } => {
+                assert!(slots.is_none());
             }
             _ => panic!("expected statusline command"),
         }

--- a/crates/budi-core/src/config.rs
+++ b/crates/budi-core/src/config.rs
@@ -225,6 +225,17 @@ impl Default for StatuslineConfig {
 }
 
 impl StatuslineConfig {
+    /// Build a fresh config with an explicit slot list and no preset
+    /// or custom format. Used by `budi statusline --slots <...>` (#639)
+    /// to override the on-disk config for a single invocation.
+    pub fn with_slots(slots: Vec<String>) -> Self {
+        Self {
+            preset: None,
+            slots,
+            format: None,
+        }
+    }
+
     /// Resolve the effective slots list.
     /// Legacy `preset` values are silently mapped to their equivalent slots.
     /// Legacy slot aliases (`today` / `week` / `month`) are normalized to


### PR DESCRIPTION
Closes #639.

## Summary

- New `budi statusline --slots <list>` flag overrides `~/.config/budi/statusline.toml` slots/preset/format for a single invocation. Comma-separated, whitespace-trimmed, legacy `today/week/month` aliases normalized to `1d/7d/30d`.
- When `session` or `message` slots are required but stdin didn't carry a `session_id` (manual TTY invocation, custom statusline drivers, non–Claude-Code agents), fall back to the daemon's `/analytics/sessions/resolve?token=current` endpoint scoped to cwd. Mirrors `budi sessions current` so the coach and full presets stop silently rendering the rolling-window fallback outside the Claude Code stdin envelope.
- Errors during the `current` resolve are swallowed so the prompt-hot path keeps rendering rather than failing the prompt.
- `StatuslineConfig::with_slots` lets the CLI construct a fresh config without touching the private `preset` field.

## Before / After

```
$ budi statusline --slots session,message
unexpected argument '--slots' found    # before
budi · $0.00 session · $0.00 message   # after
```

```
$ # ~/.config/budi/statusline.toml has preset = "coach"
$ budi statusline                      # no stdin (TTY)
budi · $0.00 1d · $0.00 7d · $0.00 30d # before — silent fallback
budi · $0.42 session · $0.05 message   # after — auto-resolved current session
```

## Test plan

- [x] `cargo test -p budi-cli statusline`
- [x] `cargo test -p budi-core statusline`
- [x] `cargo clippy -p budi-cli -p budi-core --all-targets`
- [x] `cargo fmt --all`
- [x] New unit tests:
  - `parse_slots_arg_strips_whitespace_and_normalizes` — comma split, trimming, alias normalization, empty handling
  - `slots_override_replaces_config_preset` — `--slots` clears preset/format
  - `cli_statusline_accepts_slots_flag` — clap surface for `--slots`

🤖 Generated with [Claude Code](https://claude.com/claude-code)