### PR TITLE
[8.4.2] copilot_chat: emptyWindow cwd hint from result.metadata.renderedUserMessage editorContext

### DIFF
--- a/crates/budi-core/src/analytics/tests.rs
+++ b/crates/budi-core/src/analytics/tests.rs
@@ -76,6 +76,7 @@ fn ingest_and_query() {
             tool_use_ids: Vec::new(),
             tool_files: Vec::new(),
             tool_outcomes: Vec::new(),
+            cwd_source: None,
         },
         ParsedMessage {
             uuid: "a1".to_string(),
@@ -109,6 +110,7 @@ fn ingest_and_query() {
             tool_use_ids: Vec::new(),
             tool_files: Vec::new(),
             tool_outcomes: Vec::new(),
+            cwd_source: None,
         },
     ];
 
@@ -162,6 +164,7 @@ fn rollups_track_message_updates_and_deletes() {
         tool_use_ids: Vec::new(),
         tool_files: Vec::new(),
         tool_outcomes: Vec::new(),
+        cwd_source: None,
     };
     ingest_messages(&mut conn, &[msg], None).unwrap();
 
@@ -220,6 +223,7 @@ fn rollups_are_used_only_for_hour_aligned_ranges() {
         tool_use_ids: Vec::new(),
         tool_files: Vec::new(),
         tool_outcomes: Vec::new(),
+        cwd_source: None,
     };
     ingest_messages(&mut conn, &[msg], None).unwrap();
 
@@ -296,6 +300,7 @@ fn rollup_summary_latency_smoke_on_large_dataset() {
             tool_use_ids: Vec::new(),
             tool_files: Vec::new(),
             tool_outcomes: Vec::new(),
+            cwd_source: None,
         });
     }
     ingest_messages(&mut conn, &messages, None).unwrap();
@@ -351,6 +356,7 @@ fn cost_cents_baked_at_ingest() {
         tool_use_ids: Vec::new(),
         tool_files: Vec::new(),
         tool_outcomes: Vec::new(),
+        cwd_source: None,
     };
     // CostEnricher is the single source of truth for cost_cents
     CostEnricher.enrich(&mut msg);
@@ -429,6 +435,7 @@ fn last_seen_derived_from_messages() {
             tool_use_ids: Vec::new(),
             tool_files: Vec::new(),
             tool_outcomes: Vec::new(),
+            cwd_source: None,
         },
         ParsedMessage {
             uuid: "m2".to_string(),
@@ -462,6 +469,7 @@ fn last_seen_derived_from_messages() {
             tool_use_ids: Vec::new(),
             tool_files: Vec::new(),
             tool_outcomes: Vec::new(),
+            cwd_source: None,
         },
     ];
     ingest_messages(&mut conn, &msgs, None).unwrap();
@@ -512,6 +520,7 @@ fn newest_ingested_data_uses_assistant_rows() {
             tool_use_ids: Vec::new(),
             tool_files: Vec::new(),
             tool_outcomes: Vec::new(),
+            cwd_source: None,
         },
         ParsedMessage {
             uuid: "a-only".to_string(),
@@ -545,6 +554,7 @@ fn newest_ingested_data_uses_assistant_rows() {
             tool_use_ids: Vec::new(),
             tool_files: Vec::new(),
             tool_outcomes: Vec::new(),
+            cwd_source: None,
         },
     ];
     ingest_messages(&mut conn, &msgs, None).unwrap();
@@ -586,6 +596,7 @@ fn sample_messages() -> Vec<ParsedMessage> {
             tool_use_ids: Vec::new(),
             tool_files: Vec::new(),
             tool_outcomes: Vec::new(),
+            cwd_source: None,
         },
         ParsedMessage {
             uuid: "a1".to_string(),
@@ -619,6 +630,7 @@ fn sample_messages() -> Vec<ParsedMessage> {
             tool_use_ids: Vec::new(),
             tool_files: Vec::new(),
             tool_outcomes: Vec::new(),
+            cwd_source: None,
         },
         ParsedMessage {
             uuid: "u2".to_string(),
@@ -652,6 +664,7 @@ fn sample_messages() -> Vec<ParsedMessage> {
             tool_use_ids: Vec::new(),
             tool_files: Vec::new(),
             tool_outcomes: Vec::new(),
+            cwd_source: None,
         },
     ]
 }
@@ -721,6 +734,7 @@ fn mixed_provider_messages() -> Vec<ParsedMessage> {
         tool_use_ids: Vec::new(),
         tool_files: Vec::new(),
         tool_outcomes: Vec::new(),
+        cwd_source: None,
     });
     msgs
 }
@@ -993,6 +1007,7 @@ fn messages_with_cache_patterns() -> Vec<ParsedMessage> {
             tool_use_ids: Vec::new(),
             tool_files: Vec::new(),
             tool_outcomes: Vec::new(),
+            cwd_source: None,
         },
         ParsedMessage {
             uuid: "t2".to_string(),
@@ -1026,6 +1041,7 @@ fn messages_with_cache_patterns() -> Vec<ParsedMessage> {
             tool_use_ids: Vec::new(),
             tool_files: Vec::new(),
             tool_outcomes: Vec::new(),
+            cwd_source: None,
         },
         ParsedMessage {
             uuid: "t3".to_string(),
@@ -1059,6 +1075,7 @@ fn messages_with_cache_patterns() -> Vec<ParsedMessage> {
             tool_use_ids: Vec::new(),
             tool_files: Vec::new(),
             tool_outcomes: Vec::new(),
+            cwd_source: None,
         },
     ]
 }
@@ -1165,6 +1182,7 @@ fn statusline_stats_branch_cost_scopes_to_repo_id() {
         tool_use_ids: Vec::new(),
         tool_files: Vec::new(),
         tool_outcomes: Vec::new(),
+        cwd_source: None,
     };
     let msgs = vec![
         mk("repo-a-1", "sess-a", "github.com/org/repo-a", 300.0),
@@ -1275,6 +1293,7 @@ fn statusline_stats_with_provider_filter_scopes_all_numeric_fields() {
             tool_use_ids: Vec::new(),
             tool_files: Vec::new(),
             tool_outcomes: Vec::new(),
+            cwd_source: None,
         },
         ParsedMessage {
             uuid: "cursor-1".to_string(),
@@ -1308,6 +1327,7 @@ fn statusline_stats_with_provider_filter_scopes_all_numeric_fields() {
             tool_use_ids: Vec::new(),
             tool_files: Vec::new(),
             tool_outcomes: Vec::new(),
+            cwd_source: None,
         },
     ];
     ingest_messages(&mut conn, &msgs, None).unwrap();
@@ -1414,6 +1434,7 @@ fn statusline_stats_aggregates_across_multiple_providers() {
         tool_use_ids: Vec::new(),
         tool_files: Vec::new(),
         tool_outcomes: Vec::new(),
+        cwd_source: None,
     };
 
     let msgs = vec![
@@ -1615,6 +1636,7 @@ fn multi_provider_ingest_and_query() {
             tool_use_ids: Vec::new(),
             tool_files: Vec::new(),
             tool_outcomes: Vec::new(),
+            cwd_source: None,
         },
         ParsedMessage {
             uuid: "cc-a1".to_string(),
@@ -1648,6 +1670,7 @@ fn multi_provider_ingest_and_query() {
             tool_use_ids: Vec::new(),
             tool_files: Vec::new(),
             tool_outcomes: Vec::new(),
+            cwd_source: None,
         },
     ];
 
@@ -1684,6 +1707,7 @@ fn multi_provider_ingest_and_query() {
             tool_use_ids: Vec::new(),
             tool_files: Vec::new(),
             tool_outcomes: Vec::new(),
+            cwd_source: None,
         },
         ParsedMessage {
             uuid: "cu-a1".to_string(),
@@ -1717,6 +1741,7 @@ fn multi_provider_ingest_and_query() {
             tool_use_ids: Vec::new(),
             tool_files: Vec::new(),
             tool_outcomes: Vec::new(),
+            cwd_source: None,
         },
     ];
 
@@ -1796,6 +1821,7 @@ fn cross_parse_dedup_by_request_id() {
         tool_use_ids: Vec::new(),
         tool_files: Vec::new(),
         tool_outcomes: Vec::new(),
+        cwd_source: None,
     };
     ingest_messages(&mut conn, &[intermediate], None).unwrap();
 
@@ -1836,6 +1862,7 @@ fn cross_parse_dedup_by_request_id() {
         tool_use_ids: Vec::new(),
         tool_files: Vec::new(),
         tool_outcomes: Vec::new(),
+        cwd_source: None,
     };
     ingest_messages(&mut conn, &[final_entry], None).unwrap();
 
@@ -1891,6 +1918,7 @@ fn cross_parse_dedup_keeps_higher_output() {
         tool_use_ids: Vec::new(),
         tool_files: Vec::new(),
         tool_outcomes: Vec::new(),
+        cwd_source: None,
     };
     ingest_messages(&mut conn, &[final_entry], None).unwrap();
 
@@ -1926,6 +1954,7 @@ fn cross_parse_dedup_keeps_higher_output() {
         tool_use_ids: Vec::new(),
         tool_files: Vec::new(),
         tool_outcomes: Vec::new(),
+        cwd_source: None,
     };
     ingest_messages(&mut conn, &[intermediate], None).unwrap();
 
@@ -1979,6 +2008,7 @@ fn no_request_id_no_dedup() {
         tool_use_ids: Vec::new(),
         tool_files: Vec::new(),
         tool_outcomes: Vec::new(),
+        cwd_source: None,
     };
     ingest_messages(&mut conn, &[msg1], None).unwrap();
 
@@ -2014,6 +2044,7 @@ fn no_request_id_no_dedup() {
         tool_use_ids: Vec::new(),
         tool_files: Vec::new(),
         tool_outcomes: Vec::new(),
+        cwd_source: None,
     };
     ingest_messages(&mut conn, &[msg2], None).unwrap();
 
@@ -2081,6 +2112,7 @@ fn jsonl_dedup_matches_otel_by_fingerprint_within_window() {
         tool_use_ids: Vec::new(),
         tool_files: Vec::new(),
         tool_outcomes: Vec::new(),
+        cwd_source: None,
     };
     ingest_messages(&mut conn, &[msg], None).unwrap();
 
@@ -2212,6 +2244,7 @@ fn session_cost_curve_buckets() {
             tool_use_ids: Vec::new(),
             tool_files: Vec::new(),
             tool_outcomes: Vec::new(),
+            cwd_source: None,
         });
     }
     ingest_messages(&mut conn, &msgs, None).unwrap();
@@ -2258,6 +2291,7 @@ fn cost_confidence_stats_groups_correctly() {
             tool_use_ids: Vec::new(),
             tool_files: Vec::new(),
             tool_outcomes: Vec::new(),
+            cwd_source: None,
         },
         ParsedMessage {
             uuid: "conf-2".to_string(),
@@ -2291,6 +2325,7 @@ fn cost_confidence_stats_groups_correctly() {
             tool_use_ids: Vec::new(),
             tool_files: Vec::new(),
             tool_outcomes: Vec::new(),
+            cwd_source: None,
         },
     ];
     ingest_messages(&mut conn, &msgs, None).unwrap();
@@ -2339,6 +2374,7 @@ fn subagent_cost_stats_splits_correctly() {
             tool_use_ids: Vec::new(),
             tool_files: Vec::new(),
             tool_outcomes: Vec::new(),
+            cwd_source: None,
         },
         ParsedMessage {
             uuid: "sub-1".to_string(),
@@ -2372,6 +2408,7 @@ fn subagent_cost_stats_splits_correctly() {
             tool_use_ids: Vec::new(),
             tool_files: Vec::new(),
             tool_outcomes: Vec::new(),
+            cwd_source: None,
         },
     ];
     ingest_messages(&mut conn, &msgs, None).unwrap();
@@ -2855,6 +2892,7 @@ fn assistant_msg(uuid: &str, session_id: &str, cost_cents: f64) -> ParsedMessage
         tool_use_ids: Vec::new(),
         tool_files: Vec::new(),
         tool_outcomes: Vec::new(),
+        cwd_source: None,
     }
 }
 
@@ -4243,6 +4281,7 @@ fn health_msg(
         tool_use_ids: Vec::new(),
         tool_files: Vec::new(),
         tool_outcomes: Vec::new(),
+        cwd_source: None,
     }
 }
 
@@ -6230,6 +6269,7 @@ fn provider_msg(uuid: &str, session: &str, provider: &str, cost_cents: f64) -> P
         tool_use_ids: Vec::new(),
         tool_files: Vec::new(),
         tool_outcomes: Vec::new(),
+        cwd_source: None,
     }
 }
 
@@ -6850,6 +6890,7 @@ fn session_prompt_category_tracks_latest_value() {
         tool_use_ids: Vec::new(),
         tool_files: Vec::new(),
         tool_outcomes: Vec::new(),
+        cwd_source: None,
     };
     ingest_messages(&mut conn, &[u1], Some(&[Vec::new()])).unwrap();
 
@@ -6894,6 +6935,7 @@ fn session_prompt_category_tracks_latest_value() {
         tool_use_ids: Vec::new(),
         tool_files: Vec::new(),
         tool_outcomes: Vec::new(),
+        cwd_source: None,
     };
     ingest_messages(&mut conn, &[u2], Some(&[Vec::new()])).unwrap();
 

--- a/crates/budi-core/src/jsonl.rs
+++ b/crates/budi-core/src/jsonl.rs
@@ -206,6 +206,14 @@ pub struct ParsedMessage {
     /// originating assistant message by `tool_use_id` and emits
     /// `tool_outcome` tags there. Added in R1.5 (#293); see ADR-0088 §5.
     pub tool_outcomes: Vec<ToolOutcome>,
+    /// Source label for `cwd` when the cwd was derived from a fallback
+    /// signal rather than the provider's authoritative location. `None`
+    /// means cwd is either absent or came from the authoritative source
+    /// (workspace.json for Copilot Chat, transcript metadata for Claude
+    /// Code, etc.). When set, the pipeline emits a sibling `cwd_source`
+    /// tag via `tag_keys::CWD_SOURCE`. Added in #688 for Copilot Chat
+    /// emptyWindow editor-context hints.
+    pub cwd_source: Option<String>,
 }
 
 /// One provider-reported tool outcome. Content is never stored — we only
@@ -254,6 +262,7 @@ impl Default for ParsedMessage {
             tool_use_ids: Vec::new(),
             tool_files: Vec::new(),
             tool_outcomes: Vec::new(),
+            cwd_source: None,
         }
     }
 }
@@ -543,6 +552,7 @@ fn parse_line(line: &str) -> Option<ParsedMessage> {
                 tool_use_ids: Vec::new(),
                 tool_files: Vec::new(),
                 tool_outcomes,
+                cwd_source: None,
             })
         }
         TranscriptEntry::Assistant(a) => {
@@ -595,6 +605,7 @@ fn parse_line(line: &str) -> Option<ParsedMessage> {
                 tool_use_ids,
                 tool_files,
                 tool_outcomes: Vec::new(),
+                cwd_source: None,
             })
         }
         TranscriptEntry::Other => None,
@@ -660,6 +671,7 @@ fn parse_flat_line(line: &str) -> Option<ParsedMessage> {
                 tool_use_ids,
                 tool_files,
                 tool_outcomes: Vec::new(),
+                cwd_source: None,
             })
         }
         "user" => Some(ParsedMessage {

--- a/crates/budi-core/src/pipeline/enrichers.rs
+++ b/crates/budi-core/src/pipeline/enrichers.rs
@@ -66,6 +66,19 @@ impl Enricher for GitEnricher {
             emit::ticket(&mut tags, &ticket, source);
         }
 
+        // #688: surface non-authoritative cwd provenance. Set by upstream
+        // parsers (e.g. Copilot Chat emptyWindow editor-context fallback)
+        // when `cwd` did not come from the provider's primary workspace
+        // location. Authoritative cwds leave `msg.cwd_source = None` and
+        // produce no tag, keeping the workspace-anchored path of #681
+        // unaffected.
+        if let Some(ref source) = msg.cwd_source {
+            tags.push(Tag {
+                key: tk::CWD_SOURCE.to_string(),
+                value: source.clone(),
+            });
+        }
+
         tags
     }
 }

--- a/crates/budi-core/src/pipeline/mod.rs
+++ b/crates/budi-core/src/pipeline/mod.rs
@@ -935,6 +935,7 @@ mod tests {
             tool_use_ids: Vec::new(),
             tool_files: Vec::new(),
             tool_outcomes: Vec::new(),
+            cwd_source: None,
         }
     }
 

--- a/crates/budi-core/src/providers/codex.rs
+++ b/crates/budi-core/src/providers/codex.rs
@@ -310,6 +310,7 @@ fn parse_token_count(
         tool_use_ids: Vec::new(),
         tool_files: Vec::new(),
         tool_outcomes: Vec::new(),
+        cwd_source: None,
     })
 }
 

--- a/crates/budi-core/src/providers/copilot.rs
+++ b/crates/budi-core/src/providers/copilot.rs
@@ -333,6 +333,7 @@ fn parse_usage_event(
         tool_use_ids: Vec::new(),
         tool_files: Vec::new(),
         tool_outcomes: Vec::new(),
+        cwd_source: None,
     })
 }
 

--- a/crates/budi-core/src/providers/copilot_chat.rs
+++ b/crates/budi-core/src/providers/copilot_chat.rs
@@ -701,15 +701,45 @@ fn parent_dir_from_editor_context_text(text: &str) -> Option<String> {
         return None;
     }
 
-    let p = Path::new(raw_path);
-    if !p.is_absolute() {
+    // The editor-context path is whatever shape VS Code wrote on the user's
+    // machine — POSIX-style on macOS/Linux, drive-letter or UNC on Windows.
+    // `Path::is_absolute()` is platform-conditional (returns false for
+    // `/Users/...` when the test runs on Windows CI), so we recognise the
+    // three shapes explicitly and parse the parent off the literal string
+    // rather than via `Path::parent()`.
+    if !looks_absolute(raw_path) {
         return None;
     }
-    let parent = p.parent()?;
-    if parent.as_os_str().is_empty() {
-        return None;
+    parent_dir_string(raw_path)
+}
+
+/// Cross-platform "looks absolute" check that mirrors what VS Code may
+/// write into `<editorContext>` regardless of which OS this code runs
+/// on:
+///
+/// - POSIX: leading `/`.
+/// - Windows UNC: leading `\\`.
+/// - Windows drive: `<letter>:` followed by `\` or `/`.
+fn looks_absolute(s: &str) -> bool {
+    if s.starts_with('/') || s.starts_with("\\\\") {
+        return true;
     }
-    Some(parent.to_string_lossy().into_owned())
+    let bytes = s.as_bytes();
+    bytes.len() >= 3
+        && bytes[0].is_ascii_alphabetic()
+        && bytes[1] == b':'
+        && (bytes[2] == b'\\' || bytes[2] == b'/')
+}
+
+/// Parent-directory of an absolute path string, splitting on the last
+/// `/` or `\` so the result is identical regardless of the host
+/// platform. Returns `"/"` for a root-level file like `"/foo"`.
+fn parent_dir_string(path: &str) -> Option<String> {
+    let last = path.rfind(|c: char| c == '/' || c == '\\')?;
+    if last == 0 {
+        return Some("/".to_string());
+    }
+    Some(path[..last].to_string())
 }
 
 fn parse_jsonl(path: &Path, content: &str, start_offset: usize) -> (Vec<ParsedMessage>, usize) {

--- a/crates/budi-core/src/providers/copilot_chat.rs
+++ b/crates/budi-core/src/providers/copilot_chat.rs
@@ -735,7 +735,7 @@ fn looks_absolute(s: &str) -> bool {
 /// `/` or `\` so the result is identical regardless of the host
 /// platform. Returns `"/"` for a root-level file like `"/foo"`.
 fn parent_dir_string(path: &str) -> Option<String> {
-    let last = path.rfind(|c: char| c == '/' || c == '\\')?;
+    let last = path.rfind(['/', '\\'])?;
     if last == 0 {
         return Some("/".to_string());
     }

--- a/crates/budi-core/src/providers/copilot_chat.rs
+++ b/crates/budi-core/src/providers/copilot_chat.rs
@@ -595,14 +595,121 @@ fn git_branch_for_cwd(cwd: &str) -> Option<String> {
 struct SessionEnrichment {
     cwd: Option<String>,
     git_branch: Option<String>,
+    /// Provenance label for `cwd` when it came from a fallback signal
+    /// rather than the authoritative `workspace.json`. `Some` only for
+    /// the emptyWindow editor-context hint path (#688). Workspace-anchored
+    /// cwds and absent cwds both leave this `None`.
+    cwd_source: Option<&'static str>,
 }
 
 impl SessionEnrichment {
     fn for_path(session_path: &Path) -> Self {
         let cwd = workspace_cwd_for_session_path(session_path);
         let git_branch = cwd.as_deref().and_then(git_branch_for_cwd);
-        Self { cwd, git_branch }
+        Self {
+            cwd,
+            git_branch,
+            cwd_source: None,
+        }
     }
+}
+
+/// `result.metadata.renderedUserMessage` `cwd_source` label for the
+/// emptyWindow editor-context hint path (#688). Mirrors the constant
+/// shape `<provider>:<signal>` used elsewhere in the analytics
+/// vocabulary.
+const CWD_SOURCE_EDITOR_CONTEXT_HINT: &str = "copilot_chat:editor_context_hint";
+
+/// True iff the session lives under `globalStorage/emptyWindowChatSessions/`.
+/// `workspace_cwd_for_session_path` already short-circuits this case to
+/// `None`, but the editor-context hint fallback only applies *here* —
+/// workspace-anchored sessions with a transiently-missing `workspace.json`
+/// must not silently drift onto the hint path.
+fn is_empty_window_session_path(session_path: &Path) -> bool {
+    session_path.ancestors().any(|a| {
+        a.file_name()
+            .and_then(|s| s.to_str())
+            .is_some_and(|n| n.eq_ignore_ascii_case("emptyWindowChatSessions"))
+    })
+}
+
+/// Scan the materialized session state's `requests[*].result.metadata
+/// .renderedUserMessage[*].text` for the first `<editorContext>` block
+/// and return its `parent` directory as a cwd hint. The block's
+/// canonical shape (#688):
+///
+/// ```text
+/// <editorContext>
+/// The user's current file is /Users/.../foo.md. The current selection is from line 9 to line 9.
+/// </editorContext>
+/// ```
+///
+/// Only absolute paths are accepted — relative paths cannot be resolved
+/// without a workspace root and we have none in the emptyWindow case.
+/// Returns the `parent()` of the file, not the file itself: the cwd
+/// dimension is "what folder were they in", not "what file did they
+/// have open".
+fn editor_context_cwd_hint_from_state(state: &serde_json::Value) -> Option<String> {
+    let requests = state.get("requests").and_then(|v| v.as_array())?;
+    for request in requests {
+        let arr = request
+            .pointer("/result/metadata/renderedUserMessage")
+            .and_then(|v| v.as_array());
+        let Some(arr) = arr else {
+            continue;
+        };
+        for item in arr {
+            let Some(text) = item.get("text").and_then(|v| v.as_str()) else {
+                continue;
+            };
+            if let Some(parent) = parent_dir_from_editor_context_text(text) {
+                return Some(parent);
+            }
+        }
+    }
+    None
+}
+
+/// Extract the parent directory of `<editorContext>`'s "current file"
+/// path from a single `renderedUserMessage` text. Returns `None` if no
+/// `<editorContext>` block is present, no path was extractable, or the
+/// path was not absolute.
+fn parent_dir_from_editor_context_text(text: &str) -> Option<String> {
+    const OPEN: &str = "<editorContext>";
+    const CLOSE: &str = "</editorContext>";
+    const PREFIX: &str = "The user's current file is ";
+
+    let open_at = text.find(OPEN)?;
+    let after_open = &text[open_at + OPEN.len()..];
+    let block_end = after_open.find(CLOSE).unwrap_or(after_open.len());
+    let block = &after_open[..block_end];
+
+    let p_start = block.find(PREFIX)?;
+    let after_prefix = &block[p_start + PREFIX.len()..];
+
+    // The path runs to the next sentence terminator (`. ` followed by a
+    // capitalised word, in practice "The current selection is...") or to
+    // the end of the block. Splitting on `". "` is more robust than a
+    // bare `.` because absolute file paths legitimately contain `.`s
+    // (extensions, dotted user-dirs like `ivan.seredkin`).
+    let raw_path = match after_prefix.find(". ") {
+        Some(end) => &after_prefix[..end],
+        None => after_prefix.trim_end_matches('.').trim_end(),
+    };
+    let raw_path = raw_path.trim();
+    if raw_path.is_empty() {
+        return None;
+    }
+
+    let p = Path::new(raw_path);
+    if !p.is_absolute() {
+        return None;
+    }
+    let parent = p.parent()?;
+    if parent.as_os_str().is_empty() {
+        return None;
+    }
+    Some(parent.to_string_lossy().into_owned())
 }
 
 fn parse_jsonl(path: &Path, content: &str, start_offset: usize) -> (Vec<ParsedMessage>, usize) {
@@ -641,7 +748,14 @@ fn parse_jsonl(path: &Path, content: &str, start_offset: usize) -> (Vec<ParsedMe
     // every emitted row — `parse_jsonl` corresponds 1:1 to a session, so
     // re-reading `workspace.json` per emit would be wasteful (per #681
     // "cwd should be cached per session").
-    let enrichment = SessionEnrichment::for_path(path);
+    let mut enrichment = SessionEnrichment::for_path(path);
+    // #688: emptyWindow sessions have no `workspace.json`. Defer the
+    // editor-context hint scan until after the mutation log has been
+    // replayed below — the hint reads off `result.metadata
+    // .renderedUserMessage[]`, which only materialises once kind:0/1/2
+    // patches are applied to `state`. We back-fill emitted rows after
+    // the loop rather than racing emit order against patch order.
+    let is_empty_window = is_empty_window_session_path(path);
     let mut session_default_model: Option<String> = None;
     let mut messages = Vec::new();
     // Tracks emit keys (typically `requestId`) so a request that
@@ -746,6 +860,38 @@ fn parse_jsonl(path: &Path, content: &str, start_offset: usize) -> (Vec<ParsedMe
                 } else {
                     messages.extend(rows);
                 }
+            }
+        }
+    }
+
+    // #688: emptyWindow editor-context cwd hint back-fill.
+    //
+    // Workspace-anchored sessions are already fully enriched via
+    // `workspace.json`; this fallback only applies to
+    // `globalStorage/emptyWindowChatSessions/*` where there is no
+    // workspace. We scan the *materialised* `state.requests[*].result
+    // .metadata.renderedUserMessage[*].text` for the first
+    // `<editorContext>` block and surface its file's parent directory as
+    // a hint cwd, tagging every row with `cwd_source =
+    // copilot_chat:editor_context_hint` so analytics can distinguish hint
+    // cwds from authoritative ones.
+    if is_empty_window
+        && enrichment.cwd.is_none()
+        && let Some(hint_cwd) = editor_context_cwd_hint_from_state(&state)
+    {
+        let hint_branch = git_branch_for_cwd(&hint_cwd);
+        enrichment.cwd = Some(hint_cwd.clone());
+        enrichment.git_branch = hint_branch.clone();
+        enrichment.cwd_source = Some(CWD_SOURCE_EDITOR_CONTEXT_HINT);
+        for msg in &mut messages {
+            if msg.cwd.is_none() {
+                msg.cwd = Some(hint_cwd.clone());
+            }
+            if msg.git_branch.is_none() {
+                msg.git_branch.clone_from(&hint_branch);
+            }
+            if msg.cwd_source.is_none() {
+                msg.cwd_source = Some(CWD_SOURCE_EDITOR_CONTEXT_HINT.to_string());
             }
         }
     }
@@ -1043,6 +1189,7 @@ fn build_messages_for_request(
             tool_use_ids: Vec::new(),
             tool_files: Vec::new(),
             tool_outcomes: Vec::new(),
+            cwd_source: enrichment.cwd_source.map(str::to_string),
         }
     });
 
@@ -1083,6 +1230,7 @@ fn build_messages_for_request(
         tool_use_ids: tool_data.ids,
         tool_files: tool_data.files,
         tool_outcomes: Vec::new(),
+        cwd_source: enrichment.cwd_source.map(str::to_string),
     });
 
     rows
@@ -1260,6 +1408,7 @@ fn build_message(
             tool_use_ids: Vec::new(),
             tool_files: Vec::new(),
             tool_outcomes: Vec::new(),
+            cwd_source: enrichment.cwd_source.map(str::to_string),
         }
     });
 
@@ -1300,6 +1449,7 @@ fn build_message(
         tool_use_ids: tool_data.ids,
         tool_files: tool_data.files,
         tool_outcomes: Vec::new(),
+        cwd_source: enrichment.cwd_source.map(str::to_string),
     });
 
     rows
@@ -3465,6 +3615,204 @@ mod tests {
              workspace.json (got: {:?})",
             msgs.iter().map(|m| m.cwd.as_deref()).collect::<Vec<_>>()
         );
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    // ---- #688: emptyWindow editor-context cwd hint -------------------
+
+    /// Pure-text extractor: the canonical sentence shape from
+    /// `result.metadata.renderedUserMessage[*].text` resolves to the
+    /// file's parent directory. Pins the format documented on #688.
+    #[test]
+    fn editor_context_text_extracts_parent_dir() {
+        let body = "<editorContext>\n\
+                    The user's current file is /Users/ivan.seredkin/Desktop/CP4X-GQMY-GH9C.md. \
+                    The current selection is from line 9 to line 9.\n\
+                    </editorContext>";
+        assert_eq!(
+            parent_dir_from_editor_context_text(body).as_deref(),
+            Some("/Users/ivan.seredkin/Desktop")
+        );
+    }
+
+    /// Path with spaces — the parent dir is preserved verbatim. The
+    /// editor-context block carries a literal local path, not a URI, so
+    /// no percent-decoding is needed (unlike the workspace.json `folder`
+    /// field which does require it).
+    #[test]
+    fn editor_context_text_handles_spaces_and_dots() {
+        let body = "<editorContext>\n\
+                    The user's current file is /Users/me/My Project/src/file.v2.rs. \
+                    The current selection is from line 1 to line 1.\n\
+                    </editorContext>";
+        assert_eq!(
+            parent_dir_from_editor_context_text(body).as_deref(),
+            Some("/Users/me/My Project/src")
+        );
+    }
+
+    /// Relative path — skipped. We have no workspace root in the
+    /// emptyWindow case, so a relative path cannot be turned into a
+    /// concrete cwd hint.
+    #[test]
+    fn editor_context_text_rejects_relative_path() {
+        let body = "<editorContext>\n\
+                    The user's current file is src/main.rs. \
+                    The current selection is from line 1 to line 1.\n\
+                    </editorContext>";
+        assert!(parent_dir_from_editor_context_text(body).is_none());
+    }
+
+    /// No `<editorContext>` block — None. Sessions sent before editor
+    /// focus is established legitimately omit the block.
+    #[test]
+    fn editor_context_text_absent_returns_none() {
+        let body = "<workspace_info>There is no workspace currently open.</workspace_info>";
+        assert!(parent_dir_from_editor_context_text(body).is_none());
+    }
+
+    /// End-to-end: an emptyWindow session whose first request carries an
+    /// `<editorContext>` block in `result.metadata.renderedUserMessage`
+    /// emits rows with `cwd` populated from the file's parent dir and a
+    /// `cwd_source = copilot_chat:editor_context_hint` marker so
+    /// downstream analytics can distinguish the hint from an
+    /// authoritative `workspace.json` cwd.
+    #[test]
+    fn empty_window_session_uses_editor_context_hint() {
+        let tmp = std::env::temp_dir().join("budi-copilot-chat-empty-window-hint");
+        let _ = std::fs::remove_dir_all(&tmp);
+        let empty_dir =
+            tmp.join("Library/Application Support/Code/User/globalStorage/emptyWindowChatSessions");
+        std::fs::create_dir_all(&empty_dir).unwrap();
+        let session_path = empty_dir.join("bda343f1.jsonl");
+
+        // Synthetic but shape-faithful kind:0 snapshot — one request with
+        // tokens (so it emits) and an editorContext-bearing
+        // renderedUserMessage entry.
+        let line = serde_json::json!({
+            "kind": 0,
+            "v": {
+                "sessionId": "empty-1",
+                "requests": [{
+                    "requestId": "r-1",
+                    "modelId": "copilot/gpt-4.1",
+                    "timestamp": 1715000000000_u64,
+                    "message": {"text": "summarise this file"},
+                    "result": {
+                        "metadata": {
+                            "promptTokens": 10,
+                            "outputTokens": 5,
+                            "renderedUserMessage": [{
+                                "text": "<editorContext>\nThe user's current file is /Users/ivan.seredkin/Desktop/CP4X-GQMY-GH9C.md. The current selection is from line 9 to line 9.\n</editorContext>\n<workspace_info>\nThere is no workspace currently open.\n</workspace_info>"
+                            }]
+                        }
+                    }
+                }]
+            }
+        })
+        .to_string();
+        std::fs::write(&session_path, format!("{line}\n")).unwrap();
+
+        let (msgs, _) = parse_copilot_chat(&session_path, &format!("{line}\n"), 0);
+        assert!(
+            !msgs.is_empty(),
+            "session must emit at least the assistant row"
+        );
+        for msg in &msgs {
+            assert_eq!(
+                msg.cwd.as_deref(),
+                Some("/Users/ivan.seredkin/Desktop"),
+                "every row carries the editor-context hint cwd (got role={:?}, cwd={:?})",
+                msg.role,
+                msg.cwd
+            );
+            assert_eq!(
+                msg.cwd_source.as_deref(),
+                Some(CWD_SOURCE_EDITOR_CONTEXT_HINT),
+                "every row carries the hint cwd_source marker"
+            );
+        }
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    /// Workspace-anchored sessions are unaffected: when `workspace.json`
+    /// resolves the cwd, the editor-context hint must NOT override it
+    /// and `cwd_source` stays `None` so analytics see the row as
+    /// authoritative. Pins the "primary path of #681 is unaffected"
+    /// acceptance criterion.
+    #[test]
+    fn workspace_anchored_session_does_not_apply_editor_context_hint() {
+        let tmp = std::env::temp_dir().join("budi-copilot-chat-ws-anchored-no-hint");
+        let _ = std::fs::remove_dir_all(&tmp);
+        let hash_dir = tmp.join("workspaceStorage/abc-hash");
+        let chat_dir = hash_dir.join("chatSessions");
+        std::fs::create_dir_all(&chat_dir).unwrap();
+        std::fs::write(
+            hash_dir.join("workspace.json"),
+            r#"{"folder":"file:///Users/me/repos/proj"}"#,
+        )
+        .unwrap();
+        let session_path = chat_dir.join("sess.jsonl");
+
+        // Even though the renderedUserMessage carries an editorContext
+        // block pointing somewhere else, the workspace.json folder wins
+        // and cwd_source stays None.
+        let line = serde_json::json!({
+            "kind": 0,
+            "v": {
+                "sessionId": "ws-1",
+                "requests": [{
+                    "requestId": "r-1",
+                    "modelId": "copilot/gpt-4.1",
+                    "timestamp": 1715000000000_u64,
+                    "result": {
+                        "metadata": {
+                            "promptTokens": 10,
+                            "outputTokens": 5,
+                            "renderedUserMessage": [{
+                                "text": "<editorContext>\nThe user's current file is /Users/ivan.seredkin/Desktop/foo.md. The current selection is from line 1 to line 1.\n</editorContext>"
+                            }]
+                        }
+                    }
+                }]
+            }
+        })
+        .to_string();
+        std::fs::write(&session_path, format!("{line}\n")).unwrap();
+
+        let (msgs, _) = parse_copilot_chat(&session_path, &format!("{line}\n"), 0);
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].cwd.as_deref(), Some("/Users/me/repos/proj"));
+        assert!(
+            msgs[0].cwd_source.is_none(),
+            "workspace-anchored cwd is authoritative; cwd_source must stay None"
+        );
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    /// emptyWindow session with no `<editorContext>` block in any
+    /// renderedUserMessage — cwd stays None and cwd_source stays None
+    /// (no spurious hint). Mirrors the existing #681 emptyWindow test
+    /// but goes further by also asserting the new tag.
+    #[test]
+    fn empty_window_session_without_editor_context_leaves_cwd_none() {
+        let tmp = std::env::temp_dir().join("budi-copilot-chat-empty-window-no-hint");
+        let _ = std::fs::remove_dir_all(&tmp);
+        let empty_dir =
+            tmp.join("Library/Application Support/Code/User/globalStorage/emptyWindowChatSessions");
+        std::fs::create_dir_all(&empty_dir).unwrap();
+        let session_path = empty_dir.join("e22dad3b.jsonl");
+
+        let line = r#"{"kind":2,"v":[{"requestId":"r-1","modelId":"copilot/gpt-4.1","completionTokens":42,"result":{"metadata":{"resolvedModel":"x"}}}]}"#;
+        std::fs::write(&session_path, format!("{line}\n")).unwrap();
+
+        let (msgs, _) = parse_copilot_chat(&session_path, &format!("{line}\n"), 0);
+        assert_eq!(msgs.len(), 1);
+        assert!(msgs[0].cwd.is_none());
+        assert!(msgs[0].cwd_source.is_none());
 
         let _ = std::fs::remove_dir_all(&tmp);
     }

--- a/crates/budi-core/src/providers/cursor.rs
+++ b/crates/budi-core/src/providers/cursor.rs
@@ -1069,6 +1069,7 @@ fn usage_events_to_messages(
                 tool_use_ids: Vec::new(),
                 tool_files: Vec::new(),
                 tool_outcomes: Vec::new(),
+                cwd_source: None,
             }
         })
         .collect()
@@ -1492,6 +1493,7 @@ fn bubble_to_parsed_message(
             tool_use_ids: Vec::new(),
             tool_files: Vec::new(),
             tool_outcomes: Vec::new(),
+            cwd_source: None,
         })
     } else {
         let resolved_model = match row.model.as_deref().map(str::trim) {
@@ -1539,6 +1541,7 @@ fn bubble_to_parsed_message(
             tool_use_ids: Vec::new(),
             tool_files: Vec::new(),
             tool_outcomes: Vec::new(),
+            cwd_source: None,
         })
     }
 }
@@ -2180,6 +2183,7 @@ fn parse_cursor_line(
                 tool_use_ids: Vec::new(),
                 tool_files: Vec::new(),
                 tool_outcomes: Vec::new(),
+                cwd_source: None,
             })
         }
         "assistant" | "ai" | "model" => {
@@ -2216,6 +2220,7 @@ fn parse_cursor_line(
                 tool_use_ids: Vec::new(),
                 tool_files,
                 tool_outcomes: Vec::new(),
+                cwd_source: None,
             })
         }
         _ => None,

--- a/crates/budi-core/src/tag_keys.rs
+++ b/crates/budi-core/src/tag_keys.rs
@@ -93,6 +93,19 @@ pub const FILE_PATH_SOURCE: &str = "file_path_source";
 /// per message.
 pub const FILE_PATH_CONFIDENCE: &str = "file_path_confidence";
 
+/// Source of a non-authoritative cwd. Emitted only when the cwd was
+/// derived from a fallback signal rather than the primary
+/// workspace-anchored path. Stable values:
+/// - `copilot_chat:editor_context_hint` — Copilot Chat emptyWindow
+///   session whose cwd was derived from the user's currently-open file
+///   in `result.metadata.renderedUserMessage[*].text`'s `<editorContext>`
+///   block (#688).
+///
+/// Absent when cwd came from the authoritative source for the provider
+/// (e.g. workspace.json for Copilot Chat). Lets analytics distinguish
+/// authoritative cwds from hint cwds.
+pub const CWD_SOURCE: &str = "cwd_source";
+
 /// Identity tags: constant for the entire session, deduplicated to one
 /// assistant message per session.
 pub const SESSION_IDENTITY_KEYS: &[&str] = &[


### PR DESCRIPTION
Closes #688.

Extension of #681. When `workspace.json` returns no folder *and* the session lives under `globalStorage/emptyWindowChatSessions/`, scan the materialized `result.metadata.renderedUserMessage[*].text` for the first `<editorContext>` block, take the user's current file's parent as a cwd hint, and tag every emitted row with `cwd_source = copilot_chat:editor_context_hint`. emptyWindow Copilot Chat traffic now flows through `budi stats projects --include-non-repo` as a per-folder bucket instead of staying fully cwd-less.

## What's in

- New `parent_dir_from_editor_context_text` extractor — splits on `". "` so dotted user-dirs (`/Users/ivan.seredkin/...`) and dotted filenames (`*.md`, `*.v2.rs`) round-trip cleanly.
- New `is_empty_window_session_path` guard so the hint *only* applies under `globalStorage/emptyWindowChatSessions/` — workspace-anchored sessions with a transiently-missing `workspace.json` are not silently rerouted onto the hint path.
- `SessionEnrichment` gains a `cwd_source: Option<&'static str>` field, plumbed into both `build_messages_for_request` (kind:0/1/2 reducer path) and `build_message` (flat-line back-compat).
- Late-stage back-fill at the end of `parse_jsonl`: once the mutation log has been replayed, walk the final `state.requests[*].result.metadata.renderedUserMessage[*].text`, find the first `<editorContext>` block, derive the cwd, and back-fill any rows already emitted with no cwd. The hint also feeds `git_branch_for_cwd` (which correctly returns `None` for non-repo dirs like `~/Desktop`).
- New `CWD_SOURCE` tag key + `GitEnricher` emits a `cwd_source` tag whenever `msg.cwd_source` is `Some`. Authoritative cwds leave it `None` and produce no tag, so #681's primary path is unaffected.
- New `cwd_source: Option<String>` column on `ParsedMessage` plus the matching `cwd_source: None` defaults wired through every existing `ParsedMessage` literal (codex, copilot, copilot_chat, cursor, claude_code, pipeline tests, analytics tests).

## What's not in

- No bump of `MIN_API_VERSION`. ADR-0092 §2.6 not amended — this PR consumes existing `result.metadata.renderedUserMessage` shape, no envelope change.
- No git/repo enrichment for the hint cwd beyond `git_branch_for_cwd`. By design: the editor-context cwd is typically `~/Desktop`, not a checkout, so the existing repo-id resolver correctly returns `None`. We do not try to compensate.

## What's deferred

- Sourcing editor context from anywhere other than `result.metadata.renderedUserMessage[]` (per ticket out-of-scope).
- Recovering `repo_id` / `git_branch` for emptyWindow sessions when there's no repo at the hint cwd.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo test --workspace` — green except for two known-flaky tailer tests (`run_blocking_exits_when_shutdown_flag_is_set`, `run_blocking_recovers_when_watch_root_materializes_post_boot`); both pass clean in isolation, matching the documented load-sensitivity.
- [x] `cargo test --package budi-core copilot_chat::` — 80 passed (5 new: `editor_context_text_extracts_parent_dir`, `editor_context_text_handles_spaces_and_dots`, `editor_context_text_rejects_relative_path`, `editor_context_text_absent_returns_none`, `empty_window_session_uses_editor_context_hint`, `workspace_anchored_session_does_not_apply_editor_context_hint`, `empty_window_session_without_editor_context_leaves_cwd_none`).
- [x] `bash scripts/e2e/test_655_release_smoke.sh` — green; all 22 steps pass, including step 20 (#681 cwd / repo_id / git_branch enrichment) which exercises the workspace-anchored path this change must not regress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)