### PR TITLE
[8.4.2] /analytics/messages and budi sessions: add provider filter (HTTP + CLI)

### DIFF
--- a/crates/budi-cli/src/client.rs
+++ b/crates/budi-cli/src/client.rs
@@ -987,6 +987,7 @@ impl DaemonClient {
         since: Option<&str>,
         until: Option<&str>,
         search: Option<&str>,
+        provider: Option<&str>,
         ticket: Option<&str>,
         activity: Option<&str>,
         limit: usize,
@@ -1001,6 +1002,14 @@ impl DaemonClient {
         }
         if let Some(q) = search {
             params.push(("search", q.to_string()));
+        }
+        if let Some(p) = provider {
+            // `/analytics/sessions` filters via `DimensionParams` (flattened
+            // into `SessionsQueryParams`), whose `agents` field aliases
+            // `providers`. Send the CLI's already-normalized provider name
+            // through that key so the same SQL predicate breakdown routes
+            // already use kicks in.
+            params.push(("providers", p.to_string()));
         }
         if let Some(t) = ticket {
             params.push(("ticket", t.to_string()));

--- a/crates/budi-cli/src/commands/sessions.rs
+++ b/crates/budi-cli/src/commands/sessions.rs
@@ -31,9 +31,11 @@ const MODEL_COL_WIDTH: usize = 28;
 
 use budi_core::analytics::SHORT_ID_LEN;
 
+#[allow(clippy::too_many_arguments)]
 pub fn cmd_sessions(
     period: StatsPeriod,
     search: Option<&str>,
+    provider: Option<&str>,
     ticket: Option<&str>,
     activity: Option<&str>,
     limit: usize,
@@ -49,6 +51,7 @@ pub fn cmd_sessions(
         since.as_deref(),
         until.as_deref(),
         search,
+        provider,
         ticket,
         activity,
         limit,
@@ -81,6 +84,9 @@ pub fn cmd_sessions(
     // dimension scoped the result. Both ticket and activity live in the
     // same space (tag-derived filters) and can compose in principle.
     let mut filter_bits: Vec<String> = Vec::new();
+    if let Some(p) = provider {
+        filter_bits.push(format!("provider: {p}"));
+    }
     if let Some(t) = ticket {
         filter_bits.push(format!("ticket: {t}"));
     }

--- a/crates/budi-cli/src/main.rs
+++ b/crates/budi-cli/src/main.rs
@@ -134,6 +134,12 @@ Examples:
         /// Filter sessions by search term (model, repo, branch, provider)
         #[arg(long)]
         search: Option<String>,
+        /// Filter sessions to a single provider (e.g. `copilot_chat`,
+        /// `claude_code`). Unlike `--search`, this is an exact match on
+        /// the provider field — `--search code` would also match
+        /// `claude_code`/`vscode`/`codex`.
+        #[arg(long, value_name = "NAME")]
+        provider: Option<String>,
         /// Filter sessions by ticket id (e.g. ENG-123). Matches the
         /// `ticket_id` tag emitted by the git enricher when the branch name
         /// contains a recognised ID.
@@ -745,6 +751,7 @@ fn main() -> Result<()> {
             session_id,
             period,
             search,
+            provider,
             ticket,
             activity,
             limit,
@@ -755,9 +762,13 @@ fn main() -> Result<()> {
             if let Some(id) = session_id {
                 commands::sessions::cmd_session_detail(&id, json_output)
             } else {
+                let provider = provider
+                    .map(|p| commands::normalize_provider(&p))
+                    .transpose()?;
                 commands::sessions::cmd_sessions(
                     period,
                     search.as_deref(),
+                    provider.as_deref(),
                     ticket.as_deref(),
                     activity.as_deref(),
                     limit,
@@ -1047,6 +1058,21 @@ mod tests {
         match cli.command {
             Commands::Sessions { ticket, .. } => {
                 assert_eq!(ticket.as_deref(), Some("PAVA-2057"));
+            }
+            _ => panic!("expected sessions command"),
+        }
+    }
+
+    /// #683: `--provider` complements `--search` so `budi sessions
+    /// --provider copilot_chat` no longer leaks substring matches into
+    /// `claude_code` / `vscode` / `codex`. Pre-fix the flag didn't exist.
+    #[test]
+    fn cli_parses_sessions_provider_flag() {
+        let cli = Cli::try_parse_from(["budi", "sessions", "--provider", "copilot_chat"])
+            .expect("budi sessions --provider parses");
+        match cli.command {
+            Commands::Sessions { provider, .. } => {
+                assert_eq!(provider.as_deref(), Some("copilot_chat"));
             }
             _ => panic!("expected sessions command"),
         }

--- a/crates/budi-core/src/analytics/queries.rs
+++ b/crates/budi-core/src/analytics/queries.rs
@@ -768,6 +768,11 @@ pub struct MessageListParams<'a> {
     pub sort_asc: bool,
     pub limit: usize,
     pub offset: usize,
+    /// Singular `?provider=<name>` shape — mirrors `SummaryParams`.
+    pub provider: Option<&'a str>,
+    /// Multi-value dimension filters (`providers`, `models`, `projects`,
+    /// `branches`) — same shape every breakdown route already accepts.
+    pub filters: &'a DimensionFilters,
 }
 
 /// List messages with pagination, search, and sorting.
@@ -782,6 +787,25 @@ pub fn message_list(conn: &Connection, p: &MessageListParams) -> Result<Paginate
         param_values.push(u.to_string());
         conditions.push(format!("messages.timestamp < ?{}", param_values.len()));
     }
+    if let Some(provider) = p.provider {
+        param_values.push(provider.to_string());
+        conditions.push(format!(
+            "COALESCE(messages.provider, 'claude_code') = ?{}",
+            param_values.len()
+        ));
+    }
+    let model_expr = normalized_model_expr("messages.model");
+    let project_expr = normalized_project_expr("messages.repo_id");
+    let branch_expr = normalized_branch_expr("COALESCE(messages.git_branch, s.git_branch)");
+    apply_dimension_filters(
+        &mut conditions,
+        &mut param_values,
+        p.filters,
+        "COALESCE(messages.provider, 'claude_code')",
+        &model_expr,
+        &project_expr,
+        &branch_expr,
+    );
     if let Some(q) = p.search
         && !q.is_empty()
     {

--- a/crates/budi-core/src/analytics/tests.rs
+++ b/crates/budi-core/src/analytics/tests.rs
@@ -661,6 +661,7 @@ fn message_list_returns_messages() {
     let mut conn = test_db();
     ingest_messages(&mut conn, &sample_messages(), None).unwrap();
 
+    let filters = DimensionFilters::default();
     let result = message_list(
         &conn,
         &MessageListParams {
@@ -671,6 +672,8 @@ fn message_list_returns_messages() {
             sort_asc: false,
             limit: 50,
             offset: 0,
+            provider: None,
+            filters: &filters,
         },
     )
     .unwrap();
@@ -678,6 +681,146 @@ fn message_list_returns_messages() {
     assert_eq!(result.messages.len(), 1);
     assert_eq!(result.total_count, 1);
     assert_eq!(result.messages[0].input_tokens, 100);
+}
+
+// #683: `/analytics/messages` previously dropped `?provider=` silently.
+// Mixed-provider rows must split cleanly on the singular flag and on the
+// multi-value `providers` flatten alias used by every breakdown route.
+fn mixed_provider_messages() -> Vec<ParsedMessage> {
+    let mut msgs = sample_messages();
+    // Add a copilot_chat assistant row so the fixture has two providers.
+    msgs.push(ParsedMessage {
+        uuid: "a2".to_string(),
+        session_id: Some("sess-copilot".to_string()),
+        timestamp: "2026-03-14T18:30:00Z".parse().unwrap(),
+        cwd: Some("/home/user/project-a".to_string()),
+        role: "assistant".to_string(),
+        model: Some("gpt-4o".to_string()),
+        input_tokens: 11,
+        output_tokens: 7,
+        cache_creation_tokens: 0,
+        cache_read_tokens: 0,
+        git_branch: None,
+        repo_id: None,
+        provider: "copilot_chat".to_string(),
+        cost_cents: Some(0.3),
+        session_title: None,
+        parent_uuid: None,
+        user_name: None,
+        machine_name: None,
+        cost_confidence: "exact".to_string(),
+        pricing_source: None,
+        request_id: None,
+        speed: None,
+        cache_creation_1h_tokens: 0,
+        web_search_requests: 0,
+        prompt_category: None,
+        prompt_category_source: None,
+        prompt_category_confidence: None,
+        tool_names: Vec::new(),
+        tool_use_ids: Vec::new(),
+        tool_files: Vec::new(),
+        tool_outcomes: Vec::new(),
+    });
+    msgs
+}
+
+#[test]
+fn message_list_singular_provider_filter_partitions_rows() {
+    let mut conn = test_db();
+    ingest_messages(&mut conn, &mixed_provider_messages(), None).unwrap();
+
+    let filters = DimensionFilters::default();
+    let copilot = message_list(
+        &conn,
+        &MessageListParams {
+            since: None,
+            until: None,
+            search: None,
+            sort_by: None,
+            sort_asc: false,
+            limit: 50,
+            offset: 0,
+            provider: Some("copilot_chat"),
+            filters: &filters,
+        },
+    )
+    .unwrap();
+    assert_eq!(copilot.total_count, 1);
+    assert_eq!(copilot.messages.len(), 1);
+    assert_eq!(copilot.messages[0].provider, "copilot_chat");
+
+    let claude = message_list(
+        &conn,
+        &MessageListParams {
+            since: None,
+            until: None,
+            search: None,
+            sort_by: None,
+            sort_asc: false,
+            limit: 50,
+            offset: 0,
+            provider: Some("claude_code"),
+            filters: &filters,
+        },
+    )
+    .unwrap();
+    assert_eq!(claude.total_count, 1);
+    assert_eq!(claude.messages[0].provider, "claude_code");
+}
+
+#[test]
+fn message_list_multi_provider_filter_unions_rows() {
+    let mut conn = test_db();
+    ingest_messages(&mut conn, &mixed_provider_messages(), None).unwrap();
+
+    let filters = DimensionFilters {
+        agents: vec!["copilot_chat".to_string(), "claude_code".to_string()],
+        ..DimensionFilters::default()
+    }
+    .normalize();
+    let result = message_list(
+        &conn,
+        &MessageListParams {
+            since: None,
+            until: None,
+            search: None,
+            sort_by: None,
+            sort_asc: false,
+            limit: 50,
+            offset: 0,
+            provider: None,
+            filters: &filters,
+        },
+    )
+    .unwrap();
+    assert_eq!(result.total_count, 2);
+    assert_eq!(result.messages.len(), 2);
+}
+
+#[test]
+fn message_list_unknown_provider_returns_empty() {
+    let mut conn = test_db();
+    ingest_messages(&mut conn, &mixed_provider_messages(), None).unwrap();
+
+    let filters = DimensionFilters::default();
+    let result = message_list(
+        &conn,
+        &MessageListParams {
+            since: None,
+            until: None,
+            search: None,
+            sort_by: None,
+            sort_asc: false,
+            limit: 50,
+            offset: 0,
+            provider: Some("unknown_name"),
+            filters: &filters,
+        },
+    )
+    .unwrap();
+    assert_eq!(result.total_count, 0);
+    assert!(result.messages.is_empty());
 }
 
 #[test]

--- a/crates/budi-daemon/src/routes/analytics.rs
+++ b/crates/budi-daemon/src/routes/analytics.rs
@@ -110,6 +110,13 @@ pub struct MessagesParams {
     pub sort_asc: Option<bool>,
     pub limit: Option<usize>,
     pub offset: Option<usize>,
+    /// Singular `?provider=<name>` filter, mirroring `SummaryParams`.
+    /// Multi-value `?providers=a,b` flows through the flattened
+    /// `DimensionParams.agents` field below (which has `providers` /
+    /// `agent` aliases).
+    pub provider: Option<String>,
+    #[serde(flatten)]
+    pub filters: DimensionParams,
 }
 
 const VALID_MESSAGE_SORT_BY: &[&str] = &[
@@ -151,6 +158,7 @@ pub async fn analytics_messages(
             VALID_MESSAGE_SORT_BY.join(", ")
         )));
     }
+    let filters = parse_dimension_filters(&params.filters);
     let result = tokio::task::spawn_blocking(move || {
         let db_path = analytics::db_path()?;
         let conn = analytics::open_db(&db_path)?;
@@ -164,6 +172,8 @@ pub async fn analytics_messages(
                 sort_asc: params.sort_asc.unwrap_or(false),
                 limit: params.limit.unwrap_or(50).min(200),
                 offset: params.offset.unwrap_or(0),
+                provider: params.provider.as_deref(),
+                filters: &filters,
             },
         )
     })


### PR DESCRIPTION
Closes #683.

## Summary

`/analytics/messages` and `budi sessions` accepted no provider filter — the only filter shape was `--search <substring>`, which is leaky: `--search code` matches `claude_code`, `vscode`, `codex`, and any model id containing those letters. This PR adds an exact-match `--provider` / `?provider=` filter to both surfaces, mirroring the shape `budi stats` and `/analytics/statusline` already use.

## What's in

**Server** (`crates/budi-daemon/src/routes/analytics.rs`, `crates/budi-core/src/analytics/queries.rs`)
- `MessagesParams` gains `provider: Option<String>` plus a flattened `DimensionParams` so the same `provider` / `providers` / `agents` / `models` / `projects` / `branches` aliases every breakdown route already accepts also work for `/analytics/messages`.
- `MessageListParams` gains `provider: Option<&str>` and `filters: &DimensionFilters`. `message_list` reuses the existing `apply_dimension_filters` helper and the `provider_expr = COALESCE(messages.provider, 'claude_code')` predicate.

**CLI** (`crates/budi-cli/src/main.rs`, `crates/budi-cli/src/commands/sessions.rs`, `crates/budi-cli/src/client.rs`)
- `budi sessions --provider <NAME>` clap flag, validated via the shared `normalize_provider` helper (so `--provider copilot` resolves to `copilot_cli` and unknown names error with a friendly list).
- `DaemonClient::sessions` forwards the normalized name as `?providers=` to match the existing `DimensionParams.agents` alias used by every breakdown route.
- Sessions list header now shows `provider: <NAME>` in the filter suffix.

**Tests**
- 3 new unit tests in `crates/budi-core/src/analytics/tests.rs`: `message_list_singular_provider_filter_partitions_rows`, `message_list_multi_provider_filter_unions_rows`, `message_list_unknown_provider_returns_empty` — covers the acceptance contract from the ticket.
- `cli_parses_sessions_provider_flag` in `crates/budi-cli/src/main.rs` — covers the clap surface.

## What's not in

- `/analytics/sessions`'s `SessionsQueryParams` already flattens `DimensionParams`, so `?providers=copilot_chat` was working server-side; only the CLI plumbing was missing. Not adding a singular `provider` alias to `DimensionParams.agents` because that would clash with `MessagesParams.provider` under serde flatten.
- `budi db` — only has `check` and `import` subcommands; no message listing surface to extend.

## What's deferred

- The breakdown-view `--provider` plumbing on `budi stats` shipped in #682 / da7b580 already.
- Repurposing `--search` — kept as the substring-match shape for free-form queries (`haiku`, `main`, etc.); `--provider` complements it.
- `MIN_API_VERSION` not bumped — the new query params are additive on a previously-silently-dropped request shape.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo test --workspace` — 261 + 586 + 45 + 0 tests pass
- [x] `bash scripts/e2e/test_655_release_smoke.sh` — green (analytics queries touched)
- [x] Manual: 3 new unit tests cover singular / multi / unknown-provider paths against a mixed-provider DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)