### PR TITLE
[8.4.2] sessions/messages: add surface dimension (vscode/cursor/jetbrains/terminal) — data layer

### DIFF
--- a/crates/budi-core/src/analytics/mod.rs
+++ b/crates/budi-core/src/analytics/mod.rs
@@ -203,6 +203,16 @@ pub struct MessageRow {
     pub tools: Vec<String>,
     #[serde(default)]
     pub tags: Vec<SessionTag>,
+    /// Host environment the message was produced under (`vscode`,
+    /// `cursor`, `jetbrains`, `terminal`, `unknown`). Distinct from
+    /// `provider`. The data-layer ticket (#701) only ensures the field
+    /// is present; the sibling ticket adds the filter behavior.
+    #[serde(default = "default_unknown_surface")]
+    pub surface: String,
+}
+
+fn default_unknown_surface() -> String {
+    crate::surface::UNKNOWN.to_string()
 }
 
 #[derive(Debug, Clone)]
@@ -477,15 +487,25 @@ pub fn ingest_messages_with_sync(
         // so a hypothetical future writer that skips the enricher still
         // produces a valid tag rather than NULL.
         let pricing_source: Option<&str> = msg.pricing_source.as_deref();
+        // #701: surface is provider-set (parser-local). Fall back to the
+        // provider's natural surface (terminal for claude_code/codex/
+        // copilot_cli, cursor for cursor; copilot_chat must always set
+        // its own per-path) so a writer that bypasses the parser still
+        // produces a valid tag.
+        let surface_value: String = msg
+            .surface
+            .clone()
+            .unwrap_or_else(|| crate::surface::default_for_provider(&msg.provider).to_string());
         let inserted = tx.execute(
             "INSERT OR IGNORE INTO messages
              (id, session_id, role, timestamp, model,
               input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
               cwd, repo_id, provider,
               cost_cents,
-              parent_uuid, git_branch, cost_confidence, request_id, pricing_source)
+              parent_uuid, git_branch, cost_confidence, request_id, pricing_source, surface)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17,
-                     COALESCE(?18, 'legacy:pre-manifest'))",
+                     COALESCE(?18, 'legacy:pre-manifest'),
+                     ?19)",
             params![
                 msg.uuid,
                 normalized_session_id.as_deref(),
@@ -505,6 +525,7 @@ pub fn ingest_messages_with_sync(
                 msg.cost_confidence,
                 msg.request_id,
                 pricing_source,
+                surface_value,
             ],
         )?;
 
@@ -527,7 +548,7 @@ pub fn ingest_messages_with_sync(
     // This makes `sessions` a merged metadata table populated from any source,
     // not only hooks. Hooks/OTEL will later enrich these stubs with metadata.
     {
-        let mut seen_sessions: std::collections::HashSet<(String, String)> =
+        let mut seen_sessions: std::collections::HashSet<(String, String, String)> =
             std::collections::HashSet::new();
         let mut session_categories: std::collections::HashMap<String, String> =
             std::collections::HashMap::new();
@@ -538,16 +559,19 @@ pub fn ingest_messages_with_sync(
                 .map(crate::identity::normalize_session_id)
                 .filter(|sid| !sid.is_empty())
             {
-                seen_sessions.insert((sid.clone(), msg.provider.clone()));
+                let surface_value = msg.surface.clone().unwrap_or_else(|| {
+                    crate::surface::default_for_provider(&msg.provider).to_string()
+                });
+                seen_sessions.insert((sid.clone(), msg.provider.clone(), surface_value));
                 if let Some(ref cat) = msg.prompt_category {
                     session_categories.insert(sid, cat.clone());
                 }
             }
         }
-        for (sid, provider) in &seen_sessions {
+        for (sid, provider, surface_value) in &seen_sessions {
             tx.execute(
-                "INSERT OR IGNORE INTO sessions (id, provider) VALUES (?1, ?2)",
-                params![sid, provider],
+                "INSERT OR IGNORE INTO sessions (id, provider, surface) VALUES (?1, ?2, ?3)",
+                params![sid, provider, surface_value],
             )?;
             // Without this, claude_code/codex sessions keep started_at/ended_at/
             // repo_id/git_branch = NULL forever (#569 / #577) and never reach
@@ -572,7 +596,23 @@ pub fn ingest_messages_with_sync(
                         (SELECT m.git_branch FROM messages m
                           WHERE m.session_id = ?1
                             AND m.git_branch IS NOT NULL AND m.git_branch <> ''
-                          ORDER BY m.timestamp DESC LIMIT 1))
+                          ORDER BY m.timestamp DESC LIMIT 1)),
+                    surface = CASE
+                        WHEN sessions.surface IS NULL OR sessions.surface = '' OR sessions.surface = 'unknown'
+                        THEN COALESCE(
+                            (SELECT m.surface FROM messages m
+                              WHERE m.session_id = ?1
+                                AND m.surface IS NOT NULL
+                                AND m.surface <> ''
+                                AND m.surface <> 'unknown'
+                              GROUP BY m.surface
+                              ORDER BY COUNT(*) DESC, m.surface ASC
+                              LIMIT 1),
+                            sessions.surface,
+                            'unknown'
+                        )
+                        ELSE sessions.surface
+                    END
                  WHERE id = ?1",
                 params![sid],
             )?;

--- a/crates/budi-core/src/analytics/queries.rs
+++ b/crates/budi-core/src/analytics/queries.rs
@@ -865,7 +865,8 @@ pub fn message_list(conn: &Connection, p: &MessageListParams) -> Result<Paginate
                 messages.cache_creation_tokens, messages.cache_read_tokens,
                 COALESCE(messages.cost_cents, 0.0),
                 COALESCE(messages.cost_confidence, 'estimated'),
-                COALESCE(messages.git_branch, s.git_branch)
+                COALESCE(messages.git_branch, s.git_branch),
+                COALESCE(NULLIF(messages.surface, ''), 'unknown') AS surface
          FROM messages
          LEFT JOIN sessions s ON s.id = messages.session_id
          {}
@@ -901,6 +902,7 @@ pub fn message_list(conn: &Connection, p: &MessageListParams) -> Result<Paginate
                 cost_cents: row.get(11)?,
                 cost_confidence: row.get(12)?,
                 git_branch: row.get(13)?,
+                surface: row.get(14)?,
                 request_id: None,
                 assistant_sequence: None,
                 tools: Vec::new(),

--- a/crates/budi-core/src/analytics/sessions.rs
+++ b/crates/budi-core/src/analytics/sessions.rs
@@ -241,6 +241,17 @@ pub struct SessionListEntry {
     /// may lag up to ~10 minutes per the Usage API.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cost_lag_hint: Option<String>,
+    /// Host environment the session ran under — `vscode`, `cursor`,
+    /// `jetbrains`, `terminal`, or `unknown`. Surfaced so host
+    /// extensions can render only their host's sessions. Filter behavior
+    /// is the sibling ticket; this PR only ensures the field is
+    /// returned. See `crate::surface` and ticket #701.
+    #[serde(default = "default_unknown_surface_for_session")]
+    pub surface: String,
+}
+
+fn default_unknown_surface_for_session() -> String {
+    crate::surface::UNKNOWN.to_string()
 }
 
 /// Paginated session list result.
@@ -569,7 +580,22 @@ pub fn session_list_with_filters(
                     COALESCE(s.duration_ms,
                         CAST((julianday(MAX(m.timestamp)) - julianday(MIN(m.timestamp))) * 86400000 AS INTEGER)
                     ) as duration_ms,
-                    s.title
+                    s.title,
+                    COALESCE(
+                        (
+                            SELECT m2.surface
+                            FROM messages m2
+                            WHERE m2.session_id = m.session_id
+                              AND m2.surface IS NOT NULL
+                              AND m2.surface != ''
+                              AND m2.surface != 'unknown'
+                            GROUP BY m2.surface
+                            ORDER BY COUNT(*) DESC, m2.surface ASC
+                            LIMIT 1
+                        ),
+                        NULLIF(MAX(s.surface), ''),
+                        'unknown'
+                    ) as surface
              FROM messages m
              LEFT JOIN sessions s ON s.id = m.session_id
              {where_clause}
@@ -579,7 +605,8 @@ pub fn session_list_with_filters(
          SELECT COUNT(*) OVER() as total,
                 sa.session_id, sa.started_at, sa.ended_at, sa.duration_ms,
                 sa.msg_count, sa.cost, sa.models_csv, sa.provider,
-                sa.repo_ids_csv, sa.git_branches_csv, sa.inp, sa.outp, sa.cost_confidence, sa.title
+                sa.repo_ids_csv, sa.git_branches_csv, sa.inp, sa.outp, sa.cost_confidence, sa.title,
+                sa.surface
          FROM session_agg sa
          ORDER BY {order_expr}
          LIMIT ?{limit_idx} OFFSET ?{offset_idx}",
@@ -606,6 +633,7 @@ pub fn session_list_with_filters(
                 cost_confidence: row.get(13)?,
                 health_state: None,
                 title: row.get(14)?,
+                surface: row.get(15)?,
                 work_outcome: None,
                 work_outcome_rationale: None,
                 cost_lag_hint: None,
@@ -742,7 +770,22 @@ pub fn session_detail(conn: &Connection, session_id: &str) -> Result<Option<Sess
                         WHEN SUM(CASE WHEN m.cost_confidence LIKE '%estimated%' THEN 1 ELSE 0 END) > 0 THEN 'estimated'
                         ELSE COALESCE(MAX(m.cost_confidence), 'exact')
                     END as cost_confidence,
-                    MAX(s.title) as title
+                    MAX(s.title) as title,
+                    COALESCE(
+                        (
+                            SELECT m2.surface
+                            FROM messages m2
+                            WHERE m2.session_id = sid.session_id
+                              AND m2.surface IS NOT NULL
+                              AND m2.surface != ''
+                              AND m2.surface != 'unknown'
+                            GROUP BY m2.surface
+                            ORDER BY COUNT(*) DESC, m2.surface ASC
+                            LIMIT 1
+                        ),
+                        NULLIF(MAX(s.surface), ''),
+                        'unknown'
+                    ) as surface
              FROM (SELECT ?1 AS session_id) sid
              LEFT JOIN sessions s ON s.id = sid.session_id
              LEFT JOIN messages m ON m.session_id = sid.session_id AND m.role = 'assistant'
@@ -751,7 +794,7 @@ pub fn session_detail(conn: &Connection, session_id: &str) -> Result<Option<Sess
          )
          SELECT session_id, started_at, ended_at, duration_ms, msg_count, cost,
                 models_csv, provider, repo_ids_csv, git_branches_csv,
-                inp, outp, cost_confidence, title
+                inp, outp, cost_confidence, title, surface
          FROM session_agg",
         params![session_id],
         |row| {
@@ -773,6 +816,7 @@ pub fn session_detail(conn: &Connection, session_id: &str) -> Result<Option<Sess
                 cost_confidence: row.get(12)?,
                 health_state: None,
                 title: row.get(13)?,
+                surface: row.get(14)?,
                 work_outcome: None,
                 work_outcome_rationale: None,
                 cost_lag_hint: None,
@@ -1004,7 +1048,8 @@ pub fn session_messages_with_roles(
                 COALESCE(cost_cents, 0.0),
                 COALESCE(cost_confidence, 'estimated'),
                 git_branch,
-                request_id
+                request_id,
+                COALESCE(NULLIF(surface, ''), 'unknown')
          FROM messages
          WHERE session_id = ?1",
     );
@@ -1032,6 +1077,7 @@ pub fn session_messages_with_roles(
                 cost_confidence: row.get(11)?,
                 git_branch: row.get(12)?,
                 request_id: row.get(13)?,
+                surface: row.get(14)?,
                 assistant_sequence: None,
                 tools: Vec::new(),
                 tags: Vec::new(),
@@ -1112,7 +1158,8 @@ pub fn session_message_list(
                 COALESCE(m.cost_confidence, 'estimated'),
                 m.git_branch,
                 m.request_id,
-                seq.assistant_sequence
+                seq.assistant_sequence,
+                COALESCE(NULLIF(m.surface, ''), 'unknown')
          FROM messages m
          LEFT JOIN assistant_sequence seq ON seq.id = m.id
          {where_clause}
@@ -1140,6 +1187,7 @@ pub fn session_message_list(
                 git_branch: row.get(12)?,
                 request_id: row.get(13)?,
                 assistant_sequence: row.get::<_, Option<u64>>(14)?,
+                surface: row.get(15)?,
                 tools: Vec::new(),
                 tags: Vec::new(),
             })
@@ -1219,7 +1267,8 @@ pub fn message_detail(conn: &Connection, message_id: &str) -> Result<Option<Mess
                 COALESCE(cost_cents, 0.0),
                 COALESCE(cost_confidence, 'estimated'),
                 git_branch,
-                request_id
+                request_id,
+                COALESCE(NULLIF(surface, ''), 'unknown')
          FROM messages
          WHERE id = ?1",
         params![message_id],
@@ -1240,6 +1289,7 @@ pub fn message_detail(conn: &Connection, message_id: &str) -> Result<Option<Mess
                 cost_confidence: row.get(12)?,
                 git_branch: row.get(13)?,
                 request_id: row.get(14)?,
+                surface: row.get(15)?,
                 assistant_sequence: None,
                 tools: Vec::new(),
                 tags: Vec::new(),

--- a/crates/budi-core/src/analytics/tests.rs
+++ b/crates/budi-core/src/analytics/tests.rs
@@ -77,6 +77,7 @@ fn ingest_and_query() {
             tool_files: Vec::new(),
             tool_outcomes: Vec::new(),
             cwd_source: None,
+            surface: None,
         },
         ParsedMessage {
             uuid: "a1".to_string(),
@@ -111,6 +112,7 @@ fn ingest_and_query() {
             tool_files: Vec::new(),
             tool_outcomes: Vec::new(),
             cwd_source: None,
+            surface: None,
         },
     ];
 
@@ -165,6 +167,7 @@ fn rollups_track_message_updates_and_deletes() {
         tool_files: Vec::new(),
         tool_outcomes: Vec::new(),
         cwd_source: None,
+        surface: None,
     };
     ingest_messages(&mut conn, &[msg], None).unwrap();
 
@@ -224,6 +227,7 @@ fn rollups_are_used_only_for_hour_aligned_ranges() {
         tool_files: Vec::new(),
         tool_outcomes: Vec::new(),
         cwd_source: None,
+        surface: None,
     };
     ingest_messages(&mut conn, &[msg], None).unwrap();
 
@@ -301,6 +305,7 @@ fn rollup_summary_latency_smoke_on_large_dataset() {
             tool_files: Vec::new(),
             tool_outcomes: Vec::new(),
             cwd_source: None,
+            surface: None,
         });
     }
     ingest_messages(&mut conn, &messages, None).unwrap();
@@ -357,6 +362,7 @@ fn cost_cents_baked_at_ingest() {
         tool_files: Vec::new(),
         tool_outcomes: Vec::new(),
         cwd_source: None,
+        surface: None,
     };
     // CostEnricher is the single source of truth for cost_cents
     CostEnricher.enrich(&mut msg);
@@ -436,6 +442,7 @@ fn last_seen_derived_from_messages() {
             tool_files: Vec::new(),
             tool_outcomes: Vec::new(),
             cwd_source: None,
+            surface: None,
         },
         ParsedMessage {
             uuid: "m2".to_string(),
@@ -470,6 +477,7 @@ fn last_seen_derived_from_messages() {
             tool_files: Vec::new(),
             tool_outcomes: Vec::new(),
             cwd_source: None,
+            surface: None,
         },
     ];
     ingest_messages(&mut conn, &msgs, None).unwrap();
@@ -521,6 +529,7 @@ fn newest_ingested_data_uses_assistant_rows() {
             tool_files: Vec::new(),
             tool_outcomes: Vec::new(),
             cwd_source: None,
+            surface: None,
         },
         ParsedMessage {
             uuid: "a-only".to_string(),
@@ -555,6 +564,7 @@ fn newest_ingested_data_uses_assistant_rows() {
             tool_files: Vec::new(),
             tool_outcomes: Vec::new(),
             cwd_source: None,
+            surface: None,
         },
     ];
     ingest_messages(&mut conn, &msgs, None).unwrap();
@@ -597,6 +607,7 @@ fn sample_messages() -> Vec<ParsedMessage> {
             tool_files: Vec::new(),
             tool_outcomes: Vec::new(),
             cwd_source: None,
+            surface: None,
         },
         ParsedMessage {
             uuid: "a1".to_string(),
@@ -631,6 +642,7 @@ fn sample_messages() -> Vec<ParsedMessage> {
             tool_files: Vec::new(),
             tool_outcomes: Vec::new(),
             cwd_source: None,
+            surface: None,
         },
         ParsedMessage {
             uuid: "u2".to_string(),
@@ -665,6 +677,7 @@ fn sample_messages() -> Vec<ParsedMessage> {
             tool_files: Vec::new(),
             tool_outcomes: Vec::new(),
             cwd_source: None,
+            surface: None,
         },
     ]
 }
@@ -735,6 +748,7 @@ fn mixed_provider_messages() -> Vec<ParsedMessage> {
         tool_files: Vec::new(),
         tool_outcomes: Vec::new(),
         cwd_source: None,
+        surface: None,
     });
     msgs
 }
@@ -1008,6 +1022,7 @@ fn messages_with_cache_patterns() -> Vec<ParsedMessage> {
             tool_files: Vec::new(),
             tool_outcomes: Vec::new(),
             cwd_source: None,
+            surface: None,
         },
         ParsedMessage {
             uuid: "t2".to_string(),
@@ -1042,6 +1057,7 @@ fn messages_with_cache_patterns() -> Vec<ParsedMessage> {
             tool_files: Vec::new(),
             tool_outcomes: Vec::new(),
             cwd_source: None,
+            surface: None,
         },
         ParsedMessage {
             uuid: "t3".to_string(),
@@ -1076,6 +1092,7 @@ fn messages_with_cache_patterns() -> Vec<ParsedMessage> {
             tool_files: Vec::new(),
             tool_outcomes: Vec::new(),
             cwd_source: None,
+            surface: None,
         },
     ]
 }
@@ -1183,6 +1200,7 @@ fn statusline_stats_branch_cost_scopes_to_repo_id() {
         tool_files: Vec::new(),
         tool_outcomes: Vec::new(),
         cwd_source: None,
+        surface: None,
     };
     let msgs = vec![
         mk("repo-a-1", "sess-a", "github.com/org/repo-a", 300.0),
@@ -1294,6 +1312,7 @@ fn statusline_stats_with_provider_filter_scopes_all_numeric_fields() {
             tool_files: Vec::new(),
             tool_outcomes: Vec::new(),
             cwd_source: None,
+            surface: None,
         },
         ParsedMessage {
             uuid: "cursor-1".to_string(),
@@ -1328,6 +1347,7 @@ fn statusline_stats_with_provider_filter_scopes_all_numeric_fields() {
             tool_files: Vec::new(),
             tool_outcomes: Vec::new(),
             cwd_source: None,
+            surface: None,
         },
     ];
     ingest_messages(&mut conn, &msgs, None).unwrap();
@@ -1435,6 +1455,7 @@ fn statusline_stats_aggregates_across_multiple_providers() {
         tool_files: Vec::new(),
         tool_outcomes: Vec::new(),
         cwd_source: None,
+        surface: None,
     };
 
     let msgs = vec![
@@ -1637,6 +1658,7 @@ fn multi_provider_ingest_and_query() {
             tool_files: Vec::new(),
             tool_outcomes: Vec::new(),
             cwd_source: None,
+            surface: None,
         },
         ParsedMessage {
             uuid: "cc-a1".to_string(),
@@ -1671,6 +1693,7 @@ fn multi_provider_ingest_and_query() {
             tool_files: Vec::new(),
             tool_outcomes: Vec::new(),
             cwd_source: None,
+            surface: None,
         },
     ];
 
@@ -1708,6 +1731,7 @@ fn multi_provider_ingest_and_query() {
             tool_files: Vec::new(),
             tool_outcomes: Vec::new(),
             cwd_source: None,
+            surface: None,
         },
         ParsedMessage {
             uuid: "cu-a1".to_string(),
@@ -1742,6 +1766,7 @@ fn multi_provider_ingest_and_query() {
             tool_files: Vec::new(),
             tool_outcomes: Vec::new(),
             cwd_source: None,
+            surface: None,
         },
     ];
 
@@ -1822,6 +1847,7 @@ fn cross_parse_dedup_by_request_id() {
         tool_files: Vec::new(),
         tool_outcomes: Vec::new(),
         cwd_source: None,
+        surface: None,
     };
     ingest_messages(&mut conn, &[intermediate], None).unwrap();
 
@@ -1863,6 +1889,7 @@ fn cross_parse_dedup_by_request_id() {
         tool_files: Vec::new(),
         tool_outcomes: Vec::new(),
         cwd_source: None,
+        surface: None,
     };
     ingest_messages(&mut conn, &[final_entry], None).unwrap();
 
@@ -1919,6 +1946,7 @@ fn cross_parse_dedup_keeps_higher_output() {
         tool_files: Vec::new(),
         tool_outcomes: Vec::new(),
         cwd_source: None,
+        surface: None,
     };
     ingest_messages(&mut conn, &[final_entry], None).unwrap();
 
@@ -1955,6 +1983,7 @@ fn cross_parse_dedup_keeps_higher_output() {
         tool_files: Vec::new(),
         tool_outcomes: Vec::new(),
         cwd_source: None,
+        surface: None,
     };
     ingest_messages(&mut conn, &[intermediate], None).unwrap();
 
@@ -2009,6 +2038,7 @@ fn no_request_id_no_dedup() {
         tool_files: Vec::new(),
         tool_outcomes: Vec::new(),
         cwd_source: None,
+        surface: None,
     };
     ingest_messages(&mut conn, &[msg1], None).unwrap();
 
@@ -2045,6 +2075,7 @@ fn no_request_id_no_dedup() {
         tool_files: Vec::new(),
         tool_outcomes: Vec::new(),
         cwd_source: None,
+        surface: None,
     };
     ingest_messages(&mut conn, &[msg2], None).unwrap();
 
@@ -2113,6 +2144,7 @@ fn jsonl_dedup_matches_otel_by_fingerprint_within_window() {
         tool_files: Vec::new(),
         tool_outcomes: Vec::new(),
         cwd_source: None,
+        surface: None,
     };
     ingest_messages(&mut conn, &[msg], None).unwrap();
 
@@ -2245,6 +2277,7 @@ fn session_cost_curve_buckets() {
             tool_files: Vec::new(),
             tool_outcomes: Vec::new(),
             cwd_source: None,
+            surface: None,
         });
     }
     ingest_messages(&mut conn, &msgs, None).unwrap();
@@ -2292,6 +2325,7 @@ fn cost_confidence_stats_groups_correctly() {
             tool_files: Vec::new(),
             tool_outcomes: Vec::new(),
             cwd_source: None,
+            surface: None,
         },
         ParsedMessage {
             uuid: "conf-2".to_string(),
@@ -2326,6 +2360,7 @@ fn cost_confidence_stats_groups_correctly() {
             tool_files: Vec::new(),
             tool_outcomes: Vec::new(),
             cwd_source: None,
+            surface: None,
         },
     ];
     ingest_messages(&mut conn, &msgs, None).unwrap();
@@ -2375,6 +2410,7 @@ fn subagent_cost_stats_splits_correctly() {
             tool_files: Vec::new(),
             tool_outcomes: Vec::new(),
             cwd_source: None,
+            surface: None,
         },
         ParsedMessage {
             uuid: "sub-1".to_string(),
@@ -2409,6 +2445,7 @@ fn subagent_cost_stats_splits_correctly() {
             tool_files: Vec::new(),
             tool_outcomes: Vec::new(),
             cwd_source: None,
+            surface: None,
         },
     ];
     ingest_messages(&mut conn, &msgs, None).unwrap();
@@ -2893,6 +2930,7 @@ fn assistant_msg(uuid: &str, session_id: &str, cost_cents: f64) -> ParsedMessage
         tool_files: Vec::new(),
         tool_outcomes: Vec::new(),
         cwd_source: None,
+        surface: None,
     }
 }
 
@@ -4282,6 +4320,7 @@ fn health_msg(
         tool_files: Vec::new(),
         tool_outcomes: Vec::new(),
         cwd_source: None,
+        surface: None,
     }
 }
 
@@ -6456,6 +6495,7 @@ fn provider_msg(uuid: &str, session: &str, provider: &str, cost_cents: f64) -> P
         tool_files: Vec::new(),
         tool_outcomes: Vec::new(),
         cwd_source: None,
+        surface: None,
     }
 }
 
@@ -7077,6 +7117,7 @@ fn session_prompt_category_tracks_latest_value() {
         tool_files: Vec::new(),
         tool_outcomes: Vec::new(),
         cwd_source: None,
+        surface: None,
     };
     ingest_messages(&mut conn, &[u1], Some(&[Vec::new()])).unwrap();
 
@@ -7122,6 +7163,7 @@ fn session_prompt_category_tracks_latest_value() {
         tool_files: Vec::new(),
         tool_outcomes: Vec::new(),
         cwd_source: None,
+        surface: None,
     };
     ingest_messages(&mut conn, &[u2], Some(&[Vec::new()])).unwrap();
 

--- a/crates/budi-core/src/jsonl.rs
+++ b/crates/budi-core/src/jsonl.rs
@@ -214,6 +214,13 @@ pub struct ParsedMessage {
     /// tag via `tag_keys::CWD_SOURCE`. Added in #688 for Copilot Chat
     /// emptyWindow editor-context hints.
     pub cwd_source: Option<String>,
+    /// Host environment where the AI conversation happened — `vscode`,
+    /// `cursor`, `jetbrains`, `terminal`, `unknown`. Distinct from
+    /// `provider` (which agent ran the call) and used by host extensions
+    /// to display only their host's rows. Set per-parser; the ingest path
+    /// falls back to `surface::default_for_provider` when `None`. See
+    /// `crate::surface` and ticket #701.
+    pub surface: Option<String>,
 }
 
 /// One provider-reported tool outcome. Content is never stored — we only
@@ -263,6 +270,7 @@ impl Default for ParsedMessage {
             tool_files: Vec::new(),
             tool_outcomes: Vec::new(),
             cwd_source: None,
+            surface: None,
         }
     }
 }
@@ -553,6 +561,7 @@ fn parse_line(line: &str) -> Option<ParsedMessage> {
                 tool_files: Vec::new(),
                 tool_outcomes,
                 cwd_source: None,
+                surface: Some(crate::surface::TERMINAL.to_string()),
             })
         }
         TranscriptEntry::Assistant(a) => {
@@ -606,6 +615,7 @@ fn parse_line(line: &str) -> Option<ParsedMessage> {
                 tool_files,
                 tool_outcomes: Vec::new(),
                 cwd_source: None,
+                surface: Some(crate::surface::TERMINAL.to_string()),
             })
         }
         TranscriptEntry::Other => None,
@@ -672,6 +682,7 @@ fn parse_flat_line(line: &str) -> Option<ParsedMessage> {
                 tool_files,
                 tool_outcomes: Vec::new(),
                 cwd_source: None,
+                surface: Some(crate::surface::TERMINAL.to_string()),
             })
         }
         "user" => Some(ParsedMessage {
@@ -686,6 +697,7 @@ fn parse_flat_line(line: &str) -> Option<ParsedMessage> {
             provider: "claude_code".to_string(),
             cost_confidence: "n/a".to_string(),
             pricing_source: None,
+            surface: Some(crate::surface::TERMINAL.to_string()),
             ..Default::default()
         }),
         _ => None,

--- a/crates/budi-core/src/lib.rs
+++ b/crates/budi-core/src/lib.rs
@@ -19,6 +19,7 @@ pub mod provider;
 pub mod providers;
 pub mod repo_id;
 pub mod session_resolve;
+pub mod surface;
 pub mod sync;
 pub mod tag_keys;
 pub mod update;

--- a/crates/budi-core/src/migration.rs
+++ b/crates/budi-core/src/migration.rs
@@ -137,6 +137,12 @@ fn detect_drift(conn: &Connection) -> Result<(Vec<String>, Vec<String>, Vec<Stri
     if !table_exists(conn, "pricing_manifests")? {
         added_columns.push("pricing_manifests".to_string());
     }
+    if table_exists(conn, "messages")? && !has_column(conn, "messages", "surface")? {
+        added_columns.push("messages.surface".to_string());
+    }
+    if table_exists(conn, "sessions")? && !has_column(conn, "sessions", "surface")? {
+        added_columns.push("sessions.surface".to_string());
+    }
     if table_exists(conn, "proxy_events")? {
         removed_tables.push("proxy_events".to_string());
     }
@@ -206,7 +212,8 @@ fn create_current_schema(conn: &Connection) -> Result<()> {
             git_branch             TEXT,
             cost_confidence        TEXT DEFAULT 'estimated',
             request_id             TEXT,
-            pricing_source         TEXT NOT NULL DEFAULT 'legacy:pre-manifest'
+            pricing_source         TEXT NOT NULL DEFAULT 'legacy:pre-manifest',
+            surface                TEXT NOT NULL DEFAULT 'unknown'
         );
 
         CREATE TABLE IF NOT EXISTS tags (
@@ -336,7 +343,8 @@ fn create_sessions(conn: &Connection) -> Result<()> {
             raw_json           TEXT,
             repo_id            TEXT,
             git_branch         TEXT,
-            title              TEXT
+            title              TEXT,
+            surface            TEXT NOT NULL DEFAULT 'unknown'
         );
         ",
     )?;
@@ -362,13 +370,14 @@ fn create_rollup_tables(conn: &Connection) -> Result<()> {
             model                  TEXT NOT NULL,
             repo_id                TEXT NOT NULL,
             git_branch             TEXT NOT NULL,
+            surface                TEXT NOT NULL DEFAULT 'unknown',
             message_count          INTEGER NOT NULL DEFAULT 0,
             input_tokens           INTEGER NOT NULL DEFAULT 0,
             output_tokens          INTEGER NOT NULL DEFAULT 0,
             cache_creation_tokens  INTEGER NOT NULL DEFAULT 0,
             cache_read_tokens      INTEGER NOT NULL DEFAULT 0,
             cost_cents             REAL NOT NULL DEFAULT 0,
-            PRIMARY KEY(bucket_start, role, provider, model, repo_id, git_branch)
+            PRIMARY KEY(bucket_start, role, provider, model, repo_id, git_branch, surface)
         );
 
         CREATE TABLE IF NOT EXISTS message_rollups_daily (
@@ -378,13 +387,14 @@ fn create_rollup_tables(conn: &Connection) -> Result<()> {
             model                  TEXT NOT NULL,
             repo_id                TEXT NOT NULL,
             git_branch             TEXT NOT NULL,
+            surface                TEXT NOT NULL DEFAULT 'unknown',
             message_count          INTEGER NOT NULL DEFAULT 0,
             input_tokens           INTEGER NOT NULL DEFAULT 0,
             output_tokens          INTEGER NOT NULL DEFAULT 0,
             cache_creation_tokens  INTEGER NOT NULL DEFAULT 0,
             cache_read_tokens      INTEGER NOT NULL DEFAULT 0,
             cost_cents             REAL NOT NULL DEFAULT 0,
-            PRIMARY KEY(bucket_day, role, provider, model, repo_id, git_branch)
+            PRIMARY KEY(bucket_day, role, provider, model, repo_id, git_branch, surface)
         );
         ",
     )?;
@@ -402,7 +412,7 @@ fn create_rollup_triggers(conn: &Connection) -> Result<()> {
         AFTER INSERT ON messages
         BEGIN
             INSERT INTO message_rollups_hourly (
-                bucket_start, role, provider, model, repo_id, git_branch,
+                bucket_start, role, provider, model, repo_id, git_branch, surface,
                 message_count, input_tokens, output_tokens,
                 cache_creation_tokens, cache_read_tokens, cost_cents
             )
@@ -427,6 +437,7 @@ fn create_rollup_triggers(conn: &Connection) -> Result<()> {
                     ),
                     '(untagged)'
                 ),
+                COALESCE(NULLIF(NEW.surface, ''), 'unknown'),
                 1,
                 COALESCE(NEW.input_tokens, 0),
                 COALESCE(NEW.output_tokens, 0),
@@ -434,7 +445,7 @@ fn create_rollup_triggers(conn: &Connection) -> Result<()> {
                 COALESCE(NEW.cache_read_tokens, 0),
                 COALESCE(NEW.cost_cents, 0.0)
             )
-            ON CONFLICT(bucket_start, role, provider, model, repo_id, git_branch) DO UPDATE SET
+            ON CONFLICT(bucket_start, role, provider, model, repo_id, git_branch, surface) DO UPDATE SET
                 message_count = message_count + excluded.message_count,
                 input_tokens = input_tokens + excluded.input_tokens,
                 output_tokens = output_tokens + excluded.output_tokens,
@@ -443,7 +454,7 @@ fn create_rollup_triggers(conn: &Connection) -> Result<()> {
                 cost_cents = cost_cents + excluded.cost_cents;
 
             INSERT INTO message_rollups_daily (
-                bucket_day, role, provider, model, repo_id, git_branch,
+                bucket_day, role, provider, model, repo_id, git_branch, surface,
                 message_count, input_tokens, output_tokens,
                 cache_creation_tokens, cache_read_tokens, cost_cents
             )
@@ -468,6 +479,7 @@ fn create_rollup_triggers(conn: &Connection) -> Result<()> {
                     ),
                     '(untagged)'
                 ),
+                COALESCE(NULLIF(NEW.surface, ''), 'unknown'),
                 1,
                 COALESCE(NEW.input_tokens, 0),
                 COALESCE(NEW.output_tokens, 0),
@@ -475,7 +487,7 @@ fn create_rollup_triggers(conn: &Connection) -> Result<()> {
                 COALESCE(NEW.cache_read_tokens, 0),
                 COALESCE(NEW.cost_cents, 0.0)
             )
-            ON CONFLICT(bucket_day, role, provider, model, repo_id, git_branch) DO UPDATE SET
+            ON CONFLICT(bucket_day, role, provider, model, repo_id, git_branch, surface) DO UPDATE SET
                 message_count = message_count + excluded.message_count,
                 input_tokens = input_tokens + excluded.input_tokens,
                 output_tokens = output_tokens + excluded.output_tokens,
@@ -488,7 +500,7 @@ fn create_rollup_triggers(conn: &Connection) -> Result<()> {
         AFTER DELETE ON messages
         BEGIN
             INSERT INTO message_rollups_hourly (
-                bucket_start, role, provider, model, repo_id, git_branch,
+                bucket_start, role, provider, model, repo_id, git_branch, surface,
                 message_count, input_tokens, output_tokens,
                 cache_creation_tokens, cache_read_tokens, cost_cents
             )
@@ -513,6 +525,7 @@ fn create_rollup_triggers(conn: &Connection) -> Result<()> {
                     ),
                     '(untagged)'
                 ),
+                COALESCE(NULLIF(OLD.surface, ''), 'unknown'),
                 -1,
                 -COALESCE(OLD.input_tokens, 0),
                 -COALESCE(OLD.output_tokens, 0),
@@ -520,7 +533,7 @@ fn create_rollup_triggers(conn: &Connection) -> Result<()> {
                 -COALESCE(OLD.cache_read_tokens, 0),
                 -COALESCE(OLD.cost_cents, 0.0)
             )
-            ON CONFLICT(bucket_start, role, provider, model, repo_id, git_branch) DO UPDATE SET
+            ON CONFLICT(bucket_start, role, provider, model, repo_id, git_branch, surface) DO UPDATE SET
                 message_count = message_count + excluded.message_count,
                 input_tokens = input_tokens + excluded.input_tokens,
                 output_tokens = output_tokens + excluded.output_tokens,
@@ -549,10 +562,11 @@ fn create_rollup_triggers(conn: &Connection) -> Result<()> {
                     ),
                     '(untagged)'
                )
+               AND surface = COALESCE(NULLIF(OLD.surface, ''), 'unknown')
                AND message_count <= 0;
 
             INSERT INTO message_rollups_daily (
-                bucket_day, role, provider, model, repo_id, git_branch,
+                bucket_day, role, provider, model, repo_id, git_branch, surface,
                 message_count, input_tokens, output_tokens,
                 cache_creation_tokens, cache_read_tokens, cost_cents
             )
@@ -577,6 +591,7 @@ fn create_rollup_triggers(conn: &Connection) -> Result<()> {
                     ),
                     '(untagged)'
                 ),
+                COALESCE(NULLIF(OLD.surface, ''), 'unknown'),
                 -1,
                 -COALESCE(OLD.input_tokens, 0),
                 -COALESCE(OLD.output_tokens, 0),
@@ -584,7 +599,7 @@ fn create_rollup_triggers(conn: &Connection) -> Result<()> {
                 -COALESCE(OLD.cache_read_tokens, 0),
                 -COALESCE(OLD.cost_cents, 0.0)
             )
-            ON CONFLICT(bucket_day, role, provider, model, repo_id, git_branch) DO UPDATE SET
+            ON CONFLICT(bucket_day, role, provider, model, repo_id, git_branch, surface) DO UPDATE SET
                 message_count = message_count + excluded.message_count,
                 input_tokens = input_tokens + excluded.input_tokens,
                 output_tokens = output_tokens + excluded.output_tokens,
@@ -613,6 +628,7 @@ fn create_rollup_triggers(conn: &Connection) -> Result<()> {
                     ),
                     '(untagged)'
                )
+               AND surface = COALESCE(NULLIF(OLD.surface, ''), 'unknown')
                AND message_count <= 0;
         END;
 
@@ -620,7 +636,7 @@ fn create_rollup_triggers(conn: &Connection) -> Result<()> {
         AFTER UPDATE ON messages
         BEGIN
             INSERT INTO message_rollups_hourly (
-                bucket_start, role, provider, model, repo_id, git_branch,
+                bucket_start, role, provider, model, repo_id, git_branch, surface,
                 message_count, input_tokens, output_tokens,
                 cache_creation_tokens, cache_read_tokens, cost_cents
             )
@@ -645,6 +661,7 @@ fn create_rollup_triggers(conn: &Connection) -> Result<()> {
                     ),
                     '(untagged)'
                 ),
+                COALESCE(NULLIF(OLD.surface, ''), 'unknown'),
                 -1,
                 -COALESCE(OLD.input_tokens, 0),
                 -COALESCE(OLD.output_tokens, 0),
@@ -652,7 +669,7 @@ fn create_rollup_triggers(conn: &Connection) -> Result<()> {
                 -COALESCE(OLD.cache_read_tokens, 0),
                 -COALESCE(OLD.cost_cents, 0.0)
             )
-            ON CONFLICT(bucket_start, role, provider, model, repo_id, git_branch) DO UPDATE SET
+            ON CONFLICT(bucket_start, role, provider, model, repo_id, git_branch, surface) DO UPDATE SET
                 message_count = message_count + excluded.message_count,
                 input_tokens = input_tokens + excluded.input_tokens,
                 output_tokens = output_tokens + excluded.output_tokens,
@@ -681,10 +698,11 @@ fn create_rollup_triggers(conn: &Connection) -> Result<()> {
                     ),
                     '(untagged)'
                )
+               AND surface = COALESCE(NULLIF(OLD.surface, ''), 'unknown')
                AND message_count <= 0;
 
             INSERT INTO message_rollups_daily (
-                bucket_day, role, provider, model, repo_id, git_branch,
+                bucket_day, role, provider, model, repo_id, git_branch, surface,
                 message_count, input_tokens, output_tokens,
                 cache_creation_tokens, cache_read_tokens, cost_cents
             )
@@ -709,6 +727,7 @@ fn create_rollup_triggers(conn: &Connection) -> Result<()> {
                     ),
                     '(untagged)'
                 ),
+                COALESCE(NULLIF(OLD.surface, ''), 'unknown'),
                 -1,
                 -COALESCE(OLD.input_tokens, 0),
                 -COALESCE(OLD.output_tokens, 0),
@@ -716,7 +735,7 @@ fn create_rollup_triggers(conn: &Connection) -> Result<()> {
                 -COALESCE(OLD.cache_read_tokens, 0),
                 -COALESCE(OLD.cost_cents, 0.0)
             )
-            ON CONFLICT(bucket_day, role, provider, model, repo_id, git_branch) DO UPDATE SET
+            ON CONFLICT(bucket_day, role, provider, model, repo_id, git_branch, surface) DO UPDATE SET
                 message_count = message_count + excluded.message_count,
                 input_tokens = input_tokens + excluded.input_tokens,
                 output_tokens = output_tokens + excluded.output_tokens,
@@ -745,10 +764,11 @@ fn create_rollup_triggers(conn: &Connection) -> Result<()> {
                     ),
                     '(untagged)'
                )
+               AND surface = COALESCE(NULLIF(OLD.surface, ''), 'unknown')
                AND message_count <= 0;
 
             INSERT INTO message_rollups_hourly (
-                bucket_start, role, provider, model, repo_id, git_branch,
+                bucket_start, role, provider, model, repo_id, git_branch, surface,
                 message_count, input_tokens, output_tokens,
                 cache_creation_tokens, cache_read_tokens, cost_cents
             )
@@ -773,6 +793,7 @@ fn create_rollup_triggers(conn: &Connection) -> Result<()> {
                     ),
                     '(untagged)'
                 ),
+                COALESCE(NULLIF(NEW.surface, ''), 'unknown'),
                 1,
                 COALESCE(NEW.input_tokens, 0),
                 COALESCE(NEW.output_tokens, 0),
@@ -780,7 +801,7 @@ fn create_rollup_triggers(conn: &Connection) -> Result<()> {
                 COALESCE(NEW.cache_read_tokens, 0),
                 COALESCE(NEW.cost_cents, 0.0)
             )
-            ON CONFLICT(bucket_start, role, provider, model, repo_id, git_branch) DO UPDATE SET
+            ON CONFLICT(bucket_start, role, provider, model, repo_id, git_branch, surface) DO UPDATE SET
                 message_count = message_count + excluded.message_count,
                 input_tokens = input_tokens + excluded.input_tokens,
                 output_tokens = output_tokens + excluded.output_tokens,
@@ -789,7 +810,7 @@ fn create_rollup_triggers(conn: &Connection) -> Result<()> {
                 cost_cents = cost_cents + excluded.cost_cents;
 
             INSERT INTO message_rollups_daily (
-                bucket_day, role, provider, model, repo_id, git_branch,
+                bucket_day, role, provider, model, repo_id, git_branch, surface,
                 message_count, input_tokens, output_tokens,
                 cache_creation_tokens, cache_read_tokens, cost_cents
             )
@@ -814,6 +835,7 @@ fn create_rollup_triggers(conn: &Connection) -> Result<()> {
                     ),
                     '(untagged)'
                 ),
+                COALESCE(NULLIF(NEW.surface, ''), 'unknown'),
                 1,
                 COALESCE(NEW.input_tokens, 0),
                 COALESCE(NEW.output_tokens, 0),
@@ -821,7 +843,7 @@ fn create_rollup_triggers(conn: &Connection) -> Result<()> {
                 COALESCE(NEW.cache_read_tokens, 0),
                 COALESCE(NEW.cost_cents, 0.0)
             )
-            ON CONFLICT(bucket_day, role, provider, model, repo_id, git_branch) DO UPDATE SET
+            ON CONFLICT(bucket_day, role, provider, model, repo_id, git_branch, surface) DO UPDATE SET
                 message_count = message_count + excluded.message_count,
                 input_tokens = input_tokens + excluded.input_tokens,
                 output_tokens = output_tokens + excluded.output_tokens,
@@ -862,6 +884,7 @@ fn backfill_rollup_tables(conn: &Connection) -> Result<()> {
                     ),
                     '(untagged)'
                 ) AS git_branch,
+                COALESCE(NULLIF(surface, ''), 'unknown') AS surface,
                 COALESCE(input_tokens, 0) AS input_tokens,
                 COALESCE(output_tokens, 0) AS output_tokens,
                 COALESCE(cache_creation_tokens, 0) AS cache_creation_tokens,
@@ -870,12 +893,12 @@ fn backfill_rollup_tables(conn: &Connection) -> Result<()> {
             FROM messages
         )
         INSERT INTO message_rollups_hourly (
-            bucket_start, role, provider, model, repo_id, git_branch,
+            bucket_start, role, provider, model, repo_id, git_branch, surface,
             message_count, input_tokens, output_tokens,
             cache_creation_tokens, cache_read_tokens, cost_cents
         )
         SELECT
-            bucket_hour, role, provider, model, repo_id, git_branch,
+            bucket_hour, role, provider, model, repo_id, git_branch, surface,
             COUNT(*) AS message_count,
             COALESCE(SUM(input_tokens), 0),
             COALESCE(SUM(output_tokens), 0),
@@ -883,7 +906,7 @@ fn backfill_rollup_tables(conn: &Connection) -> Result<()> {
             COALESCE(SUM(cache_read_tokens), 0),
             COALESCE(SUM(cost_cents), 0.0)
         FROM normalized
-        GROUP BY bucket_hour, role, provider, model, repo_id, git_branch;
+        GROUP BY bucket_hour, role, provider, model, repo_id, git_branch, surface;
 
         WITH normalized AS (
             SELECT
@@ -906,6 +929,7 @@ fn backfill_rollup_tables(conn: &Connection) -> Result<()> {
                     ),
                     '(untagged)'
                 ) AS git_branch,
+                COALESCE(NULLIF(surface, ''), 'unknown') AS surface,
                 COALESCE(input_tokens, 0) AS input_tokens,
                 COALESCE(output_tokens, 0) AS output_tokens,
                 COALESCE(cache_creation_tokens, 0) AS cache_creation_tokens,
@@ -914,12 +938,12 @@ fn backfill_rollup_tables(conn: &Connection) -> Result<()> {
             FROM messages
         )
         INSERT INTO message_rollups_daily (
-            bucket_day, role, provider, model, repo_id, git_branch,
+            bucket_day, role, provider, model, repo_id, git_branch, surface,
             message_count, input_tokens, output_tokens,
             cache_creation_tokens, cache_read_tokens, cost_cents
         )
         SELECT
-            bucket_day, role, provider, model, repo_id, git_branch,
+            bucket_day, role, provider, model, repo_id, git_branch, surface,
             COUNT(*) AS message_count,
             COALESCE(SUM(input_tokens), 0),
             COALESCE(SUM(output_tokens), 0),
@@ -927,7 +951,7 @@ fn backfill_rollup_tables(conn: &Connection) -> Result<()> {
             COALESCE(SUM(cache_read_tokens), 0),
             COALESCE(SUM(cost_cents), 0.0)
         FROM normalized
-        GROUP BY bucket_day, role, provider, model, repo_id, git_branch;
+        GROUP BY bucket_day, role, provider, model, repo_id, git_branch, surface;
         ",
     )?;
     Ok(())
@@ -1014,7 +1038,23 @@ pub fn backfill_session_timestamps_from_messages(conn: &Connection) -> Result<us
                 (SELECT m.git_branch FROM messages m
                   WHERE m.session_id = sessions.id
                     AND m.git_branch IS NOT NULL AND m.git_branch <> ''
-                  ORDER BY m.timestamp DESC LIMIT 1))
+                  ORDER BY m.timestamp DESC LIMIT 1)),
+            surface = CASE
+                WHEN sessions.surface IS NULL OR sessions.surface = '' OR sessions.surface = 'unknown'
+                THEN COALESCE(
+                    (SELECT m.surface FROM messages m
+                      WHERE m.session_id = sessions.id
+                        AND m.surface IS NOT NULL
+                        AND m.surface <> ''
+                        AND m.surface <> 'unknown'
+                      GROUP BY m.surface
+                      ORDER BY COUNT(*) DESC, m.surface ASC
+                      LIMIT 1),
+                    sessions.surface,
+                    'unknown'
+                )
+                ELSE sessions.surface
+            END
          WHERE EXISTS (SELECT 1 FROM messages WHERE session_id = sessions.id)
            AND (
                 started_at IS NULL
@@ -1031,6 +1071,14 @@ pub fn backfill_session_timestamps_from_messages(conn: &Connection) -> Result<us
                     AND EXISTS (SELECT 1 FROM messages m
                                 WHERE m.session_id = sessions.id
                                   AND m.git_branch IS NOT NULL AND m.git_branch <> '')
+                )
+                OR (
+                    (sessions.surface IS NULL OR sessions.surface = '' OR sessions.surface = 'unknown')
+                    AND EXISTS (SELECT 1 FROM messages m
+                                WHERE m.session_id = sessions.id
+                                  AND m.surface IS NOT NULL
+                                  AND m.surface <> ''
+                                  AND m.surface <> 'unknown')
                 )
            )",
         [],
@@ -1142,6 +1190,112 @@ fn trigger_exists(conn: &Connection, name: &str) -> Result<bool> {
     Ok(exists)
 }
 
+/// True iff the `message_rollups_hourly` PRIMARY KEY definition includes
+/// `surface`. Used by the #701 reconcile to decide whether the rollup
+/// tables need to be rebuilt with the new PK shape on an existing v1 DB.
+fn rollup_pk_includes_surface(conn: &Connection) -> Result<bool> {
+    if !table_exists(conn, "message_rollups_hourly")? {
+        return Ok(false);
+    }
+    let sql: Option<String> = conn
+        .query_row(
+            "SELECT sql FROM sqlite_master WHERE type='table' AND name='message_rollups_hourly'",
+            [],
+            |r| r.get(0),
+        )
+        .ok();
+    Ok(sql.as_deref().is_some_and(|s| s.contains("surface")))
+}
+
+/// Drop the legacy rollup tables/triggers and recreate them with the
+/// `surface`-aware PK shape. Used only in the #701 reconcile path; on a
+/// fresh schema `create_rollup_tables` already produces the right PK.
+fn rebuild_rollups_with_surface_pk(conn: &Connection) -> Result<()> {
+    conn.execute_batch(
+        "
+        DROP TRIGGER IF EXISTS trg_messages_rollup_insert;
+        DROP TRIGGER IF EXISTS trg_messages_rollup_delete;
+        DROP TRIGGER IF EXISTS trg_messages_rollup_update;
+        DROP TABLE IF EXISTS message_rollups_hourly;
+        DROP TABLE IF EXISTS message_rollups_daily;
+        ",
+    )?;
+    create_rollup_tables(conn)?;
+    create_rollup_triggers(conn)?;
+    Ok(())
+}
+
+/// Backfill the `surface` column on `messages` and `sessions` for rows
+/// that pre-date #701. Per the ticket:
+///
+/// - `claude_code` / `codex` / `copilot_cli` → `terminal` (no IDE binding)
+/// - `cursor` → `cursor`
+/// - `copilot_chat` → best-effort path-based inference from `cwd`:
+///   `Cursor/User/...` → `cursor`; `Code/User/...`,
+///   `Code - Insiders`, `Code - Exploration`, `VSCodium`, or
+///   `~/.vscode-server*`/`~/.vscode-remote*` → `vscode`; otherwise
+///   `unknown`
+/// - everything else → `terminal` as a coarse fallback
+///
+/// Idempotent: rows that already carry a non-default surface are not
+/// touched, so a second migration run no-ops. Documented as a one-shot,
+/// non-reversible step.
+fn backfill_surface(conn: &Connection) -> Result<usize> {
+    let mut total = 0usize;
+
+    // Messages: stamp every row that still carries the default `unknown`
+    // surface with the best inference we have. The `WHERE surface = ''
+    // OR surface = 'unknown' OR surface IS NULL` predicate becomes empty
+    // on subsequent runs once the column is fully populated.
+    total += conn.execute(
+        "UPDATE messages SET surface = CASE
+            WHEN provider IN ('claude_code', 'codex', 'copilot_cli') THEN 'terminal'
+            WHEN provider = 'cursor' THEN 'cursor'
+            WHEN provider = 'copilot_chat' THEN
+                CASE
+                    WHEN cwd LIKE '%/Cursor/User/%' OR cwd LIKE '%/Cursor/%' THEN 'cursor'
+                    WHEN cwd LIKE '%/Code/User/%'
+                      OR cwd LIKE '%/Code - Insiders/%'
+                      OR cwd LIKE '%/Code - Exploration/%'
+                      OR cwd LIKE '%/VSCodium/%'
+                      OR cwd LIKE '%/.vscode-server%'
+                      OR cwd LIKE '%/.vscode-remote%'
+                      OR cwd LIKE '%vscode-server%'
+                      THEN 'vscode'
+                    ELSE 'unknown'
+                END
+            ELSE 'terminal'
+        END
+        WHERE surface IS NULL OR surface = '' OR surface = 'unknown'",
+        [],
+    )?;
+
+    // Sessions inherit the dominant surface of their messages. If a
+    // session has no messages yet (cloud-shipped stub, in-flight tail),
+    // fall back to the provider rule.
+    total += conn.execute(
+        "UPDATE sessions SET surface = COALESCE(
+            (
+                SELECT m.surface FROM messages m
+                WHERE m.session_id = sessions.id
+                  AND m.surface IS NOT NULL AND m.surface != '' AND m.surface != 'unknown'
+                GROUP BY m.surface
+                ORDER BY COUNT(*) DESC, m.surface ASC
+                LIMIT 1
+            ),
+            CASE
+                WHEN sessions.provider IN ('claude_code', 'codex', 'copilot_cli') THEN 'terminal'
+                WHEN sessions.provider = 'cursor' THEN 'cursor'
+                ELSE 'unknown'
+            END
+        )
+        WHERE surface IS NULL OR surface = '' OR surface = 'unknown'",
+        [],
+    )?;
+
+    Ok(total)
+}
+
 fn drop_legacy_proxy_events_table(conn: &Connection) -> Result<bool> {
     if !table_exists(conn, "proxy_events")? {
         return Ok(false);
@@ -1210,16 +1364,50 @@ fn reconcile_schema(conn: &Connection) -> Result<SchemaReconcileReport> {
     let mut added_columns: Vec<String> = Vec::new();
     let mut removed_tables: Vec<String> = Vec::new();
 
+    // #701: add the `surface` column to messages/sessions BEFORE the
+    // rollup repair runs. The rollup triggers and backfill query both
+    // reference `messages.surface` (NEW.surface in trigger bodies, plus
+    // a SELECT in `backfill_rollup_tables`); an older v1 DB would
+    // otherwise hit "no such column: surface" the moment the new
+    // trigger SQL touches an INSERT against `messages`.
+    let mut surface_column_added = false;
+    if ensure_column(
+        conn,
+        "messages",
+        "surface",
+        "surface TEXT NOT NULL DEFAULT 'unknown'",
+    )? {
+        added_columns.push("messages.surface".to_string());
+        surface_column_added = true;
+    }
+    if ensure_column(
+        conn,
+        "sessions",
+        "surface",
+        "surface TEXT NOT NULL DEFAULT 'unknown'",
+    )? {
+        added_columns.push("sessions.surface".to_string());
+        surface_column_added = true;
+    }
+
     let has_hourly_rollups = table_exists(conn, "message_rollups_hourly")?;
     let has_daily_rollups = table_exists(conn, "message_rollups_daily")?;
     let has_rollup_insert_trigger = trigger_exists(conn, "trg_messages_rollup_insert")?;
     let has_rollup_delete_trigger = trigger_exists(conn, "trg_messages_rollup_delete")?;
     let has_rollup_update_trigger = trigger_exists(conn, "trg_messages_rollup_update")?;
+    let rollup_pk_outdated_pre = has_hourly_rollups && !rollup_pk_includes_surface(conn)?;
     let needs_rollup_repair = !has_hourly_rollups
         || !has_daily_rollups
         || !has_rollup_insert_trigger
         || !has_rollup_delete_trigger
-        || !has_rollup_update_trigger;
+        || !has_rollup_update_trigger
+        || rollup_pk_outdated_pre;
+    if rollup_pk_outdated_pre {
+        // Pre-#701 rollup tables still carry the old PK. Drop them so
+        // `ensure_rollup_schema` recreates with the surface-aware shape;
+        // the rebuild below repopulates from `messages`.
+        rebuild_rollups_with_surface_pk(conn)?;
+    }
     if needs_rollup_repair {
         ensure_rollup_schema(conn, true)?;
         if !has_hourly_rollups {
@@ -1262,6 +1450,24 @@ fn reconcile_schema(conn: &Connection) -> Result<SchemaReconcileReport> {
         added_columns.push("pricing_manifests".to_string());
     }
     seed_pricing_manifests_baseline(conn)?;
+
+    // #701: backfill the surface dimension on messages/sessions for
+    // rows that pre-date the column add at the top of this function.
+    // The column itself was added before `ensure_rollup_schema` so the
+    // trigger SQL and the rollup backfill query both have a column to
+    // reference; what remains here is to populate the per-row value
+    // from provider-local rules and rebuild rollups so they partition
+    // on surface from this point forward.
+    let backfilled_surface = backfill_surface(conn)?;
+    if backfilled_surface > 0 {
+        tracing::info!(
+            rows = backfilled_surface,
+            "Backfilled surface dimension on messages/sessions (#701)"
+        );
+    }
+    if surface_column_added || backfilled_surface > 0 {
+        backfill_rollup_tables(conn)?;
+    }
 
     if drop_legacy_proxy_events_table(conn)? {
         removed_tables.push("proxy_events".to_string());
@@ -1452,6 +1658,132 @@ mod tests {
                 .unwrap();
             assert_eq!(junk, 0, "old tables should be dropped (v{old_version})");
         }
+    }
+
+    /// #701 — an existing v1 DB that pre-dates the `surface` dimension
+    /// must gain the column on both `messages` and `sessions` through
+    /// `reconcile_schema`, populate it via the parser-rule backfill, and
+    /// rebuild rollups with the new PK shape. The fixture seeds rows
+    /// from each provider so the backfill matrix is exercised end-to-end.
+    #[test]
+    fn reconcile_adds_surface_and_backfills_existing_v1_db() {
+        let conn = Connection::open_in_memory().unwrap();
+        migrate(&conn).unwrap();
+
+        // Simulate a pre-#701 database: drop the rollup triggers (they
+        // reference `NEW.surface` after the migration) and the surface
+        // column on both tables. The reconcile path under test must
+        // recreate the triggers, the column, and the rollup PK shape.
+        conn.execute_batch(
+            "DROP TRIGGER IF EXISTS trg_messages_rollup_insert;
+             DROP TRIGGER IF EXISTS trg_messages_rollup_delete;
+             DROP TRIGGER IF EXISTS trg_messages_rollup_update;
+             ALTER TABLE messages DROP COLUMN surface;
+             ALTER TABLE sessions DROP COLUMN surface;",
+        )
+        .unwrap();
+        assert!(!has_column(&conn, "messages", "surface").unwrap());
+        assert!(!has_column(&conn, "sessions", "surface").unwrap());
+
+        // Seed one row per inference rule. `cwd` drives the
+        // copilot_chat path-based inference; the others are
+        // provider-rule rows.
+        conn.execute_batch(
+            "INSERT INTO messages (id, role, timestamp, provider, cwd) VALUES
+                ('m_cc', 'assistant', '2026-04-01T00:00:00Z', 'claude_code', '/repo/foo'),
+                ('m_cur', 'assistant', '2026-04-01T00:00:00Z', 'cursor', '/repo/foo'),
+                ('m_cli', 'assistant', '2026-04-01T00:00:00Z', 'copilot_cli', '/repo/foo'),
+                ('m_cdx', 'assistant', '2026-04-01T00:00:00Z', 'codex', '/repo/foo'),
+                ('m_chat_vscode', 'assistant', '2026-04-01T00:00:00Z', 'copilot_chat',
+                 '/Users/x/Library/Application Support/Code/User/workspaceStorage/abc'),
+                ('m_chat_cursor', 'assistant', '2026-04-01T00:00:00Z', 'copilot_chat',
+                 '/Users/x/Library/Application Support/Cursor/User/workspaceStorage/abc'),
+                ('m_chat_remote', 'assistant', '2026-04-01T00:00:00Z', 'copilot_chat',
+                 '/home/x/.vscode-server/data/User/workspaceStorage/abc'),
+                ('m_chat_unknown', 'assistant', '2026-04-01T00:00:00Z', 'copilot_chat', NULL);
+             INSERT INTO sessions (id, provider) VALUES ('sess_cc', 'claude_code'), ('sess_cur', 'cursor');",
+        )
+        .unwrap();
+
+        let report = repair(&conn).unwrap();
+        assert!(
+            report.added_columns.iter().any(|c| c == "messages.surface"),
+            "report should mention added messages.surface column; got {:?}",
+            report.added_columns
+        );
+        assert!(
+            report.added_columns.iter().any(|c| c == "sessions.surface"),
+            "report should mention added sessions.surface column; got {:?}",
+            report.added_columns
+        );
+
+        let surface_for = |id: &str| -> String {
+            conn.query_row("SELECT surface FROM messages WHERE id = ?1", [id], |r| {
+                r.get::<_, String>(0)
+            })
+            .unwrap()
+        };
+        assert_eq!(surface_for("m_cc"), "terminal");
+        assert_eq!(surface_for("m_cur"), "cursor");
+        assert_eq!(surface_for("m_cli"), "terminal");
+        assert_eq!(surface_for("m_cdx"), "terminal");
+        assert_eq!(surface_for("m_chat_vscode"), "vscode");
+        assert_eq!(surface_for("m_chat_cursor"), "cursor");
+        assert_eq!(surface_for("m_chat_remote"), "vscode");
+        assert_eq!(surface_for("m_chat_unknown"), "unknown");
+
+        // Sessions rule-fall back when no messages link to them. No
+        // message references `sess_cc` or `sess_cur`, so the provider
+        // rule kicks in.
+        let sess_cc_surface: String = conn
+            .query_row(
+                "SELECT surface FROM sessions WHERE id = 'sess_cc'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        let sess_cur_surface: String = conn
+            .query_row(
+                "SELECT surface FROM sessions WHERE id = 'sess_cur'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(sess_cc_surface, "terminal");
+        assert_eq!(sess_cur_surface, "cursor");
+
+        // Rollups should be rebuilt with surface partitioning.
+        let surfaces_in_rollups: Vec<String> = conn
+            .prepare("SELECT DISTINCT surface FROM message_rollups_daily ORDER BY surface")
+            .unwrap()
+            .query_map([], |r| r.get::<_, String>(0))
+            .unwrap()
+            .filter_map(|r| r.ok())
+            .collect();
+        // We seeded rows with vscode, cursor, terminal, and unknown.
+        assert!(
+            surfaces_in_rollups.contains(&"vscode".to_string()),
+            "daily rollups should partition on surface; got {:?}",
+            surfaces_in_rollups
+        );
+        assert!(
+            surfaces_in_rollups.contains(&"cursor".to_string()),
+            "daily rollups should partition on surface; got {:?}",
+            surfaces_in_rollups
+        );
+        assert!(
+            surfaces_in_rollups.contains(&"terminal".to_string()),
+            "daily rollups should partition on surface; got {:?}",
+            surfaces_in_rollups
+        );
+
+        // Idempotency: a second repair should be a no-op.
+        let second = repair(&conn).unwrap();
+        assert!(
+            !second.added_columns.iter().any(|c| c.contains("surface")),
+            "second repair must not re-add surface columns; got {:?}",
+            second.added_columns
+        );
     }
 
     /// 8.1 → 8.2 upgrade: an existing v1 database that pre-dates the

--- a/crates/budi-core/src/pipeline/mod.rs
+++ b/crates/budi-core/src/pipeline/mod.rs
@@ -936,6 +936,7 @@ mod tests {
             tool_files: Vec::new(),
             tool_outcomes: Vec::new(),
             cwd_source: None,
+            surface: None,
         }
     }
 

--- a/crates/budi-core/src/providers/codex.rs
+++ b/crates/budi-core/src/providers/codex.rs
@@ -311,6 +311,7 @@ fn parse_token_count(
         tool_files: Vec::new(),
         tool_outcomes: Vec::new(),
         cwd_source: None,
+        surface: Some(crate::surface::TERMINAL.to_string()),
     })
 }
 

--- a/crates/budi-core/src/providers/copilot.rs
+++ b/crates/budi-core/src/providers/copilot.rs
@@ -338,6 +338,7 @@ fn parse_usage_event(
         tool_files: Vec::new(),
         tool_outcomes: Vec::new(),
         cwd_source: None,
+        surface: Some(crate::surface::TERMINAL.to_string()),
     })
 }
 

--- a/crates/budi-core/src/providers/copilot_chat.rs
+++ b/crates/budi-core/src/providers/copilot_chat.rs
@@ -1226,6 +1226,7 @@ fn build_messages_for_request(
             tool_files: Vec::new(),
             tool_outcomes: Vec::new(),
             cwd_source: enrichment.cwd_source.map(str::to_string),
+            surface: Some(crate::surface::infer_copilot_chat_surface(path).to_string()),
         }
     });
 
@@ -1267,6 +1268,7 @@ fn build_messages_for_request(
         tool_files: tool_data.files,
         tool_outcomes: Vec::new(),
         cwd_source: enrichment.cwd_source.map(str::to_string),
+        surface: Some(crate::surface::infer_copilot_chat_surface(path).to_string()),
     });
 
     rows
@@ -1445,6 +1447,7 @@ fn build_message(
             tool_files: Vec::new(),
             tool_outcomes: Vec::new(),
             cwd_source: enrichment.cwd_source.map(str::to_string),
+            surface: Some(crate::surface::infer_copilot_chat_surface(path).to_string()),
         }
     });
 
@@ -1486,6 +1489,7 @@ fn build_message(
         tool_files: tool_data.files,
         tool_outcomes: Vec::new(),
         cwd_source: enrichment.cwd_source.map(str::to_string),
+        surface: Some(crate::surface::infer_copilot_chat_surface(path).to_string()),
     });
 
     rows
@@ -2639,6 +2643,88 @@ mod tests {
         let path = Path::new("/tmp/budi-fixtures/sess-doc-2.json");
         let (msgs, _) = parse_copilot_chat(path, content, 0);
         assert!(msgs.is_empty());
+    }
+
+    /// #701 acceptance — parser-local surface inference. The four
+    /// canonical roots from ADR-0092 §2.1 each map to a deterministic
+    /// surface label on every emitted row, so host extensions
+    /// (budi-cursor, future budi-jetbrains) can filter to "only my
+    /// host's data" without inspecting paths themselves.
+    ///
+    /// JetBrains is a placeholder — copilot_chat's discovery roots only
+    /// touch VS Code-family directories today, so a JetBrains-shaped
+    /// path is exercised at the `infer_copilot_chat_surface` unit-test
+    /// layer (see `crate::surface::tests`). The matrix here pins the
+    /// three roots that actually flow through the parser.
+    #[test]
+    fn surface_is_cursor_when_path_under_cursor_user_root() {
+        let content = r#"{"promptTokens": 1, "outputTokens": 2}"#;
+        let path = Path::new(
+            "/Users/dev/Library/Application Support/Cursor/User/workspaceStorage/abc/chatSessions/sess.jsonl",
+        );
+        let (msgs, _) = parse_copilot_chat(path, content, 0);
+        assert!(!msgs.is_empty());
+        for m in &msgs {
+            assert_eq!(
+                m.surface.as_deref(),
+                Some(crate::surface::CURSOR),
+                "Cursor/User/... must map to surface=cursor; got {:?}",
+                m.surface
+            );
+        }
+    }
+
+    #[test]
+    fn surface_is_vscode_when_path_under_code_user_root() {
+        let content = r#"{"promptTokens": 1, "outputTokens": 2}"#;
+        let path = Path::new(
+            "/Users/dev/Library/Application Support/Code/User/workspaceStorage/abc/chatSessions/sess.jsonl",
+        );
+        let (msgs, _) = parse_copilot_chat(path, content, 0);
+        assert!(!msgs.is_empty());
+        for m in &msgs {
+            assert_eq!(
+                m.surface.as_deref(),
+                Some(crate::surface::VSCODE),
+                "Code/User/... must map to surface=vscode; got {:?}",
+                m.surface
+            );
+        }
+    }
+
+    #[test]
+    fn surface_is_vscode_when_path_under_vscode_server_root() {
+        let content = r#"{"promptTokens": 1, "outputTokens": 2}"#;
+        let path = Path::new(
+            "/home/dev/.vscode-server/data/User/workspaceStorage/abc/chatSessions/sess.jsonl",
+        );
+        let (msgs, _) = parse_copilot_chat(path, content, 0);
+        assert!(!msgs.is_empty());
+        for m in &msgs {
+            assert_eq!(
+                m.surface.as_deref(),
+                Some(crate::surface::VSCODE),
+                "~/.vscode-server/... must map to surface=vscode; got {:?}",
+                m.surface
+            );
+        }
+    }
+
+    /// JetBrains placeholder — until the budi-jetbrains parser lands,
+    /// the surface module's classifier on a JetBrains-shaped path
+    /// returns the `jetbrains` placeholder so the matrix is explicit.
+    /// copilot_chat's discovery never reaches such a path today (it
+    /// iterates VS Code-family roots only), so this assertion lives at
+    /// the classifier layer rather than going through `parse_copilot_chat`.
+    #[test]
+    fn surface_jetbrains_path_classifier_returns_jetbrains_placeholder() {
+        let path = Path::new(
+            "/Users/dev/Library/Application Support/JetBrains/IntelliJIdea2026.1/copilot/sessions/x.json",
+        );
+        assert_eq!(
+            crate::surface::infer_copilot_chat_surface(path),
+            crate::surface::JETBRAINS
+        );
     }
 
     #[test]

--- a/crates/budi-core/src/providers/cursor.rs
+++ b/crates/budi-core/src/providers/cursor.rs
@@ -1070,6 +1070,7 @@ fn usage_events_to_messages(
                 tool_files: Vec::new(),
                 tool_outcomes: Vec::new(),
                 cwd_source: None,
+                surface: Some(crate::surface::CURSOR.to_string()),
             }
         })
         .collect()
@@ -1494,6 +1495,7 @@ fn bubble_to_parsed_message(
             tool_files: Vec::new(),
             tool_outcomes: Vec::new(),
             cwd_source: None,
+            surface: Some(crate::surface::CURSOR.to_string()),
         })
     } else {
         let resolved_model = match row.model.as_deref().map(str::trim) {
@@ -1542,6 +1544,7 @@ fn bubble_to_parsed_message(
             tool_files: Vec::new(),
             tool_outcomes: Vec::new(),
             cwd_source: None,
+            surface: Some(crate::surface::CURSOR.to_string()),
         })
     }
 }
@@ -2188,6 +2191,7 @@ fn parse_cursor_line(
                 tool_files: Vec::new(),
                 tool_outcomes: Vec::new(),
                 cwd_source: None,
+                surface: Some(crate::surface::CURSOR.to_string()),
             })
         }
         "assistant" | "ai" | "model" => {
@@ -2225,6 +2229,7 @@ fn parse_cursor_line(
                 tool_files,
                 tool_outcomes: Vec::new(),
                 cwd_source: None,
+                surface: Some(crate::surface::CURSOR.to_string()),
             })
         }
         _ => None,

--- a/crates/budi-core/src/surface.rs
+++ b/crates/budi-core/src/surface.rs
@@ -1,0 +1,185 @@
+//! Surface dimension for messages/sessions: the host environment where the
+//! AI conversation happened (vscode, cursor, jetbrains, terminal, unknown).
+//!
+//! Today the `provider` column collapses every Copilot Chat row into a
+//! single `copilot_chat` value regardless of whether the session ran in VS
+//! Code, JetBrains, or a remote dev container. Surface is the orthogonal
+//! axis: `provider` answers "which agent", `surface` answers "which host".
+//! Forking the provider key would fragment the Billing API reconciliation
+//! contract in ADR-0092 §3 and the manifest/alias work in ADR-0091; one
+//! provider, one bill, surface separate.
+//!
+//! Inference is parser-local — each provider returns the surface alongside
+//! the existing fields it produces. No global cwd-sniffing.
+
+use std::path::Path;
+
+/// Canonical surface values. Lowercase, no aliasing.
+pub const VSCODE: &str = "vscode";
+pub const CURSOR: &str = "cursor";
+pub const JETBRAINS: &str = "jetbrains";
+pub const TERMINAL: &str = "terminal";
+/// Hard fallback so the column stays NOT NULL even when we cannot infer.
+pub const UNKNOWN: &str = "unknown";
+
+/// Default surface for a provider when the provider does not set one
+/// itself. Used by the ingest path as a `COALESCE`-style fallback so a
+/// hypothetical future writer that skips inference still produces a valid
+/// (if coarse) tag rather than NULL.
+///
+/// `claude_code`, `copilot` (CLI), `codex`, and the legacy proxy path all
+/// run in the user's terminal — there is no IDE binding to capture. Cursor
+/// is its own surface. Copilot Chat must always populate `surface` itself
+/// (path-based per ADR-0092 §2.1); falling through to UNKNOWN here is the
+/// "we do not know" signal rather than guessing.
+pub fn default_for_provider(provider: &str) -> &'static str {
+    match provider {
+        "claude_code" => TERMINAL,
+        "cursor" => CURSOR,
+        // The Copilot CLI provider id is `copilot_cli` (not `copilot`);
+        // it tails `~/.copilot/session-state/` and runs in any shell.
+        "copilot_cli" => TERMINAL,
+        "codex" => TERMINAL,
+        _ => UNKNOWN,
+    }
+}
+
+/// Infer the surface for a Copilot Chat session file from the path it was
+/// discovered under. Threaded through alongside the path so the parser
+/// stays surface-agnostic and only the discovery layer needs to map watch
+/// roots → host kind.
+///
+/// Mapping (per ADR-0092 §2.1 + ticket #701):
+///
+/// - `Cursor/User/...` → `cursor`
+/// - `Code/User/...`, `Code - Insiders/User/...`, `Code - Exploration/User/...`,
+///   `VSCodium/User/...` → `vscode`
+/// - `~/.vscode-server/...`, `~/.vscode-server-insiders/...`,
+///   `~/.vscode-remote/...`, `/tmp/.vscode-server/...`,
+///   `/workspace/.vscode-server/...` → `vscode`
+/// - JetBrains-shaped paths (`JetBrains/<IDE>/...`, `Library/Logs/JetBrains/...`,
+///   `~/.config/JetBrains/...`) → `jetbrains` (placeholder; the JetBrains
+///   parser lands later — until then the row never reaches this function)
+/// - Anything else → `unknown`
+pub fn infer_copilot_chat_surface(path: &Path) -> &'static str {
+    let path_str = path.to_string_lossy();
+
+    // Cursor's VS Code fork keeps its `User/` directory under a top-level
+    // `Cursor` segment. Match the segment name literally so a folder named
+    // `Cursor Backup` or a file inside `mycursorlib` does not collide.
+    if path_segment_matches(path, |s| s == "Cursor") {
+        return CURSOR;
+    }
+
+    // VS Code stable / insiders / exploration / VSCodium all live under a
+    // recognizable top-level directory.
+    if path_segment_matches(path, |s| {
+        s == "Code" || s == "Code - Insiders" || s == "Code - Exploration" || s == "VSCodium"
+    }) {
+        return VSCODE;
+    }
+
+    // Remote installs (SSH remote, dev containers, Codespaces, Tunnels).
+    if path_segment_matches(path, |s| {
+        s == ".vscode-server" || s == ".vscode-server-insiders" || s == ".vscode-remote"
+    }) {
+        return VSCODE;
+    }
+
+    // Catch the absolute remote roots that live outside the user's home
+    // (`/tmp/.vscode-server`, `/workspace/.vscode-server`) — they share
+    // the directory name but `path_segment_matches` already covers that.
+    // The substring fallback below is a last-resort signal for paths that
+    // do not segment cleanly (e.g. a URI representation).
+    if path_str.contains(".vscode-server") || path_str.contains(".vscode-remote") {
+        return VSCODE;
+    }
+
+    // JetBrains-shaped path placeholder. The JetBrains Copilot parser is
+    // out of 8.4 scope (ADR-0092 §"Out of scope"); this branch exists so
+    // the matrix is explicit and a hand-crafted test fixture can exercise
+    // the surface rule without wiring up a real parser.
+    if path_segment_matches(path, |s| s == "JetBrains") {
+        return JETBRAINS;
+    }
+
+    UNKNOWN
+}
+
+fn path_segment_matches<F>(path: &Path, pred: F) -> bool
+where
+    F: Fn(&str) -> bool,
+{
+    path.components()
+        .any(|c| c.as_os_str().to_str().is_some_and(&pred))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn cursor_user_root_maps_to_cursor() {
+        let p = PathBuf::from(
+            "/Users/ivan/Library/Application Support/Cursor/User/workspaceStorage/abc/chatSessions/x.jsonl",
+        );
+        assert_eq!(infer_copilot_chat_surface(&p), CURSOR);
+    }
+
+    #[test]
+    fn code_user_root_maps_to_vscode() {
+        let p = PathBuf::from(
+            "/Users/ivan/Library/Application Support/Code/User/workspaceStorage/abc/chatSessions/x.jsonl",
+        );
+        assert_eq!(infer_copilot_chat_surface(&p), VSCODE);
+    }
+
+    #[test]
+    fn code_insiders_maps_to_vscode() {
+        let p = PathBuf::from(
+            "/Users/ivan/Library/Application Support/Code - Insiders/User/workspaceStorage/abc/chatSessions/x.jsonl",
+        );
+        assert_eq!(infer_copilot_chat_surface(&p), VSCODE);
+    }
+
+    #[test]
+    fn vscode_server_remote_maps_to_vscode() {
+        let p = PathBuf::from(
+            "/home/ivan/.vscode-server/data/User/workspaceStorage/abc/chatSessions/x.jsonl",
+        );
+        assert_eq!(infer_copilot_chat_surface(&p), VSCODE);
+    }
+
+    #[test]
+    fn vscode_server_absolute_maps_to_vscode() {
+        let p = PathBuf::from(
+            "/tmp/.vscode-server/data/User/workspaceStorage/abc/chatSessions/x.jsonl",
+        );
+        assert_eq!(infer_copilot_chat_surface(&p), VSCODE);
+    }
+
+    #[test]
+    fn jetbrains_shape_maps_to_jetbrains_placeholder() {
+        let p = PathBuf::from(
+            "/Users/ivan/Library/Application Support/JetBrains/IdeaIC2026.1/copilot/sessions/x.json",
+        );
+        assert_eq!(infer_copilot_chat_surface(&p), JETBRAINS);
+    }
+
+    #[test]
+    fn unknown_path_maps_to_unknown() {
+        let p = PathBuf::from("/some/random/path/x.jsonl");
+        assert_eq!(infer_copilot_chat_surface(&p), UNKNOWN);
+    }
+
+    #[test]
+    fn default_for_provider_maps_known_providers() {
+        assert_eq!(default_for_provider("claude_code"), TERMINAL);
+        assert_eq!(default_for_provider("cursor"), CURSOR);
+        assert_eq!(default_for_provider("copilot_cli"), TERMINAL);
+        assert_eq!(default_for_provider("codex"), TERMINAL);
+        assert_eq!(default_for_provider("copilot_chat"), UNKNOWN);
+        assert_eq!(default_for_provider("anything_else"), UNKNOWN);
+    }
+}

--- a/crates/budi-daemon/src/routes/hooks.rs
+++ b/crates/budi-daemon/src/routes/hooks.rs
@@ -18,6 +18,12 @@ pub struct HealthResponse {
     /// on startup and warns if its expected API version is unsupported.
     /// Bump when a breaking change is made to any management API endpoint.
     pub api_version: u32,
+    /// Canonical surface values this daemon's data layer can emit on the
+    /// `surface` dimension. Lets host extensions introspect the value
+    /// space (instead of hardcoding it against an old daemon) before
+    /// rendering a host filter UI. Added in 8.4.2 (#701) alongside the
+    /// `api_version` bump to 3.
+    pub surfaces: &'static [&'static str],
 }
 
 #[derive(serde::Serialize)]
@@ -252,13 +258,29 @@ pub async fn favicon() -> impl IntoResponse {
 /// dollars (was cents). Host extensions that compiled against the cents
 /// contract render 100× too small until they bump their `MIN_API_VERSION`,
 /// so the `/health` advertisement bumps in the same PR.
-pub const API_VERSION: u32 = 2;
+///
+/// 8.4.2 (#701) — every message/session row now carries a `surface`
+/// dimension (`vscode`, `cursor`, `jetbrains`, `terminal`, `unknown`).
+/// Sibling host extensions (budi-cursor, the future budi-jetbrains) gate
+/// their host-scoped filter UI on this `api_version` advertisement so
+/// they can fall back to the all-rows view when talking to an older
+/// daemon. Sibling ticket adds the HTTP + CLI filter; this PR ships the
+/// data layer and the `surface` field shows up in returned rows.
+pub const API_VERSION: u32 = 3;
+
+/// Canonical surface values advertised on `/health` (#701). Mirrors
+/// `budi_core::surface`'s `VSCODE` / `CURSOR` / `JETBRAINS` / `TERMINAL`
+/// / `UNKNOWN` constants; we materialize the slice at this seam rather
+/// than re-exporting an array from `budi_core` so the daemon's wire
+/// format stays a deliberate snapshot rather than a transitive view.
+const SURFACES: &[&str] = &["vscode", "cursor", "jetbrains", "terminal", "unknown"];
 
 pub async fn health() -> Json<HealthResponse> {
     Json(HealthResponse {
         ok: true,
         version: env!("CARGO_PKG_VERSION"),
         api_version: API_VERSION,
+        surfaces: SURFACES,
     })
 }
 


### PR DESCRIPTION
Implements #701.

## Summary

Adds a `surface` axis (`vscode`, `cursor`, `jetbrains`, `terminal`, `unknown`) to messages, sessions, and rollups so we can distinguish where a Copilot Chat (or any other) row was actually produced. `provider` answers *which agent*; `surface` answers *which host*.

Per ADR-0092 §"Out of scope" — JetBrains Copilot Chat coverage is now coming online (siropkin/budi-jetbrains discovery), and budi-cursor / budi-jetbrains both need to filter to "only my host's data". Forking the provider key (`copilot_chat_vscode` vs `copilot_chat_jetbrains`) was rejected in the ticket because it fragments the Billing API reconciliation in ADR-0092 §3 and the manifest/alias work in ADR-0091. One provider, one bill; surface is a separate axis.

## What's in

- New `budi_core::surface` module — canonical constants (`VSCODE`, `CURSOR`, `JETBRAINS`, `TERMINAL`, `UNKNOWN`), `default_for_provider()` fallback, and `infer_copilot_chat_surface(path)` path-based classifier per ADR-0092 §2.1.
- `surface TEXT NOT NULL DEFAULT 'unknown'` added to `messages` and `sessions` tables (fresh schema + additive reconcile path for existing v1 DBs).
- `surface` added to `message_rollups_hourly` / `_daily` PRIMARY KEY, every INSERT / DELETE / UPDATE trigger arm, and the bulk backfill query.
- One-shot, non-reversible migration backfill: `claude_code` / `codex` / `copilot_cli` → `terminal`, `cursor` → `cursor`, `copilot_chat` → best-effort path inference from `cwd` (Cursor → cursor; Code/VSCodium/`.vscode-server*`/`.vscode-remote*` → vscode; otherwise unknown). Sessions inherit the dominant surface of their messages, falling back to provider rule when stub-only.
- `ParsedMessage` gains `surface: Option<String>`; every provider parser populates it inline (claude_code, copilot_cli, codex, cursor → constants; copilot_chat → path-based, threaded from the discovery roots through every emit site in `parse_jsonl` / `parse_json_document`).
- Daemon `/health` advertises surface support: `api_version` bumps to `3` and a new `surfaces: [...]` array enumerates the canonical value space (so host extensions don't have to hardcode it).
- `MessageRow` and `SessionListEntry` carry `surface` end-to-end through `/analytics/messages`, `/analytics/sessions`, `budi sessions --format json`, and the per-session detail/curve/messages endpoints.

## What's not in

- HTTP `?surface=` filter and CLI `--surface` flag — sibling ticket #702.
- `/analytics/surfaces` breakdown — sibling ticket #702.
- JetBrains Copilot Chat parser. The `jetbrains` value is a placeholder so the matrix is explicit; a real budi-jetbrains parser is the next discovery ticket.
- Sub-IDE breakdown for JetBrains (IDEA vs GoLand vs ...) — one bucket now.
- Surface-aware pricing — pricing remains keyed on (provider, model).
- Cloud-side surface visualization — sibling ticket in budi-cloud.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo test --workspace` — 964 tests pass; the two known-flaky tailer-shutdown timing tests (`run_blocking_exits_when_shutdown_flag_is_set`, `run_blocking_recovers_when_watch_root_materializes_post_boot`) pass green in isolation per the ticket's flake-handling rule.
- [x] `cargo clippy --workspace --all-targets` — no warnings.
- [x] `bash scripts/e2e/test_655_release_smoke.sh` — green on the automated portion; copilot_chat real-shape fixture, in-flight kind:2/kind:1 streaming, and doctor AMBER flips all pass.
- [x] New unit tests pin the parser-local matrix per the ticket's acceptance:
  - `surface_is_cursor_when_path_under_cursor_user_root`
  - `surface_is_vscode_when_path_under_code_user_root`
  - `surface_is_vscode_when_path_under_vscode_server_root`
  - `surface_jetbrains_path_classifier_returns_jetbrains_placeholder`
  - `reconcile_adds_surface_and_backfills_existing_v1_db` (end-to-end migration: drops the column on a fresh DB, re-runs `repair`, verifies every backfill rule, asserts rollups partition on surface, asserts second `repair` is a no-op).
- [ ] Manual smoke: `budi sessions --format json` shows `surface` on every session; `/analytics/messages` carries `surface` per row; `/health` reports `api_version: 3` and `surfaces: ["vscode","cursor","jetbrains","terminal","unknown"]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)