### PR TITLE
docs: 8.3.18 update pass — session/message slots, health removal (#640)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,15 @@ Headline: **statusline slots are now fully composable** — `session` and
   created dead code, config confusion, and a hard-coded emoji.
   All presets now expand to regular slot arrays at config load time;
   `render_coach` and the 📊 prefix are removed.
+- **Remove vestigial `health` statusline slot; coach preset → session + message** —
+  the `health` slot was a leftover from the old `render_coach`
+  codepath that rendered the same `session_cost` dollar amount as the
+  `session` slot, so the legacy `coach` preset showed duplicate values
+  (`$1.22 session · $1.22 health`). The `health` slot is removed from
+  the slot vocabulary entirely; legacy `preset = "coach"` /
+  `preset = "full"` values in older `statusline.toml` files now expand
+  to `["session", "message"]` / `["session", "message", "1d"]` for
+  migration. Patched in after the initial 8.3.18 release prep.
 
 ### Fixed
 

--- a/SOUL.md
+++ b/SOUL.md
@@ -407,11 +407,19 @@ Key points:
 - **Slot config aliases.** `~/.config/budi/statusline.toml` files
   written against the 8.0 vocabulary (`slots = ["today", "week",
   "month"]`) continue to render, since `today` / `week` / `month` are
-  normalized to `1d` / `7d` / `30d` at load time.
+  normalized to `1d` / `7d` / `30d` at load time. The current slot
+  vocabulary is `1d` / `7d` / `30d` / `session` / `message` / `branch`
+  / `project` / `provider` (see `STATUSLINE_SLOTS` in
+  `crates/budi-core/src/config.rs`); the 8.0 `health` slot was a
+  vestigial alias for `session_cost` and was removed in 8.3.18 (#640).
 - **Default install path is quiet.** `budi init` and
   `budi integrations install` install the rolling `1d` / `7d` / `30d`
-  preset without prompting. The `coach` and `full` presets remain
-  opt-in advanced variants documented in `README.md`.
+  slots without prompting. Legacy `preset = "coach"` /
+  `preset = "full"` values in older `statusline.toml` files are
+  silently mapped to `["session", "message"]` /
+  `["session", "message", "1d"]` at load time for migration; the
+  `preset` key itself was removed from the documented surface in
+  8.3.18 (#632) along with the `render_coach` codepath and 📊 emoji.
 - **`budi init` installs the statusline by default.** A fresh
   `budi init` wires the Budi statusline into `~/.claude/settings.json`
   (and installs the Cursor extension when the Cursor CLI is on PATH)

--- a/crates/budi-core/src/config.rs
+++ b/crates/budi-core/src/config.rs
@@ -210,7 +210,7 @@ pub struct StatuslineConfig {
     /// Ordered list of data slots to display. Default: ["1d", "7d", "30d"].
     pub slots: Vec<String>,
     /// Optional custom format template. Overrides `slots` when set.
-    /// Placeholders: {1d}, {7d}, {30d}, {session}, {message}, {branch}, {project}, {provider}, {health}
+    /// Placeholders: {1d}, {7d}, {30d}, {session}, {message}, {branch}, {project}, {provider}
     pub format: Option<String>,
 }
 

--- a/docs/statusline-contract.md
+++ b/docs/statusline-contract.md
@@ -74,7 +74,7 @@ All parameters are optional. Omit them to get unscoped, context-free totals.
 - Rust types: `budi_core::analytics::queries::{StatuslineStats, StatuslineParams}` in `crates/budi-core/src/analytics/queries.rs`
 - Daemon handler: `analytics_statusline` in `crates/budi-daemon/src/routes/analytics.rs`
 - CLI consumer: `cmd_statusline` in `crates/budi-cli/src/commands/statusline.rs`
-- Config + slot vocabulary: `crates/budi-core/src/config.rs` (`STATUSLINE_SLOTS`, `STATUSLINE_PRESETS`, `normalize_statusline_slot`)
+- Config + slot vocabulary: `crates/budi-core/src/config.rs` (`STATUSLINE_SLOTS`, `normalize_statusline_slot`)
 
 ## Consumer playbook
 


### PR DESCRIPTION
## Summary

Closes #640. Audit-and-update pass on in-repo docs to consistently reflect the 8.3.18 statusline changes:

- `session` and `message` as first-class slots (#631 / PR #635)
- removal of `preset` / `render_coach` machinery and 📊 emoji (#632 / PR #636)
- post-prep removal of the vestigial `health` slot and remap of `coach` / `full` legacy presets to `session` + `message` (commit db3a911)

## Changes

- **SOUL.md** — spell out the current slot vocabulary (`1d`, `7d`, `30d`, `session`, `message`, `branch`, `project`, `provider`), note the `health` slot removal, and replace the stale "coach/full presets remain documented in README" line with the actual legacy-migration behavior.
- **CHANGELOG.md** — add a `Changed` entry under 8.3.18 for the vestigial `health` slot removal and coach preset remapping that landed after release prep.
- **crates/budi-core/src/config.rs** — drop `{health}` from the `StatuslineConfig::format` placeholder docstring (the slot is gone).
- **docs/statusline-contract.md** — drop reference to the removed `STATUSLINE_PRESETS` constant.

The seeded `STATUSLINE_TOML_TEMPLATE` and the README slot-list section were already updated in db3a911 — verified, no changes needed.

ADRs were audited (`docs/adr/`): no `render_coach` or `health` statusline-slot references found. The remaining `health` references in ADRs all refer to session-health vitals, daemon health, or `/health` endpoints, all of which are still valid.

## Test plan

- [x] `cargo check -p budi-core` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `grep -rn "STATUSLINE_PRESETS"` — no remaining references
- [x] `grep -rn "render_coach"` — only describing-the-removal references in CHANGELOG / SOUL remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)