### PR TITLE
[8.4.2] copilot_chat globalStorage glob is too broad: tracks embedding caches and CLI state blobs as session files

### DIFF
--- a/crates/budi-core/src/providers/copilot_chat.rs
+++ b/crates/budi-core/src/providers/copilot_chat.rs
@@ -301,9 +301,12 @@ fn collect_session_files(user_root: &Path, out: &mut Vec<PathBuf>) {
     // intentionally recursive — the sub-directory layout has shifted multiple
     // times across releases. Iterate the actual on-disk dir entries so
     // case-insensitive filesystems collapse to a single match instead of
-    // double-counting both casings.
+    // double-counting both casings. The recursion bottom-out is anchored at
+    // a known session-storage directory name (chatSessions / chat-sessions /
+    // sessions) so embedding caches and CLI state blobs sitting one level
+    // under the publisher dir don't get pulled in (#684).
     for pub_dir in publisher_subdirs(&gs) {
-        push_session_files_recursive(&pub_dir, out, 0);
+        push_global_storage_session_files(&pub_dir, out, 0, false);
     }
 
     // Dedup the slice we just appended. On case-insensitive filesystems
@@ -337,6 +340,51 @@ fn push_session_files_recursive(dir: &Path, out: &mut Vec<PathBuf>, depth: u32) 
             out.push(path);
         }
     }
+}
+
+/// Recurse through `globalStorage/{GitHub,github}.copilot{,-chat}/**` per
+/// ADR-0092 §2.2, but only collect `*.json` / `*.jsonl` files that live under
+/// a directory named `chatSessions`, `chat-sessions`, or `sessions`. The
+/// recursion still tolerates layout shuffles below the publisher-id directory
+/// (the canonical reason §2.2 is recursive at all), but the bottom-out is
+/// anchored at a known session-storage directory name so the embedding caches
+/// (`commandEmbeddings.json`, `settingEmbeddings.json`) and the Copilot CLI
+/// state blob (`copilot.cli.oldGlobalSessions.json`) sitting as siblings of
+/// the session directory never match (#684).
+fn push_global_storage_session_files(
+    dir: &Path,
+    out: &mut Vec<PathBuf>,
+    depth: u32,
+    inside_session_dir: bool,
+) {
+    if depth > 8 {
+        return;
+    }
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            let next_inside = inside_session_dir
+                || path
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .is_some_and(is_session_storage_dir_name);
+            push_global_storage_session_files(&path, out, depth + 1, next_inside);
+        } else if inside_session_dir
+            && let Some(ext) = path.extension().and_then(|e| e.to_str())
+            && (ext.eq_ignore_ascii_case("json") || ext.eq_ignore_ascii_case("jsonl"))
+        {
+            out.push(path);
+        }
+    }
+}
+
+fn is_session_storage_dir_name(name: &str) -> bool {
+    name.eq_ignore_ascii_case("chatSessions")
+        || name.eq_ignore_ascii_case("chat-sessions")
+        || name.eq_ignore_ascii_case("sessions")
 }
 
 // ---------------------------------------------------------------------------
@@ -1843,6 +1891,85 @@ mod tests {
         collect_session_files(&tmp, &mut out);
         assert_eq!(out.len(), 1);
         assert!(out[0].ends_with("a.jsonl"));
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn collect_session_files_skips_global_publisher_siblings_of_session_dir() {
+        // ADR-0092 §2.2 directory-name allowlist (#684): under
+        // globalStorage/{publisher}/, only files inside chatSessions,
+        // chat-sessions, or sessions subtrees are session files. Embedding
+        // caches and CLI state blobs sitting as siblings must be skipped.
+        let tmp = std::env::temp_dir().join("budi-copilot-chat-skip-siblings");
+        let _ = std::fs::remove_dir_all(&tmp);
+        let pub_dir = tmp.join("globalStorage/github.copilot-chat");
+        std::fs::create_dir_all(&pub_dir).unwrap();
+
+        // Sibling files (NOT chat sessions): VS Code embedding caches and
+        // the Copilot CLI v2 state blob.
+        std::fs::write(
+            pub_dir.join("commandEmbeddings.json"),
+            // Large embedding-only payload, no `kind`/`requests`/`messages` keys.
+            br#"{"core":{"editor.action.setSelectionAnchor":{"embedding":[0.008,-0.029,0.061]}}}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            pub_dir.join("settingEmbeddings.json"),
+            br#"{"core":{"editor.fontSize":{"embedding":[0.1,0.2]}}}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            pub_dir.join("copilot.cli.oldGlobalSessions.json"),
+            br#"{"version":2,"sessions":{}}"#,
+        )
+        .unwrap();
+
+        // Real session file under a known session-storage directory.
+        let chat_sessions = pub_dir.join("chatSessions");
+        std::fs::create_dir_all(&chat_sessions).unwrap();
+        std::fs::write(
+            chat_sessions.join("0e3b1f3c-1234-4abc-9def-aaaabbbbcccc.jsonl"),
+            br#"{"kind":0,"v":{"sessionId":"abc","creationDate":"2026-04-15T10:00:00Z"}}
+"#,
+        )
+        .unwrap();
+
+        let mut out = Vec::new();
+        collect_session_files(&tmp, &mut out);
+        assert_eq!(
+            out.len(),
+            1,
+            "only the chatSessions/<uuid>.jsonl is collected; \
+             commandEmbeddings.json / settingEmbeddings.json / \
+             copilot.cli.oldGlobalSessions.json siblings are skipped, got {out:?}"
+        );
+        assert!(out[0].ends_with("0e3b1f3c-1234-4abc-9def-aaaabbbbcccc.jsonl"));
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn collect_session_files_accepts_chat_sessions_chat_sessions_and_sessions_subdirs() {
+        // The directory-name allowlist (#684) covers all three known
+        // session-storage names. A future fourth name must amend ADR-0092
+        // §2.2 in lockstep.
+        let tmp = std::env::temp_dir().join("budi-copilot-chat-allowlist-names");
+        let _ = std::fs::remove_dir_all(&tmp);
+        let pub_dir = tmp.join("globalStorage/GitHub.copilot-chat");
+        for name in ["chatSessions", "chat-sessions", "sessions"] {
+            let d = pub_dir.join(name);
+            std::fs::create_dir_all(&d).unwrap();
+            std::fs::write(d.join("s.jsonl"), b"{}\n").unwrap();
+        }
+
+        let mut out = Vec::new();
+        collect_session_files(&tmp, &mut out);
+        assert_eq!(
+            out.len(),
+            3,
+            "all three allowlisted names match, got {out:?}"
+        );
 
         let _ = std::fs::remove_dir_all(&tmp);
     }

--- a/docs/adr/0092-copilot-chat-data-contract.md
+++ b/docs/adr/0092-copilot-chat-data-contract.md
@@ -48,10 +48,10 @@ Five candidate subpath shapes, all checked. The `{GitHub,github}` brace expansio
 - `workspaceStorage/<hash>/{GitHub,github}.copilot-chat/{chatSessions,debug-logs}/`
 - `workspaceStorage/<hash>/{GitHub,github}.copilot/{chatSessions,debug-logs}/`
 - `globalStorage/emptyWindowChatSessions/`
-- `globalStorage/{GitHub,github}.copilot-chat/**` (recursive)
-- `globalStorage/{GitHub,github}.copilot/**` (recursive)
+- `globalStorage/{GitHub,github}.copilot-chat/**/{chatSessions,chat-sessions,sessions}/**/*.{json,jsonl}`
+- `globalStorage/{GitHub,github}.copilot/**/{chatSessions,chat-sessions,sessions}/**/*.{json,jsonl}`
 
-The two `globalStorage/{GitHub,github}.copilot{,-chat}/**` patterns are intentionally recursive: GitHub has shipped at least three different sub-directory layouts under that prefix (`chatSessions/`, `chat-sessions/`, `sessions/<lang>/`), and pinning to any one shape regresses on the next release. The recursion bottoms out at any `*.json` or `*.jsonl` file.
+The two `globalStorage/{GitHub,github}.copilot{,-chat}/...` patterns are intentionally recursive in the middle segment: GitHub has shipped at least three different sub-directory layouts under that prefix (`chatSessions/`, `chat-sessions/`, `sessions/<lang>/`), and pinning to any one shape regresses on the next release. The bottom-out is anchored at a directory-name allowlist (`chatSessions`, `chat-sessions`, `sessions`) instead of "any `*.json` or `*.jsonl`" — anchoring at a known session-storage directory name keeps the recursion tolerant of layout shuffles below the publisher-id directory while excluding files the Copilot extension parks as siblings of those directories. Concretely, embedding caches (`commandEmbeddings.json`, `settingEmbeddings.json`) and the Copilot CLI v2 state blob (`copilot.cli.oldGlobalSessions.json`) live one level under the publisher-id directory and never inside a session-storage directory; the allowlist is the cheapest invariant that excludes them without preempting the next layout shuffle ([#684](https://github.com/siropkin/budi/issues/684)). When the Copilot extension introduces a fourth session-storage directory name in a future release, this allowlist is amended in lockstep — the same drill as §2.3 record-shape additions. This is a discovery-layer change; `MIN_API_VERSION` does not bump (the §2.6 record-shape contract is untouched).
 
 #### 2.3 File shapes and token-key dispatch
 


### PR DESCRIPTION
Closes #684.

## Summary

The `copilot_chat` discovery glob `globalStorage/{GitHub,github}.copilot{,-chat}/**` (ADR-0092 §2.2) bottomed out at any `*.json` / `*.jsonl` file. That predicate is too broad: VS Code parks embedding caches (`commandEmbeddings.json`, `settingEmbeddings.json`) and the Copilot CLI v2 state blob (`copilot.cli.oldGlobalSessions.json`) as siblings of the session-storage directory under that prefix. Each consumed a `tail_offsets` row, was re-read on every backstop tick, and emitted a once-per-daemon-run `copilot_chat_unknown_record_shape` warn.

Anchor the bottom-out at a directory-name allowlist (`chatSessions`, `chat-sessions`, `sessions`) instead. The recursion still tolerates layout shuffles below the publisher-id directory — that was the original reason §2.2 was recursive — but the allowlist anchors the bottom-out at *known session-storage directory names* so siblings of the session directory never match.

## What's in

- `crates/budi-core/src/providers/copilot_chat.rs`: new `push_global_storage_session_files` helper that recurses through the publisher-id subtree but only collects `*.json` / `*.jsonl` files when an ancestor directory's basename is `chatSessions`, `chat-sessions`, or `sessions`. The `emptyWindowChatSessions` path stays on the existing `push_session_files_recursive` helper (it's pinned to a single fixed name, not a publisher subtree). The `workspaceStorage` enumeration is already pinned to fixed `chatSessions` / `debug-logs` subdirs and is unchanged.
- Two new unit tests:
  - `collect_session_files_skips_global_publisher_siblings_of_session_dir` — drops `commandEmbeddings.json`, `settingEmbeddings.json`, `copilot.cli.oldGlobalSessions.json` siblings of a `chatSessions/<uuid>.jsonl` under `globalStorage/github.copilot-chat/` and asserts only the session file is collected.
  - `collect_session_files_accepts_chat_sessions_chat_sessions_and_sessions_subdirs` — pins all three allowlisted directory names so a future fourth name forces an ADR amendment in lockstep.
- ADR-0092 §2.2 amended: the recursive globs now read `…/{chatSessions,chat-sessions,sessions}/**/*.{json,jsonl}` instead of `…/**`, with the rationale (\"directory-name anchors the bottom-out\") inline and a forward-pointer for the next layout shuffle.

## What's not in

- `MIN_API_VERSION` does **not** bump. This is a discovery-layer fix; the §2.6 record-shape contract is untouched.
- The §2.3 record-shape parser is unchanged — files that no longer get discovered no longer reach the parser at all, so the unknown-shape warn for them goes away as a side effect of the discovery fix, not a parser change.

## What's deferred

- One-shot pruning of stale `tail_offsets` rows for the misclassified paths (out-of-scope per the ticket — they will simply stop receiving updates after the glob tightens).
- Heuristic content sniffing (`requests` / `kind` key probe) — not shipped preemptively; the directory-name allowlist is the cheaper invariant.
- `copilot_cli` provider claiming `copilot.cli.oldGlobalSessions.json` — unrelated to this ticket.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo test --workspace` — 1 flaky failure (`workers::tailer::tests::run_blocking_exits_when_shutdown_flag_is_set`) which passed in isolation on rerun, per the documented flake.
- [x] `cargo test -p budi-core providers::copilot_chat` — 53 pass including the two new tests.
- [x] `bash scripts/e2e/test_655_release_smoke.sh` — green; the parser pipeline + globalStorage materialization steps still pass end-to-end.
- [x] Manual: confirmed by inspection that `globalStorage/github.copilot-chat/commandEmbeddings.json` no longer matches the discovery walk, while `globalStorage/github.copilot-chat/chatSessions/<uuid>.jsonl` still does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)