### PR TITLE
docs: list all 6 ecosystem repos in SOUL.md + README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Everything stays on your machine by default. Optional cloud sync pushes aggregat
 | **[budi](https://github.com/siropkin/budi)** ← you are here | Core Rust daemon and CLI |
 | **[budi-cloud](https://github.com/siropkin/budi-cloud)** | Team dashboard and ingest API at [app.getbudi.dev](https://app.getbudi.dev) |
 | **[budi-cursor](https://github.com/siropkin/budi-cursor)** | VS Code / Cursor status bar extension |
+| **[budi-jetbrains](https://github.com/siropkin/budi-jetbrains)** | JetBrains IDE status bar plugin (Kotlin) |
+| **[homebrew-budi](https://github.com/siropkin/homebrew-budi)** | Homebrew tap for `brew install siropkin/budi/budi` |
 | **[getbudi.dev](https://getbudi.dev)** | Website and documentation |
 
 ## Supported agents

--- a/SOUL.md
+++ b/SOUL.md
@@ -80,13 +80,16 @@ macOS and Linux use the Unix daemon startup path (`lsof`, `ps`, `kill`) to repla
 
 ### Product boundaries
 
-Three independent repos (extraction completed per [ADR-0086](docs/adr/0086-extraction-boundaries.md)). 8.x as a whole is organized as one local product with optional cloud visibility, not two peer products — see [ADR-0088](docs/adr/0088-8x-local-developer-first-product-contract.md) for the local-developer-first product contract governing 8.1 scope, classification principles, statusline contract, and 8.2 / 9.0 deferrals.
+Six independent repos in the budi ecosystem (core extraction completed per [ADR-0086](docs/adr/0086-extraction-boundaries.md)). 8.x as a whole is organized as one local product with optional cloud visibility, not two peer products — see [ADR-0088](docs/adr/0088-8x-local-developer-first-product-contract.md) for the local-developer-first product contract governing 8.1 scope, classification principles, statusline contract, and 8.2 / 9.0 deferrals.
 
 | Product | Repo | Role |
 |---------|------|------|
-| **budi-core** | [`siropkin/budi`](https://github.com/siropkin/budi) | Rust workspace: daemon, CLI, core business logic |
-| **budi-cursor** | [`siropkin/budi-cursor`](https://github.com/siropkin/budi-cursor) | VS Code/Cursor extension. Communicates with daemon over HTTP and `budi` CLI |
-| **budi-cloud** | [`siropkin/budi-cloud`](https://github.com/siropkin/budi-cloud) | Cloud dashboard + ingest API (Next.js + Supabase) |
+| **budi-core** | [`siropkin/budi`](https://github.com/siropkin/budi) | Rust workspace: daemon, CLI, transcript tailer, core business logic |
+| **budi-cursor** | [`siropkin/budi-cursor`](https://github.com/siropkin/budi-cursor) | VS Code / Cursor status-bar extension |
+| **budi-jetbrains** | [`siropkin/budi-jetbrains`](https://github.com/siropkin/budi-jetbrains) | JetBrains IDE status-bar plugin (Kotlin) |
+| **budi-cloud** | [`siropkin/budi-cloud`](https://github.com/siropkin/budi-cloud) | Cloud dashboard + ingest API at `app.getbudi.dev` |
+| **homebrew-budi** | [`siropkin/homebrew-budi`](https://github.com/siropkin/homebrew-budi) | Homebrew tap for `brew install siropkin/budi/budi` |
+| **getbudi.dev** | [`siropkin/getbudi.dev`](https://github.com/siropkin/getbudi.dev) | Marketing site (Astro) at `getbudi.dev` |
 
 ### Crates
 


### PR DESCRIPTION
## Summary

Closes #715.

- Extend `SOUL.md` Product boundaries table from 3 → 6 ecosystem repos (adds `budi-jetbrains`, `homebrew-budi`, `getbudi.dev`).
- Extend `README.md` Ecosystem table from 4 → 6 ecosystem repos (adds `budi-jetbrains`, `homebrew-budi`).
- Update the intro sentence above the SOUL.md table from "Three independent repos" to "Six independent repos" so the prose matches the table.

## Test plan

- [x] `SOUL.md` Product boundaries table lists all six repos.
- [x] `README.md` Ecosystem table lists all six repos.
- [x] `AGENTS.md` / `CLAUDE.md` left untouched (already on the standard pointer stub).

🤖 Generated with [Claude Code](https://claude.com/claude-code)