### PR TITLE
fix(copilot_chat): parse real on-disk envelopes + output-only fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License](https://img.shields.io/github/license/siropkin/budi)](https://github.com/siropkin/budi/blob/main/LICENSE)
 [![GitHub stars](https://img.shields.io/github/stars/siropkin/budi?style=social)](https://github.com/siropkin/budi)
 
-**Local-first cost analytics for AI coding agents.** See where your tokens and money go across Claude Code, Cursor, Codex, and Copilot CLI — broken down by repo, branch, ticket, and file.
+**Local-first cost analytics for AI coding agents.** See where your tokens and money go across Claude Code, Cursor, Codex, Copilot CLI, and Copilot Chat (VS Code) — broken down by repo, branch, ticket, and file.
 
 ```bash
 brew install siropkin/budi/budi && budi init
@@ -337,7 +337,7 @@ Data views accept `--period today|week|month|all` (or relative like `7d`, `2w`, 
 
 | | budi | ccusage | Claude `/cost` |
 |---|---|---|---|
-| Multi-agent support | **Yes** (Claude Code, Codex CLI, Cursor, Copilot CLI) | Claude Code only | Claude Code only |
+| Multi-agent support | **Yes** (Claude Code, Codex CLI, Cursor, Copilot CLI, Copilot Chat) | Claude Code only | Claude Code only |
 | Live local transcript tailing | **Yes** | No | No |
 | Cost history | **Per-message + daily** | Per-session | Current session only |
 | Cloud team dashboard | **Yes** ([app.getbudi.dev](https://app.getbudi.dev)) | No | No |

--- a/SOUL.md
+++ b/SOUL.md
@@ -158,9 +158,10 @@ Core tables:
 
 | Source | Confidence | What it provides |
 |--------|-----------|-----------------|
-| **JSONL tailer** (Claude Code, Codex, Copilot CLI) | `estimated` | Per-message tokens parsed from the agent's local transcript as it grows. Same parser as `budi db import`; same enricher chain. |
+| **JSONL tailer** (Claude Code, Codex, Copilot CLI, Copilot Chat) | `estimated` | Per-message tokens parsed from the agent's local transcript as it grows. Same parser as `budi db import`; same enricher chain. Copilot Chat uses an output-only fallback for May-2026+ VS Code builds that drop prompt-token counts client-side ([ADR-0092](docs/adr/0092-copilot-chat-data-contract.md) §2.3). |
 | **Cursor Usage API** | `exact` | Per-request tokens + totalCents pulled from Cursor's API. Reconciles cost/token data the JSONL doesn't carry; scheduled pull, not a live path. Lag profile p50 ≈ 70 s, p99 ≈ 6 min (measured in #321, embedded in [ADR-0089](docs/adr/0089-reverse-proxy-first-jsonl-tailing-as-sole-live-path.md) §7). |
-| **JSONL backfill** (`budi db import`) | `estimated` (Claude Code / Codex / Copilot CLI) / `exact` (Cursor) | Same providers, one-shot mode for historical backfill. Used after install or after `budi db import --force`. |
+| **GitHub Billing API** (Copilot Chat individual licences) | `exact` | Per-`(date, model)` dollar buckets pulled from GitHub's user-billing endpoint, scaling existing local-tail rows in place (`pricing_source = 'billing_api:copilot_chat'`). Org-managed seats yield a 200 with empty usage and no truth-up; local-tail tokens × manifest pricing remain in effect ([ADR-0092](docs/adr/0092-copilot-chat-data-contract.md) §3). |
+| **JSONL backfill** (`budi db import`) | `estimated` (Claude Code / Codex / Copilot CLI / Copilot Chat) / `exact` (Cursor) | Same providers, one-shot mode for historical backfill. Used after install or after `budi db import --force`. |
 | **Legacy proxy** (pre-8.2 history only) | `proxy_estimated` | Rows written by the 8.0/8.1 proxy remain queryable. No new writes; the proxy runtime was deleted in 8.2. |
 
 Historical OTEL data (`otel_exact` confidence) remains queryable but OTEL ingestion has been removed.
@@ -185,8 +186,8 @@ CLI, daemon, and dashboard tell the same story (see ADR-0082 and
   the insert path normalizes `""` to `NULL` so ghost `(empty)` sessions
   cannot appear. Rows with NULL/empty `session_id` are invisible to
   `budi sessions` by design — they indicate an attribution bug upstream.
-- **`provider`** — canonical provider key (`claude_code`, `cursor`, `openai`,
-  `copilot`). `COALESCE(provider, 'claude_code')` is the legacy fallback for
+- **`provider`** — canonical provider key (`claude_code`, `cursor`, `codex`,
+  `copilot_cli`, `copilot_chat`, `openai`). `COALESCE(provider, 'claude_code')` is the legacy fallback for
   pre-8.0 rows; new writes MUST set it explicitly.
 - **`git_branch`** — written without the `refs/heads/` prefix
   (`session_list_with_filters` strips it defensively for older rows). The
@@ -483,6 +484,8 @@ Key points:
 - `crates/budi-core/src/providers/claude_code.rs` — Claude Code provider (JSONL discovery + live watch).
 - `crates/budi-core/src/providers/codex.rs` — Codex provider (Codex Desktop/CLI transcripts under `~/.codex/sessions/`).
 - `crates/budi-core/src/providers/copilot.rs` — Copilot CLI provider (transcripts under `~/.copilot/session-state/`).
+- `crates/budi-core/src/providers/copilot_chat.rs` — Copilot Chat (VS Code) provider. Tails JSON/JSONL session files written by the `github.copilot-chat` extension under `workspaceStorage` and `globalStorage` across Code, Insiders, Exploration, VSCodium, Cursor, and remote-server installs. Five token-key shapes ([ADR-0092](docs/adr/0092-copilot-chat-data-contract.md) §2.3) including the v3 output-only fallback that captures May-2026+ VS Code builds dropping prompt-token counts client-side.
+- `crates/budi-core/src/sync/copilot_chat_billing.rs` — Copilot Chat dollar reconciliation against the GitHub Billing API. Scales `(date, model)` buckets in place; bumps `cost_confidence` to `exact` and tags `pricing_source = 'billing_api:copilot_chat'`. Two-tick empty-response heuristic detects org-managed licences and short-circuits until the next billing cycle.
 - `crates/budi-core/src/providers/cursor.rs` — Cursor provider (Usage API primary + transcript fallback; auth/session context from `state.vscdb` across macOS/Linux/Windows). Usage-API rows write `pricing_source = 'upstream:api'`; transcript-fallback rows flow through `pricing::lookup`.
 - `crates/budi-core/src/migration.rs` — Schema v1, all migration paths.
 - `crates/budi-core/src/cloud_sync.rs` — Cloud sync worker: envelope builder, watermark tracking, HTTPS-only HTTP client with retry/backoff, privacy-safe rollup extraction.

--- a/crates/budi-cli/src/commands/mod.rs
+++ b/crates/budi-cli/src/commands/mod.rs
@@ -221,7 +221,14 @@ pub fn format_cost(dollars: f64) -> String {
 /// stay quiet on a typo can map this error to a soft fallback themselves
 /// (#615).
 pub fn normalize_provider(input: &str) -> Result<String> {
-    const KNOWN_PROVIDERS: &[&str] = &["claude_code", "cursor", "codex", "copilot_cli", "openai"];
+    const KNOWN_PROVIDERS: &[&str] = &[
+        "claude_code",
+        "cursor",
+        "codex",
+        "copilot_cli",
+        "copilot_chat",
+        "openai",
+    ];
 
     if KNOWN_PROVIDERS.contains(&input) {
         return Ok(input.to_string());
@@ -354,7 +361,14 @@ mod tests {
         // Every canonical name routed through the shared helper round-
         // trips unchanged so callers can pass the result straight to the
         // SQL `provider` column.
-        for name in ["claude_code", "cursor", "codex", "copilot_cli", "openai"] {
+        for name in [
+            "claude_code",
+            "cursor",
+            "codex",
+            "copilot_cli",
+            "copilot_chat",
+            "openai",
+        ] {
             assert_eq!(normalize_provider(name).unwrap(), name);
         }
     }
@@ -380,6 +394,7 @@ mod tests {
             "cursor",
             "codex",
             "copilot_cli",
+            "copilot_chat",
             "openai",
             "copilot",
             "anthropic",

--- a/crates/budi-cli/src/main.rs
+++ b/crates/budi-cli/src/main.rs
@@ -182,7 +182,7 @@ Examples:
         /// Output format: claude (ANSI+OSC8), starship (plain text), json, custom (uses config template)
         #[arg(long, value_enum, default_value_t = StatuslineFormat::Claude)]
         format: StatuslineFormat,
-        /// Scope all costs to a single provider (claude_code, cursor, codex, copilot_cli).
+        /// Scope all costs to a single provider (claude_code, cursor, codex, copilot_cli, copilot_chat).
         /// Defaults to `claude_code` when `--format claude` is used so the
         /// Claude Code statusline never shows blended multi-provider totals.
         #[arg(long)]
@@ -276,7 +276,7 @@ pub struct StatsOpts {
     /// `file` detail views (recommended when names repeat across repos).
     #[arg(long, global = true)]
     pub repo: Option<String>,
-    /// Filter by provider (e.g. claude_code, cursor, codex, copilot_cli, openai). Only meaningful for the default summary view.
+    /// Filter by provider (e.g. claude_code, cursor, codex, copilot_cli, copilot_chat, openai). Only meaningful for the default summary view.
     #[arg(long, global = true)]
     pub provider: Option<String>,
     /// Maximum rows in breakdown views (`projects`, `branches`, `tickets`,

--- a/crates/budi-core/src/providers/copilot_chat.rs
+++ b/crates/budi-core/src/providers/copilot_chat.rs
@@ -26,7 +26,20 @@ use crate::provider::{DiscoveredFile, Provider};
 /// #653) when the parser shape changes. Mirrors the budi-cursor
 /// `MIN_API_VERSION` pattern (ADR-0092 §2.6). Bump in lockstep with §2.3
 /// of ADR-0092 whenever a fifth (or later) token-key shape lands.
-pub const MIN_API_VERSION: u32 = 1;
+///
+/// v2 (8.4.0): the parser now descends into the `{ "kind": N, "v": [...] }`
+/// JSONL envelope and the `{ "requests": [...] }` JSON-document envelope
+/// that real VS Code Copilot Chat session files actually use. The four
+/// token-key shapes from v1 still apply — they just match against records
+/// inside the envelope rather than the envelope itself.
+///
+/// v3 (8.4.0): added a fifth shape — top-level `completionTokens` only —
+/// to capture VS Code Copilot Chat builds that persist output-token
+/// counts but no input-token counterpart anywhere on disk. These records
+/// emit with `input_tokens = 0` so the row at least exists; the Billing
+/// API reconciliation in §3 of ADR-0092 truths up the dollar number to
+/// the real bill on the next tick for individually-licensed users.
+pub const MIN_API_VERSION: u32 = 3;
 
 /// VS Code-family directory names. Casing is preserved for the macOS
 /// "Application Support" path, where the disk layout is case-sensitive on
@@ -347,6 +360,10 @@ fn parse_jsonl(path: &Path, content: &str, start_offset: usize) -> (Vec<ParsedMe
     let session_id = session_id_for_path(path);
     let mut session_default_model: Option<String> = None;
     let mut line_index: usize = byte_offset_to_line_index(content, start_offset);
+    // Per-record counter so deterministic_uuid stays unique across multiple
+    // records emitted from the same line (envelope shapes — see
+    // [`flatten_records`]).
+    let mut record_index: usize = 0;
 
     let remaining = &content[start_offset..];
     let mut pos = 0;
@@ -372,20 +389,32 @@ fn parse_jsonl(path: &Path, content: &str, start_offset: usize) -> (Vec<ParsedMe
             continue;
         };
 
+        // Session-default model can be advertised either on the envelope
+        // itself (older flat-line shape) or on the manifest record VS Code
+        // writes as `kind: 0` (real on-disk shape — see ADR-0092 §2.3).
         if let Some(model) = extract_session_default_model(&value) {
             session_default_model = Some(model);
         }
 
-        if let Some(msg) = build_message(
-            path,
-            &value,
-            session_id.as_deref(),
-            session_default_model.as_deref(),
-            line_index,
-        ) {
-            messages.push(msg);
-        } else if !shape_matches_any(&value) {
-            log_unknown_shape_once(path, &value);
+        for record in flatten_records(&value) {
+            if let Some(model) = extract_session_default_model(record) {
+                session_default_model = Some(model);
+            }
+            record_index += 1;
+            let composite_index = line_index
+                .wrapping_mul(1_000_000)
+                .wrapping_add(record_index);
+            if let Some(msg) = build_message(
+                path,
+                record,
+                session_id.as_deref(),
+                session_default_model.as_deref(),
+                composite_index,
+            ) {
+                messages.push(msg);
+            } else if !shape_matches_any(record) {
+                log_unknown_shape_once(path, record);
+            }
         }
     }
 
@@ -411,14 +440,14 @@ fn parse_json_document(path: &Path, content: &str) -> (Vec<ParsedMessage>, usize
         .map(|s| s.to_string())
         .or_else(|| session_id_for_path(path));
 
-    let session_default_model = extract_session_default_model(&doc);
+    let mut session_default_model = extract_session_default_model(&doc);
 
-    let records: &[serde_json::Value] = match doc.get("messages").and_then(|v| v.as_array()) {
-        Some(arr) => arr.as_slice(),
-        None => &[],
-    };
+    let records: Vec<&serde_json::Value> = flatten_records(&doc);
 
     for (index, record) in records.iter().enumerate() {
+        if let Some(model) = extract_session_default_model(record) {
+            session_default_model = Some(model);
+        }
         if let Some(msg) = build_message(
             path,
             record,
@@ -433,6 +462,34 @@ fn parse_json_document(path: &Path, content: &str) -> (Vec<ParsedMessage>, usize
     }
 
     (messages, new_offset)
+}
+
+/// Return the candidate records to try for token extraction.
+///
+/// Per ADR-0092 §2.3: the on-disk shapes wrap their per-message records
+/// inside an envelope key. Three are known:
+///
+/// * `{ "kind": N, "v": [ ... ] }` — JSONL line written by recent VS Code
+///   builds. Each item in `v` is a request/response record carrying tokens
+///   under one of the four shapes from §2.3 (typically
+///   `result.metadata.{promptTokens,outputTokens}`).
+/// * `{ "requests": [ ... ] }` — `.json` document written by the same
+///   extension as a session snapshot.
+/// * `{ "messages": [ ... ] }` — older `.json` document shape, retained
+///   for back-compat with the synthetic fixtures used by §2.3 v1.
+///
+/// If none of the envelope keys are present (or `v` is an object rather
+/// than an array, as on the `kind: 0` manifest line that carries
+/// session-level metadata), fall back to treating the value itself as a
+/// flat record. This preserves the v1 flat-line shape that the unit
+/// fixtures and the budi-cursor integration tests rely on.
+fn flatten_records(value: &serde_json::Value) -> Vec<&serde_json::Value> {
+    for key in ["v", "requests", "messages"] {
+        if let Some(arr) = value.get(key).and_then(|v| v.as_array()) {
+            return arr.iter().collect();
+        }
+    }
+    vec![value]
 }
 
 fn build_message(
@@ -489,7 +546,8 @@ fn build_message(
 
 /// Return tokens for the first shape (in §2.3 order) where both input and
 /// output token counts are non-zero. ADR-0092 §2.3 — partial matches do not
-/// count.
+/// count, EXCEPT for the output-only fallback (§2.3.v3) which is tried
+/// last and emits a row with `input = 0`.
 fn extract_tokens(record: &serde_json::Value) -> Option<TokenSet> {
     if let Some(t) = extract_tokens_vscode_delta(record) {
         return Some(t);
@@ -501,6 +559,11 @@ fn extract_tokens(record: &serde_json::Value) -> Option<TokenSet> {
         return Some(t);
     }
     if let Some(t) = extract_tokens_feb_2026(record) {
+        return Some(t);
+    }
+    // Output-only fallback — must be tried after the four full-pair shapes
+    // so a record that legitimately carries both keys never lands here.
+    if let Some(t) = extract_tokens_completion_only(record) {
         return Some(t);
     }
     None
@@ -595,13 +658,40 @@ fn extract_tokens_feb_2026(record: &serde_json::Value) -> Option<TokenSet> {
     })
 }
 
-/// Returns true when *any* of the four token-key shapes can be located on
+/// Output-only fallback shape (v3, 8.4.x amendment to ADR-0092 §2.3) —
+/// top-level `completionTokens` with no input-token counterpart. Captures
+/// VS Code Copilot Chat builds that persist response-token counts but not
+/// prompt-token counts anywhere on disk.
+///
+/// The emitted [`TokenSet`] has `input = 0` and a non-zero `output`. This
+/// is the only shape where the both-non-zero invariant from the four
+/// full-pair shapes is intentionally relaxed; it is also the only shape
+/// allowed to produce a row with zero input tokens. Downstream cost
+/// pricing handles `input = 0` correctly (cost is output-only at the
+/// manifest layer); the Billing API reconciliation worker truths the
+/// dollar number up to the real bill on the next tick for users with a
+/// configured PAT (see §3 of ADR-0092).
+fn extract_tokens_completion_only(record: &serde_json::Value) -> Option<TokenSet> {
+    let output = record.get("completionTokens")?.as_u64()?;
+    if output == 0 {
+        return None;
+    }
+    Some(TokenSet {
+        input: 0,
+        output,
+        cache_read: 0,
+        cache_write: 0,
+    })
+}
+
+/// Returns true when *any* of the five token-key shapes can be located on
 /// this record, even if the values are zero. Used to distinguish "valid
 /// shape, just an empty record" (no warn) from "shape we don't recognize"
 /// (warn-once via [`log_unknown_shape_once`]).
 fn shape_matches_any(record: &serde_json::Value) -> bool {
     record.get("promptTokens").is_some()
         || record.get("outputTokens").is_some()
+        || record.get("completionTokens").is_some()
         || record.pointer("/modelMetrics/inputTokens").is_some()
         || record.pointer("/modelMetrics/outputTokens").is_some()
         || record.pointer("/usage/promptTokens").is_some()
@@ -612,6 +702,12 @@ fn shape_matches_any(record: &serde_json::Value) -> bool {
 
 /// Strip a `copilot/` model-id prefix per ADR-0092 §2.4.
 fn extract_model_id(record: &serde_json::Value) -> Option<String> {
+    // `modelId` is the user-facing label (e.g. `copilot/claude-haiku-4.5`,
+    // `copilot/auto`). Prefer it over `result.metadata.resolvedModel` —
+    // that field is either a dated version suffix (`claude-haiku-4-5-20251001`)
+    // or an internal GPU-fleet code (`capi-noe-ptuc-h200-oswe-vscode-prime`)
+    // that does not map to manifest entries. The fleet-code form means
+    // `resolvedModel` cannot be trusted as a pricing key.
     if let Some(model) = record.get("modelId").and_then(|v| v.as_str()) {
         return Some(strip_copilot_prefix(model).to_string());
     }
@@ -1042,5 +1138,187 @@ mod tests {
         assert!(roots.is_empty());
 
         let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    /// Real on-disk JSONL shape from `chatSessions/<id>.jsonl` written by
+    /// the `github.copilot-chat` extension circa 2026-04. The token-bearing
+    /// records are wrapped under the `kind: 2 / v: [...]` envelope and the
+    /// counts live at `result.metadata.{promptTokens,outputTokens}`. This
+    /// fixture is captured from a real session on a developer machine and
+    /// then trimmed to the fields the parser inspects — the structural
+    /// envelope (kind / v / nesting depth) is preserved verbatim so any
+    /// future regression of [`flatten_records`] is caught here.
+    #[test]
+    fn parse_jsonl_real_kind_v_envelope() {
+        let content = concat!(
+            // kind:0 manifest line — no tokens, must not produce a message
+            // and must not trigger an unknown-shape warn (its `v` is an
+            // object, which is the documented "session manifest" shape).
+            r#"{"kind":0,"v":{"sessionId":"abc","creationDate":"2026-04-15T10:00:00Z"}}"#,
+            "\n",
+            // kind:1 string — text fragment, no tokens, must not produce.
+            r#"{"kind":1,"v":"user prompt text"}"#,
+            "\n",
+            // kind:2 response — the token-bearing shape. `v` is an array of
+            // one assistant turn, tokens at result.metadata.{promptTokens,outputTokens}.
+            r#"{"kind":2,"v":[{"modelId":"copilot/claude-haiku-4.5","completionTokens":191,"requestId":"req-1","timestamp":1715000000000,"result":{"metadata":{"promptTokens":26412,"outputTokens":191,"modelMessageId":"m-1","resolvedModel":"claude-haiku-4.5"}}}]}"#,
+            "\n",
+        );
+        let path = Path::new("/tmp/budi-fixtures/sess-real-jsonl.jsonl");
+        let (msgs, offset) = parse_copilot_chat(path, content, 0);
+        assert_eq!(msgs.len(), 1, "exactly one assistant turn carries tokens");
+        let m = &msgs[0];
+        assert_eq!(m.input_tokens, 26412);
+        assert_eq!(m.output_tokens, 191);
+        assert_eq!(m.model.as_deref(), Some("claude-haiku-4.5"));
+        assert_eq!(m.provider, "copilot_chat");
+        assert_eq!(offset, content.len());
+    }
+
+    /// Real on-disk `.json` snapshot shape — `requests: [...]` envelope,
+    /// each request carrying tokens at
+    /// `result.metadata.{promptTokens,outputTokens}`. Mirrors the .jsonl
+    /// shape but as a single document (older / persisted-on-close form).
+    #[test]
+    fn parse_json_document_real_requests_envelope() {
+        let content = r#"{
+            "sessionId": "real-doc-1",
+            "version": 3,
+            "requesterUsername": "alice",
+            "responderUsername": "GitHub Copilot",
+            "requests": [
+                {
+                    "modelId": "github.copilot-chat/claude-sonnet-4",
+                    "requestId": "r-1",
+                    "timestamp": 1715000001000,
+                    "result": {
+                        "metadata": {
+                            "promptTokens": 1234,
+                            "outputTokens": 56,
+                            "modelMessageId": "mm-1"
+                        }
+                    }
+                },
+                {
+                    "modelId": "github.copilot-chat/claude-sonnet-4",
+                    "requestId": "r-2-no-tokens",
+                    "timestamp": 1715000002000
+                }
+            ]
+        }"#;
+        let path = Path::new("/tmp/budi-fixtures/sess-real-doc.json");
+        let (msgs, _) = parse_copilot_chat(path, content, 0);
+        assert_eq!(
+            msgs.len(),
+            1,
+            "only the request with result.metadata tokens produces a message"
+        );
+        let m = &msgs[0];
+        assert_eq!(m.input_tokens, 1234);
+        assert_eq!(m.output_tokens, 56);
+        // `github.copilot-chat/` prefix should be normalised the same way
+        // `copilot/` is — the strip happens via [`strip_copilot_prefix`].
+        // Today only `copilot/` is stripped, so we assert the full id
+        // passes through unchanged; if that ever changes, tighten here.
+        assert!(
+            m.model.as_deref().unwrap_or("").contains("claude-sonnet-4"),
+            "model id should mention claude-sonnet-4, got {:?}",
+            m.model
+        );
+        assert_eq!(m.session_id.as_deref(), Some("real-doc-1"));
+    }
+
+    /// `kind:1` lines whose `v` is an array of state events (no tokens
+    /// anywhere) must not emit an unknown-shape warn — the wrapper is
+    /// known, the inner records simply don't carry tokens. Pinning this
+    /// keeps the warn-once log from getting noisy on real sessions.
+    #[test]
+    fn parse_jsonl_kind1_array_silently_yields_no_messages() {
+        let content = concat!(
+            r#"{"kind":1,"v":[{"role":"user","content":"hi"},{"role":"system","content":"ok"}]}"#,
+            "\n",
+        );
+        let path = Path::new("/tmp/budi-fixtures/sess-kind1.jsonl");
+        let (msgs, _) = parse_copilot_chat(path, content, 0);
+        assert!(msgs.is_empty());
+    }
+
+    /// v3 (8.4.0) output-only fallback shape — VS Code Copilot Chat builds
+    /// circa 2026-05 persist `completionTokens` at the top of each
+    /// response record but no `promptTokens` counterpart anywhere. The
+    /// parser must still emit a row (with `input_tokens = 0`) so the
+    /// session is visible in the local-tail surface and the Billing API
+    /// reconciliation worker has a `(date, model)` bucket to truth up.
+    #[test]
+    fn extract_tokens_completion_only_shape() {
+        let record = serde_json::json!({
+            "modelId": "copilot/auto",
+            "completionTokens": 65,
+            "result": {
+                "metadata": {
+                    "resolvedModel": "capi-noe-ptuc-h200-oswe-vscode-prime"
+                }
+            }
+        });
+        let tokens = extract_tokens(&record).expect("must match output-only fallback");
+        assert_eq!(tokens.input, 0);
+        assert_eq!(tokens.output, 65);
+    }
+
+    /// Output-only fallback must not fire when `completionTokens == 0` —
+    /// that case is "valid shape, empty record" (the surrounding logic
+    /// would emit a useless 0/0 row otherwise).
+    #[test]
+    fn extract_tokens_completion_only_zero_skips() {
+        let record = serde_json::json!({"modelId": "x", "completionTokens": 0});
+        assert!(extract_tokens(&record).is_none());
+    }
+
+    /// Full-pair shapes must outrank the output-only fallback when both
+    /// keys are present — otherwise the `feb_2026` shape would lose its
+    /// input-token count to the fallback's `input = 0`.
+    #[test]
+    fn extract_tokens_full_pair_outranks_completion_only_fallback() {
+        let record = serde_json::json!({
+            "modelId": "copilot/x",
+            "completionTokens": 999,
+            "result": {
+                "metadata": {
+                    "promptTokens": 100,
+                    "outputTokens": 50
+                }
+            }
+        });
+        let tokens = extract_tokens(&record).expect("feb_2026 shape must win");
+        assert_eq!(tokens.input, 100);
+        assert_eq!(tokens.output, 50);
+    }
+
+    /// End-to-end on a real-shape JSONL with the v3 output-only records
+    /// (kind:0 manifest, kind:1 state events, kind:2 response with only
+    /// `completionTokens`). Three response turns → three messages; the
+    /// kind:0 / kind:1 lines emit nothing and stay silent.
+    #[test]
+    fn parse_jsonl_real_v3_completion_only_turns() {
+        let content = concat!(
+            r#"{"kind":0,"v":{"sessionId":"s","creationDate":"2026-05-07T15:00:00Z"}}"#,
+            "\n",
+            r#"{"kind":1,"v":{"completedAt":1715000000000,"value":"prompt"}}"#,
+            "\n",
+            r#"{"kind":2,"v":[{"modelId":"copilot/auto","completionTokens":65,"requestId":"r1","result":{"metadata":{"resolvedModel":"capi-noe-ptuc-h200-oswe-vscode-prime"}}}]}"#,
+            "\n",
+            r#"{"kind":2,"v":[{"modelId":"copilot/auto","completionTokens":115,"requestId":"r2","result":{"metadata":{"resolvedModel":"capi-noe-ptuc-h200-oswe-vscode-prime"}}},{"modelId":"copilot/auto","completionTokens":117,"requestId":"r3","result":{"metadata":{"resolvedModel":"capi-noe-ptuc-h200-oswe-vscode-prime"}}}]}"#,
+            "\n",
+        );
+        let path = Path::new("/tmp/budi-fixtures/sess-v3.jsonl");
+        let (msgs, _) = parse_copilot_chat(path, content, 0);
+        assert_eq!(msgs.len(), 3);
+        assert!(msgs.iter().all(|m| m.input_tokens == 0));
+        assert_eq!(
+            msgs.iter().map(|m| m.output_tokens).sum::<u64>(),
+            65 + 115 + 117
+        );
+        // All emit with the user-facing modelId, not the fleet-code resolvedModel.
+        assert!(msgs.iter().all(|m| m.model.as_deref() == Some("auto")));
     }
 }

--- a/docs/adr/0092-copilot-chat-data-contract.md
+++ b/docs/adr/0092-copilot-chat-data-contract.md
@@ -55,7 +55,18 @@ The two `globalStorage/{GitHub,github}.copilot{,-chat}/**` patterns are intentio
 
 #### 2.3 File shapes and token-key dispatch
 
-Each candidate path is read as a stream of newline-delimited JSON (`*.jsonl`) or as a JSON document containing a `messages: []` array (`*.json`). The parser tolerates **any** of the four token-key shapes below and dispatches per-line / per-message:
+Each candidate path is read as a stream of newline-delimited JSON (`*.jsonl`) or as a JSON document (`*.json`). Both forms wrap their per-message records in an envelope key — the parser flattens the envelope before applying the token-key dispatch.
+
+**Envelope keys** (any one of these may be present; first match wins):
+
+| Format | Envelope shape | Notes |
+|---|---|---|
+| JSONL line wrapper | `{ "kind": N, "v": [ ... ] }` | The `github.copilot-chat` extension's persisted per-line shape. `kind: 0` carries session manifest (object `v`, no records); `kind: 1`/`2` carry request/response items in array `v`. Lines whose `v` is an object or scalar fall through to the flat-record path with no records emitted (no warn). |
+| JSON document | `{ "requests": [ ... ] }` | Persisted-on-close session snapshot. Each item in `requests` is a turn with optional `result.metadata.{promptTokens,outputTokens}`. |
+| JSON document (legacy) | `{ "messages": [ ... ] }` | Older synthetic-fixture shape. Retained for back-compat. |
+| Bare record (no envelope) | `{ ...token keys... }` | Treated as a single-record envelope. Used by the v1 unit fixtures and any future format that drops the wrapper. |
+
+**Token-key shapes** (applied to each flattened record; first non-zero pair wins):
 
 | Format | Shape origin | Input-tokens key | Output-tokens key |
 |---|---|---|---|
@@ -63,8 +74,15 @@ Each candidate path is read as a stream of newline-delimited JSON (`*.jsonl`) or
 | Copilot CLI | shape inherited from the standalone `copilot` CLI in 2025 | `modelMetrics.inputTokens` | `modelMetrics.outputTokens` |
 | Legacy | the OpenAI-ish shape Copilot Chat used through 2025-Q4 | `usage.promptTokens` | `usage.completionTokens` |
 | Feb 2026+ | nested-result shape introduced in the Feb-2026 Copilot Chat release | `result.metadata.promptTokens` | `result.metadata.outputTokens` |
+| Output-only fallback (v3, 8.4.0) | shape used by VS Code Copilot Chat builds circa May-2026 that persist response token counts but **not** prompt token counts | _(input = 0)_ | `completionTokens` |
 
-The parser tries the four shapes in the order above per record and uses the first one that yields both a non-zero input and a non-zero output count. Records that match no shape are skipped (see §2.6).
+The parser tries the **four full-pair shapes** in the order above per record and uses the first one that yields both a non-zero input and a non-zero output count. If none match, it tries the **output-only fallback** as a last resort and emits the row with `input_tokens = 0`. Records that match no shape — full-pair or fallback — are skipped (see §2.6).
+
+The envelope split was added in 8.4.0 after the smoke-gate fixtures uncovered that real on-disk JSONL files write tokens at `v[].result.metadata.{promptTokens,outputTokens}` rather than at the top of the line — the four token-key shapes are unchanged, the parser just looks one level deeper before applying them. `MIN_API_VERSION` was bumped to `2` in lockstep (§2.6).
+
+The output-only fallback was added in the same 8.4.0 cycle after smoke-gate verification on a freshly captured session uncovered that newer VS Code Copilot Chat builds (May-2026) persist `completionTokens` at the top of each response record but **drop the prompt-token counterpart entirely** — `result.metadata` no longer contains `promptTokens` or `outputTokens` for these records. The fallback is the only shape allowed to relax the both-non-zero invariant from the four full-pair shapes; rows it emits flow through downstream pricing as output-only at the manifest layer and are truthed up to the real bill by the §3 Billing API reconciliation worker on the next tick (for users with a configured PAT). `MIN_API_VERSION` was bumped to `3`.
+
+A side note from the same investigation: `result.metadata.resolvedModel` is **not** safe to use as a pricing key. On older sessions it was a dated version suffix (`claude-haiku-4-5-20251001`); on May-2026+ sessions it is an internal GPU-fleet code (`capi-noe-ptuc-h200-oswe-vscode-prime`) that does not map to manifest entries. The parser uses `modelId` (post-`copilot/` strip per §2.4) as the pricing key, even when the value is a router placeholder like `auto` — pricing then falls through to `unpriced:no_pricing` and the Billing API reconciliation supplies the dollar truth.
 
 Cache-token keys, when present, follow the same per-shape pattern under `cacheReadTokens` / `cacheWriteTokens` (delta and Feb-2026 shapes) or under `usage.cacheReadInputTokens` / `usage.cacheCreationInputTokens` (legacy). Cache tokens are best-effort — Copilot Chat does not expose cache fields on every record.
 


### PR DESCRIPTION
## Summary

The R1.4 (#651) Copilot Chat parser landed against synthetic flat-record fixtures and produced **zero rows** against real `github.copilot-chat` session files. Two layers of structure were missing:

1. **Envelope wrappers**: real JSONL lines are `{"kind": N, "v": [...records...]}` and real `.json` documents wrap records under `requests: [...]`. The four token-key shapes from ADR-0092 §2.3 v1 only matched at the top level.
2. **Output-only persistence**: May-2026 VS Code Copilot Chat builds persist `completionTokens` per response but no `promptTokens` counterpart anywhere on disk. The four full-pair shapes all skip these records by design.

End-to-end verified against a freshly captured local session: 7 turns, 966 output tokens (model `auto`), plus 1 older session at 26412 input / 191 output (claude-haiku-4.5).

## Changes

- `flatten_records` helper descends into `v[]` (jsonl wrapper) and `requests[]` / `messages[]` (json wrappers). Falls back to the bare-record path so v1 fixtures and budi-cursor integration tests keep working.
- `extract_tokens_completion_only` is the v3 fifth shape — output-only fallback tried after the four full-pair shapes. Emits with `input_tokens = 0`; downstream pricing handles output-only and the §3 Billing API reconciliation worker truths the dollar number up to the real bill for individually-licensed users.
- `extract_model_id` documents why `result.metadata.resolvedModel` is **not** used as a pricing key (internal GPU-fleet code on May-2026 sessions, dated version suffix on older sessions — neither maps to manifest entries).
- `MIN_API_VERSION` bumped from 1 → 3 (envelope + output-only fallback) per the ADR-0092 §2.6 contract.
- `normalize_provider` in budi-cli accepts `copilot_chat` (was rejecting with "Unknown provider"). Help text updated.
- ADR-0092 §2.3 amended with the envelope table, the v3 row, and an explanatory paragraph on `resolvedModel`.
- 5 new fixture tests pin the real-shape envelopes, the v3 fallback, the zero-completion skip, the full-pair outranks fallback ordering, and an end-to-end multi-turn session.

## Test plan

- [x] `cargo test --workspace` — 845 tests pass in debug mode
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `bash scripts/e2e/test_655_release_smoke.sh` — PASS (steps 13–15, 18, 19)
- [x] Real-data harness: 8 messages extracted from 22 local session files (was 0 pre-fix)
- [ ] Manual host-extension verification on macOS/Linux/Windows per `docs/release/v8.4.0-smoke-test.md` steps 6–10 (gated on budi-cursor 1.4.x)

## Release impact

This is a release blocker for v8.4.0 (epic #647). Without these fixes, Copilot Chat shows \$0 in the status bar regardless of usage. Block R2.3 (#656) until this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)