### PR TITLE
docs(readme): mark JetBrains supported + link Marketplace (#716)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Everything stays on your machine by default. Optional cloud sync pushes aggregat
 | **[budi](https://github.com/siropkin/budi)** ← you are here | Core Rust daemon and CLI |
 | **[budi-cloud](https://github.com/siropkin/budi-cloud)** | Team dashboard and ingest API at [app.getbudi.dev](https://app.getbudi.dev) |
 | **[budi-cursor](https://github.com/siropkin/budi-cursor)** | VS Code / Cursor status bar extension |
-| **[budi-jetbrains](https://github.com/siropkin/budi-jetbrains)** | JetBrains IDE status bar plugin (Kotlin) |
+| **[budi-jetbrains](https://github.com/siropkin/budi-jetbrains)** | JetBrains IDE status bar plugin (Kotlin) — [Marketplace listing](https://plugins.jetbrains.com/plugin/31662-budi) |
 | **[homebrew-budi](https://github.com/siropkin/homebrew-budi)** | Homebrew tap for `brew install siropkin/budi/budi` |
 | **[getbudi.dev](https://getbudi.dev)** | Website and documentation |
 
@@ -66,7 +66,8 @@ Everything stays on your machine by default. Optional cloud sync pushes aggregat
 | **Codex CLI** | Supported | Live transcript tailing |
 | **Cursor** | Supported | Live tailing + Usage API reconciliation |
 | **Copilot CLI** | Supported | Live transcript tailing |
-| **Copilot Chat (VS Code)** | Supported | Live JSON/JSONL tailing + GitHub Billing API reconciliation ([ADR-0092](docs/adr/0092-copilot-chat-data-contract.md)) |
+| **Copilot Chat (VS Code / Cursor)** | Supported | Live JSON/JSONL tailing + GitHub Billing API reconciliation ([ADR-0092](docs/adr/0092-copilot-chat-data-contract.md)) |
+| **Copilot Chat (JetBrains)** | Partial (statusline only) | Surface classified as `jetbrains`; storage tailer pending fixture capture ([#716](https://github.com/siropkin/budi/issues/716)) |
 | **Gemini CLI** | Deferred | Tracked in [#294](https://github.com/siropkin/budi/issues/294) |
 
 All agents also support one-time historical import via `budi db import`.


### PR DESCRIPTION
## Summary

Addresses the README portion of #716:

- Splits the Copilot Chat row in the "Supported agents" table into **VS Code / Cursor** (supported, unchanged behaviour) and **JetBrains** (partial — statusline only, storage tailer pending fixture capture).
- Adds the live Marketplace URL (`https://plugins.jetbrains.com/plugin/31662-budi`) to the `budi-jetbrains` row in the Ecosystem table.

## Scope

This PR delivers the two README acceptance items from #716:
- [x] `README.md` "Supported agents" table marks JetBrains explicitly.
- [x] `README.md` ecosystem row for `budi-jetbrains` links the Marketplace listing.

**Deferred** (require a JetBrains IDE with the official GitHub Copilot plugin signed in — not available in the CI/automation environment that opened this PR):
- [ ] Redacted Copilot-for-JetBrains storage fixture under `crates/budi-core/src/providers/copilot_chat/fixtures/`.
- [ ] ADR-0092 amendment (or new ADR) documenting the JetBrains storage shape.

The source-side placeholder cleanup at `copilot_chat.rs:2654-2658` / `2713-2718` is also deferred — per the ticket "May be a follow-up ticket — fine to scope out of this one."

Recommend keeping #716 open after merge to track the fixture capture, or splitting the remaining items into a follow-up issue.

## Test plan
- [x] `README.md` renders correctly (table syntax preserved).
- [x] Marketplace URL resolves: https://plugins.jetbrains.com/plugin/31662-budi
- [ ] (Follow-up) Fixture-driven parser stub against real JetBrains storage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)