### PR TITLE
docs(adr): normalize statuses and add ADR index (#717)

### DIFF
--- a/docs/adr/0081-product-contract-and-deprecation-policy.md
+++ b/docs/adr/0081-product-contract-and-deprecation-policy.md
@@ -1,7 +1,7 @@
 # ADR-0081: 8.0 Product Contract and Deprecation Policy
 
 - **Date**: 2026-04-10
-- **Status**: Implemented (amended — see banner)
+- **Status**: Accepted (amended by [ADR-0089](./0089-reverse-proxy-first-jsonl-tailing-as-sole-live-path.md) — see banner)
 - **Issue**: [#81](https://github.com/siropkin/budi/issues/81)
 - **Milestone**: 8.0.0
 

--- a/docs/adr/0083-cloud-ingest-identity-and-privacy-contract.md
+++ b/docs/adr/0083-cloud-ingest-identity-and-privacy-contract.md
@@ -1,7 +1,7 @@
 # ADR-0083: Cloud Ingest, Identity, and Privacy Contract
 
 - **Date**: 2026-04-10
-- **Status**: Implemented (amended — see banner)
+- **Status**: Accepted (amended by [ADR-0091](./0091-model-pricing-manifest-source-of-truth.md) — see banner)
 - **Issue**: [#83](https://github.com/siropkin/budi/issues/83)
 - **Milestone**: 8.0.0
 - **Depends on**: [ADR-0082](./0082-proxy-compatibility-matrix-and-gateway-contract.md)

--- a/docs/adr/0086-extraction-boundaries.md
+++ b/docs/adr/0086-extraction-boundaries.md
@@ -1,7 +1,7 @@
 # ADR-0086: Extraction Boundaries for budi-cursor and budi-cloud
 
 - **Date**: 2026-04-10
-- **Status**: Implemented
+- **Status**: Accepted
 - **Issue**: [#86](https://github.com/siropkin/budi/issues/86)
 - **Milestone**: 8.0.0
 - **Depends on**: [ADR-0081](./0081-product-contract-and-deprecation-policy.md), [ADR-0082](./0082-proxy-compatibility-matrix-and-gateway-contract.md), [ADR-0083](./0083-cloud-ingest-identity-and-privacy-contract.md)

--- a/docs/adr/0087-cloud-infrastructure-and-deployment.md
+++ b/docs/adr/0087-cloud-infrastructure-and-deployment.md
@@ -1,7 +1,7 @@
 # ADR-0087: Cloud Infrastructure, Deployment, and Domain Strategy
 
 - **Date**: 2026-04-11
-- **Status**: Implemented
+- **Status**: Accepted
 - **Milestone**: 8.0.0
 - **Depends on**: [ADR-0083](./0083-cloud-ingest-identity-and-privacy-contract.md), [ADR-0086](./0086-extraction-boundaries.md)
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,28 @@
+# Architecture Decision Records
+
+This directory holds the durable architecture decisions for Budi. Each ADR captures the context, decision, and consequences of one choice. Status values:
+
+- **Accepted** — the ADR is in force. May carry banner amendments that narrow or extend specific sections without invalidating the record.
+- **Superseded by ADR-XXXX** — replaced in full by a later ADR. Kept for historical context; do not act on its decisions.
+- **Deprecated** — no longer in force and not replaced by a successor ADR. Kept for historical context.
+
+When an ADR is amended (banner at top) the rest of the record still stands except for the sections the amendment names. When an ADR is superseded, read the successor for the current contract.
+
+## Index
+
+| ADR | Title | Status | Summary |
+|-----|-------|--------|---------|
+| [0081](./0081-product-contract-and-deprecation-policy.md) | 8.0 Product Contract and Deprecation Policy | Accepted (amended by [0089](./0089-reverse-proxy-first-jsonl-tailing-as-sole-live-path.md)) | Locks the 8.0 product contract, surface taxonomy, and deprecation policy for the proxy-first / cloud-enabled pivot. |
+| [0082](./0082-proxy-compatibility-matrix-and-gateway-contract.md) | Proxy Compatibility Matrix and Local Gateway Contract | Superseded by [0089](./0089-reverse-proxy-first-jsonl-tailing-as-sole-live-path.md) | Original proxy-first agent compatibility matrix, gateway contract, and `X-Budi-*` attribution header protocol. Retired in 8.2 R2.1. |
+| [0083](./0083-cloud-ingest-identity-and-privacy-contract.md) | Cloud Ingest, Identity, and Privacy Contract | Accepted (amended by [0091](./0091-model-pricing-manifest-source-of-truth.md)) | Defines what data leaves the machine, how identity and dedup work, and the outbound-network surface for the cloud layer. |
+| [0086](./0086-extraction-boundaries.md) | Extraction Boundaries for budi-cursor and budi-cloud | Accepted | Locks repo boundaries and API contracts between `budi-core`, `budi-cursor`, and `budi-cloud` ahead of monorepo extraction. |
+| [0087](./0087-cloud-infrastructure-and-deployment.md) | Cloud Infrastructure, Deployment, and Domain Strategy | Accepted | Pins Supabase dev/prod separation, domain strategy, dashboard auth, daemon lifecycle, and the cloud-side deployment topology. |
+| [0088](./0088-8x-local-developer-first-product-contract.md) | 8.x Local-Developer-First Product Contract | Accepted (amended by [0089](./0089-reverse-proxy-first-jsonl-tailing-as-sole-live-path.md) and [#648](https://github.com/siropkin/budi/issues/648)) | Sets the 8.x persona priority (local-developer-first), round order, statusline contract, classification intent, and host- vs. provider-scoped surface rule. |
+| [0089](./0089-reverse-proxy-first-jsonl-tailing-as-sole-live-path.md) | Reverse Proxy-First Architecture — JSONL Tailing as Sole Live Path | Accepted | Reverses the proxy-first contract: JSONL tailing of agent transcripts becomes the sole live ingestion path; the proxy is removed. Supersedes [0082](./0082-proxy-compatibility-matrix-and-gateway-contract.md). |
+| [0090](./0090-cursor-usage-api-contract.md) | Cursor Usage API Contract | Accepted | Pins the undocumented `cursor.com/api/dashboard/*` endpoints, auth, headers, and response shapes that the Cursor provider depends on. |
+| [0091](./0091-model-pricing-manifest-source-of-truth.md) | Model Pricing via Embedded Baseline + LiteLLM Runtime Refresh | Accepted | Replaces hand-rolled per-provider pricing functions with an embedded baseline manifest plus optional LiteLLM runtime refresh; extends the outbound-network surface. |
+| [0092](./0092-copilot-chat-data-contract.md) | Copilot Chat Data Contract (Local Tail + GitHub Billing API) | Accepted | Pins the Copilot Chat local JSON/JSONL tail surface and the GitHub Billing API truth-up contract used by the `copilot_chat` provider. |
+
+## Numbering
+
+ADR numbers are assigned chronologically and never reused. Gaps in the sequence (e.g. missing 0084 / 0085) reflect numbers reserved during drafting that did not land — they should not be reissued.


### PR DESCRIPTION
## Summary

Closes #717.

- Normalize every ADR's `Status:` header to one of **Accepted** / **Superseded by ADR-XXXX** / **Deprecated**. The four ADRs that read `Implemented` (0081, 0083, 0086, 0087) now read `Accepted`.
- ADR-0081 and ADR-0083 gain explicit forward links to their amending ADRs (0089 and 0091) in the status line — previously the amendment was only in the prose banner.
- ADR-0082 already named its successor (ADR-0089) and is unchanged.
- Add `docs/adr/README.md` with a status legend, an index table (ADR / Title / Status / one-line summary) for all ten ADRs, and a note on the gaps in the numbering (0084 / 0085 reserved but unused).

No ADRs in the directory are stale or unamended — all ten are either still in force or formally superseded — so no `Deprecated` entries were needed.

## Test plan

- [x] `grep '^- \*\*Status\*\*' docs/adr/*.md` shows each ADR has a normalized status (Accepted or Superseded), with a link to the replacing ADR where superseded.
- [x] `docs/adr/README.md` renders as a table with one row per ADR; links resolve to the right files.
- [x] No content changes to the body of any ADR — only the status line and the new index file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)