### PR TITLE
[8.4.1][R1.5] Smoke gate exercises the real parser pipeline (not synthetic DB inserts)

### DIFF
--- a/docs/release/v8.4.1-smoke-test.md
+++ b/docs/release/v8.4.1-smoke-test.md
@@ -1,0 +1,184 @@
+# Budi v8.4.1 — Release smoke test plan
+
+**Status**: Hard release gate for [#673](https://github.com/siropkin/budi/issues/673) under epic [#667](https://github.com/siropkin/budi/issues/667).
+**Predecessor**: [v8.4.0 smoke test plan](./v8.4.0-smoke-test.md). 8.4.1 is a single-vertical patch that fixes the Copilot Chat live-tailer regression discovered immediately after 8.4.0 ([#647](https://github.com/siropkin/budi/issues/647) post-mortem). The plan below is the v8.4.0 plan extended with three new automated steps (20–22) that close the parser-pipeline gap that let the regression ship green.
+
+## How this gate is run
+
+Every step below MUST be exercised on **macOS, Linux, and Windows** before R2 ([#673](https://github.com/siropkin/budi/issues/673)) tags `v8.4.1`. Steps split into two categories:
+
+- **Automated** — covered by `scripts/e2e/test_655_release_smoke.sh`. Build release binaries (`cargo build --release`) and run the script on each platform's CI runner; PASS exit is required. Steps 13–15 (multi-provider endpoint contract), 18 (path-watcher resilience), 19 (daemon `/health` advertises `api_version`), and the new **20–22** (real-shape parser pipeline, streaming-truncation resilience, doctor AMBER signal) are wired into the script.
+- **Manual** — host-extension UI verification. The Cursor / VS Code status bar, `budi doctor` output on a clean machine, and the click-through dashboard surface cannot be exercised from a shell. The release driver runs each manual step on a real install and pastes a PASS/AMBER/FAIL note into the per-platform record below.
+
+Acceptance from #673: **all steps green on each platform**. Any step amber requires a release-block decision in #673 before tagging proceeds.
+
+## What changed vs. v8.4.0
+
+The 8.4.0 R2.2 smoke gate covered the multi-provider statusline wire shape thoroughly (steps 13–15) and the path-watcher resilience contract (step 18), but it seeded `messages` directly via sqlite3 rather than dropping a real-shape session file under the daemon's watched root and letting the parser ingest it. A parser regression of the kind documented in [#668](https://github.com/siropkin/budi/issues/668) — the `github.copilot-chat` ≥0.47.0 mutation-log shape silently dropping every active row — is, by construction, invisible to a smoke gate that doesn't run the parser.
+
+8.4.1 closes that gap with three additions, all in the same `test_655_release_smoke.sh` script (kept under the original name so the per-platform PASS rows in §Per-platform PASS record stay aligned with the script that produces them):
+
+- **Step 20** — drop the [#669](https://github.com/siropkin/budi/issues/669) `vscode_chat_0_47_0.jsonl` real-extension fixture under `workspaceStorage/<hash>/chatSessions/<uuid>.jsonl` and assert the expected per-request rows materialize via parser → tailer → DB. FAILs against the 8.4.0 broken parser, PASSes against the post-#R1.1 reducer.
+- **Step 21** — append a kind:2 request stub (no `completionTokens` yet) to the live session file and assert the row count is unchanged (no premature emit). Then append the kind:1 `completionTokens` patch and assert exactly one new row materializes. Pins the no-emit-until-completion contract from [#668](https://github.com/siropkin/budi/issues/668) against the live tailer.
+- **Step 22** — verify `budi doctor --format json` reports `pass` for the `tailer rows / Copilot Chat` check after step 20 (rows did flow), then simulate the 8.4.0 broken-parser state (bytes consumed, zero rows emitted) and assert the same check flips to `warn` (AMBER) with the parser-regression hint. The simulated state is byte-equivalent to running the v3 parser against a v4 mutation-log fixture, so this is the gate that would have caught 8.4.0 before the tag.
+
+The test daemon stays on port 17865 (unchanged from 8.4.0) so the script can run alongside a developer's real daemon on the default port 7878. Step 22's `budi doctor` invocation reads daemon_port from `BudiConfig::default()` (= 7878) and therefore reports its `daemon health` check as FAIL (no test daemon answering on 7878 because we point `BUDI_DAEMON_BIN` at a missing path so doctor doesn't auto-start one), but the JSON payload is emitted before the FAIL-induced `exit 2`, so the `tailer rows / Copilot Chat` check is still observable. That check reads `tail_offsets` and `messages` from the analytics DB directly, so it doesn't depend on the daemon being up — exactly what we want for a parser-pipeline assertion.
+
+## Pre-flight (per platform, once)
+
+1. `git fetch && git checkout v8.4.1-rc<n>` (or the candidate ref R2 will tag).
+2. `cargo build --release` — produces `target/release/budi` and `target/release/budi-daemon`.
+3. Install the matching `siropkin/budi-cursor` 1.4.x extension build into both Cursor and VS Code on the test machine. The 1.4.x line is what advertises `copilot_chat` to the host-scoped statusline endpoint and what consumes the new `contributing_providers` tooltip field.
+4. `bash scripts/e2e/test_655_release_smoke.sh` — green is the entry gate for the manual section. If this script fails, **stop and fix**; do not proceed to manual steps until automated coverage is clean.
+
+## Manual section
+
+### Cursor host (regression — must remain identical to 8.3.x / 8.4.0)
+
+This block is the back-compat gate. Anything that diverges from main is a release block — the Cursor surface ships the byte-identical 8.1 single-provider statusline shape (ADR-0088 §4) and clicking through still routes to the provider-scoped Cursor dashboard (ADR-0088 §7, unchanged for provider-scoped surfaces).
+
+1. Fresh `budi init` on a Cursor-only machine.
+2. Send one prompt in Cursor chat.
+3. Status bar shows `budi · $X 1d · $Y 7d · $Z 30d` within one poll cycle. Cost can lag the Usage API by ~10 min per ADR-0090 — wait a cycle if needed.
+4. `budi doctor` lists `cursor` as the detected provider.
+5. Click status bar → `app.getbudi.dev/dashboard/sessions` opens, scoped to `provider=cursor`.
+
+### VS Code host (8.4.1 regression — must work on extension ≥0.47.0)
+
+The 8.4.0 cycle shipped a parser that worked on synthetic fixtures but emitted **zero rows** from active `github.copilot-chat` ≥0.47.0 sessions. The 8.4.1 manual gate must be exercised on a machine where the installed extension is ≥0.47.0 (the v1.109+ VS Code chat session storage format). The post-#R1.1 reducer (ADR-0092 §2.3 v4) replays the kind:0 + kind:1/kind:2 mutation log and emits per-request rows synchronously with the response stream — a non-zero `$1d` should be visible in one poll cycle of the first prompt.
+
+6. Fresh `budi init` on a VS Code-only machine with `github.copilot-chat ≥0.47.0` installed.
+7. Send one prompt in Copilot Chat.
+8. Status bar shows non-zero `$1d` within one poll cycle. **This is the line that 8.4.0 broke** — verify on a real install before tag.
+9. `budi doctor` lists `copilot_chat` as the detected provider with non-zero session count and reports `MIN_API_VERSION = 4` (the ADR-0092 §2.6 v4 baseline introduced in R1.1 #668).
+10. `budi doctor` reports `pass` for the `tailer rows / Copilot Chat` check (R1.3 #670 signal: bytes flowing AND rows landing).
+11. Click status bar → cloud dashboard opens, provider-scoped to `copilot_chat` (ADR-0088 §7 — provider-scoped surfaces stay provider-only even when the host extension is multi-provider).
+
+### VS Code + Cursor on the same host
+
+This is the host-scoped surface ADR-0088 §7 was amended to allow (#648). The host extension running in each editor scopes its statusline to its own host's providers; the cloud dashboard never blends them.
+
+12. Both editors active. Status bar in Cursor scopes to `cursor`. Status bar in VS Code scopes to `copilot_chat`. Tooltip in each editor names only that host's provider(s). The cloud dashboard still shows separate per-provider views, never blended (ADR-0088 §7 unchanged for provider-scoped surfaces).
+
+## Automated section
+
+Run `bash scripts/e2e/test_655_release_smoke.sh` after `cargo build --release`. The script exits non-zero on the first FAIL and prints the offending payload. The steps it pins:
+
+### Multi-provider endpoint contract (ADR-0088 §7, statusline-contract.md) — unchanged from 8.4.0
+
+13. `?provider=cursor,copilot_chat` aggregates 1d/7d/30d and emits `contributing_providers`. The script seeds two assistant rows ($5 cursor + $7 copilot_chat) and asserts the comma-list response sums to $12 with `contributing_providers: ["cursor","copilot_chat"]`. `provider_scope` is omitted on multi-provider requests (single-provider-only field).
+14. `?provider=cursor` returns the byte-identical 8.1 single-provider shape: `cost_1d == 7.0`, `provider_scope == "cursor"`. Backwards-compat regression gate.
+15. `?provider=unknown_provider` returns 200 with zeros, not an error; `contributing_providers` carries the unknown name through unchanged.
+
+### GitHub Billing API reconciliation (manual — same as 8.4.0)
+
+These two steps are **manual** because they require a configured GitHub PAT under an individual-licensed account and an org-managed test account. Fixtures cannot be checked in (real PAT material). The release driver runs them out-of-band and pastes the PASS notes into the per-platform record.
+
+16. With a configured PAT under an individual-plan fixture: dollar totals in `budi stats --provider copilot_chat` reconcile to GitHub's user billing dashboard within rounding (per ADR-0092 §3.5: `(date, model)` bucket truth-up, `cost_confidence` flips to `exact`, `pricing_source` becomes `billing_api:copilot_chat`).
+17. With an org-managed test fixture: the reconciliation call short-circuits cleanly after the two-tick empty-response heuristic from ADR-0092 §3.4. `budi doctor` reports the org-managed line. Local-tail dollars continue to flow with `cost_confidence = estimated` and `pricing_source = manifest:vNNN`.
+
+### Daemon stability — unchanged from 8.4.0
+
+18. Daemon stays up over an extended run with all path watchers attached even when target directories don't yet exist. The script seeds **no** Copilot Chat dirs at boot, materializes the `globalStorage/github.copilot-chat/chatSessions/` tree mid-run, and asserts the watcher attaches on the next backstop tick **without a daemon restart** (the #385 contract).
+19. Old daemon + new extension: the daemon's `/health` exposes a numeric `api_version` so the host extension can compare its compiled `MIN_API_VERSION` and surface a remediation banner instead of rendering `$0`.
+
+### Real-shape Copilot Chat parser pipeline (8.4.1 R1.5 #672) — new
+
+20. Real-shape parser pipeline. The script copies the R1.2 ([#669](https://github.com/siropkin/budi/issues/669)) `vscode_chat_0_47_0.jsonl` fixture into a freshly-materialized `workspaceStorage/<hash>/chatSessions/<session-id>.jsonl` path under the test `$HOME`, waits one tailer backstop cycle, and asserts the row count and `SUM(output_tokens)` match the per-request tuples in `vscode_chat_0_47_0.expected.json`. **FAILs against the 8.4.0 broken parser; PASSes against the post-#R1.1 reducer.** This is the gate that would have caught the 8.4.0 ship.
+21. Streaming-truncation resilience. The script appends a kind:2 stub for a brand-new request (no `completionTokens` inline, no kind:1 patch) to the live session file and asserts the row count is unchanged (no premature emit). Then it appends the kind:1 `completionTokens` patch and asserts exactly one new row materializes. Pins the "wait for the completion token to arrive" contract from #R1.1 against the live tailer (the unit-test sibling lives in `crates/budi-core/src/providers/copilot_chat.rs`).
+22. Doctor AMBER signal. The script runs `budi doctor --format json` and asserts the `tailer rows / Copilot Chat` check is `pass` after step 20 (rows landed). It then simulates the 8.4.0 broken-parser state (bytes consumed, zero rows emitted) by clearing copilot_chat rows from `messages` while leaving `tail_offsets` intact, runs doctor again, and asserts the same check flips to `warn` (AMBER) with the parser-regression hint (`ADR-0092 §2.6 / MIN_API_VERSION` in the detail). The simulated state is byte-equivalent to running the v3 parser against a v4 mutation-log fixture, so this is the gate that would have caught 8.4.0 before tag (the R1.3 [#670](https://github.com/siropkin/budi/issues/670) signal in action).
+
+## Per-platform PASS record
+
+Fill these in during R2 execution. Any non-PASS line blocks the v8.4.1 tag until #673 carries an explicit defer or fix decision.
+
+### macOS
+
+| Step | Status | Notes |
+|------|--------|-------|
+| 1    |        |       |
+| 2    |        |       |
+| 3    |        |       |
+| 4    |        |       |
+| 5    |        |       |
+| 6    |        |       |
+| 7    |        |       |
+| 8    |        | 8.4.0 regression — exercise on a real ≥0.47.0 install |
+| 9    |        | MIN_API_VERSION must read 4 |
+| 10   |        | tailer rows / Copilot Chat = pass on a clean install |
+| 11   |        |       |
+| 12   |        |       |
+| 13   |        | covered by `scripts/e2e/test_655_release_smoke.sh` |
+| 14   |        | covered by `scripts/e2e/test_655_release_smoke.sh` |
+| 15   |        | covered by `scripts/e2e/test_655_release_smoke.sh` |
+| 16   |        | individual-plan PAT fixture |
+| 17   |        | org-managed PAT fixture |
+| 18   |        | covered by `scripts/e2e/test_655_release_smoke.sh` |
+| 19   |        | covered by `scripts/e2e/test_655_release_smoke.sh` |
+| 20   |        | covered by `scripts/e2e/test_655_release_smoke.sh` |
+| 21   |        | covered by `scripts/e2e/test_655_release_smoke.sh` |
+| 22   |        | covered by `scripts/e2e/test_655_release_smoke.sh` |
+
+### Linux
+
+| Step | Status | Notes |
+|------|--------|-------|
+| 1    |        |       |
+| 2    |        |       |
+| 3    |        |       |
+| 4    |        |       |
+| 5    |        |       |
+| 6    |        |       |
+| 7    |        |       |
+| 8    |        | 8.4.0 regression — exercise on a real ≥0.47.0 install |
+| 9    |        | MIN_API_VERSION must read 4 |
+| 10   |        | tailer rows / Copilot Chat = pass on a clean install |
+| 11   |        |       |
+| 12   |        |       |
+| 13   |        | covered by `scripts/e2e/test_655_release_smoke.sh` |
+| 14   |        | covered by `scripts/e2e/test_655_release_smoke.sh` |
+| 15   |        | covered by `scripts/e2e/test_655_release_smoke.sh` |
+| 16   |        | individual-plan PAT fixture |
+| 17   |        | org-managed PAT fixture |
+| 18   |        | covered by `scripts/e2e/test_655_release_smoke.sh` |
+| 19   |        | covered by `scripts/e2e/test_655_release_smoke.sh` |
+| 20   |        | covered by `scripts/e2e/test_655_release_smoke.sh` |
+| 21   |        | covered by `scripts/e2e/test_655_release_smoke.sh` |
+| 22   |        | covered by `scripts/e2e/test_655_release_smoke.sh` |
+
+### Windows
+
+| Step | Status | Notes |
+|------|--------|-------|
+| 1    |        |       |
+| 2    |        |       |
+| 3    |        |       |
+| 4    |        |       |
+| 5    |        |       |
+| 6    |        |       |
+| 7    |        |       |
+| 8    |        | 8.4.0 regression — exercise on a real ≥0.47.0 install |
+| 9    |        | MIN_API_VERSION must read 4 |
+| 10   |        | tailer rows / Copilot Chat = pass on a clean install |
+| 11   |        |       |
+| 12   |        |       |
+| 13   |        | covered by `scripts/e2e/test_655_release_smoke.sh` |
+| 14   |        | covered by `scripts/e2e/test_655_release_smoke.sh` |
+| 15   |        | covered by `scripts/e2e/test_655_release_smoke.sh` |
+| 16   |        | individual-plan PAT fixture |
+| 17   |        | org-managed PAT fixture |
+| 18   |        | covered by `scripts/e2e/test_655_release_smoke.sh` |
+| 19   |        | covered by `scripts/e2e/test_655_release_smoke.sh` |
+| 20   |        | covered by `scripts/e2e/test_655_release_smoke.sh` |
+| 21   |        | covered by `scripts/e2e/test_655_release_smoke.sh` |
+| 22   |        | covered by `scripts/e2e/test_655_release_smoke.sh` |
+
+## References
+
+- Plan ticket: [#673](https://github.com/siropkin/budi/issues/673) (R2 — release readiness, smoke run, tag, publish, promote)
+- Smoke-gate ticket: [#672](https://github.com/siropkin/budi/issues/672) (R1.5 — this gate's automation)
+- Parent epic: [#667](https://github.com/siropkin/budi/issues/667) (8.4.1 patch)
+- Predecessor: [v8.4.0 smoke test plan](./v8.4.0-smoke-test.md), epic [#647](https://github.com/siropkin/budi/issues/647)
+- Statusline contract: [`docs/statusline-contract.md`](../statusline-contract.md)
+- ADRs: [ADR-0088 §7](../adr/0088-8x-local-developer-first-product-contract.md), [ADR-0092 §2.3 v4 + §2.6](../adr/0092-copilot-chat-data-contract.md)
+- R1 implementation tickets: #668 (mutation-log reducer), #669 (real-extension fixture), #670 (doctor AMBER), #671 (`auto` resolver), #672 (this smoke gate)

--- a/scripts/e2e/test_655_release_smoke.sh
+++ b/scripts/e2e/test_655_release_smoke.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
-# Release smoke gate for v8.4.0 — pins the automated portion of the #655
-# smoke test plan (docs/release/v8.4.0-smoke-test.md).
+# Release smoke gate for v8.4.0 / v8.4.1 — pins the automated portion of
+# the #655 (8.4.0) and #672 (8.4.1) smoke test plans
+# (docs/release/v8.4.0-smoke-test.md, docs/release/v8.4.1-smoke-test.md).
 #
 # This script is the executable contract behind the R2.2 release gate.
 # Manual host-extension UI verification (Cursor / VS Code status bar,
 # `budi doctor` output on a clean machine, dashboard click-through) lives
-# in docs/release/v8.4.0-smoke-test.md and is run out-of-band by the
+# in docs/release/v8.4.{0,1}-smoke-test.md and is run out-of-band by the
 # release driver. This script covers the steps that CAN be exercised
 # from a shell:
 #
@@ -26,10 +27,29 @@
 #       `api_version` so the host extension can compare its compiled
 #       MIN_API_VERSION and surface a remediation banner instead of
 #       rendering $0.
+#   20. Real-shape Copilot Chat parser pipeline (8.4.1 R1.5 #672) — drop
+#       the R1.2 (#669) `vscode_chat_0_47_0.jsonl` fixture into the
+#       daemon's watched workspaceStorage path and assert rows materialize
+#       through parser → tailer → DB. Would have FAILed on the 8.4.0
+#       broken parser; PASSes on the post-#R1.1 reducer.
+#   21. Streaming-truncation resilience (8.4.1 R1.5 #672) — append a
+#       kind:2 stub (no completionTokens yet) and assert no row emits;
+#       then append the kind:1 completionTokens patch and assert exactly
+#       one new row materializes. Pins the no-emit-until-completion
+#       contract from #R1.1 against the live tailer.
+#   22. Doctor AMBER signal (8.4.1 R1.5 #672 / R1.3 #670) — verify
+#       `budi doctor --format json` reports `pass` for the
+#       `tailer rows / Copilot Chat` check after step 20, then simulate
+#       the 8.4.0 broken-parser state (bytes consumed, zero rows
+#       emitted) by clearing copilot_chat messages while leaving
+#       tail_offsets intact, and assert the same check flips to `warn`
+#       with the parser-regression hint. The state we simulate is the
+#       exact one a v3 parser would have produced on a v4 mutation log,
+#       so this is the gate that would have caught 8.4.0 before tag.
 #
 # Steps 1-12 (host extension UI) and 16-17 (Billing API reconciliation
 # fixtures) are manual and tracked in the per-platform PASS table in
-# docs/release/v8.4.0-smoke-test.md.
+# docs/release/v8.4.{0,1}-smoke-test.md.
 #
 # Run:
 #   cargo build --release
@@ -275,6 +295,253 @@ if [[ "$POST_HEALTH" != "200" ]]; then
 fi
 echo "[e2e] OK: daemon still healthy (PID $DAEMON_PID, /health 200) after materialize"
 
-step "PASS: automated portion of v8.4.0 smoke test plan green"
+# ---------------------------------------------------------------------------
+# Step 20 — real-shape Copilot Chat parser pipeline (8.4.1 R1.5, #672).
+#
+# Drop the R1.2 (#669) `vscode_chat_0_47_0.jsonl` fixture under the
+# daemon's watched `workspaceStorage/<hash>/chatSessions/` path and
+# assert rows materialize via parser → tailer → DB. The 8.4.0 R2.2 gate
+# (steps 13–15) seeded `messages` directly with sqlite3 to exercise the
+# wire shape of the multi-provider statusline endpoint, which is the
+# right test for ADR-0088 §7 contract enforcement but bypasses the
+# parser entirely. A parser regression of the kind documented in #668
+# is, by construction, invisible to a smoke gate that doesn't run the
+# parser. Step 20 closes that gap.
+# ---------------------------------------------------------------------------
+
+step "step 20: real-shape Copilot Chat fixture flows through the parser pipeline"
+
+FIXTURE_SRC="$ROOT/crates/budi-core/src/providers/copilot_chat/fixtures/vscode_chat_0_47_0.jsonl"
+FIXTURE_EXPECTED="$ROOT/crates/budi-core/src/providers/copilot_chat/fixtures/vscode_chat_0_47_0.expected.json"
+if [[ ! -f "$FIXTURE_SRC" || ! -f "$FIXTURE_EXPECTED" ]]; then
+  echo "[e2e] FAIL: R1.2 fixtures missing — expected:" >&2
+  echo "  $FIXTURE_SRC" >&2
+  echo "  $FIXTURE_EXPECTED" >&2
+  exit 1
+fi
+
+# The fixture's kind:0 snapshot pins sessionId
+# 35a2ecbc-1144-4ac2-993e-1ca6850280a3 (sanitized from a real
+# github.copilot-chat 0.47.0 capture per ADR-0092 §2.3 v4). Place under
+# a freshly-materialized workspaceStorage hash dir so the tailer
+# attaches a watcher on the next backstop tick (#385) and ingests the
+# file from offset 0 (post-boot materialization is treated as live
+# content, not history — see tailer.rs `backstop_scan`).
+FIXTURE_SESSION_ID="35a2ecbc-1144-4ac2-993e-1ca6850280a3"
+FIXTURE_DEST_DIR="$USER_ROOT/workspaceStorage/r1-5-smoke-hash/chatSessions"
+FIXTURE_DEST="$FIXTURE_DEST_DIR/$FIXTURE_SESSION_ID.jsonl"
+mkdir -p "$FIXTURE_DEST_DIR"
+cp "$FIXTURE_SRC" "$FIXTURE_DEST"
+echo "[e2e] dropped fixture: $FIXTURE_DEST"
+
+EXPECTED_COUNT=$(python3 -c "import json; d=json.load(open('$FIXTURE_EXPECTED')); print(len(d))")
+EXPECTED_OUTPUT_TOKENS=$(python3 -c "import json; d=json.load(open('$FIXTURE_EXPECTED')); print(sum(int(r['output_tokens']) for r in d))")
+echo "[e2e] fixture expects $EXPECTED_COUNT requests, $EXPECTED_OUTPUT_TOKENS total output tokens"
+
+# BACKSTOP_POLL is 5 s in the tailer; allow one full reconcile tick for
+# attach_new_watchers + backstop_scan + ingest_messages, plus buffer.
+sleep 7
+
+ROW_COUNT=$(sqlite3 "$DB" \
+  "SELECT COUNT(*) FROM messages WHERE provider='copilot_chat' AND session_id='$FIXTURE_SESSION_ID';")
+if [[ "$ROW_COUNT" != "$EXPECTED_COUNT" ]]; then
+  echo "[e2e] FAIL: copilot_chat rows for session $FIXTURE_SESSION_ID = $ROW_COUNT, expected $EXPECTED_COUNT" >&2
+  echo "[e2e] daemon log tail:" >&2
+  tail -n 120 "$TMPDIR_ROOT/daemon.log" >&2 || true
+  echo "[e2e] tail_offsets snapshot:" >&2
+  sqlite3 "$DB" "SELECT provider, path, byte_offset, last_seen FROM tail_offsets WHERE provider='copilot_chat';" >&2 || true
+  exit 1
+fi
+echo "[e2e] OK: parser materialized $ROW_COUNT row(s) for session $FIXTURE_SESSION_ID"
+
+OUTPUT_TOKENS=$(sqlite3 "$DB" \
+  "SELECT COALESCE(SUM(output_tokens), 0) FROM messages WHERE provider='copilot_chat' AND session_id='$FIXTURE_SESSION_ID';")
+if [[ "$OUTPUT_TOKENS" != "$EXPECTED_OUTPUT_TOKENS" ]]; then
+  echo "[e2e] FAIL: SUM(output_tokens) for session $FIXTURE_SESSION_ID = $OUTPUT_TOKENS, expected $EXPECTED_OUTPUT_TOKENS" >&2
+  exit 1
+fi
+echo "[e2e] OK: SUM(output_tokens) for session $FIXTURE_SESSION_ID == $OUTPUT_TOKENS"
+
+# ---------------------------------------------------------------------------
+# Step 21 — streaming-truncation resilience (8.4.1 R1.5, #672).
+#
+# Append a kind:2 stub for a brand-new request (no completionTokens
+# inline, no kind:1 patch yet) to the live session file. Assert the
+# tailer's reducer does NOT emit a row for the in-flight request — it
+# must wait for a token-bearing patch. Then append the kind:1
+# completionTokens patch and assert exactly one new row materializes.
+# This pins the "wait for the completion token to arrive" contract
+# from #R1.1 against the live tailer (the unit-test sibling lives in
+# crates/budi-core/src/providers/copilot_chat.rs).
+# ---------------------------------------------------------------------------
+
+step "step 21: in-flight kind:2 stub does not emit; kind:1 completionTokens patch emits exactly one row"
+
+STREAMING_REQUEST_ID="request_e2e655-r1-5-streaming-stub"
+# Index 9 in the requests array — step 20's full fixture produced a 9-item
+# array (one initial request from kind:0 + eight requests added by kind:2
+# splices in lines 5-9 of the fixture, so indices 0-8 are populated).
+STREAMING_INDEX=9
+STREAMING_STUB_LINE='{"kind":2,"k":["requests"],"v":[{"requestId":"'"$STREAMING_REQUEST_ID"'","timestamp":1778172900000,"modelId":"copilot/auto","modelState":{"value":0},"timeSpentWaiting":1778172900000}]}'
+printf '%s\n' "$STREAMING_STUB_LINE" >>"$FIXTURE_DEST"
+echo "[e2e] appended kind:2 stub for $STREAMING_REQUEST_ID (no completionTokens yet)"
+
+sleep 7
+
+PRE_PATCH_COUNT=$(sqlite3 "$DB" \
+  "SELECT COUNT(*) FROM messages WHERE provider='copilot_chat' AND session_id='$FIXTURE_SESSION_ID';")
+if [[ "$PRE_PATCH_COUNT" != "$EXPECTED_COUNT" ]]; then
+  echo "[e2e] FAIL: streaming stub emitted prematurely — count for session $FIXTURE_SESSION_ID = $PRE_PATCH_COUNT, expected $EXPECTED_COUNT (no new row until completionTokens arrives)" >&2
+  exit 1
+fi
+echo "[e2e] OK: in-flight stub did NOT emit ($PRE_PATCH_COUNT row(s), unchanged from step 20)"
+
+STREAMING_PATCH_LINE='{"kind":1,"k":["requests",'"$STREAMING_INDEX"',"completionTokens"],"v":42}'
+printf '%s\n' "$STREAMING_PATCH_LINE" >>"$FIXTURE_DEST"
+echo "[e2e] appended kind:1 completionTokens=42 patch at requests[$STREAMING_INDEX]"
+
+sleep 7
+
+POST_PATCH_COUNT=$(sqlite3 "$DB" \
+  "SELECT COUNT(*) FROM messages WHERE provider='copilot_chat' AND session_id='$FIXTURE_SESSION_ID';")
+EXPECTED_POST_PATCH=$((EXPECTED_COUNT + 1))
+if [[ "$POST_PATCH_COUNT" != "$EXPECTED_POST_PATCH" ]]; then
+  echo "[e2e] FAIL: completionTokens patch did not emit exactly one new row — count = $POST_PATCH_COUNT, expected $EXPECTED_POST_PATCH" >&2
+  exit 1
+fi
+echo "[e2e] OK: completionTokens patch emitted exactly one new row ($PRE_PATCH_COUNT → $POST_PATCH_COUNT)"
+
+# ---------------------------------------------------------------------------
+# Step 22 — doctor AMBER signal (8.4.1 R1.5 #672 / R1.3 #670).
+#
+# After steps 20 and 21, `tail_offsets` for copilot_chat shows non-zero
+# advance and a recent `last_seen`, AND `messages` carries fresh rows
+# (the step 13 seed insert is also recent). The R1.3 doctor check
+# `tailer rows / Copilot Chat` must report `pass` here.
+#
+# Then we simulate the exact state the 8.4.0 broken parser would have
+# produced — bytes consumed, no rows emitted — by deleting every
+# copilot_chat row from `messages` while leaving `tail_offsets` intact.
+# The state below is byte-equivalent to running the v3 parser against a
+# v4 (mutation-log) fixture: tailer happily advances bytes, parser
+# returns zero rows. The R1.3 check must flip to `warn` (AMBER) with
+# the parser-regression hint.
+#
+# We don't need to actually swap to a broken parser binary — the doctor
+# signal is a downstream-of-parser observation (`tail_offsets` advance
+# AND `messages` empty), so simulating that state directly is faithful
+# to the gate's purpose ("would 8.4.0 have FAILed this gate before
+# tag"). The same gate would catch the 8.4.0 regression unmodified.
+#
+# Note on daemon-port plumbing: `budi doctor` reads daemon_port from
+# `BudiConfig::default()` (= 7878) when no per-repo config.toml is
+# resolvable, but the test daemon is on $DAEMON_PORT (17865) for
+# isolation from a developer's real daemon. So the doctor's
+# `daemon health` check probes 7878 and fails (we point BUDI_DAEMON_BIN
+# at a missing path so it doesn't auto-start a competing daemon either),
+# which makes doctor exit 2 because of the daemon-health FAIL row. The
+# JSON payload is still printed before the exit, so we capture it with
+# `|| true` and parse it regardless. The `tailer rows / Copilot Chat`
+# check doesn't depend on the daemon being up — it reads tail_offsets
+# and messages from the analytics DB directly via the schema check's
+# connection, which is what we're asserting on here.
+# ---------------------------------------------------------------------------
+
+step "step 22: budi doctor flips to AMBER for tailer rows / Copilot Chat under broken-parser state"
+
+# Helper: extract the status of a check by name from doctor's JSON.
+doctor_status_for() {
+  local json="$1"
+  local check_name="$2"
+  python3 -c "
+import json, sys
+with open('$json') as f:
+    d = json.load(f)
+for c in d.get('checks', []):
+    if c.get('name') == '$check_name':
+        print(c.get('status', ''))
+        sys.exit(0)
+print('NOT_FOUND')
+"
+}
+
+# Helper: extract the detail string of a check by name.
+doctor_detail_for() {
+  local json="$1"
+  local check_name="$2"
+  python3 -c "
+import json
+with open('$json') as f:
+    d = json.load(f)
+for c in d.get('checks', []):
+    if c.get('name') == '$check_name':
+        print(c.get('detail', ''))
+        break
+"
+}
+
+run_doctor() {
+  local out="$1"
+  # BUDI_DAEMON_BIN points at a missing path so doctor does not try to
+  # auto-start a competing daemon on the default port (7878) — we want
+  # doctor to read the analytics DB only, not interact with a daemon.
+  # Doctor will exit 2 because of the daemon-health FAIL row; the JSON
+  # is emitted before the exit, so `|| true` keeps the script alive.
+  BUDI_DAEMON_BIN="/definitely/missing/budi-daemon" \
+    "$BUDI" doctor --format json >"$out" 2>"$out.stderr" || true
+  if [[ ! -s "$out" ]]; then
+    echo "[e2e] FAIL: \`budi doctor --format json\` produced no JSON output" >&2
+    cat "$out.stderr" >&2 || true
+    exit 1
+  fi
+}
+
+DOCTOR_PASS_JSON="$TMPDIR_ROOT/doctor-pass.json"
+run_doctor "$DOCTOR_PASS_JSON"
+
+PASS_STATUS=$(doctor_status_for "$DOCTOR_PASS_JSON" "tailer rows / Copilot Chat")
+if [[ "$PASS_STATUS" != "pass" ]]; then
+  echo "[e2e] FAIL: post-step-20 'tailer rows / Copilot Chat' status = '$PASS_STATUS', expected 'pass'" >&2
+  echo "[e2e] doctor json:" >&2
+  cat "$DOCTOR_PASS_JSON" >&2 || true
+  exit 1
+fi
+echo "[e2e] OK: doctor reports 'tailer rows / Copilot Chat' = pass after rows landed"
+
+# Simulate the 8.4.0 broken-parser state: tail_offsets show recent
+# byte advance, but `messages` carries zero copilot_chat rows. The
+# DELETE clears the step-13 seed plus the parser-emitted rows; we keep
+# `tail_offsets` rows untouched so the doctor's classify_tailer_rows
+# logic sees `advanced_bytes > 0 && last_seen recent && rows_in_window
+# == 0` — the AMBER trigger from R1.3.
+sqlite3 "$DB" "DELETE FROM messages WHERE provider='copilot_chat';"
+TAIL_BYTES=$(sqlite3 "$DB" "SELECT COALESCE(SUM(byte_offset), 0) FROM tail_offsets WHERE provider='copilot_chat';")
+if [[ "$TAIL_BYTES" == "0" ]]; then
+  echo "[e2e] FAIL: tail_offsets shows zero bytes for copilot_chat after step 21 — AMBER trigger requires advanced_bytes > 0" >&2
+  exit 1
+fi
+echo "[e2e] simulated broken-parser state: rows cleared, tail_offsets shows $TAIL_BYTES bytes advanced"
+
+DOCTOR_AMBER_JSON="$TMPDIR_ROOT/doctor-amber.json"
+run_doctor "$DOCTOR_AMBER_JSON"
+
+AMBER_STATUS=$(doctor_status_for "$DOCTOR_AMBER_JSON" "tailer rows / Copilot Chat")
+if [[ "$AMBER_STATUS" != "warn" ]]; then
+  echo "[e2e] FAIL: under broken-parser state, 'tailer rows / Copilot Chat' status = '$AMBER_STATUS', expected 'warn' (AMBER)" >&2
+  echo "[e2e] doctor json:" >&2
+  cat "$DOCTOR_AMBER_JSON" >&2 || true
+  exit 1
+fi
+echo "[e2e] OK: doctor flipped 'tailer rows / Copilot Chat' to warn (AMBER) under broken-parser state"
+
+AMBER_DETAIL=$(doctor_detail_for "$DOCTOR_AMBER_JSON" "tailer rows / Copilot Chat")
+if ! grep -Fq "ADR-0092 §2.6 / MIN_API_VERSION" <<<"$AMBER_DETAIL"; then
+  echo "[e2e] FAIL: AMBER detail missing the parser-regression hint (ADR-0092 §2.6 / MIN_API_VERSION)" >&2
+  echo "[e2e] detail: $AMBER_DETAIL" >&2
+  exit 1
+fi
+echo "[e2e] OK: AMBER detail carries the parser-regression hint"
+
+step "PASS: automated portion of v8.4.{0,1} smoke test plan green"
 echo "Manual UI steps 1–12 + Billing API steps 16–17 are tracked in"
-echo "docs/release/v8.4.0-smoke-test.md per-platform PASS tables."
+echo "docs/release/v8.4.{0,1}-smoke-test.md per-platform PASS tables."


### PR DESCRIPTION
## Summary

- Adds steps 20–22 to `scripts/e2e/test_655_release_smoke.sh` so the release gate exercises the **real Copilot Chat parser pipeline** (parser → tailer → DB), not just the wire shape via direct sqlite3 inserts. This is the gate that would have caught the 8.4.0 ship.
- Step 20 drops the R1.2 (#669) `vscode_chat_0_47_0.jsonl` fixture under a freshly-materialized `workspaceStorage/<hash>/chatSessions/` path and asserts the per-request rows and `SUM(output_tokens)` materialize. Step 21 appends a kind:2 stub (no `completionTokens`), asserts no premature emit, then appends the kind:1 patch and asserts exactly one new row. Step 22 verifies `budi doctor --format json` reports `pass` for `tailer rows / Copilot Chat` after rows land, then simulates the 8.4.0 broken-parser state (rows cleared, `tail_offsets` intact) and asserts the same check flips to `warn` (AMBER) with the `ADR-0092 §2.6 / MIN_API_VERSION` parser-regression hint.
- Adds `docs/release/v8.4.1-smoke-test.md` carrying steps 1–22 in the per-platform PASS table that R2 (#673) will fill in.

## Implementation notes

- The test daemon stays on port 17865 (unchanged from 8.4.0) so the script keeps coexisting with a developer's real daemon on 7878. `budi doctor` reads daemon_port from `BudiConfig::default()` (= 7878) and reports its `daemon health` check as FAIL because we point `BUDI_DAEMON_BIN` at a missing path so doctor doesn't auto-start a competing daemon. The doctor JSON is emitted before the FAIL-induced `exit 2`, so we capture it with `|| true` and parse it regardless. The `tailer rows / Copilot Chat` check reads `tail_offsets` and `messages` directly from the analytics DB and doesn't depend on the daemon being up — exactly the assertion we want.
- Step 22's broken-parser simulation deletes copilot_chat messages while leaving `tail_offsets` intact. That state is byte-equivalent to running the v3 parser against a v4 (mutation-log) fixture, so it's a faithful proxy for "did this gate catch the 8.4.0 regression" without requiring a separate broken-parser binary.
- I verified locally against the post-#R1.1 reducer: step 20 materializes 8 rows summing to 1005 output tokens, step 21 emits exactly one new row after the patch, step 22 reports `pass` then `warn` with the expected hint. `cargo test --workspace` is green.

## Tickets

- Closes #672 (R1.5).
- Parent: #667 (8.4.1 epic).
- Pairs with #669 (R1.2 fixture) and #670 (R1.3 doctor AMBER signal).

## Test plan

- [x] `cargo test --workspace` — 869 tests passing.
- [x] `cargo build --release && bash scripts/e2e/test_655_release_smoke.sh` — all steps green on macOS.
- [ ] CI runner on Linux + Windows confirms the same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)