### PR TITLE
[8.4][R1.3] Multi-provider statusline endpoint — accept and aggregate `?provider=a,b,c`

### DIFF
--- a/crates/budi-core/src/analytics/queries.rs
+++ b/crates/budi-core/src/analytics/queries.rs
@@ -3275,6 +3275,13 @@ pub struct StatuslineStats {
     pub project_cost: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub active_provider: Option<String>,
+    /// Providers contributing to the aggregated totals when more than one
+    /// provider was passed in the filter (host-scoped surface, ADR-0088 §7
+    /// post-#648). Empty for unscoped requests and for single-provider
+    /// requests, so the byte shape of the existing single-provider response
+    /// is preserved.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub contributing_providers: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub health_state: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -3302,19 +3309,53 @@ pub struct StatuslineParams {
     /// consumers that can't resolve a repo identity (no git, shell not in a
     /// repo, etc.). See issue #347.
     pub repo_id: Option<String>,
-    /// Optional provider filter. When set, every numeric field
-    /// (`cost_1d/7d/30d`, `session_cost`, `branch_cost`, `project_cost`) and
-    /// `active_provider` are scoped to this provider. Provider-scoped
-    /// surfaces (the Claude Code statusline, the Cursor extension) must set
-    /// this; unscoped blended totals remain available for advanced users and
-    /// for the `budi stats` command.
-    pub provider: Option<String>,
+    /// Optional provider filter. Accepts a comma-separated list — e.g.
+    /// `?provider=cursor` (provider-scoped) or `?provider=cursor,copilot_chat`
+    /// (host-scoped, aggregates the listed providers). Single-value form is
+    /// preserved for backward compatibility with budi-cursor 1.3.x and the
+    /// 8.1+ provider-scoped statusline contract. When the filter is empty
+    /// every numeric field is unscoped (all enabled providers).
+    ///
+    /// Repeated forms (`?provider=a&provider=b`) are not supported by
+    /// axum's default `serde_urlencoded`-backed `Query` extractor — only the
+    /// last value would survive. Callers that need multi-provider must use
+    /// the comma-list form. See ADR-0088 §7 (post-#648).
+    #[serde(default, deserialize_with = "deserialize_provider_filter")]
+    pub provider: Vec<String>,
+}
+
+fn deserialize_provider_filter<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::Deserialize;
+    let raw: Option<String> = Option::deserialize(deserializer)?;
+    Ok(parse_provider_filter(raw.as_deref()))
+}
+
+/// Parse a comma-separated provider filter string into a normalized
+/// `Vec<String>`. Empty / whitespace-only entries are dropped, duplicates
+/// are removed in input order, and `None` collapses to an empty vec.
+pub(crate) fn parse_provider_filter(raw: Option<&str>) -> Vec<String> {
+    let mut seen = std::collections::HashSet::new();
+    raw.unwrap_or_default()
+        .split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .filter_map(|s| {
+            if seen.insert(s.to_string()) {
+                Some(s.to_string())
+            } else {
+                None
+            }
+        })
+        .collect()
 }
 
 fn assistant_cost_since_from_rollups(
     conn: &Connection,
     since: &str,
-    provider: Option<&str>,
+    providers: &[String],
 ) -> Option<f64> {
     if !rollups_available(conn) {
         return None;
@@ -3323,9 +3364,10 @@ fn assistant_cost_since_from_rollups(
     let mut conditions = vec!["role = 'assistant'".to_string()];
     let mut params: Vec<String> = Vec::new();
     append_rollup_time_filters(&mut conditions, &mut params, &window);
-    if let Some(p) = provider {
-        conditions.push("provider = ?".to_string());
-        params.push(p.to_string());
+    if !providers.is_empty() {
+        let placeholders = vec!["?"; providers.len()].join(", ");
+        conditions.push(format!("provider IN ({placeholders})"));
+        params.extend(providers.iter().cloned());
     }
     let sql = format!(
         "SELECT COALESCE(SUM(cost_cents), 0.0)
@@ -3354,19 +3396,28 @@ pub fn statusline_stats(
     since_30d: &str,
     params: &StatuslineParams,
 ) -> Result<StatuslineStats> {
-    let provider_filter = params.provider.as_deref();
+    let provider_filter: &[String] = &params.provider;
+
+    // Helper: append `provider IN (?, ?, ...)` to `sql` and the matching
+    // bindings, using whatever placeholder syntax the caller is already using.
+    // Skipped when the filter is empty (unscoped — sums across every provider).
+    let push_provider_in = |sql: &mut String, bindings: &mut Vec<String>| {
+        if provider_filter.is_empty() {
+            return;
+        }
+        let placeholders = vec!["?"; provider_filter.len()].join(", ");
+        sql.push_str(&format!(" AND provider IN ({placeholders})"));
+        bindings.extend(provider_filter.iter().cloned());
+    };
 
     let cost_since = |since: &str| -> f64 {
         assistant_cost_since_from_rollups(conn, since, provider_filter).unwrap_or_else(|| {
             let mut sql = String::from(
                 "SELECT COALESCE(SUM(cost_cents), 0.0) FROM messages \
-                     WHERE timestamp >= ?1 AND role = 'assistant'",
+                     WHERE timestamp >= ? AND role = 'assistant'",
             );
             let mut bindings: Vec<String> = vec![since.to_string()];
-            if let Some(p) = provider_filter {
-                sql.push_str(" AND provider = ?2");
-                bindings.push(p.to_string());
-            }
+            push_provider_in(&mut sql, &mut bindings);
             let refs: Vec<&dyn rusqlite::types::ToSql> = bindings
                 .iter()
                 .map(|s| s as &dyn rusqlite::types::ToSql)
@@ -3388,13 +3439,10 @@ pub fn statusline_stats(
     let session_cost = normalized_session_id.as_ref().map(|sid| {
         let mut sql = String::from(
             "SELECT COALESCE(SUM(cost_cents), 0.0) FROM messages \
-             WHERE session_id = ?1 AND role = 'assistant'",
+             WHERE session_id = ? AND role = 'assistant'",
         );
         let mut bindings: Vec<String> = vec![sid.clone()];
-        if let Some(p) = provider_filter {
-            sql.push_str(" AND provider = ?2");
-            bindings.push(p.to_string());
-        }
+        push_provider_in(&mut sql, &mut bindings);
         let refs: Vec<&dyn rusqlite::types::ToSql> = bindings
             .iter()
             .map(|s| s as &dyn rusqlite::types::ToSql)
@@ -3420,10 +3468,7 @@ pub fn statusline_stats(
             sql.push_str(" AND COALESCE(repo_id, '') = ?");
             bindings.push(repo.to_string());
         }
-        if let Some(p) = provider_filter {
-            sql.push_str(" AND provider = ?");
-            bindings.push(p.to_string());
-        }
+        push_provider_in(&mut sql, &mut bindings);
         let refs: Vec<&dyn rusqlite::types::ToSql> = bindings
             .iter()
             .map(|s| s as &dyn rusqlite::types::ToSql)
@@ -3437,13 +3482,10 @@ pub fn statusline_stats(
     let project_cost = params.project_dir.as_ref().map(|dir| {
         let mut sql = String::from(
             "SELECT COALESCE(SUM(cost_cents), 0.0) FROM messages \
-             WHERE cwd = ?1 AND role = 'assistant'",
+             WHERE cwd = ? AND role = 'assistant'",
         );
         let mut bindings: Vec<String> = vec![dir.clone()];
-        if let Some(p) = provider_filter {
-            sql.push_str(" AND provider = ?2");
-            bindings.push(p.to_string());
-        }
+        push_provider_in(&mut sql, &mut bindings);
         let refs: Vec<&dyn rusqlite::types::ToSql> = bindings
             .iter()
             .map(|s| s as &dyn rusqlite::types::ToSql)
@@ -3453,16 +3495,14 @@ pub fn statusline_stats(
             / 100.0
     });
 
-    // Active provider: most recent provider used in the last 24h.
-    // When the request is already provider-scoped, this is just the same
-    // provider when there's recent activity, or None if the window is empty.
+    // Active provider: most recent provider seen in the 1d window, after the
+    // provider filter is applied. Under multi-provider this is the provider
+    // with the most recent traffic — host-scoped click-through routes to its
+    // dashboard (ADR-0088 §7 post-#648).
     let active_provider: Option<String> = {
-        let mut sql = String::from("SELECT provider FROM messages WHERE timestamp >= ?1");
+        let mut sql = String::from("SELECT provider FROM messages WHERE timestamp >= ?");
         let mut bindings: Vec<String> = vec![since_1d.to_string()];
-        if let Some(p) = provider_filter {
-            sql.push_str(" AND provider = ?2");
-            bindings.push(p.to_string());
-        }
+        push_provider_in(&mut sql, &mut bindings);
         sql.push_str(" ORDER BY timestamp DESC LIMIT 1");
         let refs: Vec<&dyn rusqlite::types::ToSql> = bindings
             .iter()
@@ -3484,17 +3524,38 @@ pub fn statusline_stats(
         })
         .unwrap_or((None, None, None));
 
-    let cost_lag_hint = if active_provider.as_deref() == Some("cursor") {
+    // Lag hint fires whenever `cursor` is part of the aggregated totals,
+    // not just when it's the active provider — a host-scoped roll-up that
+    // *includes* Cursor still shows lagging numbers even if Copilot Chat
+    // happened to be the most recent traffic in the 1d window.
+    let cursor_in_filter = provider_filter.iter().any(|p| p == "cursor");
+    let cursor_active = active_provider.as_deref() == Some("cursor");
+    let cost_lag_hint = if cursor_in_filter || cursor_active {
         Some(crate::analytics::CURSOR_LAG_HINT.to_string())
     } else {
         None
+    };
+
+    // `provider_scope` keeps its single-provider semantics: echoed back when
+    // exactly one provider was filtered, omitted otherwise. Multi-provider
+    // requests advertise their scope via `contributing_providers`. Single-
+    // provider responses stay byte-identical to the 8.1 contract.
+    let provider_scope = if provider_filter.len() == 1 {
+        Some(provider_filter[0].clone())
+    } else {
+        None
+    };
+    let contributing_providers = if provider_filter.len() > 1 {
+        provider_filter.to_vec()
+    } else {
+        Vec::new()
     };
 
     Ok(StatuslineStats {
         cost_1d,
         cost_7d,
         cost_30d,
-        provider_scope: params.provider.clone(),
+        provider_scope,
         today_cost: cost_1d,
         week_cost: cost_7d,
         month_cost: cost_30d,
@@ -3502,6 +3563,7 @@ pub fn statusline_stats(
         branch_cost,
         project_cost,
         active_provider,
+        contributing_providers,
         health_state,
         health_tip,
         session_msg_cost,

--- a/crates/budi-core/src/analytics/tests.rs
+++ b/crates/budi-core/src/analytics/tests.rs
@@ -1191,7 +1191,7 @@ fn statusline_stats_with_provider_filter_scopes_all_numeric_fields() {
         since_7d,
         since_30d,
         &StatuslineParams {
-            provider: Some("claude_code".to_string()),
+            provider: vec!["claude_code".to_string()],
             session_id: Some("claude-sess".to_string()),
             branch: Some("main".to_string()),
             project_dir: Some("/proj/a".to_string()),
@@ -1200,6 +1200,7 @@ fn statusline_stats_with_provider_filter_scopes_all_numeric_fields() {
     )
     .unwrap();
     assert_eq!(claude.provider_scope.as_deref(), Some("claude_code"));
+    assert!(claude.contributing_providers.is_empty());
     assert_eq!(claude.cost_1d, 5.0);
     assert_eq!(claude.cost_7d, 5.0);
     assert_eq!(claude.cost_30d, 5.0);
@@ -1214,7 +1215,7 @@ fn statusline_stats_with_provider_filter_scopes_all_numeric_fields() {
         since_7d,
         since_30d,
         &StatuslineParams {
-            provider: Some("cursor".to_string()),
+            provider: vec!["cursor".to_string()],
             branch: Some("main".to_string()),
             project_dir: Some("/proj/a".to_string()),
             ..Default::default()
@@ -1225,6 +1226,213 @@ fn statusline_stats_with_provider_filter_scopes_all_numeric_fields() {
     assert_eq!(cursor.branch_cost, Some(7.0));
     assert_eq!(cursor.project_cost, Some(7.0));
     assert_eq!(cursor.active_provider.as_deref(), Some("cursor"));
+    assert!(cursor.contributing_providers.is_empty());
+}
+
+/// R1.3 (#650): the statusline endpoint accepts a comma-separated provider
+/// list and aggregates the result for host-scoped surfaces (the VS Code /
+/// Cursor extension status bar). Provider-scoped surfaces (single
+/// `?provider=`) keep their byte-identical 8.1 contract; multi-provider
+/// requests sum across the listed providers and advertise their scope via
+/// `contributing_providers`.
+#[test]
+fn statusline_stats_aggregates_across_multiple_providers() {
+    let mut conn = test_db();
+
+    let mk = |uuid: &str, session: &str, provider: &str, cost_cents: f64, ts: &str| ParsedMessage {
+        uuid: uuid.to_string(),
+        session_id: Some(session.to_string()),
+        timestamp: ts.parse().unwrap(),
+        cwd: Some("/proj/a".to_string()),
+        role: "assistant".to_string(),
+        model: Some("m".to_string()),
+        input_tokens: 100,
+        output_tokens: 50,
+        cache_creation_tokens: 0,
+        cache_read_tokens: 0,
+        git_branch: Some("main".to_string()),
+        repo_id: Some("repo-1".to_string()),
+        provider: provider.to_string(),
+        cost_cents: Some(cost_cents),
+        session_title: None,
+        parent_uuid: None,
+        user_name: None,
+        machine_name: None,
+        cost_confidence: "exact".to_string(),
+        pricing_source: None,
+        request_id: None,
+        speed: None,
+        cache_creation_1h_tokens: 0,
+        web_search_requests: 0,
+        prompt_category: None,
+        prompt_category_source: None,
+        prompt_category_confidence: None,
+        tool_names: Vec::new(),
+        tool_use_ids: Vec::new(),
+        tool_files: Vec::new(),
+        tool_outcomes: Vec::new(),
+    };
+
+    let msgs = vec![
+        mk("cur-1", "cur-sess", "cursor", 300.0, "2026-04-15T09:00:00Z"),
+        mk(
+            "cop-1",
+            "cop-sess",
+            "copilot_chat",
+            500.0,
+            "2026-04-15T11:00:00Z",
+        ),
+        mk(
+            "cc-1",
+            "cc-sess",
+            "claude_code",
+            900.0,
+            "2026-04-15T11:30:00Z",
+        ),
+    ];
+    ingest_messages(&mut conn, &msgs, None).unwrap();
+
+    let since_1d = "2026-04-15T00:00:00Z";
+    let since_7d = "2026-04-10T00:00:00Z";
+    let since_30d = "2026-03-20T00:00:00Z";
+
+    // Single-provider (backward-compatible): same shape, single value.
+    let single = statusline_stats(
+        &conn,
+        since_1d,
+        since_7d,
+        since_30d,
+        &StatuslineParams {
+            provider: vec!["cursor".to_string()],
+            branch: Some("main".to_string()),
+            project_dir: Some("/proj/a".to_string()),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(single.cost_1d, 3.0);
+    assert_eq!(single.provider_scope.as_deref(), Some("cursor"));
+    assert!(
+        single.contributing_providers.is_empty(),
+        "single-provider responses must omit contributing_providers to keep the 8.1 byte shape"
+    );
+    assert_eq!(single.active_provider.as_deref(), Some("cursor"));
+    assert!(
+        single.cost_lag_hint.is_some(),
+        "cursor in filter → lag hint"
+    );
+
+    // Multi-provider: sums cursor + copilot_chat = 800c = $8.0; excludes
+    // claude_code which is not in the filter.
+    let multi = statusline_stats(
+        &conn,
+        since_1d,
+        since_7d,
+        since_30d,
+        &StatuslineParams {
+            provider: vec!["cursor".to_string(), "copilot_chat".to_string()],
+            branch: Some("main".to_string()),
+            project_dir: Some("/proj/a".to_string()),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(multi.cost_1d, 8.0);
+    assert_eq!(multi.cost_7d, 8.0);
+    assert_eq!(multi.cost_30d, 8.0);
+    assert_eq!(multi.branch_cost, Some(8.0));
+    assert_eq!(multi.project_cost, Some(8.0));
+    // active_provider is the most recent inside the filter — copilot_chat at
+    // 11:00 beats cursor at 09:00; claude_code at 11:30 is excluded.
+    assert_eq!(multi.active_provider.as_deref(), Some("copilot_chat"));
+    assert!(
+        multi.provider_scope.is_none(),
+        "multi-provider scope expressed via contributing_providers, not provider_scope"
+    );
+    assert_eq!(
+        multi.contributing_providers,
+        vec!["cursor".to_string(), "copilot_chat".to_string()]
+    );
+    assert!(
+        multi.cost_lag_hint.is_some(),
+        "cursor in multi-filter → lag hint even when copilot_chat is active"
+    );
+
+    // Empty filter (today's `?provider=` or no `?provider=`): unscoped sum.
+    let unscoped = statusline_stats(
+        &conn,
+        since_1d,
+        since_7d,
+        since_30d,
+        &StatuslineParams::default(),
+    )
+    .unwrap();
+    assert_eq!(unscoped.cost_1d, 17.0);
+    assert!(unscoped.provider_scope.is_none());
+    assert!(unscoped.contributing_providers.is_empty());
+
+    // Unknown provider name is treated as a zero-row filter, not an error.
+    let unknown = statusline_stats(
+        &conn,
+        since_1d,
+        since_7d,
+        since_30d,
+        &StatuslineParams {
+            provider: vec!["nonexistent_agent".to_string()],
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(unknown.cost_1d, 0.0);
+    assert_eq!(unknown.cost_30d, 0.0);
+    assert!(unknown.active_provider.is_none());
+
+    // Multi with one unknown still sums the known ones. Order in the filter
+    // is preserved for `contributing_providers` so the tooltip render is
+    // deterministic.
+    let mixed = statusline_stats(
+        &conn,
+        since_1d,
+        since_7d,
+        since_30d,
+        &StatuslineParams {
+            provider: vec!["nonexistent_agent".to_string(), "cursor".to_string()],
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(mixed.cost_1d, 3.0);
+    assert_eq!(
+        mixed.contributing_providers,
+        vec!["nonexistent_agent".to_string(), "cursor".to_string()]
+    );
+}
+
+/// R1.3 (#650): comma-list parsing for the statusline `?provider=` query
+/// param. `?provider=cursor` keeps the 8.1 single-provider behavior;
+/// `?provider=cursor,copilot_chat` is the host-scoped form. Empty / absent
+/// collapse to "no filter" (unscoped). Duplicates and whitespace are
+/// cleaned up so the contributing-providers tooltip doesn't render
+/// "Cursor + Cursor".
+#[test]
+fn statusline_provider_filter_parses_comma_list_forms() {
+    use super::queries::parse_provider_filter;
+
+    assert!(parse_provider_filter(None).is_empty());
+    assert!(parse_provider_filter(Some("")).is_empty());
+    assert_eq!(
+        parse_provider_filter(Some("cursor")),
+        vec!["cursor".to_string()]
+    );
+    assert_eq!(
+        parse_provider_filter(Some("cursor,copilot_chat")),
+        vec!["cursor".to_string(), "copilot_chat".to_string()]
+    );
+    // Whitespace + empty entries dropped, duplicates collapsed in input order.
+    assert_eq!(
+        parse_provider_filter(Some("cursor, ,cursor, copilot_chat")),
+        vec!["cursor".to_string(), "copilot_chat".to_string()]
+    );
 }
 
 #[test]

--- a/docs/statusline-contract.md
+++ b/docs/statusline-contract.md
@@ -1,15 +1,20 @@
 # Statusline status contract (provider-scoped)
 
-**Status**: Active — shipped in 8.1 under [#224](https://github.com/siropkin/budi/issues/224)
-**Governance**: [ADR-0088](./adr/0088-8x-local-developer-first-product-contract.md) §4
+**Status**: Active — shipped in 8.1 under [#224](https://github.com/siropkin/budi/issues/224); host-scoped multi-provider extension shipped in 8.4 under [#650](https://github.com/siropkin/budi/issues/650)
+**Governance**: [ADR-0088](./adr/0088-8x-local-developer-first-product-contract.md) §4 + §7 (post-#648)
 
-This document pins the shared provider-scoped status contract emitted by Budi's local status surfaces. It is the single JSON shape consumed by:
+This document pins the shared status contract emitted by Budi's local status surfaces. It is the single JSON shape consumed by:
 
 - the CLI statusline (`budi statusline --format json`)
-- the Cursor extension ([#232](https://github.com/siropkin/budi/issues/232), surfaced as a single Cursor status bar item — no sidebar, no side panel)
+- the Cursor / VS Code extensions ([#232](https://github.com/siropkin/budi/issues/232), surfaced as a single editor status bar item — no sidebar, no side panel)
 - the cloud dashboard's provider-scoped views ([#235](https://github.com/siropkin/budi/issues/235))
 
 Provider is an explicit filter rather than a family of per-surface shapes. Future agents added under [#294](https://github.com/siropkin/budi/issues/294) slot into the same shape — they do not each invent their own statusline schema.
+
+The same endpoint serves two scopes (ADR-0088 §7 post-#648):
+
+- **Provider-scoped** — `?provider=<single>`. Cloud dashboard, per-provider drill-downs, and the Claude Code statusline. No blending across providers.
+- **Host-scoped** — `?provider=<a>,<b>,<c>`. The VS Code / Cursor extension status bar aggregates over the providers detected in that editor host. The response carries a `contributing_providers` list for tooltip rendering and click-through routing.
 
 ## Endpoint
 
@@ -23,13 +28,13 @@ The daemon only accepts loopback connections. The contract is also available via
 
 All parameters are optional. Omit them to get unscoped, context-free totals.
 
-| Parameter      | Type   | Effect |
-|----------------|--------|--------|
-| `provider`     | string | Scopes every numeric field (`cost_1d` / `cost_7d` / `cost_30d`, `session_cost`, `branch_cost`, `project_cost`) and `active_provider` to one provider. Canonical values: `claude_code`, `cursor`, `codex`, `copilot_cli`. Provider-scoped surfaces (the Claude Code statusline, the Cursor extension) **must** set this. |
-| `session_id`   | string | Additionally compute `session_cost` and session health (`health_state`, `health_tip`, `session_msg_cost`). |
-| `branch`       | string | Additionally compute `branch_cost` for this git branch. |
-| `repo_id`      | string | Scope `branch_cost` to `(repo_id, branch)` so developers who sit on `main` / `master` in multiple repos don't get a cross-repo sum. Only meaningful when `branch` is also set. Format matches `budi_core::repo_id` (e.g. `github.com/siropkin/budi`). |
-| `project_dir`  | string | Additionally compute `project_cost` for this directory. |
+| Parameter      | Type                  | Effect |
+|----------------|-----------------------|--------|
+| `provider`     | string \| comma-list  | Scopes every numeric field (`cost_1d` / `cost_7d` / `cost_30d`, `session_cost`, `branch_cost`, `project_cost`) and `active_provider`. **Single value** (`?provider=cursor`) — provider-scoped, byte-identical to the 8.1 contract. **Comma-list** (`?provider=cursor,copilot_chat`) — host-scoped, aggregates the listed providers and populates `contributing_providers`. Canonical values: `claude_code`, `cursor`, `codex`, `copilot_cli`, `copilot_chat`. Empty / absent → unscoped (sums every provider). Whitespace and duplicate names are normalized away. The repeated form `?provider=a&provider=b` is **not** supported (axum's default `Query` extractor takes the last value only) — callers that need multi-provider must use the comma-list form. |
+| `session_id`   | string                | Additionally compute `session_cost` and session health (`health_state`, `health_tip`, `session_msg_cost`). |
+| `branch`       | string                | Additionally compute `branch_cost` for this git branch. |
+| `repo_id`      | string                | Scope `branch_cost` to `(repo_id, branch)` so developers who sit on `main` / `master` in multiple repos don't get a cross-repo sum. Only meaningful when `branch` is also set. Format matches `budi_core::repo_id` (e.g. `github.com/siropkin/budi`). |
+| `project_dir`  | string                | Additionally compute `project_cost` for this directory. |
 
 ## Response shape
 
@@ -38,17 +43,19 @@ All parameters are optional. Omit them to get unscoped, context-free totals.
   "cost_1d": 2.34,              // rolling last 24h, dollars
   "cost_7d": 12.50,             // rolling last 7d, dollars
   "cost_30d": 48.10,            // rolling last 30d, dollars
-  "provider_scope": "claude_code", // echoes the `provider` filter, if set
+  "provider_scope": "claude_code", // echoes the `provider` filter when exactly one provider was passed; omitted otherwise
+  "contributing_providers": ["cursor", "copilot_chat"], // present iff multi-provider; tooltip + click-through source
   "today_cost": 2.34,           // deprecated alias for cost_1d; removed in 9.0
   "week_cost": 12.50,           // deprecated alias for cost_7d; removed in 9.0
   "month_cost": 48.10,          // deprecated alias for cost_30d; removed in 9.0
   "session_cost": 0.41,         // present iff session_id was passed
   "branch_cost": 8.70,          // present iff branch was passed
   "project_cost": 12.10,        // present iff project_dir was passed
-  "active_provider": "claude_code", // most recent provider seen in 24h (filtered)
+  "active_provider": "claude_code", // most recent provider seen in 24h (filtered); under multi-provider, the most recent from the contributing set
   "health_state": "green",      // present iff session_id was passed
   "health_tip": "session healthy", // present iff session_id was passed
-  "session_msg_cost": 0.03      // present iff session_id was passed
+  "session_msg_cost": 0.03,     // present iff session_id was passed
+  "cost_lag_hint": "..."        // present iff Cursor data is in the response (active or contributing); ~10 min Usage API lag
 }
 ```
 
@@ -56,10 +63,13 @@ All parameters are optional. Omit them to get unscoped, context-free totals.
 
 - **Windows are rolling**, not calendar. `cost_1d` = spend in the last 24 hours. `cost_7d` = spend in the last 7 days. `cost_30d` = spend in the last 30 days. This is a deliberate shift from 8.0 (which used calendar today / Monday-of-week / first-of-month), governed by ADR-0088 §4. `budi stats` and the cloud dashboard's cost charts keep calendar semantics — the rolling windows live only on the statusline surface and the Cursor extension that renders this contract. See [README → Windows: rolling vs calendar](../README.md#windows-rolling-vs-calendar) for the user-facing explanation.
 - **Costs are in dollars**, rounded to two decimal places at the rendering layer.
-- **Provider scoping is strict.** When `provider=claude_code`, a machine that also uses Cursor will not see Cursor spend in `cost_1d` / `cost_7d` / `cost_30d`. This is the fix for the 8.0 bug where Claude Code's statusline showed blended multi-provider totals (ADR-0088 §4, #224).
+- **Provider scoping is strict for provider-scoped surfaces.** When `provider=claude_code`, a machine that also uses Cursor will not see Cursor spend in `cost_1d` / `cost_7d` / `cost_30d`. This is the fix for the 8.0 bug where Claude Code's statusline showed blended multi-provider totals (ADR-0088 §4, #224). Multi-provider requests (host-scoped) opt in by passing a comma-list and explicitly aggregate over the listed providers per ADR-0088 §7 (post-#648).
 - **Empty window vs stalled data.** All three cost fields are always present and default to `0.0` when the DB has no matching rows. An empty 30d window with a healthy daemon means "you have not used this provider in 30 days", not "the daemon is broken".
-- **`active_provider`** is the most recent `provider` value seen inside the 1d window, after the provider filter is applied. It exists so downstream surfaces can render "last touched" hints without a second API call.
-- **`provider_scope`** echoes back the filter the daemon applied. Consumers should display the scope alongside totals when the filter is active.
+- **`active_provider`** is the most recent `provider` value seen inside the 1d window, after the provider filter is applied. It exists so downstream surfaces can render "last touched" hints without a second API call. Under multi-provider, it is the most recent provider drawn from the contributing set — host-scoped click-through routes to its dashboard.
+- **`provider_scope`** echoes back the filter the daemon applied **only when exactly one provider was passed**, preserving the 8.1 byte shape. For multi-provider requests it is omitted; the active scope is advertised via `contributing_providers` instead.
+- **`contributing_providers`** is populated only for multi-provider requests (the comma-list form). It is the deduplicated, normalized list of providers the response sums over, in the input order. Single-provider requests omit the field. Consumers that render a tooltip should join the entries with their own separator (e.g. `Cursor + Copilot Chat`).
+- **Unknown provider names are not errors.** A name with no matching rows contributes `0.0` to every numeric field and survives in `contributing_providers`. This keeps the host-scoped rollup forgiving when a host-detector advertises a provider that hasn't ingested any messages yet.
+- **`cost_lag_hint`** fires when Cursor data is in the response — either as the active provider or as a member of the contributing set — because the Cursor Usage API can lag up to ~10 minutes (ADR-0090).
 - **Deprecated fields** (`today_cost`, `week_cost`, `month_cost`) are populated with the same rolling values as `cost_1d` / `cost_7d` / `cost_30d` for one release of backward compatibility with 8.0 consumers that predate this contract. They are removed in 9.0. New consumers MUST read the `cost_1d` / `cost_7d` / `cost_30d` fields.
 - **`branch_cost` is repo-scoped when `repo_id` is passed.** Consumers that can resolve a repo identity (the CLI does this via `budi_core::repo_id` when it has a cwd) should pass `repo_id` alongside `branch` so `branch_cost` reflects "this branch in this repo" rather than "this branch name across every repo on the machine". Omitting `repo_id` preserves the pre-8.2.1 behavior, which sums across all repos that share the branch name (#347).
 
@@ -93,6 +103,16 @@ budi statusline
 ```sh
 budi statusline --format json --provider cursor
 ```
+
+### VS Code / multi-provider host extensions ([#650](https://github.com/siropkin/budi/issues/650))
+
+The VS Code extension calls the daemon directly with the comma-list form so a single editor window that runs Copilot Chat, Continue, and Cline is summed honestly:
+
+```
+GET http://127.0.0.1:7878/analytics/statusline?provider=cursor,copilot_chat
+```
+
+The response shape is identical to the single-provider response except that `provider_scope` is omitted and `contributing_providers` lists the requested providers. Render the totals from `cost_1d` / `cost_7d` / `cost_30d` and the tooltip from `contributing_providers`; click-through routes to `active_provider`'s dashboard.
 
 ### Cloud dashboard provider-scoped tiles ([#235](https://github.com/siropkin/budi/issues/235))
 


### PR DESCRIPTION
## Summary

- Extends `/analytics/statusline` to accept a comma-separated provider list and sum the rolling `1d` / `7d` / `30d` windows across the listed providers, unblocking the host-scoped VS Code / Cursor extension surfaces (ADR-0088 §7 post-#648).
- Adds an optional `contributing_providers: Vec<String>` to the response so the extension can render `Cursor + Copilot Chat` in the tooltip without a second API call. `active_provider` is now resolved within the multi-provider filter set, so click-through still routes to a single provider's dashboard.
- `provider_scope` stays single-string and is omitted under multi-provider, keeping the 8.1 single-provider response byte-identical for the budi-cursor 1.3.x and Claude Code statusline consumers.

## Wire shape

Picked the comma-list form, matching the existing `DimensionParams` (`agents`, `models`, ...) pattern and avoiding the `?provider=a&provider=b` repeated form (axum's default `Query<T>` only keeps the last value). Documented in `docs/statusline-contract.md`.

| Query | Behavior |
|-------|----------|
| `?provider=cursor` | Provider-scoped (unchanged from 8.1). `provider_scope: "cursor"`, no `contributing_providers`. |
| `?provider=cursor,copilot_chat` | Host-scoped. Sums both, omits `provider_scope`, returns `contributing_providers: ["cursor", "copilot_chat"]`. |
| `?provider=` / absent | Unscoped — sums every provider. |
| `?provider=cursor,nonexistent` | Unknown names contribute `0.0`, not an error; survive in `contributing_providers`. |

## Implementation notes

- `StatuslineParams.provider` is now `Vec<String>` with a custom serde deserializer that splits the comma-list, trims whitespace, drops empty entries, and dedupes in input order.
- SQL filter switches from `provider = ?` to `provider IN (...)` across cost / session / branch / project / active-provider queries, including the rollup fast path.
- `cost_lag_hint` now fires whenever Cursor is present in the response (active or contributing), so a host-scoped rollup that includes lag-prone Cursor data still warns honestly.
- Pure-helper `parse_provider_filter` covers single, comma-list, empty, whitespace, and dedup cases under unit test.

## Test plan

- [x] `cargo test --workspace` (557 tests, all green)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (clean)
- [x] `cargo fmt --all` applied
- [x] New unit tests cover: single-provider (back-compat), multi-provider sum, empty filter (unscoped), unknown provider name (zero, not error), multi with one unknown, comma-list parsing edge cases (whitespace, empty entries, duplicates).

Closes #650 — parent epic #647.

🤖 Generated with [Claude Code](https://claude.com/claude-code)