### PR TITLE
[8.4.2] statusline: `message` slot avg should be session_cost / user-prompt count, not / every assistant row

### DIFF
--- a/crates/budi-cli/src/commands/statusline.rs
+++ b/crates/budi-cli/src/commands/statusline.rs
@@ -892,6 +892,26 @@ mod tests {
     }
 
     #[test]
+    fn build_slot_values_message_matches_session_cost_for_single_user_turn_with_fanout() {
+        // #691: a session with one user prompt that fanned out into multiple
+        // assistant calls should render `message` ≈ `session` because the
+        // user-typed prompt count (1) is the denominator. Pre-#691 the
+        // denominator was every assistant row (3 here) and the slot read low.
+        // The daemon emits session_msg_cost in cents (=$6.23 * 100 / 1 prompt
+        // = 623 cents); the slot divides by 100 for dollars.
+        let data = json!({
+            "cost_1d": 10.0,
+            "cost_7d": 50.0,
+            "cost_30d": 200.0,
+            "session_cost": 6.23,
+            "session_msg_cost": 623.0,
+        });
+        let vals = build_slot_values(&data);
+        assert_eq!(vals.get("session").unwrap(), "$6.23");
+        assert_eq!(vals.get("message").unwrap(), "$6.23");
+    }
+
+    #[test]
     fn build_slot_values_message_absent_without_session_msg_cost() {
         let data = json!({
             "cost_1d": 1.0,

--- a/crates/budi-core/src/analytics/health.rs
+++ b/crates/budi-core/src/analytics/health.rs
@@ -84,6 +84,14 @@ pub const STATE_INSUFFICIENT_DATA: &str = "insufficient_data";
 pub struct SessionHealth {
     pub state: String,
     pub message_count: u64,
+    /// Denominator the statusline `message` slot divides session cost by
+    /// (#691). Counts user-typed prompts so subagent fan-out and unpriced
+    /// rows don't deflate the per-message average. For providers that don't
+    /// yet capture user rows (copilot_chat pre-#686 sessions), falls back to
+    /// `COUNT(DISTINCT request_id WHERE role='assistant' AND cost_cents > 0)`
+    /// so the slot still reads sensibly.
+    #[serde(default)]
+    pub user_prompt_count: u64,
     pub total_cost_cents: f64,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cost_lag_hint: Option<String>,
@@ -186,6 +194,7 @@ pub fn session_health(conn: &Connection, session_id: Option<&str>) -> Result<Ses
                     return Ok(SessionHealth {
                         state: "green".to_string(),
                         message_count: 0,
+                        user_prompt_count: 0,
                         total_cost_cents: 0.0,
                         cost_lag_hint: None,
                         vitals: SessionVitals {
@@ -215,6 +224,7 @@ pub fn session_health(conn: &Connection, session_id: Option<&str>) -> Result<Ses
     let messages = session_messages(conn, &sid)?;
     let msg_count = messages.len() as u64;
     let total_cost: f64 = messages.iter().map(|m| m.cost_cents).sum();
+    let user_prompt_count = compute_user_prompt_count(conn, &sid, &provider_str)?;
     let metrics = messages
         .iter()
         .map(|m| HealthMessage {
@@ -276,6 +286,7 @@ pub fn session_health(conn: &Connection, session_id: Option<&str>) -> Result<Ses
     Ok(SessionHealth {
         state: overall_state,
         message_count: msg_count,
+        user_prompt_count,
         total_cost_cents: total_cost,
         cost_lag_hint,
         vitals,
@@ -1008,4 +1019,43 @@ fn load_tool_events(
     _session_ids: &[&str],
 ) -> Result<HashMap<String, Vec<SessionToolEvent>>> {
     Ok(HashMap::new())
+}
+
+/// Denominator for the statusline `message` slot (#691).
+///
+/// Default path counts `role='user'` rows so a single user prompt fanning
+/// out into N subagents stays at `1`, and zero-cost assistant rows from
+/// unpriced models don't dilute the average.
+///
+/// Fallback: `copilot_chat` shipped user-row capture in #686, but pre-#686
+/// sessions still on disk don't have any user rows. For that provider only,
+/// when no user rows exist, count distinct priced assistant requests so the
+/// slot still renders something sensible. Once those legacy sessions age
+/// out, the fallback is silently inert because the user-row path wins.
+fn compute_user_prompt_count(conn: &Connection, sid: &str, provider: &str) -> Result<u64> {
+    let user_count: u64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM messages WHERE session_id = ?1 AND role = 'user'",
+            params![sid],
+            |r| r.get(0),
+        )
+        .context("Failed to count user-role messages for session")?;
+    if user_count > 0 {
+        return Ok(user_count);
+    }
+    if provider == "copilot_chat" {
+        let priced_requests: u64 = conn
+            .query_row(
+                "SELECT COUNT(DISTINCT request_id) FROM messages
+                 WHERE session_id = ?1
+                   AND role = 'assistant'
+                   AND request_id IS NOT NULL
+                   AND COALESCE(cost_cents, 0.0) > 0.0",
+                params![sid],
+                |r| r.get(0),
+            )
+            .context("Failed to count priced copilot_chat requests for session")?;
+        return Ok(priced_requests);
+    }
+    Ok(0)
 }

--- a/crates/budi-core/src/analytics/queries.rs
+++ b/crates/budi-core/src/analytics/queries.rs
@@ -3539,8 +3539,14 @@ pub fn statusline_stats(
         .as_ref()
         .and_then(|sid| super::health::session_health(conn, Some(sid)).ok())
         .map(|h| {
-            let avg = if h.message_count > 0 {
-                Some(h.total_cost_cents / h.message_count as f64)
+            // #691: average is session_cost / user-typed prompts. Subagent
+            // fan-outs only emit assistant rows so a multi-call turn stays at
+            // 1, and zero-cost unpriced rows contribute 0 to the numerator
+            // without inflating the denominator. `user_prompt_count` carries
+            // the copilot_chat fallback for sessions with no captured user
+            // rows (see `compute_user_prompt_count`).
+            let avg = if h.user_prompt_count > 0 {
+                Some(h.total_cost_cents / h.user_prompt_count as f64)
             } else {
                 None
             };

--- a/crates/budi-core/src/analytics/tests.rs
+++ b/crates/budi-core/src/analytics/tests.rs
@@ -5382,6 +5382,192 @@ fn health_cursor_multi_reply_session_not_false_red() {
     );
 }
 
+// --- #691: session_msg_cost denominator = user-prompt count -----------------
+
+fn user_prompt_msg(uuid: &str, session_id: &str, idx: u64, provider: &str) -> ParsedMessage {
+    let ts = chrono::NaiveDateTime::parse_from_str(
+        &format!("2026-03-14 10:{idx:02}:00"),
+        "%Y-%m-%d %H:%M:%S",
+    )
+    .unwrap()
+    .and_utc();
+    ParsedMessage {
+        uuid: uuid.to_string(),
+        session_id: Some(session_id.to_string()),
+        timestamp: ts,
+        role: "user".to_string(),
+        provider: provider.to_string(),
+        cost_cents: None,
+        cost_confidence: "exact".to_string(),
+        ..Default::default()
+    }
+}
+
+fn assistant_msg_with_request(
+    uuid: &str,
+    session_id: &str,
+    idx: u64,
+    provider: &str,
+    request_id: Option<&str>,
+    cost: f64,
+) -> ParsedMessage {
+    let mut m = health_msg(uuid, session_id, idx, 100, 900, cost);
+    m.provider = provider.to_string();
+    m.request_id = request_id.map(|s| s.to_string());
+    m
+}
+
+#[test]
+fn health_user_prompt_count_single_turn() {
+    // One user + one assistant → denominator stays at 1, avg == session_cost.
+    let mut conn = test_db();
+    conn.execute(
+        "INSERT INTO sessions (id, provider, started_at) VALUES ('s1', 'claude_code', '2026-03-14')",
+        [],
+    ).unwrap();
+
+    let msgs = vec![
+        user_prompt_msg("u1", "s1", 0, "claude_code"),
+        assistant_msg_with_request("a1", "s1", 1, "claude_code", Some("req-1"), 7.5),
+    ];
+    ingest_messages(&mut conn, &msgs, None).unwrap();
+
+    let h = session_health(&conn, Some("s1")).unwrap();
+    assert_eq!(h.user_prompt_count, 1);
+    assert_eq!(h.total_cost_cents, 7.5);
+    let avg = h.total_cost_cents / h.user_prompt_count as f64;
+    assert!((avg - 7.5).abs() < f64::EPSILON);
+}
+
+#[test]
+fn health_user_prompt_count_subagent_fanout_stays_one() {
+    // One user prompt → main assistant + 2 subagent assistants. Denominator
+    // must still be 1 even though dedup-by-request_id keeps three rows.
+    let mut conn = test_db();
+    conn.execute(
+        "INSERT INTO sessions (id, provider, started_at) VALUES ('s1', 'claude_code', '2026-03-14')",
+        [],
+    ).unwrap();
+
+    let msgs = vec![
+        user_prompt_msg("u1", "s1", 0, "claude_code"),
+        assistant_msg_with_request("a-main", "s1", 1, "claude_code", Some("req-main"), 4.0),
+        assistant_msg_with_request("a-sub-1", "s1", 2, "claude_code", Some("req-sub-1"), 3.0),
+        assistant_msg_with_request("a-sub-2", "s1", 3, "claude_code", Some("req-sub-2"), 5.0),
+    ];
+    ingest_messages(&mut conn, &msgs, None).unwrap();
+
+    let h = session_health(&conn, Some("s1")).unwrap();
+    assert_eq!(h.user_prompt_count, 1);
+    assert_eq!(h.total_cost_cents, 12.0);
+    let avg = h.total_cost_cents / h.user_prompt_count as f64;
+    assert!((avg - 12.0).abs() < f64::EPSILON);
+}
+
+#[test]
+fn health_user_prompt_count_zero_cost_assistant_does_not_inflate_denominator() {
+    // 2 user prompts + 2 assistants where one is unpriced (cost_cents = 0).
+    // Denominator = 2 (user count, untouched by zero-cost row), numerator =
+    // sum of priced rows only → avg = session_cost / 2.
+    let mut conn = test_db();
+    conn.execute(
+        "INSERT INTO sessions (id, provider, started_at) VALUES ('s1', 'claude_code', '2026-03-14')",
+        [],
+    ).unwrap();
+
+    let msgs = vec![
+        user_prompt_msg("u1", "s1", 0, "claude_code"),
+        assistant_msg_with_request("a1", "s1", 1, "claude_code", Some("req-1"), 6.0),
+        user_prompt_msg("u2", "s1", 2, "claude_code"),
+        assistant_msg_with_request("a2", "s1", 3, "claude_code", Some("req-2"), 0.0),
+    ];
+    ingest_messages(&mut conn, &msgs, None).unwrap();
+
+    let h = session_health(&conn, Some("s1")).unwrap();
+    assert_eq!(h.user_prompt_count, 2);
+    assert_eq!(h.total_cost_cents, 6.0);
+    let avg = h.total_cost_cents / h.user_prompt_count as f64;
+    assert!((avg - 3.0).abs() < f64::EPSILON);
+}
+
+#[test]
+fn health_user_prompt_count_empty_user_returns_zero_for_priced_provider() {
+    // Provider that captures user rows but the session has none yet (e.g.
+    // assistant rows arrived first, or it's a degenerate sample). Denominator
+    // is 0 → queries.rs returns None → statusline `message` slot is absent.
+    let mut conn = test_db();
+    conn.execute(
+        "INSERT INTO sessions (id, provider, started_at) VALUES ('s1', 'claude_code', '2026-03-14')",
+        [],
+    ).unwrap();
+
+    let msgs = vec![assistant_msg_with_request(
+        "a1",
+        "s1",
+        0,
+        "claude_code",
+        Some("req-1"),
+        5.0,
+    )];
+    ingest_messages(&mut conn, &msgs, None).unwrap();
+
+    let h = session_health(&conn, Some("s1")).unwrap();
+    assert_eq!(h.user_prompt_count, 0);
+}
+
+#[test]
+fn health_user_prompt_count_copilot_chat_fallback_uses_priced_distinct_requests() {
+    // Pre-#686 copilot_chat session: zero user rows, three assistant rows
+    // where one is unpriced (cost_cents = 0). The fallback counts DISTINCT
+    // request_id WHERE cost_cents > 0, so the unpriced row is excluded from
+    // the denominator and contributes 0 to the numerator. Expected:
+    // denominator = 2, avg = sum_cost / 2 (matches ticket #691 acceptance).
+    let mut conn = test_db();
+    conn.execute(
+        "INSERT INTO sessions (id, provider, started_at) VALUES ('s1', 'copilot_chat', '2026-03-14')",
+        [],
+    ).unwrap();
+
+    let msgs = vec![
+        assistant_msg_with_request("a1", "s1", 0, "copilot_chat", Some("req-A"), 3.0),
+        assistant_msg_with_request("a2", "s1", 1, "copilot_chat", Some("req-B"), 0.0),
+        assistant_msg_with_request("a3", "s1", 2, "copilot_chat", Some("req-C"), 5.0),
+    ];
+    ingest_messages(&mut conn, &msgs, None).unwrap();
+
+    let h = session_health(&conn, Some("s1")).unwrap();
+    assert_eq!(h.user_prompt_count, 2);
+    assert_eq!(h.total_cost_cents, 8.0);
+    let avg = h.total_cost_cents / h.user_prompt_count as f64;
+    assert!((avg - 4.0).abs() < f64::EPSILON);
+}
+
+#[test]
+fn health_user_prompt_count_copilot_chat_user_rows_take_precedence() {
+    // Once #686 lands, copilot_chat sessions capture user rows and the
+    // user-row path wins — fallback is silently inert.
+    let mut conn = test_db();
+    conn.execute(
+        "INSERT INTO sessions (id, provider, started_at) VALUES ('s1', 'copilot_chat', '2026-03-14')",
+        [],
+    ).unwrap();
+
+    let msgs = vec![
+        user_prompt_msg("u1", "s1", 0, "copilot_chat"),
+        user_prompt_msg("u2", "s1", 1, "copilot_chat"),
+        user_prompt_msg("u3", "s1", 2, "copilot_chat"),
+        // Three assistants; one shares a request_id with another. If the
+        // fallback ran it would return 2; user-row path returns 3.
+        assistant_msg_with_request("a1", "s1", 3, "copilot_chat", Some("req-A"), 2.0),
+        assistant_msg_with_request("a2", "s1", 4, "copilot_chat", Some("req-A"), 1.0),
+        assistant_msg_with_request("a3", "s1", 5, "copilot_chat", Some("req-B"), 6.0),
+    ];
+    ingest_messages(&mut conn, &msgs, None).unwrap();
+
+    let h = session_health(&conn, Some("s1")).unwrap();
+    assert_eq!(h.user_prompt_count, 3);
+}
+
 #[test]
 fn health_no_sessions_returns_green() {
     let conn = test_db();


### PR DESCRIPTION
Closes #691.

## Summary

The statusline `message` slot was averaging session cost across every
assistant row in the session, which inflated the denominator with
subagent fan-out and zero-cost unpriced rows so the rendered avg
consistently read lower than the user's intuition ("$X / N prompts I
typed"). Switch to `COUNT(*) WHERE role='user'` for the denominator,
with a provider-keyed fallback for pre-#686 copilot_chat data.

## What's in

- `SessionHealth.user_prompt_count: u64` — new field carrying the
  denominator the statusline uses. Computed in
  `compute_user_prompt_count()` (`crates/budi-core/src/analytics/health.rs`).
- Default path: `COUNT(*) FROM messages WHERE session_id = ? AND role = 'user'`.
  Stable across `claude_code`, `codex`, `cursor` — all three already
  capture user rows, so subagent fan-out keeps the denominator at 1 and
  zero-cost assistant rows contribute 0 to the numerator without
  touching the denominator.
- Fallback (copilot_chat only, when no user rows exist):
  `COUNT(DISTINCT request_id) WHERE role='assistant' AND cost_cents > 0`.
  Once pre-#686 sessions age out, the user-row path takes over silently
  with no further code change.
- `crates/budi-core/src/analytics/queries.rs`: `session_msg_cost`
  divides by `h.user_prompt_count` instead of `h.message_count`.
- Six new unit tests in `crates/budi-core/src/analytics/tests.rs`
  covering the four shapes called out in #691 plus the
  copilot_chat-fallback and copilot_chat-precedence paths:
  - `health_user_prompt_count_single_turn`
  - `health_user_prompt_count_subagent_fanout_stays_one`
  - `health_user_prompt_count_zero_cost_assistant_does_not_inflate_denominator`
  - `health_user_prompt_count_empty_user_returns_zero_for_priced_provider`
  - `health_user_prompt_count_copilot_chat_fallback_uses_priced_distinct_requests`
  - `health_user_prompt_count_copilot_chat_user_rows_take_precedence`
- Statusline integration test extended with a multi-assistant-per-turn
  fixture demonstrating that `message` ≈ `session` once the denominator
  is the user-prompt count.

## What's not in

- No `MIN_API_VERSION` bump. `SessionHealth.user_prompt_count` is
  serialized with `#[serde(default)]` and the existing `message_count`
  field stays untouched, so older clients keep parsing the response
  shape.
- No removal of `message_count` from `SessionHealth` — the field is
  still consumed by the `insufficient_data` tip generator and by the
  CLI's `budi sessions <id>` view.

## What's deferred

- Persisting `is_sidechain` on `ParsedMessage` / `messages`. The
  user-row denominator side-steps the need; defer the schema add to a
  follow-up if drift is observed (out-of-scope per #691).
- The cents-vs-dollars unit-inconsistency on `session_msg_cost`
  (sibling ticket #692) — landed independently.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo build --workspace`
- [x] `cargo test --workspace` — all green except the known-flaky
  `workers::tailer::tests::run_blocking_exits_when_shutdown_flag_is_set`
  and `run_blocking_recovers_when_watch_root_materializes_post_boot`.
  Both pass cleanly in isolation (re-ran twice; documented flake
  under load).
- [x] `bash scripts/e2e/test_655_release_smoke.sh` — green (touches
  analytics queries, so the smoke gate applies).
- Manual: rebuild a session with 1 user prompt + 3 assistant rows,
  observe statusline `message` slot reading ≈ session cost, no longer
  deflated by the fan-out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)