### PR TITLE
[8.4][R2.3] Tag, publish, and promote budi v8.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 8.4.0 — Unreleased
+## 8.4.0 — 2026-05-07
 
 8.4.0 is the **VS Code-side coverage** release: the budi extension now hosts inside VS Code as well as Cursor, with **GitHub Copilot Chat** as the first non-Cursor provider. The architectural pieces this round forces into the codebase — a host-scoped statusline surface that aggregates over multiple providers in a single editor window, a third-party-API-as-reconciliation pattern (GitHub Billing API), and a `MIN_API_VERSION` pattern for provider-side data contracts — are the same pieces every later 9.0.0 provider will need (#647).
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,7 +175,7 @@ dependencies = [
 
 [[package]]
 name = "budi-cli"
-version = "8.3.19"
+version = "8.4.0"
 dependencies = [
  "anyhow",
  "budi-core",
@@ -195,7 +195,7 @@ dependencies = [
 
 [[package]]
 name = "budi-core"
-version = "8.3.19"
+version = "8.4.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -211,7 +211,7 @@ dependencies = [
 
 [[package]]
 name = "budi-daemon"
-version = "8.3.19"
+version = "8.4.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "8.3.19"
+version = "8.4.0"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"


### PR DESCRIPTION
## Summary

Prep PR for **R2.3 ([#656](https://github.com/siropkin/budi/issues/656))** under epic [#647](https://github.com/siropkin/budi/issues/647). Bumps the workspace version `8.3.19 → 8.4.0` and stamps the v8.4.0 CHANGELOG entry (drafted in R2.1, [#663](https://github.com/siropkin/budi/pull/663)) with the `2026-05-07` release date.

The actual destructive / external steps from the R2.3 checklist happen **post-merge** by a human, not in this PR:

- Cut the `v8.4.0` tag from the merge commit (gated on R2.1 ([#654](https://github.com/siropkin/budi/issues/654)) + R2.2 ([#655](https://github.com/siropkin/budi/issues/655)) green — both already closed).
- Publish the GitHub release with R2.1 release notes attached.
- Crates: `budi-core`, `budi-cli`, `budi-daemon` to crates.io.
- Homebrew formula bump in `siropkin/homebrew-budi`.
- Lockstep `siropkin/budi-cursor` 1.4.x extension release (Marketplace + Open VSX).
- `getbudi.dev` copy + screenshots refresh per the public-site sync rule.

## Files

- `Cargo.toml` — workspace version `8.3.19 → 8.4.0`.
- `Cargo.lock` — re-locked for the three workspace crates.
- `CHANGELOG.md` — `8.4.0 — Unreleased` → `8.4.0 — 2026-05-07`. The entry body itself is unchanged from R2.1.

README and `docs/statusline-contract.md` already reflect the 8.4.0 scope (VS Code support + `copilot_chat` first-class) — landed in R2.1 ([#663](https://github.com/siropkin/budi/pull/663)). No SOUL.md changes — it carries no `current version` field, only historical references.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo check --workspace`
- [x] `cargo test --workspace` (45 passed; one timing-flake on `run_blocking_exits_when_shutdown_flag_is_set` cleared on rerun, unrelated to the version bump)
- [ ] CI green (rust matrix, e2e, clippy)
- [ ] After merge: tag `v8.4.0`, publish release with R2.1 notes, run release pipeline (crates + Homebrew), ship `siropkin/budi-cursor` 1.4.x lockstep, refresh `getbudi.dev` per the public-site sync rule.

## References

- Ticket: [#656](https://github.com/siropkin/budi/issues/656) — R2.3 tag/publish/promote
- Parent epic: [#647](https://github.com/siropkin/budi/issues/647) — VS Code-side coverage
- R2.1 release notes: [#654](https://github.com/siropkin/budi/issues/654) / [#663](https://github.com/siropkin/budi/pull/663)
- R2.2 smoke test plan: [#655](https://github.com/siropkin/budi/issues/655) / [#664](https://github.com/siropkin/budi/pull/664)

🤖 Generated with [Claude Code](https://claude.com/claude-code)