### PR TITLE
[8.4][R2.1] Release readiness for VS Code support v8.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## 8.4.0 — Unreleased
+
+8.4.0 is the **VS Code-side coverage** release: the budi extension now hosts inside VS Code as well as Cursor, with **GitHub Copilot Chat** as the first non-Cursor provider. The architectural pieces this round forces into the codebase — a host-scoped statusline surface that aggregates over multiple providers in a single editor window, a third-party-API-as-reconciliation pattern (GitHub Billing API), and a `MIN_API_VERSION` pattern for provider-side data contracts — are the same pieces every later 9.0.0 provider will need (#647).
+
+### Added
+
+- **`copilot_chat` provider plugin — local JSON/JSONL tailing** (R1.4, #651) — new provider tails per-message tokens out of VS Code's `workspaceStorage` and `globalStorage` for the GitHub Copilot Chat extension on macOS / Linux / Windows. Tokens × pricing manifest is the primary live cost path; ADR-0092 §2 pins the on-disk format with a `MIN_API_VERSION = 1` guard so a future Copilot Chat schema flip surfaces in `budi doctor` rather than producing silent zeros. Org-managed users (where the GitHub Billing API is unavailable) rely entirely on this local-tail × pricing path.
+- **GitHub Billing API reconciliation worker for `copilot_chat`** (R1.5, #652) — `sync_direct` worker pulls per-user dollar truth-up for individually-licensed users and reconciles against the local-tail rows. Org-managed users see an empty endpoint and the worker no-ops cleanly. Runs on the same configurable interval as the cloud-sync worker; auth/schema errors are structured-logged and surfaced on the existing pricing/sync status endpoints. ADR-0092 §3 governs the contract.
+- **Multi-provider statusline endpoint — `?provider=a,b,c`** (R1.3, #650) — `GET /analytics/statusline` and `budi statusline --format json` now accept a comma-list `?provider=` value and aggregate every numeric field (`cost_1d` / `cost_7d` / `cost_30d`, `session_cost`, `branch_cost`, `project_cost`) over the listed providers. The response carries a new `contributing_providers` array for tooltip rendering and click-through routing; `provider_scope` is omitted under multi-provider so the byte shape of the single-provider response is unchanged. Single-provider `?provider=cursor` is byte-identical to the 8.1 contract — no consumer is forced to change. The endpoint is host-scoped per the ADR-0088 §7 amendment (#648); cloud dashboard tiles stay provider-scoped.
+- **`budi doctor` surfaces installed VS Code AI extensions and tailer health** (R1.6, #653) — `budi doctor` detects installed Copilot Chat / Continue / Cline / Roo Code / Aider / Windsurf extensions in VS Code, reports per-provider tailer health, and flags ADR-0092 §2.6 `MIN_API_VERSION` mismatches (Copilot Chat schema flip → visible warning, not silent zeros). Org-managed Copilot users and unconfigured-PAT cases are surfaced as informational signals (ADR-0092 §3.3 / §3.4) so the install-funnel state is visible without remote telemetry.
+
+### Changed
+
+- **Supported agents — Copilot Chat is now first-class.** README's supported-agent table now lists Copilot Chat alongside Claude Code, Codex CLI, Cursor, and Copilot CLI. The VS Code host is documented as a peer of the Cursor host for the budi extension.
+- **`docs/statusline-contract.md` updated for the host-scoped surface** — the contract now documents both **provider-scoped** (`?provider=<single>`) and **host-scoped** (`?provider=<a>,<b>,<c>`) behavior, the `contributing_providers` field, and the unknown-provider tolerance rule (unknown names contribute `0.0` and survive in `contributing_providers`). Provider-scoped consumers (Claude Code statusline, cloud dashboard tiles) are unaffected.
+
+### Architecture decisions
+
+- **ADR-0088 §7 amended — host-scoped vs. provider-scoped surfaces** (R1.1, #648). The host extension surface (the VS Code / Cursor status bar) is allowed to aggregate across providers detected in that editor host; provider-scoped surfaces (Claude Code statusline, cloud dashboard per-provider tiles) remain provider-only. Cloud dashboard rollups stay provider-scoped per the existing §7 — only the in-editor surface aggregates. The amendment lands ahead of the multi-provider endpoint so the endpoint is not an ADR violation at merge time.
+- **ADR-0092 — `copilot_chat` data contract** (R1.2, #649). Pins the on-disk format Copilot Chat writes under `workspaceStorage` / `globalStorage`, the GitHub Billing API contract for individually-licensed users, the `MIN_API_VERSION` bump rule for visible drift detection, and the org-managed-user fallback path (local-tail × pricing).
+
+### Cross-repo lockstep
+
+- **`siropkin/budi-cursor` 1.4.x** ships VS Code host detection, the multi-provider request shape (`?provider=cursor,copilot_chat` when both are detected), tooltip copy update for the host-scoped surface, and a `MIN_API_VERSION` bump in `budiClient.ts` matched to this contract. Older daemons continue to surface the existing API-version warning rather than rendering silent zeros. The bundled vsix in this repo was retired in 8.0 (#96), so there is nothing to refresh on the budi side.
+- **`siropkin/getbudi.dev`** copy and screenshots refresh for VS Code support is threaded into the public-site sync ticket; never let the public-site copy drift from shipped behavior.
+
+### Non-blocking, carried forward
+
+- **Cloud Overview cost / token totals diverge from local CLI** (#10) — presentation-layer aggregation difference, not data loss.
+- **RC-4 Part B** (#504) — Cursor Usage API auth root-cause; Part A shipped with `v8.3.1`.
+- **ADR-0090 supersede** — pending one release cycle of live validation on the now-working `cursorDiskKV` bubbles path before the Usage API §1 surface can be retired.
+- **Continue, Cline, Roo Code, Aider, Windsurf, Gemini CLI providers** — deferred to the 9.0.0 breadth round (#295, #161). 8.4.0 ships the architectural pieces every one of those providers will reuse: host-scoped surface, multi-provider endpoint, third-party-API-as-reconciliation pattern.
+
 ## 8.3.19 — 2026-05-05
 
 8.3.19 is a quality-of-life release that improves statusline ergonomics

--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ Everything stays on your machine by default. Optional cloud sync pushes aggregat
 
 ## What budi does
 
-- **Tracks every AI coding agent** — Claude Code, Cursor, Codex CLI, and Copilot CLI in one place
+- **Tracks every AI coding agent** — Claude Code, Cursor, Codex CLI, Copilot CLI, and Copilot Chat (VS Code) in one place
 - **Per-message cost and tokens** — not just session totals; every API call attributed individually
 - **Repo, branch, and ticket breakdown** — know which project, PR branch, or ticket is driving spend
 - **Session health** — detects context bloat, cache degradation, and cost acceleration with actionable tips
-- **Live status line** in Claude Code and Cursor showing rolling 1d / 7d / 30d spend
+- **Live status line** in Claude Code, Cursor, and VS Code showing rolling 1d / 7d / 30d spend (VS Code aggregates over Copilot Chat + any other detected provider)
 - **Team dashboard** at [app.getbudi.dev](https://app.getbudi.dev) — optional sync sends only aggregated metrics; prompts and code never leave your machine
 - **~6 MB Rust binary**, zero config required, minimal footprint
 
@@ -64,6 +64,7 @@ Everything stays on your machine by default. Optional cloud sync pushes aggregat
 | **Codex CLI** | Supported | Live transcript tailing |
 | **Cursor** | Supported | Live tailing + Usage API reconciliation |
 | **Copilot CLI** | Supported | Live transcript tailing |
+| **Copilot Chat (VS Code)** | Supported | Live JSON/JSONL tailing + GitHub Billing API reconciliation ([ADR-0092](docs/adr/0092-copilot-chat-data-contract.md)) |
 | **Gemini CLI** | Deferred | Tracked in [#294](https://github.com/siropkin/budi/issues/294) |
 
 All agents also support one-time historical import via `budi db import`.


### PR DESCRIPTION
Closes #654. Parent epic: #647.

## Summary

Drafts the v8.4.0 CHANGELOG entry (VS Code-side coverage; Copilot Chat as the first non-Cursor provider) and refreshes the README supported-agent table + status-line copy. Version bumps are deferred to R2.3 (#656).

## Release readiness state for #654

**Implementation tickets — all closed:**

- [x] R1.1 — Amend ADR-0088 §7: host-scoped vs. provider-scoped surfaces (#648, merged 9aab924)
- [x] R1.2 — ADR-0092: `copilot_chat` data contract (#649, merged 62b78f2)
- [x] R1.3 — Multi-provider statusline endpoint `?provider=a,b,c` (#650, merged 9555031)
- [x] R1.4 — Provider plugin for Copilot Chat — local JSON/JSONL tailing (#651, merged 0253c59)
- [x] R1.5 — Copilot Chat reconciliation via GitHub Billing API (#652, merged e05a556)
- [x] R1.6 — `budi doctor` surfaces installed VS Code AI extensions (#653, merged d4131f9 / a1f73d1)

**Ordering invariant preserved:** ADR-0088 §7 amendment landed in `main` (9aab924, 2026-04-30) ahead of the multi-provider endpoint (9555031, 2026-05-01), so the host-scoped surface is not an ADR violation at any point in the merge sequence.

**Statusline contract:** `docs/statusline-contract.md` already documents both provider-scoped (`?provider=<single>`) and host-scoped (`?provider=<a>,<b>,<c>`) behavior, the `contributing_providers` field, and the unknown-provider tolerance rule. No drift from the shipped daemon code.

**Bundled vsix:** Retired in 8.0 (#96) — the Cursor extension is now installed via VS Code Marketplace or `budi integrations install --with cursor-extension`. There is nothing to refresh on the budi side; the lockstep requirement applies only to the budi-cursor repo's vsix release.

**Workspace tests:** `cargo test --workspace -- --test-threads=1` is **clean** (838 tests across `budi-core` / `budi-cli` / `budi-daemon`). With the default parallel runner there is a known flake in `budi-daemon::workers::tailer::run_blocking_exits_when_shutdown_flag_is_set` — the test's 7 s deadline (`BACKSTOP_POLL=5s + 2s`) is tight under heavy parallel load. The test passes when isolated, has been on `main` since 8.2 (a5c5a26, #384), and is not introduced by any 8.4.0 work. Filed as a 9.0-era follow-up rather than a release blocker.

## Cross-repo lockstep — still required before R2.3 can tag

- [ ] **`siropkin/budi-cursor` 1.4.x** (currently 1.3.3) — VS Code host detection, multi-provider request shape (`?provider=cursor,copilot_chat` when both detected), `MIN_API_VERSION` bump in `budiClient.ts` to match this contract, tooltip copy update for the host-scoped surface.
- [ ] **`siropkin/getbudi.dev`** — copy + screenshots refreshed for VS Code support so the public-site copy doesn't drift from shipped behavior.

These are explicit prerequisites for the R2.3 tag (#656) and called out as such in the new CHANGELOG entry.

## Test plan

- [x] `cargo fmt --all` clean
- [x] `cargo test --workspace -- --test-threads=1` — 838 / 838 pass
- [ ] R2.2 smoke plan (#655) green on macOS / Linux / Windows host (gates R2.3)
- [ ] budi-cursor 1.4.x release shipped before R2.3 tags (gates R2.3)
- [ ] getbudi.dev copy + screenshots refreshed before R2.3 promotes (gates R2.3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)