### PR TITLE
[8.4.2] integrations: atomic_write_json drops file mode bits and replaces symlinks — chmod 600 ~/.claude/settings.json becomes 644 after budi init

### DIFF
--- a/crates/budi-cli/src/commands/mod.rs
+++ b/crates/budi-cli/src/commands/mod.rs
@@ -90,16 +90,118 @@ fn backup_invalid_json(path: &Path) -> Result<PathBuf> {
 }
 
 /// Write JSON to a file atomically (write to .tmp, then rename).
+///
+/// Two contracts beyond the bare write-then-rename (#697):
+///
+/// 1. **Mode bits preserved.** If the target file already exists, its
+///    `st_mode` is captured before the rename and restored after, so a
+///    user-set `chmod 600 ~/.claude/settings.json` survives `budi init`
+///    rather than reverting to the writer's umask (typically 644).
+///    Unix only — Windows is a no-op.
+/// 2. **Symlinks preserved.** If `path` is a symlink (dotfile managers
+///    like `chezmoi`/`stow`/`yadm` symlink configs into a Git-tracked
+///    repo), the symlink itself is left intact and the new content is
+///    written atomically at its canonicalized target. If we can't
+///    place the tmp inside the target's parent (cross-filesystem
+///    rename, permissions, etc.), we fall back to a non-atomic
+///    in-place write through the symlink and emit a warning so
+///    dotfile managers don't desync silently.
 pub fn atomic_write_json(path: &Path, value: &Value) -> Result<()> {
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent)
-            .with_context(|| format!("Failed to create {}", parent.display()))?;
-    }
     let out = serde_json::to_string_pretty(value)?;
-    let tmp = path.with_extension(format!("json.{}.tmp", std::process::id()));
+
+    // If `path` is a symlink, write to its canonical target so the
+    // symlink survives — dotfile managers expect the source-of-truth
+    // file (in their tracked repo) to be the one mutated, not the
+    // symlink itself.
+    let symlink_meta = fs::symlink_metadata(path).ok();
+    let is_symlink = symlink_meta
+        .as_ref()
+        .map(|m| m.file_type().is_symlink())
+        .unwrap_or(false);
+
+    let write_target: PathBuf = if is_symlink {
+        match fs::canonicalize(path) {
+            Ok(real) => real,
+            Err(e) => {
+                tracing::warn!(
+                    "atomic_write_json: {} is a symlink but its target could not be \
+                     resolved ({}); writing through the symlink (non-atomic)",
+                    path.display(),
+                    e
+                );
+                fs::write(path, &out)
+                    .with_context(|| format!("Failed to write {}", path.display()))?;
+                return Ok(());
+            }
+        }
+    } else {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("Failed to create {}", parent.display()))?;
+        }
+        path.to_path_buf()
+    };
+
+    // Capture the target's mode bits before we replace it so the
+    // umask-derived mode of the freshly written tmp doesn't silently
+    // relax a user-set `chmod 600`.
+    #[cfg(unix)]
+    let preserved_mode: Option<u32> = fs::metadata(&write_target).ok().map(|m| {
+        use std::os::unix::fs::PermissionsExt;
+        m.permissions().mode()
+    });
+
+    // Place the tmp next to the resolved target so the rename stays on
+    // the same filesystem.
+    let tmp_dir = write_target
+        .parent()
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(|| PathBuf::from("."));
+    let tmp_name = format!(
+        "{}.{}.tmp",
+        write_target
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("budi"),
+        std::process::id()
+    );
+    let tmp = tmp_dir.join(tmp_name);
+
     fs::write(&tmp, &out).with_context(|| format!("Failed to write {}", tmp.display()))?;
-    fs::rename(&tmp, path)
-        .with_context(|| format!("Failed to rename {} → {}", tmp.display(), path.display()))?;
+
+    if let Err(e) = fs::rename(&tmp, &write_target) {
+        // Cross-filesystem rename, missing-parent race, or similar —
+        // fall back to a plain in-place write so the user sees *some*
+        // update rather than silent loss. The warn lets dotfile-manager
+        // users notice the divergence on next sync.
+        tracing::warn!(
+            "atomic_write_json: rename {} → {} failed ({}); falling back to in-place write",
+            tmp.display(),
+            write_target.display(),
+            e
+        );
+        let _ = fs::remove_file(&tmp);
+        fs::write(&write_target, &out)
+            .with_context(|| format!("Failed to write {}", write_target.display()))?;
+    }
+
+    // Restore the original mode bits captured above (Unix only). The
+    // tmp file picked up the umask of the writing process, so without
+    // this step a `chmod 600` config gets quietly broadened to 644.
+    #[cfg(unix)]
+    if let Some(mode) = preserved_mode {
+        use std::os::unix::fs::PermissionsExt;
+        let perms = std::fs::Permissions::from_mode(mode);
+        if let Err(e) = fs::set_permissions(&write_target, perms) {
+            tracing::warn!(
+                "atomic_write_json: failed to restore mode 0o{:o} on {}: {}",
+                mode,
+                write_target.display(),
+                e
+            );
+        }
+    }
+
     Ok(())
 }
 
@@ -401,6 +503,82 @@ mod tests {
         ] {
             assert!(msg.contains(expected), "error '{msg}' missing '{expected}'");
         }
+    }
+
+    // --- atomic_write_json (#697) ------------------------------------
+
+    /// `chmod 600` on a pre-existing settings.json must survive a
+    /// rewrite. Without mode preservation the tmp file's umask-derived
+    /// mode (typically 644) becomes the new mode after the rename and
+    /// quietly relaxes the user's privacy setting.
+    #[cfg(unix)]
+    #[test]
+    fn atomic_write_json_preserves_mode_bits() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = std::env::temp_dir().join(format!(
+            "budi-atomic-mode-{}-{}",
+            std::process::id(),
+            chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default()
+        ));
+        std::fs::create_dir_all(&dir).expect("create temp dir");
+        let file = dir.join("settings.json");
+        std::fs::write(&file, "{}\n").expect("seed file");
+        std::fs::set_permissions(&file, std::fs::Permissions::from_mode(0o600)).expect("chmod 600");
+
+        atomic_write_json(&file, &serde_json::json!({"updated": true}))
+            .expect("atomic write should succeed");
+
+        let mode = std::fs::metadata(&file)
+            .expect("stat after write")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o600, "expected mode to stay 0o600, got 0o{mode:o}");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// When the target path is a symlink (dotfile managers like
+    /// chezmoi / stow / yadm rely on this layout), the symlink itself
+    /// must survive and the new content must land at the symlink's
+    /// canonical target.
+    #[cfg(unix)]
+    #[test]
+    fn atomic_write_json_preserves_symlinks() {
+        use std::os::unix::fs;
+
+        let dir = std::env::temp_dir().join(format!(
+            "budi-atomic-symlink-{}-{}",
+            std::process::id(),
+            chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default()
+        ));
+        std::fs::create_dir_all(&dir).expect("create temp dir");
+        let target = dir.join("target.json");
+        let link = dir.join("settings.json");
+        std::fs::write(&target, "{}\n").expect("seed target");
+        fs::symlink(&target, &link).expect("create symlink");
+
+        atomic_write_json(&link, &serde_json::json!({"via": "symlink"}))
+            .expect("atomic write through symlink should succeed");
+
+        let link_meta = std::fs::symlink_metadata(&link).expect("stat the link path itself");
+        assert!(
+            link_meta.file_type().is_symlink(),
+            "link must still be a symlink after write"
+        );
+        let resolved = std::fs::read_link(&link).expect("read symlink target");
+        assert_eq!(
+            resolved, target,
+            "symlink must still point at the original target"
+        );
+        let body = std::fs::read_to_string(&target).expect("read canonical target");
+        assert!(
+            body.contains("\"via\""),
+            "new content must land at the canonical target, got: {body}"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/scripts/e2e/test_697_atomic_write_preserves_mode_and_symlinks.sh
+++ b/scripts/e2e/test_697_atomic_write_preserves_mode_and_symlinks.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# Smoke gate for #697 — `atomic_write_json` must preserve POSIX mode bits
+# AND symlinks on the files it rewrites under ~/.claude.
+#
+# Boots a release-built `budi` against a throwaway HOME and asserts:
+#
+#   1. `chmod 600 ~/.claude/settings.json` survives a
+#      `budi integrations install --with claude-code-statusline --yes`.
+#      (Privacy regression — the file holds env vars, OTEL endpoints,
+#      sometimes anthropic keys; relaxing it to 644 by umask is silent
+#      data exposure.)
+#
+#   2. A symlinked `~/.claude/settings.json -> ~/dotfiles/...` survives
+#      the same install: the symlink stays, the real (canonicalized)
+#      target gets the updated content. (Correctness regression for
+#      chezmoi / stow / yadm users who manage their config from a
+#      Git-tracked dotfiles repo.)
+#
+# Negative-prove the gate: revert the mode/symlink preservation in
+# `crates/budi-cli/src/commands/mod.rs::atomic_write_json` and rerun
+# this script — both assertions should flip from PASS to FAIL.
+#
+# Run:
+#   cargo build --release
+#   bash scripts/e2e/test_697_atomic_write_preserves_mode_and_symlinks.sh
+#   KEEP_TMP=1 bash scripts/e2e/test_697_atomic_write_preserves_mode_and_symlinks.sh
+set -euo pipefail
+
+export NO_COLOR="${NO_COLOR:-1}"
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BUDI="$ROOT/target/release/budi"
+
+if [[ ! -x "$BUDI" ]]; then
+  echo "error: release binary not built. run \`cargo build --release\` first." >&2
+  exit 2
+fi
+
+TMPDIR_ROOT="$(mktemp -d -t budi-e2e-697-XXXXXX)"
+export HOME="$TMPDIR_ROOT"
+export BUDI_HOME="$HOME/.local/share/budi"
+
+cleanup() {
+  local status=$?
+  if [[ "${KEEP_TMP:-0}" == "1" ]]; then
+    echo "[e2e] leaving tmp: $TMPDIR_ROOT"
+  else
+    rm -rf "$TMPDIR_ROOT"
+  fi
+  exit $status
+}
+trap cleanup EXIT INT TERM
+
+step() {
+  echo
+  echo "=================================================================="
+  echo "[e2e] $*"
+  echo "=================================================================="
+}
+
+# Portable mode reader — `stat -c` on Linux, `stat -f` on macOS / BSD.
+read_mode() {
+  local path="$1"
+  if stat -c '%a' "$path" >/dev/null 2>&1; then
+    stat -c '%a' "$path"
+  else
+    stat -f '%Lp' "$path"
+  fi
+}
+
+echo "[e2e] HOME=$HOME"
+
+# ------------------------------------------------------------------
+# Scenario 1 — chmod 600 settings.json must survive the install.
+# ------------------------------------------------------------------
+step "scenario 1: chmod 600 ~/.claude/settings.json must survive integrations install"
+
+mkdir -p "$HOME/.claude"
+SETTINGS="$HOME/.claude/settings.json"
+echo '{}' > "$SETTINGS"
+chmod 600 "$SETTINGS"
+
+before_mode="$(read_mode "$SETTINGS")"
+if [[ "$before_mode" != "600" ]]; then
+  echo "[e2e] FAIL: pre-install mode was $before_mode, expected 600" >&2
+  exit 1
+fi
+echo "[e2e] pre-install mode: $before_mode"
+
+"$BUDI" integrations install --with claude-code-statusline --yes \
+  >"$TMPDIR_ROOT/install-1.log" 2>&1 || {
+  cat "$TMPDIR_ROOT/install-1.log" >&2
+  echo "[e2e] FAIL: \`integrations install\` exited non-zero" >&2
+  exit 1
+}
+
+if [[ ! -f "$SETTINGS" ]]; then
+  echo "[e2e] FAIL: $SETTINGS missing after install" >&2
+  exit 1
+fi
+
+after_mode="$(read_mode "$SETTINGS")"
+echo "[e2e] post-install mode: $after_mode"
+if [[ "$after_mode" != "600" ]]; then
+  echo "[e2e] FAIL: mode bits were not preserved (expected 600, got $after_mode)" >&2
+  ls -l "$SETTINGS" >&2
+  exit 1
+fi
+
+if ! grep -q '"statusLine"' "$SETTINGS"; then
+  echo "[e2e] FAIL: install ran but did not write the statusLine entry" >&2
+  cat "$SETTINGS" >&2
+  exit 1
+fi
+echo "[e2e] OK: mode 600 preserved AND statusLine installed"
+
+# ------------------------------------------------------------------
+# Scenario 2 — symlinked settings.json must stay a symlink, content
+# must land at the canonical target (dotfile-manager contract).
+# ------------------------------------------------------------------
+step "scenario 2: symlinked settings.json must stay a symlink, content updates at the canonical target"
+
+# Reset HOME state — the previous scenario already wrote the file, and
+# we want a clean slate for the symlink test.
+rm -f "$SETTINGS"
+
+DOTFILES_DIR="$HOME/dotfiles/claude"
+DOTFILES_TARGET="$DOTFILES_DIR/settings.json"
+mkdir -p "$DOTFILES_DIR"
+echo '{}' > "$DOTFILES_TARGET"
+
+ln -s "$DOTFILES_TARGET" "$SETTINGS"
+
+if [[ ! -L "$SETTINGS" ]]; then
+  echo "[e2e] FAIL: pre-install $SETTINGS is not a symlink" >&2
+  exit 1
+fi
+echo "[e2e] pre-install symlink target: $(readlink "$SETTINGS")"
+
+"$BUDI" integrations install --with claude-code-statusline --yes \
+  >"$TMPDIR_ROOT/install-2.log" 2>&1 || {
+  cat "$TMPDIR_ROOT/install-2.log" >&2
+  echo "[e2e] FAIL: \`integrations install\` exited non-zero in symlink scenario" >&2
+  exit 1
+}
+
+if [[ ! -L "$SETTINGS" ]]; then
+  echo "[e2e] FAIL: post-install $SETTINGS is no longer a symlink" >&2
+  ls -l "$SETTINGS" >&2
+  exit 1
+fi
+
+post_target="$(readlink "$SETTINGS")"
+if [[ "$post_target" != "$DOTFILES_TARGET" ]]; then
+  echo "[e2e] FAIL: symlink target changed (expected $DOTFILES_TARGET, got $post_target)" >&2
+  exit 1
+fi
+echo "[e2e] post-install symlink target: $post_target"
+
+if ! grep -q '"statusLine"' "$DOTFILES_TARGET"; then
+  echo "[e2e] FAIL: canonical target $DOTFILES_TARGET did not receive the statusLine update" >&2
+  cat "$DOTFILES_TARGET" >&2
+  exit 1
+fi
+echo "[e2e] OK: symlink preserved, content landed at $DOTFILES_TARGET"
+
+step "all assertions passed"
+exit 0


### PR DESCRIPTION
Fixes #697.

## Summary

`atomic_write_json` (`crates/budi-cli/src/commands/mod.rs`) — the single
writer for every JSON file `budi` puts under `~/.claude` and `~/.cursor`
(`install_claude_settings`, `apply_otel_env_vars`, `apply_cc_hooks`,
hooks-route handlers, `uninstall`) — did `fs::write(tmp); fs::rename(tmp, path)`.
The rename is atomic but two side effects came along uninvited:

1. **Mode bits reset to umask defaults.** A user-set
   `chmod 600 ~/.claude/settings.json` (that file holds env vars, OTEL
   endpoints, sometimes anthropic keys) was silently relaxed to 644 on
   every `budi init` / `budi integrations install`. Privacy regression.
2. **Symlinks replaced with regular files.** Dotfile managers
   (`chezmoi`, `stow`, `yadm`, hand-rolled `ln -s`) manage
   `~/.claude/settings.json` as a symlink into a Git-tracked dotfiles
   repo. After `budi init` the symlink was gone and the file was a stale
   local copy. Correctness regression.

Both fired on a routine install — no flags, no warning. ADR-0083 says
local-only surface stays local-only, *including* OS-level access bits.

## What's in

- `atomic_write_json` now:
  - Stats the target before writing, captures `st_mode`, and restores
    it via `set_permissions` after the rename (Unix only; gated behind
    `cfg(unix)` and `std::os::unix::fs::PermissionsExt`).
  - Detects symlink targets via `fs::symlink_metadata`, resolves via
    `fs::canonicalize`, and places the tmp + rename inside the
    *resolved* parent — so the symlink stays intact and dotfile
    managers keep seeing the canonical file as the source of truth.
  - Falls back to a non-atomic in-place write (with a clear
    `tracing::warn!`) when canonicalize fails (broken symlink) or
    rename fails (cross-fs, permissions) — audible divergence over
    silent loss.
- Two new unit tests under `commands::tests::`:
  - `atomic_write_json_preserves_mode_bits` — `chmod 600` round-trip.
  - `atomic_write_json_preserves_symlinks` — symlink stays a symlink,
    new content lands at the canonical target.
- New smoke gate
  `scripts/e2e/test_697_atomic_write_preserves_mode_and_symlinks.sh`
  that drives the real release binary against both scenarios end-to-end
  via `budi integrations install --with claude-code-statusline --yes`.

## What's not in

- No backup-on-write feature. `backup_invalid_json` already runs on
  parse failure and that's the right scope (per ticket).
- No special handling for the symlinked-target-lives-in-user's-dotfiles-repo
  case beyond best-effort symlink preservation — deeper integration with
  `chezmoi` / `stow` is not budi's job (per ticket).
- No bump of `MIN_API_VERSION`. Ticket is a CLI-side regression; the
  HTTP wire contract is untouched.

## What's deferred

Nothing.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo test --workspace` — all green; tailer-shutdown timing test
      flaked once under load and passed in isolation on rerun
      (per CONTRIBUTING guidance for #410).
- [x] `bash scripts/e2e/test_697_atomic_write_preserves_mode_and_symlinks.sh`
      — both scenarios PASS against a release-built `budi`.
- [x] Manual reproducer from the ticket:
      ```sh
      $ chmod 600 ~/.claude/settings.json
      $ budi integrations install --with claude-code-statusline --yes
      $ stat -f '%Lp' ~/.claude/settings.json   # → 600 (was 644)
      ```
      ```sh
      $ ln -s ~/dotfiles/claude/settings.json ~/.claude/settings.json
      $ budi integrations install --with claude-code-statusline --yes
      $ ls -l ~/.claude/settings.json           # still a symlink
      ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)