### PR TITLE
[8.4.2] copilot_chat: prefer result.metadata.resolvedModel over agent.id static-table for model attribution

### DIFF
--- a/crates/budi-core/src/pricing/mod.rs
+++ b/crates/budi-core/src/pricing/mod.rs
@@ -269,6 +269,26 @@ pub fn lookup(model_id: &str, provider: &str) -> PricingOutcome {
     }
 }
 
+/// Non-warning probe: does `model_id` resolve to a manifest entry
+/// directly or through the alias overlay?
+///
+/// Used by parsers that need to decide whether a candidate model id is
+/// safe to attribute to a row before [`lookup`] runs (8.4.2 / #685 —
+/// Copilot Chat `result.metadata.resolvedModel` precedence). Unlike
+/// [`lookup`], this does not emit `warn_once_unknown` on miss, so it is
+/// safe to call as a shape probe without polluting the unknown-model
+/// log with values the parser is about to discard.
+pub fn is_known(model_id: &str) -> bool {
+    let guard = state().read().expect("pricing state RwLock poisoned");
+    if guard.manifest.entries.contains_key(model_id) {
+        return true;
+    }
+    if let Some(canonical) = guard.manifest.aliases.get(model_id) {
+        return guard.manifest.entries.contains_key(canonical.as_str());
+    }
+    false
+}
+
 /// Snapshot of the current in-memory manifest for `GET /pricing/status`
 /// and `budi pricing status`. Shape is golden-file tested (#376 gate 9).
 ///
@@ -530,6 +550,12 @@ pub const EMBEDDED_ALIASES: &[(&str, &str)] = &[
     ("claude-4.6-opus-high-thinking", "claude-opus-4-6"),
     ("claude-4.7-opus-high", "claude-opus-4-7"),
     ("claude-4.7-opus-high-thinking", "claude-opus-4-7"),
+    // xAI surface form Copilot Chat persists in
+    // `result.metadata.resolvedModel` for `auto`-routed Grok turns
+    // (`grok-code-fast-1`) → LiteLLM-canonical key
+    // (`xai/grok-code-fast-1`). Verified on a real session
+    // (`e22dad3b`) during 8.4.1 release verification — see #685.
+    ("grok-code-fast-1", "xai/grok-code-fast-1"),
 ];
 
 /// Build the alias map from [`EMBEDDED_ALIASES`]. Cheap (≤20

--- a/crates/budi-core/src/providers/copilot_chat.rs
+++ b/crates/budi-core/src/providers/copilot_chat.rs
@@ -1323,16 +1323,45 @@ fn shape_matches_any(record: &serde_json::Value) -> bool {
         || record.pointer("/result/metadata/outputTokens").is_some()
 }
 
-/// Strip a `copilot/` model-id prefix per ADR-0092 §2.4 and resolve the
-/// router placeholder `"auto"` to a concrete pricing key via `agent.id`
-/// (ADR-0092 §2.4.1, R1.4 #671).
+/// Resolve the model id Budi attributes a Copilot Chat row to.
+///
+/// Three-step fallback (ADR-0092 §2.4, amended by #685):
+///
+/// 1. `result.metadata.resolvedModel` — when shape-clean and known to
+///    the pricing manifest (or its alias overlay), this is the actual
+///    model GitHub routed to. Catches non-Anthropic `auto` routes
+///    (e.g. `grok-code-fast-1`) and dated Anthropic forms
+///    (`claude-haiku-4-5-20251001`) without us guessing. Skips
+///    GPU-fleet codes (`capi-noe-ptuc-h200-oswe-vscode-prime`) because
+///    they're never in the manifest.
+/// 2. `modelId` (top-level or under `result.metadata`) — the
+///    user-facing label, with the optional `copilot/` prefix stripped.
+///    Returned as-is unless it is the literal `"auto"` router
+///    placeholder.
+/// 3. `auto` + `agent.id` static-table fallback (ADR-0092 §2.4.1,
+///    R1.4 / #671) — optimistic guess based on the agent surface the
+///    user invoked. Demoted from primary to last-resort by #685.
+///
+/// The §2.4.1 table stays intact as the safety net for sessions where
+/// `resolvedModel` is missing or fleet-shaped; only its precedence
+/// changes.
 fn extract_model_id(record: &serde_json::Value) -> Option<String> {
-    // `modelId` is the user-facing label (e.g. `copilot/claude-haiku-4.5`,
-    // `copilot/auto`). Prefer it over `result.metadata.resolvedModel` —
-    // that field is either a dated version suffix (`claude-haiku-4-5-20251001`)
-    // or an internal GPU-fleet code (`capi-noe-ptuc-h200-oswe-vscode-prime`)
-    // that does not map to manifest entries. The fleet-code form means
-    // `resolvedModel` cannot be trusted as a pricing key.
+    // (1) Prefer the actual server-side resolution when we can prove
+    // it prices cleanly. Manifest membership (direct or via alias) is
+    // the gate — fleet codes aren't in the manifest, so they fall
+    // through to step (2)/(3) without a wrong guess.
+    if let Some(resolved) = record
+        .pointer("/result/metadata/resolvedModel")
+        .and_then(|v| v.as_str())
+    {
+        let candidate = strip_copilot_prefix(resolved);
+        if is_clean_model_shape(candidate) && crate::pricing::is_known(candidate) {
+            return Some(candidate.to_string());
+        }
+    }
+
+    // (2) User-facing modelId. Strip the optional `copilot/` prefix
+    // and return as-is unless it's the `"auto"` router placeholder.
     let raw = record
         .get("modelId")
         .and_then(|v| v.as_str())
@@ -1347,20 +1376,36 @@ fn extract_model_id(record: &serde_json::Value) -> Option<String> {
         return Some(raw);
     }
 
-    // Router-placeholder: the user picked "auto" in the model selector and
-    // GitHub Copilot Chat picked the actual model server-side. The
-    // user-facing label is "auto", which the LiteLLM pricing manifest does
-    // not know about, so a literal "auto" prices to `unpriced:no_pricing`.
-    // ADR-0092 §2.4.1 resolves it via `agent.id`; on miss, leave the value
-    // as "auto" so the row still emits (priced through to `no_pricing`,
-    // trued up by §3 reconciliation on the next tick for individually-
-    // licensed users).
+    // (3) Router-placeholder fallback. The user picked "auto" in the
+    // model selector and GitHub Copilot Chat picked the actual model
+    // server-side, but step (1) couldn't pin it down (resolvedModel
+    // missing, fleet-shaped, or unknown to the manifest). ADR-0092
+    // §2.4.1 resolves "auto" via `agent.id`; on miss, leave the value
+    // as "auto" so the row still emits (priced through to
+    // `no_pricing`, trued up by §3 reconciliation on the next tick
+    // for individually-licensed users).
     if let Some(agent_id) = record.pointer("/agent/id").and_then(|v| v.as_str())
         && let Some(resolved) = resolve_auto_model_id(agent_id)
     {
         return Some(resolved.to_string());
     }
     Some(raw)
+}
+
+/// Cheap shape filter for a candidate model id pulled from
+/// `result.metadata.resolvedModel`: lowercase ASCII letters, digits,
+/// and hyphens, leading character must be a letter. Rejects values
+/// with dots, slashes, or uppercase characters before the manifest
+/// probe. Note this does NOT exclude GPU-fleet codes — those share
+/// the same shape — so the manifest membership check in step (1) is
+/// the real safety guard.
+fn is_clean_model_shape(s: &str) -> bool {
+    let mut chars = s.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_lowercase() => {}
+        _ => return false,
+    }
+    chars.all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
 }
 
 fn strip_copilot_prefix(model: &str) -> &str {
@@ -1688,6 +1733,87 @@ mod tests {
             r#"{"result": {"metadata": {"modelId": "copilot/auto"}}, "agent": {"id": "github.copilot.editsAgent"}}"#,
         );
         assert_eq!(extract_model_id(&v).as_deref(), Some("claude-sonnet-4-5"));
+    }
+
+    /// #685: `result.metadata.resolvedModel` outranks the §2.4.1
+    /// `agent.id` static table when the resolved value is shape-clean
+    /// and the pricing manifest knows about it. Three real on-disk
+    /// sessions drove this priority flip:
+    ///
+    /// - dated LiteLLM-canonical Anthropic key (`claude-haiku-4-5-20251001`)
+    ///   wins directly via manifest entries — no alias hop needed.
+    /// - non-Anthropic auto-routed key (`grok-code-fast-1`) wins via
+    ///   the alias overlay — without this, it would be wrongly
+    ///   attributed to `claude-sonnet-4-5` by the editsAgent fallback.
+    /// - GPU-fleet code (`capi-noe-ptuc-h200-oswe-vscode-prime`)
+    ///   isn't in the manifest, so step (1) fails and the agent.id
+    ///   fallback runs — current behavior preserved.
+    #[test]
+    fn extract_model_id_prefers_resolved_when_manifest_known() {
+        // Anthropic dated form — direct manifest hit.
+        let v = make_message(
+            r#"{
+                "modelId": "copilot/claude-haiku-4.5",
+                "agent": {"id": "github.copilot.editsAgent"},
+                "result": {"metadata": {"resolvedModel": "claude-haiku-4-5-20251001"}}
+            }"#,
+        );
+        assert_eq!(
+            extract_model_id(&v).as_deref(),
+            Some("claude-haiku-4-5-20251001"),
+            "dated LiteLLM-canonical Anthropic key must win directly via manifest"
+        );
+
+        // Grok auto-route — alias-overlay hit, beats Sonnet fallback.
+        let v = make_message(
+            r#"{
+                "modelId": "copilot/auto",
+                "agent": {"id": "github.copilot.editsAgent"},
+                "result": {"metadata": {"resolvedModel": "grok-code-fast-1"}}
+            }"#,
+        );
+        assert_eq!(
+            extract_model_id(&v).as_deref(),
+            Some("grok-code-fast-1"),
+            "Grok resolvedModel must win over editsAgent → claude-sonnet-4-5"
+        );
+
+        // Fleet code — manifest miss, falls through to editsAgent table.
+        let v = make_message(
+            r#"{
+                "modelId": "copilot/auto",
+                "agent": {"id": "github.copilot.editsAgent"},
+                "result": {"metadata": {"resolvedModel": "capi-noe-ptuc-h200-oswe-vscode-prime"}}
+            }"#,
+        );
+        assert_eq!(
+            extract_model_id(&v).as_deref(),
+            Some("claude-sonnet-4-5"),
+            "fleet-code resolvedModel must fall through to §2.4.1 agent.id table"
+        );
+
+        // No resolvedModel at all — current §2.4.1 behavior preserved.
+        let v = make_message(
+            r#"{"modelId": "copilot/auto", "agent": {"id": "github.copilot.editsAgent"}}"#,
+        );
+        assert_eq!(extract_model_id(&v).as_deref(), Some("claude-sonnet-4-5"));
+    }
+
+    /// `is_clean_model_shape` must pass real model ids and reject
+    /// anything carrying dots, slashes, uppercase, or empty input —
+    /// the gate that lets the manifest probe in step (1) of
+    /// `extract_model_id` stay correct without false positives on
+    /// surface forms it can't handle.
+    #[test]
+    fn is_clean_model_shape_filters() {
+        assert!(is_clean_model_shape("grok-code-fast-1"));
+        assert!(is_clean_model_shape("claude-haiku-4-5-20251001"));
+        assert!(is_clean_model_shape("capi-noe-ptuc-h200-oswe-vscode-prime"));
+        assert!(!is_clean_model_shape("claude-haiku-4.5"));
+        assert!(!is_clean_model_shape("xai/grok-code-fast-1"));
+        assert!(!is_clean_model_shape("Claude-Haiku"));
+        assert!(!is_clean_model_shape("1grok"));
+        assert!(!is_clean_model_shape(""));
     }
 
     /// Direct unit test on the static table — pin every entry so a stale

--- a/docs/adr/0092-copilot-chat-data-contract.md
+++ b/docs/adr/0092-copilot-chat-data-contract.md
@@ -97,25 +97,32 @@ Tail offset semantics: `tail_offsets.byte_offset` still records bytes consumed a
 
 **Canonical fixture (R1.2, 8.4.1, [#669](https://github.com/siropkin/budi/issues/669)).** The shape described above is pinned to a real on-disk capture at `crates/budi-core/src/providers/copilot_chat/fixtures/vscode_chat_0_47_0.jsonl` (sanitized — prompt text, response markdown, code citations, file paths, and local-machine metadata stripped; envelope keys, `requestId`, timestamps, `agent.*`, `modelId`, `responseId`, `modelState`, and `completionTokens` / `promptTokens` patches preserved). A sibling `vscode_chat_0_47_0.expected.json` lists the per-request `(requestId, output_tokens, input_tokens, model)` tuples the reducer must materialize. A truncated companion `vscode_chat_0_47_0_streaming.jsonl` slices the fixture mid-stream — kind:2 stub written, kind:1 `completionTokens` patch not yet — and pins the no-emit-until-completion-token contract from R1.1. When extension N+1 changes the format again, the next bump captures a new fixture and the previous one is kept as a regression for the older format.
 
-A side note from the same investigation: `result.metadata.resolvedModel` is **not** safe to use as a pricing key. On older sessions it was a dated version suffix (`claude-haiku-4-5-20251001`); on May-2026+ sessions it is an internal GPU-fleet code (`capi-noe-ptuc-h200-oswe-vscode-prime`) that does not map to manifest entries. The parser uses `modelId` (post-`copilot/` strip per §2.4) as the pricing key. When the value is the router placeholder `auto`, the §2.4.1 resolver maps it to a concrete model via `agent.id`; if no mapping exists the literal `"auto"` is preserved and pricing falls through to `unpriced:no_pricing` with the §3 Billing API reconciliation supplying the dollar truth.
+A side note from the same investigation, **amended 8.4.2 ([#685](https://github.com/siropkin/budi/issues/685))**: the original 8.4.1 wording ruled `result.metadata.resolvedModel` out as a pricing key wholesale, citing dated suffixes (`claude-haiku-4-5-20251001`) and GPU-fleet codes (`capi-noe-ptuc-h200-oswe-vscode-prime`) as evidence. That rule was too strong — it conflated the fleet-code shape with all uses of the field. Across three real on-disk sessions on 2026-05-07, `resolvedModel` carried a clean LiteLLM-canonical Anthropic key, a clean non-Anthropic key (`grok-code-fast-1` for an `auto`-routed Grok turn), and a fleet code respectively. Discriminating by shape alone is unsafe — fleet codes share the same `[a-z0-9-]+` shape as real model ids — but **shape + manifest membership** is a clean filter: fleet codes are never in the manifest, real model ids always are. Per §2.4 the parser now prefers `resolvedModel` when both gates pass and falls through to `modelId` / the §2.4.1 `agent.id` table otherwise, so the previous "never use resolvedModel" rule no longer applies. The Billing API reconciliation in §3 still supplies the dollar truth for individually-licensed users on every tick.
 
 Cache-token keys, when present, follow the same per-shape pattern under `cacheReadTokens` / `cacheWriteTokens` (delta and Feb-2026 shapes) or under `usage.cacheReadInputTokens` / `usage.cacheCreationInputTokens` (legacy). Cache tokens are best-effort — Copilot Chat does not expose cache fields on every record.
 
 #### 2.4 Model-id key
 
-- Top-level `modelId` — strip the `copilot/` prefix if present (e.g. `copilot/claude-sonnet-4-5` → `claude-sonnet-4-5`).
-- `result.metadata.modelId` — Feb-2026+ shape.
-- Fall back to a per-session default if a record carries tokens without a model id (e.g. interrupted sessions). Default is the per-session model recorded in the session manifest, if any; otherwise the model id is left empty and the row is tagged `unpriced:no_model` by the cost enricher (consistent with how `unpriced:no_tokens` is handled in ADR-0090 §2026-04-23).
+The parser walks three sources in this order (precedence flipped 8.4.2 / [#685](https://github.com/siropkin/budi/issues/685); previously `resolvedModel` was ruled out wholesale and `modelId` led):
+
+1. **`result.metadata.resolvedModel`** — when the value is shape-clean (`^[a-z][a-z0-9-]*$`) **and** known to the in-memory pricing manifest (directly or via the alias overlay from #680). This is the actual model GitHub routed to. Captures non-Anthropic `auto`-routed turns (`grok-code-fast-1`) and dated LiteLLM-canonical Anthropic keys (`claude-haiku-4-5-20251001`) without us guessing. Skips GPU-fleet codes (`capi-noe-ptuc-h200-oswe-vscode-prime`) because they're never in the manifest, so the worst case here is a no-op falling through to (2)/(3).
+2. **`modelId`** — top-level `modelId`, then `result.metadata.modelId` (Feb-2026+ shape). Strip the `copilot/` prefix if present (e.g. `copilot/claude-sonnet-4-5` → `claude-sonnet-4-5`). Returned as-is unless it is the literal `"auto"` router placeholder, in which case (3) runs.
+3. **§2.4.1 `agent.id` static-table fallback** — see below. The 8.4.1 R1.4 resolver, demoted from primary to last-resort by #685; the table itself is unchanged.
+
+If none of the three yield a value, fall back to a per-session default if a record carries tokens without a model id (e.g. interrupted sessions). Default is the per-session model recorded in the session manifest, if any; otherwise the model id is left empty and the row is tagged `unpriced:no_model` by the cost enricher (consistent with how `unpriced:no_tokens` is handled in ADR-0090 §2026-04-23).
+
+This is a model-extraction priority change, not a §2.3 record-shape change — `MIN_API_VERSION` does **not** bump.
 
 #### 2.4.1 `auto` router resolution (R1.4, 8.4.1, [#671](https://github.com/siropkin/budi/issues/671))
 
 When the user picks `auto` in the Copilot Chat model selector, GitHub picks the actual model server-side and persists the literal string `"auto"` as the request's `modelId`. The LiteLLM pricing manifest has no `auto` entry, so a literal `"auto"` model id falls through to `unpriced:no_pricing` and rows price at \$0 — the headline post-#R1.1 user-visible defect (#671) on the surface of `budi sessions` for any developer who leaves the model picker on the default.
 
-The parser therefore resolves `"auto"` to a concrete model id via `agent.id` immediately after the §2.4 prefix-strip, before the row is handed to the pricing layer:
+The parser resolves `"auto"` to a concrete model id via `agent.id` only after §2.4 step (1) (manifest-known `resolvedModel`) and step (2) (concrete `modelId`) have both failed. The order, post-#685:
 
-1. If `modelId != "auto"` — pass through as-is (current §2.4 behavior, unchanged).
-2. Otherwise, look at `agent.id` on the same record and resolve via the table below.
-3. If `agent.id` is missing or unrecognised, preserve the literal `"auto"` so the row still emits — pricing then falls through to `unpriced:no_pricing` and the §3 Billing API reconciliation worker trues the dollar number up to the real bill on the next tick (for individually-licensed users with a configured PAT).
+1. If §2.4 step (1) hit a manifest-known `resolvedModel` — done; this section never runs.
+2. If `modelId != "auto"` — pass through as-is (§2.4 step (2)).
+3. Otherwise, look at `agent.id` on the same record and resolve via the table below.
+4. If `agent.id` is missing or unrecognised, preserve the literal `"auto"` so the row still emits — pricing then falls through to `unpriced:no_pricing` and the §3 Billing API reconciliation worker trues the dollar number up to the real bill on the next tick (for individually-licensed users with a configured PAT).
 
 | `agent.id` | Resolves to | Notes |
 |---|---|---|


### PR DESCRIPTION
Closes #685.

## What's in

- `extract_model_id` precedence flipped (ADR-0092 §2.4):
  1. `result.metadata.resolvedModel` — when shape-clean (`^[a-z][a-z0-9-]*$`) AND known to the pricing manifest (directly or via alias overlay).
  2. `modelId` (top-level then `result.metadata.modelId`), `copilot/` prefix stripped.
  3. §2.4.1 `agent.id` static-table fallback — same R1.4 (#671) table, demoted from primary to last-resort.
- New `pricing::is_known(model_id)` non-warning probe so the parser can gate step (1) on manifest membership without polluting `warn_once_unknown`.
- New embedded alias `grok-code-fast-1 → xai/grok-code-fast-1` so the auto-routed Grok turn prices via the existing manifest entry.
- `is_clean_model_shape` shape filter inline in `copilot_chat.rs` (no new dependency).
- ADR-0092 §2.4 / §2.4.1 amended in the same PR; the side note that previously ruled `resolvedModel` out wholesale is replaced with the shape+manifest gate rationale.
- New unit tests:
  - `extract_model_id_prefers_resolved_when_manifest_known` — covers the three reproducer sessions from the ticket (Anthropic dated, Grok auto, fleet-code fallback) plus the no-`resolvedModel` baseline.
  - `is_clean_model_shape_filters` — pins the shape-filter contract.

## What's not in

- No new manifest aliases beyond the single `grok-code-fast-1` entry needed for the Grok acceptance case. The broader alias overlay tracking continues in #680 with narrower scope (sessions where `resolvedModel` is missing or fleet-shaped, plus Cursor cases).
- No history backfill — existing rows remain attributed under the prior precedence and are upgradable via `budi db import --force` (modulo the separately-tracked copilot_chat history-import gap).

## What's deferred

- Migration of the §2.4.1 `agent.id` table to the manifest `model_aliases` block (ADR-0092 §2.4.1 Option C) stays deferred to 9.0.0.

## Versioning

- `MIN_API_VERSION` does **not** bump — model-extraction priority change, not a §2.3 record-shape change. ADR-0092 §2.4 is amended in the same PR, but the §2.6 record-shape contract is untouched.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo test --workspace` — green (the documented flaky `workers::tailer::tests::run_blocking_exits_when_shutdown_flag_is_set` failed once under load; passed cleanly in isolation per the established re-run policy).
- [x] `bash scripts/e2e/test_655_release_smoke.sh` — green end-to-end (parser pipeline + analytics + tailer + doctor steps all PASS, including step 20 real-shape Copilot Chat fixture flow).
- [ ] Manual: re-import the three reproducer sessions from the ticket via `budi db import --force` and verify the new attribution per the acceptance table (`bda343f1` → `claude-haiku-4-5-20251001`, `e22dad3b` → `grok-code-fast-1`, `35a2ecbc` → unchanged via §2.4.1 fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)