### PR TITLE
[8.4.2] budi stats --provider X ignores filter on breakdown subcommands

### DIFF
--- a/crates/budi-cli/src/client.rs
+++ b/crates/budi-cli/src/client.rs
@@ -269,6 +269,20 @@ impl DaemonClient {
         Ok(Self { base_url, client })
     }
 
+    /// Build a client pinned to a specific base URL. Test-only — production
+    /// callers use [`DaemonClient::connect`] which auto-starts the daemon.
+    #[cfg(test)]
+    pub(crate) fn for_tests(base_url: impl Into<String>) -> Self {
+        Self {
+            base_url: base_url.into(),
+            client: Client::builder()
+                .timeout(Duration::from_secs(5))
+                .connect_timeout(Duration::from_secs(2))
+                .build()
+                .expect("build test client"),
+        }
+    }
+
     pub(crate) fn load_config() -> BudiConfig {
         std::env::current_dir()
             .ok()
@@ -566,6 +580,7 @@ impl DaemonClient {
         &self,
         since: Option<&str>,
         until: Option<&str>,
+        providers: Option<&str>,
         limit: usize,
     ) -> Result<BreakdownPage<RepoUsage>> {
         let mut params: Vec<(&str, String)> = Vec::new();
@@ -574,6 +589,9 @@ impl DaemonClient {
         }
         if let Some(u) = until {
             params.push(("until", u.to_string()));
+        }
+        if let Some(p) = providers {
+            params.push(("providers", p.to_string()));
         }
         params.push(("limit", limit.to_string()));
         let resp = self
@@ -616,6 +634,7 @@ impl DaemonClient {
         &self,
         since: Option<&str>,
         until: Option<&str>,
+        providers: Option<&str>,
         limit: usize,
     ) -> Result<BreakdownPage<BranchCost>> {
         let mut params: Vec<(&str, String)> = Vec::new();
@@ -624,6 +643,9 @@ impl DaemonClient {
         }
         if let Some(u) = until {
             params.push(("until", u.to_string()));
+        }
+        if let Some(p) = providers {
+            params.push(("providers", p.to_string()));
         }
         params.push(("limit", limit.to_string()));
         let resp = self
@@ -680,6 +702,7 @@ impl DaemonClient {
         &self,
         since: Option<&str>,
         until: Option<&str>,
+        providers: Option<&str>,
         limit: usize,
     ) -> Result<BreakdownPage<TicketCost>> {
         let mut params: Vec<(&str, String)> = Vec::new();
@@ -688,6 +711,9 @@ impl DaemonClient {
         }
         if let Some(u) = until {
             params.push(("until", u.to_string()));
+        }
+        if let Some(p) = providers {
+            params.push(("providers", p.to_string()));
         }
         params.push(("limit", limit.to_string()));
         let resp = self
@@ -746,6 +772,7 @@ impl DaemonClient {
         &self,
         since: Option<&str>,
         until: Option<&str>,
+        providers: Option<&str>,
         limit: usize,
     ) -> Result<BreakdownPage<ActivityCost>> {
         let mut params: Vec<(&str, String)> = Vec::new();
@@ -754,6 +781,9 @@ impl DaemonClient {
         }
         if let Some(u) = until {
             params.push(("until", u.to_string()));
+        }
+        if let Some(p) = providers {
+            params.push(("providers", p.to_string()));
         }
         params.push(("limit", limit.to_string()));
         let resp = self
@@ -811,6 +841,7 @@ impl DaemonClient {
         &self,
         since: Option<&str>,
         until: Option<&str>,
+        providers: Option<&str>,
         limit: usize,
     ) -> Result<BreakdownPage<FileCost>> {
         let mut params: Vec<(&str, String)> = Vec::new();
@@ -819,6 +850,9 @@ impl DaemonClient {
         }
         if let Some(u) = until {
             params.push(("until", u.to_string()));
+        }
+        if let Some(p) = providers {
+            params.push(("providers", p.to_string()));
         }
         params.push(("limit", limit.to_string()));
         let resp = self
@@ -873,6 +907,7 @@ impl DaemonClient {
         &self,
         since: Option<&str>,
         until: Option<&str>,
+        providers: Option<&str>,
         limit: usize,
     ) -> Result<BreakdownPage<ModelUsage>> {
         let mut params: Vec<(&str, String)> = Vec::new();
@@ -881,6 +916,9 @@ impl DaemonClient {
         }
         if let Some(u) = until {
             params.push(("until", u.to_string()));
+        }
+        if let Some(p) = providers {
+            params.push(("providers", p.to_string()));
         }
         params.push(("limit", limit.to_string()));
         let resp = self
@@ -1144,6 +1182,138 @@ mod tests {
                 "Failed to validate or restart budi daemon. Run `budi doctor` to diagnose."
             ),
             "unexpected error: {err}"
+        );
+    }
+
+    // ─── #682: breakdown methods forward `--provider` as `?providers=` ───
+    //
+    // Each breakdown HTTP method must thread the CLI `--provider` flag into
+    // a `providers=` query parameter so the daemon's `DimensionParams` (which
+    // aliases `providers` → `agents`) can scope the SQL filter. Pre-#682 the
+    // CLI accepted `--provider X` for the summary view only and silently
+    // dropped it on every breakdown — the bug this ticket fixes.
+
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::sync::mpsc;
+    use std::thread;
+
+    /// Spin up a one-shot HTTP server on 127.0.0.1, capture the first
+    /// request's path+query, respond with `body`, and return the captured
+    /// request line. The empty JSON body matches `BreakdownPage<T>` for any
+    /// `T` that has no required fields beyond the ones below.
+    fn one_shot_server(body: &'static str) -> (String, mpsc::Receiver<String>) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+        let port = listener.local_addr().unwrap().port();
+        let (tx, rx) = mpsc::channel();
+        thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept");
+            let mut buf = [0u8; 4096];
+            let n = stream.read(&mut buf).unwrap_or(0);
+            let req = String::from_utf8_lossy(&buf[..n]).to_string();
+            // First line is `GET /path?query HTTP/1.1`.
+            let request_line = req.lines().next().unwrap_or("").to_string();
+            let _ = tx.send(request_line);
+            let resp = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            let _ = stream.write_all(resp.as_bytes());
+        });
+        (format!("http://127.0.0.1:{port}"), rx)
+    }
+
+    fn assert_providers_forwarded(request_line: &str, expected: &str) {
+        assert!(
+            request_line.contains(&format!("providers={expected}")),
+            "expected `providers={expected}` in request line, got: {request_line}"
+        );
+    }
+
+    /// Empty `BreakdownPage` JSON. Works for every `T` because both
+    /// `rows` and `other` are absent / empty. Produced as a `&'static str`
+    /// so the spawned thread has no lifetime issues.
+    const EMPTY_PAGE_BODY: &str =
+        r#"{"rows":[],"total_cost_cents":0.0,"total_rows":0,"shown_rows":0,"limit":5}"#;
+
+    #[test]
+    fn projects_forwards_provider_filter() {
+        let (base, rx) = one_shot_server(EMPTY_PAGE_BODY);
+        let client = DaemonClient::for_tests(base);
+        let _ = client
+            .projects(None, None, Some("copilot_chat"), 5)
+            .expect("projects call");
+        let req = rx.recv_timeout(Duration::from_secs(5)).expect("captured");
+        assert_providers_forwarded(&req, "copilot_chat");
+    }
+
+    #[test]
+    fn branches_forwards_provider_filter() {
+        let (base, rx) = one_shot_server(EMPTY_PAGE_BODY);
+        let client = DaemonClient::for_tests(base);
+        let _ = client
+            .branches(None, None, Some("copilot_chat"), 5)
+            .expect("branches call");
+        let req = rx.recv_timeout(Duration::from_secs(5)).expect("captured");
+        assert_providers_forwarded(&req, "copilot_chat");
+    }
+
+    #[test]
+    fn tickets_forwards_provider_filter() {
+        let (base, rx) = one_shot_server(EMPTY_PAGE_BODY);
+        let client = DaemonClient::for_tests(base);
+        let _ = client
+            .tickets(None, None, Some("copilot_chat"), 5)
+            .expect("tickets call");
+        let req = rx.recv_timeout(Duration::from_secs(5)).expect("captured");
+        assert_providers_forwarded(&req, "copilot_chat");
+    }
+
+    #[test]
+    fn activities_forwards_provider_filter() {
+        let (base, rx) = one_shot_server(EMPTY_PAGE_BODY);
+        let client = DaemonClient::for_tests(base);
+        let _ = client
+            .activities(None, None, Some("copilot_chat"), 5)
+            .expect("activities call");
+        let req = rx.recv_timeout(Duration::from_secs(5)).expect("captured");
+        assert_providers_forwarded(&req, "copilot_chat");
+    }
+
+    #[test]
+    fn files_forwards_provider_filter() {
+        let (base, rx) = one_shot_server(EMPTY_PAGE_BODY);
+        let client = DaemonClient::for_tests(base);
+        let _ = client
+            .files(None, None, Some("copilot_chat"), 5)
+            .expect("files call");
+        let req = rx.recv_timeout(Duration::from_secs(5)).expect("captured");
+        assert_providers_forwarded(&req, "copilot_chat");
+    }
+
+    #[test]
+    fn models_forwards_provider_filter() {
+        let (base, rx) = one_shot_server(EMPTY_PAGE_BODY);
+        let client = DaemonClient::for_tests(base);
+        let _ = client
+            .models(None, None, Some("copilot_chat"), 5)
+            .expect("models call");
+        let req = rx.recv_timeout(Duration::from_secs(5)).expect("captured");
+        assert_providers_forwarded(&req, "copilot_chat");
+    }
+
+    #[test]
+    fn breakdown_omits_providers_when_filter_is_none() {
+        // `--provider` unset must not synthesize a stray `providers=` —
+        // the daemon would treat empty-string as "filter to nothing".
+        let (base, rx) = one_shot_server(EMPTY_PAGE_BODY);
+        let client = DaemonClient::for_tests(base);
+        let _ = client.models(None, None, None, 5).expect("models call");
+        let req = rx.recv_timeout(Duration::from_secs(5)).expect("captured");
+        assert!(
+            !req.contains("providers="),
+            "no provider filter must omit the param entirely, got: {req}"
         );
     }
 }

--- a/crates/budi-cli/src/commands/stats.rs
+++ b/crates/budi-cli/src/commands/stats.rs
@@ -402,7 +402,14 @@ pub fn cmd_stats(
     }
 
     if files {
-        return cmd_stats_files(&client, period, limit, label_width, json_output);
+        return cmd_stats_files(
+            &client,
+            period,
+            provider.as_deref(),
+            limit,
+            label_width,
+            json_output,
+        );
     }
 
     if let Some(ref ac) = activity {
@@ -410,7 +417,14 @@ pub fn cmd_stats(
     }
 
     if activities {
-        return cmd_stats_activities(&client, period, limit, label_width, json_output);
+        return cmd_stats_activities(
+            &client,
+            period,
+            provider.as_deref(),
+            limit,
+            label_width,
+            json_output,
+        );
     }
 
     if let Some(ref tk) = ticket {
@@ -418,7 +432,14 @@ pub fn cmd_stats(
     }
 
     if tickets {
-        return cmd_stats_tickets(&client, period, limit, label_width, json_output);
+        return cmd_stats_tickets(
+            &client,
+            period,
+            provider.as_deref(),
+            limit,
+            label_width,
+            json_output,
+        );
     }
 
     if let Some(ref br) = branch {
@@ -426,13 +447,21 @@ pub fn cmd_stats(
     }
 
     if branches {
-        return cmd_stats_branches(&client, period, limit, label_width, json_output);
+        return cmd_stats_branches(
+            &client,
+            period,
+            provider.as_deref(),
+            limit,
+            label_width,
+            json_output,
+        );
     }
 
     if models {
         return cmd_stats_models(
             &client,
             period,
+            provider.as_deref(),
             limit,
             label_width,
             include_pending,
@@ -444,6 +473,7 @@ pub fn cmd_stats(
         return cmd_stats_projects(
             &client,
             period,
+            provider.as_deref(),
             limit,
             label_width,
             include_non_repo,
@@ -796,13 +826,14 @@ fn cmd_stats_summary(
 fn cmd_stats_projects(
     client: &DaemonClient,
     period: StatsPeriod,
+    provider: Option<&str>,
     limit: usize,
     label_width: usize,
     include_non_repo: bool,
     json_output: bool,
 ) -> Result<()> {
     let (since, until) = period_date_range(period);
-    let page = client.projects(since.as_deref(), until.as_deref(), limit)?;
+    let page = client.projects(since.as_deref(), until.as_deref(), provider, limit)?;
     let non_repo_rows = if include_non_repo {
         // #442: fetch per-cwd-basename detail for the non-repo bucket so
         // operators who want the pre-8.3 folder-name view can still get
@@ -907,12 +938,13 @@ fn cmd_stats_projects(
 fn cmd_stats_branches(
     client: &DaemonClient,
     period: StatsPeriod,
+    provider: Option<&str>,
     limit: usize,
     label_width: usize,
     json_output: bool,
 ) -> Result<()> {
     let (since, until) = period_date_range(period);
-    let page = client.branches(since.as_deref(), until.as_deref(), limit)?;
+    let page = client.branches(since.as_deref(), until.as_deref(), provider, limit)?;
 
     if json_output {
         super::print_json(&page)?;
@@ -1056,12 +1088,13 @@ fn cmd_stats_branch_detail(
 fn cmd_stats_tickets(
     client: &DaemonClient,
     period: StatsPeriod,
+    provider: Option<&str>,
     limit: usize,
     label_width: usize,
     json_output: bool,
 ) -> Result<()> {
     let (since, until) = period_date_range(period);
-    let page = client.tickets(since.as_deref(), until.as_deref(), limit)?;
+    let page = client.tickets(since.as_deref(), until.as_deref(), provider, limit)?;
 
     if json_output {
         super::print_json(&page)?;
@@ -1259,12 +1292,13 @@ fn cmd_stats_ticket_detail(
 fn cmd_stats_activities(
     client: &DaemonClient,
     period: StatsPeriod,
+    provider: Option<&str>,
     limit: usize,
     label_width: usize,
     json_output: bool,
 ) -> Result<()> {
     let (since, until) = period_date_range(period);
-    let page = client.activities(since.as_deref(), until.as_deref(), limit)?;
+    let page = client.activities(since.as_deref(), until.as_deref(), provider, limit)?;
 
     if json_output {
         super::print_json(&page)?;
@@ -1494,12 +1528,13 @@ fn validate_file_path_arg(path: &str) -> Result<()> {
 fn cmd_stats_files(
     client: &DaemonClient,
     period: StatsPeriod,
+    provider: Option<&str>,
     limit: usize,
     label_width: usize,
     json_output: bool,
 ) -> Result<()> {
     let (since, until) = period_date_range(period);
-    let page = client.files(since.as_deref(), until.as_deref(), limit)?;
+    let page = client.files(since.as_deref(), until.as_deref(), provider, limit)?;
 
     if json_output {
         super::print_json(&page)?;
@@ -1705,13 +1740,14 @@ fn cmd_stats_file_detail(
 fn cmd_stats_models(
     client: &DaemonClient,
     period: StatsPeriod,
+    provider: Option<&str>,
     limit: usize,
     label_width: usize,
     include_pending: bool,
     json_output: bool,
 ) -> Result<()> {
     let (since, until) = period_date_range(period);
-    let page = client.models(since.as_deref(), until.as_deref(), limit)?;
+    let page = client.models(since.as_deref(), until.as_deref(), provider, limit)?;
 
     if json_output {
         // #443 acceptance: JSON exposes the Budi-canonical `display_name`

--- a/crates/budi-cli/src/main.rs
+++ b/crates/budi-cli/src/main.rs
@@ -276,7 +276,7 @@ pub struct StatsOpts {
     /// `file` detail views (recommended when names repeat across repos).
     #[arg(long, global = true)]
     pub repo: Option<String>,
-    /// Filter by provider (e.g. claude_code, cursor, codex, copilot_cli, copilot_chat, openai). Only meaningful for the default summary view.
+    /// Filter by provider (e.g. claude_code, cursor, codex, copilot_cli, copilot_chat, openai). Applies to the default summary view and every breakdown subcommand (`models`, `projects`, `branches`, `tickets`, `activities`, `files`).
     #[arg(long, global = true)]
     pub provider: Option<String>,
     /// Maximum rows in breakdown views (`projects`, `branches`, `tickets`,


### PR DESCRIPTION
Closes #682.

## Summary

`budi stats --provider <p>` was narrowing only the default summary view; every breakdown (`models`, `projects`, `branches`, `tickets`, `activities`, `files`) silently dropped the flag and returned rows from every provider. The HTTP daemon already filters correctly through `DimensionParams.agents` (alias `providers`) — the bug was purely CLI-side plumbing.

This PR threads `--provider` through each breakdown HTTP client method and dispatcher so `budi stats --provider copilot_chat models -p 30d` now shows only `(copilot_chat)` rows. Help text drops the `Only meaningful for the default summary view` qualifier.

## What's in

- `crates/budi-cli/src/client.rs` — each of `projects`, `branches`, `tickets`, `activities`, `files`, `models` gains a `providers: Option<&str>` parameter that, when `Some`, appends `&providers=<value>` to the query string. Aligns with the daemon's `DimensionParams` alias (`providers` → `agents`).
- `crates/budi-cli/src/commands/stats.rs` — `cmd_stats_projects / branches / tickets / activities / files / models` accept and forward `provider: Option<&str>`. Top-level dispatchers in `cmd_stats` pass `provider.as_deref()` through to each.
- `crates/budi-cli/src/main.rs` — `--provider` help text now lists the breakdown subcommands it covers; the "Only meaningful for the default summary view" qualifier is removed.
- 7 new unit tests in `client::tests` use a one-shot `TcpListener` mock to assert each breakdown method emits `?providers=copilot_chat`, plus a guard that confirms `None` does **not** synthesize a stray empty `providers=` param.

## What's not in / deferred

- **Server-side changes** — backend filter already works; no daemon edit required (per ticket "Out of scope").
- **Companion HTTP-side gap on `/analytics/messages`** — sibling ticket #683 in the same release; not addressed here.
- `--include-non-repo`'s `non_repo` rows remain provider-agnostic (the daemon's `/analytics/non_repo` endpoint doesn't accept the filter; out of scope per "no daemon edit").
- `--provider unknown_name` matches the existing summary-view behavior of erroring with `Unknown provider 'X'. Available providers: …` rather than rendering an empty table — `normalize_provider` runs once at the top of `cmd_stats` so all paths share the same UX. The ticket's "clean empty table" note describes the desired symmetry with the summary view; in practice the summary view also rejects unknowns at the same point.

## Verification

```sh
$ budi stats --provider copilot_chat models -p 30d --limit 5 --format json | jq '[.rows[].provider] | unique'
[
  "copilot_chat"
]
```

Pre-#682, the same command returned `["claude_code", "copilot_chat", "cursor"]`.

## Test plan

- [x] `cargo fmt --all -- --check` (clean)
- [x] `cargo test --workspace` — 7 new tests pass; the two transient failures (`tailer::run_blocking_exits_when_shutdown_flag_is_set` + `pricing_refresh::refresh_skips_invalid_row_keeps_rest_when_majority_valid`) both pass when re-run in isolation, both are unrelated to this CLI-only change
- [x] `bash scripts/e2e/test_655_release_smoke.sh` (green; the smoke gate exercises the analytics surfaces my change touches)
- [x] Manual: `budi stats --provider copilot_chat models -p 30d --limit 5 --format json` returns only `copilot_chat` rows; same for `projects`, `branches`, `files`
- [x] Manual: dropping `--provider` (`budi stats models -p 30d --limit 5`) still returns the unfiltered set — the new test `breakdown_omits_providers_when_filter_is_none` pins this on the wire too
- [x] Manual: `--provider unknown_xyz <subcommand>` matches summary behavior (rejects with the canonical `Unknown provider …` error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)