### PR TITLE
[8.4.2] daemon: HTTP API has no Host-header validation — DNS-rebinding lets a malicious webpage read all analytics and trigger loopback-only admin endpoints

### DIFF
--- a/crates/budi-daemon/src/main.rs
+++ b/crates/budi-daemon/src/main.rs
@@ -3,7 +3,7 @@ use std::net::SocketAddr;
 use anyhow::Result;
 use axum::Router;
 use axum::extract::DefaultBodyLimit;
-use axum::middleware::from_fn;
+use axum::middleware::{from_fn, from_fn_with_state};
 use axum::routing::{get, post};
 use budi_core::analytics;
 use budi_core::config::{DEFAULT_DAEMON_HOST, DEFAULT_DAEMON_PORT};
@@ -49,10 +49,10 @@ pub struct AppState {
     pub sync_progress: std::sync::Arc<std::sync::Mutex<Option<budi_core::analytics::SyncProgress>>>,
 }
 
-fn build_router(app_state: AppState) -> Router {
+fn build_router(app_state: AppState, host_allowlist: routes::HostAllowlist) -> Router {
     use routes::{
         analytics as a, cloud as c, hooks as h, pricing as p, require_current_schema,
-        require_loopback,
+        require_local_host, require_loopback,
     };
 
     // Loopback-only admin / sync / cloud mutation routes.
@@ -183,6 +183,12 @@ fn build_router(app_state: AppState) -> Router {
         .merge(analytics_routes)
         .merge(protected_routes)
         .layer(DefaultBodyLimit::max(2 * 1024 * 1024))
+        // DNS-rebinding defense (#695): every route — public, protected,
+        // and the schema-gated analytics surface — must pass the Host
+        // header allowlist before any handler runs. The peer IP is
+        // loopback in the rebinding scenario, so `require_loopback`
+        // alone is not enough.
+        .layer(from_fn_with_state(host_allowlist, require_local_host))
         .with_state(app_state)
 }
 
@@ -223,7 +229,8 @@ async fn main() -> Result<()> {
         sync_progress: std::sync::Arc::new(std::sync::Mutex::new(None)),
     };
 
-    let app = build_router(app_state);
+    let host_allowlist = routes::HostAllowlist::new(&host, port);
+    let app = build_router(app_state, host_allowlist);
 
     // Ensure the database exists and schema is up-to-date.
     // This makes the daemon self-sufficient — it doesn't require `budi init` to have run first.
@@ -378,13 +385,22 @@ async fn main() -> Result<()> {
             target: "budi_daemon::dummy_proxy",
             "legacy proxy residue detected; starting dummy proxy on 9878 to return actionable 400s to agents"
         );
+        // #695: same Host-header allowlist as the main listener — the
+        // dummy 9878 server is also bound to loopback, so DNS-rebinding
+        // would otherwise let a browser drive arbitrary requests at it.
+        let dummy_allowlist = routes::HostAllowlist::new("127.0.0.1", 9878);
         tokio::spawn(async move {
-            let dummy_app = axum::Router::new().fallback(axum::routing::any(|| async {
-                (
-                    axum::http::StatusCode::BAD_REQUEST,
-                    "Budi proxy was removed in 8.2.0. Run `budi doctor` to see which managed blocks remain in your shell profile, then remove them by hand or run `budi uninstall`."
-                )
-            }));
+            let dummy_app = axum::Router::new()
+                .fallback(axum::routing::any(|| async {
+                    (
+                        axum::http::StatusCode::BAD_REQUEST,
+                        "Budi proxy was removed in 8.2.0. Run `budi doctor` to see which managed blocks remain in your shell profile, then remove them by hand or run `budi uninstall`."
+                    )
+                }))
+                .layer(from_fn_with_state(
+                    dummy_allowlist,
+                    routes::require_local_host,
+                ));
             if let Ok(listener) = tokio::net::TcpListener::bind("127.0.0.1:9878").await {
                 let _ = axum::serve(listener, dummy_app).await;
             }
@@ -655,12 +671,31 @@ mod tests {
     use tower::ServiceExt;
 
     fn test_app() -> Router {
-        build_router(AppState {
-            syncing: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
-            integrations_installing: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
-            cloud_syncing: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
-            sync_progress: std::sync::Arc::new(std::sync::Mutex::new(None)),
-        })
+        build_router(
+            AppState {
+                syncing: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+                integrations_installing: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(
+                    false,
+                )),
+                cloud_syncing: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+                sync_progress: std::sync::Arc::new(std::sync::Mutex::new(None)),
+            },
+            routes::HostAllowlist::for_tests(),
+        )
+    }
+
+    /// Helper: attach `Host: 127.0.0.1` and a loopback `ConnectInfo` so
+    /// requests pass both `require_local_host` and `require_loopback`.
+    fn with_loopback(mut req: Request<Body>) -> Request<Body> {
+        if !req.headers().contains_key(axum::http::header::HOST) {
+            req.headers_mut().insert(
+                axum::http::header::HOST,
+                axum::http::HeaderValue::from_static("127.0.0.1"),
+            );
+        }
+        req.extensions_mut()
+            .insert(ConnectInfo(SocketAddr::from(([127, 0, 0, 1], 54545))));
+        req
     }
 
     #[test]
@@ -690,10 +725,8 @@ mod tests {
     #[tokio::test]
     async fn health_returns_ok() {
         let app = test_app();
-        let resp = app
-            .oneshot(Request::get("/health").body(Body::empty()).unwrap())
-            .await
-            .unwrap();
+        let req = with_loopback(Request::get("/health").body(Body::empty()).unwrap());
+        let resp = app.oneshot(req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
         let body = resp.into_body().collect().await.unwrap().to_bytes();
         let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
@@ -708,35 +741,36 @@ mod tests {
     #[tokio::test]
     async fn favicon_returns_ok() {
         let app = test_app();
-        let resp = app
-            .oneshot(Request::get("/favicon.ico").body(Body::empty()).unwrap())
-            .await
-            .unwrap();
+        let req = with_loopback(Request::get("/favicon.ico").body(Body::empty()).unwrap());
+        let resp = app.oneshot(req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
     }
 
     #[tokio::test]
     async fn protected_admin_route_requires_connect_info() {
+        // No `ConnectInfo` extension — but still set a valid Host so we
+        // exercise the require_loopback branch instead of being short-
+        // circuited by the new require_local_host middleware (#695).
         let app = test_app();
-        let resp = app
-            .oneshot(
-                Request::get("/admin/providers")
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
+        let mut req = Request::get("/admin/providers")
+            .body(Body::empty())
             .unwrap();
+        req.headers_mut().insert(
+            axum::http::header::HOST,
+            axum::http::HeaderValue::from_static("127.0.0.1"),
+        );
+        let resp = app.oneshot(req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::FORBIDDEN);
     }
 
     #[tokio::test]
     async fn protected_admin_route_allows_loopback_client() {
         let app = test_app();
-        let mut req = Request::get("/admin/providers")
-            .body(Body::empty())
-            .unwrap();
-        req.extensions_mut()
-            .insert(ConnectInfo(SocketAddr::from(([127, 0, 0, 1], 54545))));
+        let req = with_loopback(
+            Request::get("/admin/providers")
+                .body(Body::empty())
+                .unwrap(),
+        );
         let resp = app.oneshot(req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
     }
@@ -747,6 +781,10 @@ mod tests {
         let mut req = Request::get("/admin/providers")
             .body(Body::empty())
             .unwrap();
+        req.headers_mut().insert(
+            axum::http::header::HOST,
+            axum::http::HeaderValue::from_static("127.0.0.1"),
+        );
         req.extensions_mut()
             .insert(ConnectInfo(SocketAddr::from(([192, 168, 1, 10], 54545))));
         let resp = app.oneshot(req).await.unwrap();
@@ -757,6 +795,10 @@ mod tests {
     async fn sync_mutation_route_blocks_non_loopback_client() {
         let app = test_app();
         let mut req = Request::post("/sync").body(Body::empty()).unwrap();
+        req.headers_mut().insert(
+            axum::http::header::HOST,
+            axum::http::HeaderValue::from_static("127.0.0.1"),
+        );
         req.extensions_mut()
             .insert(ConnectInfo(SocketAddr::from(([10, 0, 0, 4], 43434))));
         let resp = app.oneshot(req).await.unwrap();
@@ -767,6 +809,10 @@ mod tests {
     async fn cloud_sync_route_blocks_non_loopback_client() {
         let app = test_app();
         let mut req = Request::post("/cloud/sync").body(Body::empty()).unwrap();
+        req.headers_mut().insert(
+            axum::http::header::HOST,
+            axum::http::HeaderValue::from_static("127.0.0.1"),
+        );
         req.extensions_mut()
             .insert(ConnectInfo(SocketAddr::from(([10, 0, 0, 4], 43434))));
         let resp = app.oneshot(req).await.unwrap();
@@ -776,10 +822,8 @@ mod tests {
     #[tokio::test]
     async fn cloud_status_route_public_and_reports_shape() {
         let app = test_app();
-        let resp = app
-            .oneshot(Request::get("/cloud/status").body(Body::empty()).unwrap())
-            .await
-            .unwrap();
+        let req = with_loopback(Request::get("/cloud/status").body(Body::empty()).unwrap());
+        let resp = app.oneshot(req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
         let body = resp.into_body().collect().await.unwrap().to_bytes();
         let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
@@ -795,6 +839,141 @@ mod tests {
             json.get("endpoint").is_some(),
             "cloud/status should include `endpoint`"
         );
+    }
+
+    // ─── #695 DNS-rebinding / Host-header allowlist regression tests ─────
+    //
+    // These tests pin the spec contract from the ticket acceptance:
+    //
+    // - GET /health with Host: attacker.example   → 403
+    // - GET /health with Host: 127.0.0.1[:port]   → 200
+    // - GET /analytics/sessions with bad Host     → 403
+    // - POST /admin/integrations/install with bad Host AND a loopback
+    //   peer IP → 403 (the rebinding-attack shape).
+    //
+    // The peer IP is loopback in every "bad Host" case below — that's
+    // the whole point of DNS rebinding. The middleware closes the gap
+    // that `require_loopback` leaves open.
+
+    fn with_host_and_loopback(
+        uri: &str,
+        host: &'static str,
+        method: axum::http::Method,
+    ) -> Request<Body> {
+        let mut req = Request::builder()
+            .method(method)
+            .uri(uri)
+            .body(Body::empty())
+            .unwrap();
+        req.headers_mut().insert(
+            axum::http::header::HOST,
+            axum::http::HeaderValue::from_static(host),
+        );
+        req.extensions_mut()
+            .insert(ConnectInfo(SocketAddr::from(([127, 0, 0, 1], 54545))));
+        req
+    }
+
+    #[tokio::test]
+    async fn host_allowlist_rejects_rebound_host_on_health() {
+        let app = test_app();
+        let req = with_host_and_loopback("/health", "attacker.example", axum::http::Method::GET);
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["ok"], false);
+        assert_eq!(json["error"], "invalid Host header");
+    }
+
+    #[tokio::test]
+    async fn host_allowlist_accepts_loopback_host_on_health() {
+        let app = test_app();
+        // Bare `127.0.0.1` (no port) is accepted — the allowlist contains
+        // the bare host as well as `host:port`.
+        let req = with_host_and_loopback("/health", "127.0.0.1", axum::http::Method::GET);
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn host_allowlist_accepts_localhost_with_port() {
+        let app = test_app();
+        // `for_tests()` allowlist was built with port 0, so `localhost:0`
+        // is valid; `localhost` (bare) is also valid.
+        let req = with_host_and_loopback("/health", "localhost:0", axum::http::Method::GET);
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn host_allowlist_rejects_rebound_host_on_analytics_sessions() {
+        let app = test_app();
+        let req = with_host_and_loopback(
+            "/analytics/sessions",
+            "rebound.example",
+            axum::http::Method::GET,
+        );
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn host_allowlist_rejects_rebound_host_on_admin_install_even_with_loopback_peer() {
+        // The rebinding-attack shape: peer IP is loopback (because the
+        // browser dialed 127.0.0.1), Host header is the attacker's
+        // rebound name. Pre-#695 the loopback peer alone let this
+        // through; with the Host check, it is rejected before the
+        // handler runs.
+        let app = test_app();
+        let req = with_host_and_loopback(
+            "/admin/integrations/install",
+            "attacker.example",
+            axum::http::Method::POST,
+        );
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn host_allowlist_rejects_missing_host_header() {
+        let app = test_app();
+        // No Host header at all — `oneshot` does not synthesize one.
+        // Anomalous on a loopback API and treated as bad.
+        let mut req = Request::get("/health").body(Body::empty()).unwrap();
+        req.extensions_mut()
+            .insert(ConnectInfo(SocketAddr::from(([127, 0, 0, 1], 54545))));
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[test]
+    fn host_allowlist_includes_configured_override_host() {
+        // Operator runs `budi-daemon serve --host 192.168.1.50 --port 7878`
+        // — that exact `host:port` literal is added to the allowlist so
+        // requests issued by tools using the configured base URL still
+        // reach the daemon.
+        let allow = routes::HostAllowlist::new("192.168.1.50", 7878);
+        assert!(allow.allows("192.168.1.50:7878"));
+        assert!(allow.allows("192.168.1.50"));
+        assert!(allow.allows("127.0.0.1:7878"));
+        assert!(allow.allows("[::1]:7878"));
+        assert!(allow.allows("localhost:7878"));
+        assert!(!allow.allows("attacker.example"));
+        assert!(!allow.allows("attacker.example:7878"));
+    }
+
+    #[test]
+    fn host_allowlist_skips_wildcard_bind_sentinel() {
+        // `--host 0.0.0.0` is a wildcard listener bind; the literal
+        // `0.0.0.0` is never a valid Host value clients would send, so
+        // it must not become an allowlist entry. Loopback variants are
+        // still admitted (those are the real client paths).
+        let allow = routes::HostAllowlist::new("0.0.0.0", 7878);
+        assert!(!allow.allows("0.0.0.0"));
+        assert!(!allow.allows("0.0.0.0:7878"));
+        assert!(allow.allows("127.0.0.1:7878"));
+        assert!(allow.allows("localhost:7878"));
     }
 
     // ─── #366 stale-schema 503 regression tests ──────────────────────────

--- a/crates/budi-daemon/src/routes/mod.rs
+++ b/crates/budi-daemon/src/routes/mod.rs
@@ -3,11 +3,14 @@ pub mod cloud;
 pub mod hooks;
 pub mod pricing;
 
+use std::collections::HashSet;
 use std::net::SocketAddr;
+use std::sync::Arc;
 
 use axum::Json;
-use axum::extract::{ConnectInfo, Request};
+use axum::extract::{ConnectInfo, Request, State};
 use axum::http::StatusCode;
+use axum::http::header;
 use axum::middleware::Next;
 use axum::response::Response;
 
@@ -171,6 +174,102 @@ pub fn forbidden(msg: impl std::fmt::Display) -> (StatusCode, Json<serde_json::V
         StatusCode::FORBIDDEN,
         Json(serde_json::json!({ "ok": false, "error": format!("{msg}") })),
     )
+}
+
+/// Allowlist of `Host` header values the daemon accepts.
+///
+/// DNS-rebinding defense (#695): a malicious page can resolve a hostile
+/// name to `127.0.0.1` and then have the user's browser hit the daemon
+/// on a loopback connection.  `require_loopback` only inspects the peer
+/// IP, which is loopback in that scenario, so it lets the request
+/// through.  Layering [`require_local_host`] in front of every route
+/// closes the gap: the rebound page sends `Host: attacker.example`,
+/// which is not in the allowlist, so the request is rejected before any
+/// handler runs.
+///
+/// The allowlist contains, with and without an explicit port:
+/// - `127.0.0.1`
+/// - `[::1]` (canonical bracketed IPv6)
+/// - `localhost`
+/// - the literal `--host` value the daemon was started with (so
+///   `--host 0.0.0.0 --port 7878` still accepts `Host: 0.0.0.0:7878`
+///   for the operator who explicitly opened the listener).
+///
+/// Anything else returns `403` with `invalid Host header` and a
+/// `tracing::warn!` line for ops visibility.
+#[derive(Clone, Debug)]
+pub struct HostAllowlist {
+    hosts: Arc<HashSet<String>>,
+}
+
+impl HostAllowlist {
+    pub fn new(configured_host: &str, port: u16) -> Self {
+        let mut hosts = HashSet::new();
+        let bases = ["127.0.0.1", "[::1]", "localhost", configured_host];
+        for base in bases {
+            // `0.0.0.0` is a wildcard bind sentinel, never a valid Host
+            // value — skip it so an operator running `--host 0.0.0.0`
+            // doesn't silently widen the allowlist with an unreachable
+            // literal.
+            if base.is_empty() || base == "0.0.0.0" {
+                continue;
+            }
+            hosts.insert(base.to_string());
+            hosts.insert(format!("{base}:{port}"));
+        }
+        Self {
+            hosts: Arc::new(hosts),
+        }
+    }
+
+    /// Test/dev convenience: a permissive default whose only consumers
+    /// are router-level unit tests where the Host header is unset.
+    /// Production callers always go through `HostAllowlist::new`.
+    #[cfg(test)]
+    pub fn for_tests() -> Self {
+        Self::new("127.0.0.1", 0)
+    }
+
+    pub fn allows(&self, host: &str) -> bool {
+        self.hosts.contains(host)
+    }
+}
+
+/// Reject any request whose `Host` header is not in the local-host
+/// allowlist.  Layered onto every route (public and protected) to defend
+/// against DNS-rebinding (#695) — the peer IP is loopback in that
+/// scenario, so `require_loopback` alone is insufficient.
+pub async fn require_local_host(
+    State(allowlist): State<HostAllowlist>,
+    req: Request,
+    next: Next,
+) -> Result<Response, (StatusCode, Json<serde_json::Value>)> {
+    let host = req
+        .headers()
+        .get(header::HOST)
+        .and_then(|v| v.to_str().ok());
+    match host {
+        Some(h) if allowlist.allows(h) => Ok(next.run(req).await),
+        Some(h) => {
+            tracing::warn!(
+                host = %h,
+                path = %req.uri().path(),
+                "blocked request with non-local Host header (DNS-rebinding defense, #695)"
+            );
+            Err(forbidden("invalid Host header"))
+        }
+        None => {
+            // HTTP/1.1 requires a Host header; HTTP/2 carries `:authority`
+            // which axum surfaces as `Host` here. A missing/non-ASCII Host
+            // is anomalous on a loopback API and not worth distinguishing
+            // from an explicitly bad value.
+            tracing::warn!(
+                path = %req.uri().path(),
+                "blocked request with missing or non-ASCII Host header"
+            );
+            Err(forbidden("invalid Host header"))
+        }
+    }
 }
 
 pub async fn require_loopback(

--- a/scripts/e2e/test_695_host_header_validation.sh
+++ b/scripts/e2e/test_695_host_header_validation.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# Smoke gate for #695 — DNS-rebinding defense via Host header allowlist.
+#
+# Boots a release-built daemon on a dedicated port and asserts that
+# requests carrying a non-local Host header are rejected with 403 on:
+#   - GET  /health                       (public, was un-gated by require_loopback)
+#   - GET  /analytics/sessions           (public analytics surface)
+#   - POST /admin/integrations/install   (loopback-only protected route)
+#
+# Negative-prove the gate: revert the require_local_host layer in
+# `crates/budi-daemon/src/main.rs::build_router` and rerun this script —
+# every assertion below should flip from PASS to FAIL.
+#
+# Run:
+#   cargo build --release
+#   bash scripts/e2e/test_695_host_header_validation.sh
+#   KEEP_TMP=1 bash scripts/e2e/test_695_host_header_validation.sh   # post-mortem
+set -euo pipefail
+
+export NO_COLOR="${NO_COLOR:-1}"
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BUDI_DAEMON="$ROOT/target/release/budi-daemon"
+
+if [[ ! -x "$BUDI_DAEMON" ]]; then
+  echo "error: release daemon binary not built. run \`cargo build --release\` first." >&2
+  exit 2
+fi
+
+TMPDIR_ROOT="$(mktemp -d -t budi-e2e-695-XXXXXX)"
+export HOME="$TMPDIR_ROOT"
+mkdir -p "$HOME/.config/budi"
+
+DAEMON_PORT=17895
+DAEMON_PID=""
+
+cleanup() {
+  local status=$?
+  { kill "${DAEMON_PID:-}" 2>/dev/null || true; } >/dev/null 2>&1
+  pkill -f "budi-daemon serve --host 127.0.0.1 --port $DAEMON_PORT" >/dev/null 2>&1 || true
+  if [[ "${KEEP_TMP:-0}" == "1" ]]; then
+    echo "[e2e] leaving tmp: $TMPDIR_ROOT"
+  else
+    rm -rf "$TMPDIR_ROOT"
+  fi
+  exit $status
+}
+trap cleanup EXIT INT TERM
+
+step() {
+  echo
+  echo "=================================================================="
+  echo "[e2e] $*"
+  echo "=================================================================="
+}
+
+start_daemon() {
+  RUST_LOG=info "$BUDI_DAEMON" serve \
+    --host 127.0.0.1 --port "$DAEMON_PORT" \
+    >>"$TMPDIR_ROOT/daemon.log" 2>&1 &
+  DAEMON_PID=$!
+
+  for _ in {1..50}; do
+    if curl -s -o /dev/null -w "%{http_code}" --max-time 1 \
+        "http://127.0.0.1:$DAEMON_PORT/health" | grep -q "^200"; then
+      return 0
+    fi
+    sleep 0.1
+  done
+  echo "[e2e] FAIL: daemon did not come up on :$DAEMON_PORT" >&2
+  tail -n 80 "$TMPDIR_ROOT/daemon.log" >&2 || true
+  exit 1
+}
+
+step "boot daemon on :$DAEMON_PORT"
+start_daemon
+
+# ---------------------------------------------------------------------------
+# Step 1 — baseline: a request with the canonical local Host header is 200.
+# ---------------------------------------------------------------------------
+
+step "step 1: GET /health with Host: 127.0.0.1:$DAEMON_PORT returns 200"
+GOOD_HEALTH=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 \
+  -H "Host: 127.0.0.1:$DAEMON_PORT" \
+  "http://127.0.0.1:$DAEMON_PORT/health")
+if [[ "$GOOD_HEALTH" != "200" ]]; then
+  echo "[e2e] FAIL: /health with valid Host = $GOOD_HEALTH (expected 200)" >&2
+  tail -n 80 "$TMPDIR_ROOT/daemon.log" >&2 || true
+  exit 1
+fi
+echo "[e2e] OK: /health with valid Host returned 200"
+
+# ---------------------------------------------------------------------------
+# Step 2 — DNS-rebinding shape: the peer is 127.0.0.1 (curl's TCP target),
+# but the Host header advertises an attacker-controlled name. require_loopback
+# alone would let this through; require_local_host must reject it on every
+# affected route. We inspect both the status and the body shape so a future
+# refactor that returns 403 from a different source is also caught.
+# ---------------------------------------------------------------------------
+
+assert_rejected() {
+  local label="$1"
+  local method="$2"
+  local path="$3"
+  local out="$TMPDIR_ROOT/${label}.out"
+  local code
+
+  code=$(curl -s -o "$out" -w "%{http_code}" --max-time 5 \
+    -X "$method" \
+    -H "Host: rebound.example" \
+    "http://127.0.0.1:$DAEMON_PORT$path")
+
+  if [[ "$code" != "403" ]]; then
+    echo "[e2e] FAIL: $method $path with rebound Host returned $code (expected 403)" >&2
+    cat "$out" >&2 || true
+    tail -n 80 "$TMPDIR_ROOT/daemon.log" >&2 || true
+    exit 1
+  fi
+
+  # Body must match the contract from the ticket acceptance:
+  #   { "ok": false, "error": "invalid Host header" }
+  local err
+  err=$(python3 -c "import json; d=json.load(open('$out')); print(d.get('ok'), d.get('error'))" 2>/dev/null || echo "PARSE_ERROR")
+  if [[ "$err" != "False invalid Host header" ]]; then
+    echo "[e2e] FAIL: $method $path body did not match contract — got: $err" >&2
+    cat "$out" >&2 || true
+    exit 1
+  fi
+  echo "[e2e] OK: $method $path with rebound Host -> 403 invalid Host header"
+}
+
+step "step 2: GET /health with Host: rebound.example returns 403"
+assert_rejected health GET /health
+
+step "step 3: GET /analytics/sessions with Host: rebound.example returns 403"
+assert_rejected sessions GET /analytics/sessions
+
+step "step 4: POST /admin/integrations/install with Host: rebound.example returns 403"
+# This is the rebinding shape that pre-#695 was reachable: peer is
+# loopback (127.0.0.1) so require_loopback admits the request, the Host
+# header is the attacker's rebound DNS name. The middleware closes the
+# gap before the handler ever spawns `budi integrations install`.
+assert_rejected admin_install POST /admin/integrations/install
+
+step "step 5: warn line was emitted to daemon.log for each blocked request"
+# Pin the operator-visibility contract: each rejection should leave a
+# tracing::warn! line so ops can grep for it. Three blocked requests in
+# steps 2–4, so we expect at least three matching lines.
+WARN_LINES=$(grep -c "blocked request with non-local Host header" "$TMPDIR_ROOT/daemon.log" || true)
+if [[ "$WARN_LINES" -lt 3 ]]; then
+  echo "[e2e] FAIL: expected >= 3 warn lines for blocked Host headers, saw $WARN_LINES" >&2
+  tail -n 120 "$TMPDIR_ROOT/daemon.log" >&2 || true
+  exit 1
+fi
+echo "[e2e] OK: $WARN_LINES warn line(s) recorded for blocked Host headers"
+
+step "PASS: #695 Host-header allowlist rejects rebound names on public, analytics, and admin routes"


### PR DESCRIPTION
Closes #695.

## Summary

`require_loopback` only inspects the socket peer IP. A page rebinding
`attacker.example` to 127.0.0.1 in the user's browser drives a request
that lands on the daemon as a loopback-peered connection, so the
existing guard accepts it. With no `Host` check and no CORS layer, a
drive-by webpage could read every `/analytics/*` endpoint and
force-trigger every `/admin`, `/sync`, and `/cloud` mutation route.

This PR adds a `HostAllowlist` and a `require_local_host` middleware
that is layered onto **every** route on both the main listener and the
dummy 9878 listener. The allowlist contains `127.0.0.1`, `[::1]`,
`localhost`, and the configured `--host` literal — each with and
without an explicit port. Anything else returns 403 with
`{ "ok": false, "error": "invalid Host header" }` plus a
`tracing::warn!` line for ops visibility.

## What's in
- `routes::HostAllowlist` + `routes::require_local_host` middleware in
  `crates/budi-daemon/src/routes/mod.rs`.
- Layer applied on the primary router and the legacy-residue dummy 9878
  listener (`crates/budi-daemon/src/main.rs`).
- `0.0.0.0` is dropped from the allowlist as a wildcard-bind sentinel
  so `--host 0.0.0.0` doesn't widen the allowlist with an unreachable
  literal.
- Router unit tests for every spec assertion from the ticket
  (`/health`, `/analytics/sessions`,
  `POST /admin/integrations/install` with both good and bad Host).
- `scripts/e2e/test_695_host_header_validation.sh` — boots a
  release-built daemon and asserts 403 + body shape on the three
  affected route classes, plus a `daemon.log` warn-line count
  assertion.

## What's not in
- A CORS layer. Out of scope per the ticket — the daemon has no
  documented browser consumer.
- Per-request authentication tokens. ADR-0083 keeps the trust model
  "anyone with loopback access is the user"; this PR only restores the
  implicit assumption that "loopback" excludes browser-driven
  DNS-rebinding clients.

## What's deferred
- Nothing — the ticket scope is fully implemented.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo test --workspace` — green (the
  `workers::tailer::tests::run_blocking_exits_when_shutdown_flag_is_set`
  flake hit once under workspace load and passed twice in isolation
  per the project's documented re-run rule).
- [x] `bash scripts/e2e/test_695_host_header_validation.sh` — PASS.
- [x] `bash scripts/e2e/test_655_release_smoke.sh` — PASS (no
  regressions on the analytics surface introduced by the new layer).
- [x] Negative-proved the new smoke script: reverted the
  `from_fn_with_state(host_allowlist, require_local_host)` layer and
  confirmed step 2 flips from PASS to FAIL — the rebound-Host request
  is admitted again, exactly the pre-fix behavior.
- [x] Manual reproducer from the ticket on the patched daemon:
  `curl -H 'Host: attacker.example' http://127.0.0.1:7878/analytics/sessions`
  returns `403` with `{"ok":false,"error":"invalid Host header"}` and a
  warn line in `daemon.log`. The same request with no `Host` override
  still returns 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)