### PR TITLE
feat(schema): dual cost columns on messages (#730)

### DIFF
--- a/crates/budi-cli/src/commands/doctor.rs
+++ b/crates/budi-cli/src/commands/doctor.rs
@@ -1974,10 +1974,11 @@ mod tests {
             );
             INSERT INTO messages (
                 id, role, timestamp, model, provider, input_tokens, output_tokens,
-                cache_creation_tokens, cache_read_tokens, cost_cents, cost_confidence
+                cache_creation_tokens, cache_read_tokens,
+                cost_cents_ingested, cost_cents_effective, cost_confidence
             ) VALUES (
                 'legacy-proxy-row', 'assistant', '2026-04-19T17:00:00Z', 'gpt-4o',
-                'openai', 1, 1, 0, 0, 0.5, 'proxy_estimated'
+                'openai', 1, 1, 0, 0, 0.5, 0.5, 'proxy_estimated'
             );
             ",
         )

--- a/crates/budi-core/src/analytics/health.rs
+++ b/crates/budi-core/src/analytics/health.rs
@@ -313,7 +313,7 @@ pub fn session_health_batch(
     let sql = format!(
         "SELECT session_id, input_tokens, output_tokens,
                 cache_creation_tokens, cache_read_tokens,
-                COALESCE(cost_cents, 0.0), model, timestamp
+                COALESCE(cost_cents_effective, 0.0), model, timestamp
          FROM messages
          WHERE session_id IN ({in_clause}) AND role = 'assistant'
          ORDER BY session_id, timestamp ASC"
@@ -1050,7 +1050,7 @@ fn compute_user_prompt_count(conn: &Connection, sid: &str, provider: &str) -> Re
                  WHERE session_id = ?1
                    AND role = 'assistant'
                    AND request_id IS NOT NULL
-                   AND COALESCE(cost_cents, 0.0) > 0.0",
+                   AND COALESCE(cost_cents_effective, 0.0) > 0.0",
                 params![sid],
                 |r| r.get(0),
             )

--- a/crates/budi-core/src/analytics/mod.rs
+++ b/crates/budi-core/src/analytics/mod.rs
@@ -461,7 +461,8 @@ pub fn ingest_messages_with_sync(
                     tx.execute(
                         "UPDATE messages SET
                             output_tokens = ?1,
-                            cost_cents = ?2
+                            cost_cents_ingested = COALESCE(?2, 0),
+                            cost_cents_effective = ?2
                          WHERE id = ?3",
                         params![msg.output_tokens as i64, cost_cents, existing_uuid,],
                     )?;
@@ -496,16 +497,21 @@ pub fn ingest_messages_with_sync(
             .surface
             .clone()
             .unwrap_or_else(|| crate::surface::default_for_provider(&msg.provider).to_string());
+        // ADR-0094 §1: write the same value into both `cost_cents_ingested`
+        // (immutable per ADR-0091 §5 Rule D) and `cost_cents_effective`
+        // (read surface). The team-pricing worker (#731) rewrites only
+        // `_effective`; until it ships `_effective = _ingested`.
+        let cost_cents_ingested = cost_cents.unwrap_or(0.0);
         let inserted = tx.execute(
             "INSERT OR IGNORE INTO messages
              (id, session_id, role, timestamp, model,
               input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
               cwd, repo_id, provider,
-              cost_cents,
+              cost_cents_ingested, cost_cents_effective,
               parent_uuid, git_branch, cost_confidence, request_id, pricing_source, surface)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17,
-                     COALESCE(?18, 'legacy:pre-manifest'),
-                     ?19)",
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18,
+                     COALESCE(?19, 'legacy:pre-manifest'),
+                     ?20)",
             params![
                 msg.uuid,
                 normalized_session_id.as_deref(),
@@ -519,6 +525,7 @@ pub fn ingest_messages_with_sync(
                 msg.cwd,
                 msg.repo_id,
                 msg.provider,
+                cost_cents_ingested,
                 cost_cents,
                 msg.parent_uuid,
                 git_branch,

--- a/crates/budi-core/src/analytics/queries.rs
+++ b/crates/budi-core/src/analytics/queries.rs
@@ -552,7 +552,7 @@ pub fn usage_summary(
                 COALESCE(SUM(output_tokens), 0),
                 COALESCE(SUM(cache_creation_tokens), 0),
                 COALESCE(SUM(cache_read_tokens), 0),
-                COALESCE(SUM(cost_cents), 0.0)
+                COALESCE(SUM(cost_cents_effective), 0.0)
          FROM messages {}",
         where_clause
     );
@@ -641,7 +641,7 @@ fn usage_summary_from_rollups(
             COALESCE(SUM(output_tokens), 0),
             COALESCE(SUM(cache_creation_tokens), 0),
             COALESCE(SUM(cache_read_tokens), 0),
-            COALESCE(SUM(cost_cents), 0.0)
+            COALESCE(SUM(cost_cents_effective), 0.0)
          FROM {} {where_clause}",
         rollup_table(window.level)
     );
@@ -755,7 +755,7 @@ pub fn usage_summary_with_filters(
                 COALESCE(SUM(output_tokens), 0),
                 COALESCE(SUM(cache_creation_tokens), 0),
                 COALESCE(SUM(cache_read_tokens), 0),
-                COALESCE(SUM(cost_cents), 0.0)
+                COALESCE(SUM(cost_cents_effective), 0.0)
          FROM messages {}",
         where_clause
     );
@@ -885,7 +885,7 @@ pub fn message_list(conn: &Connection, p: &MessageListParams) -> Result<Paginate
             }
         }
         "tokens" => format!("(messages.input_tokens + messages.output_tokens) {dir}"),
-        "cost" => format!("COALESCE(messages.cost_cents, 0.0) {dir}"),
+        "cost" => format!("COALESCE(messages.cost_cents_effective, 0.0) {dir}"),
         "branch" | "git_branch" | "ticket" => {
             let col = "COALESCE(messages.git_branch, s.git_branch)";
             if p.sort_asc {
@@ -911,7 +911,7 @@ pub fn message_list(conn: &Connection, p: &MessageListParams) -> Result<Paginate
                 COALESCE(messages.repo_id, s.repo_id),
                 messages.input_tokens, messages.output_tokens,
                 messages.cache_creation_tokens, messages.cache_read_tokens,
-                COALESCE(messages.cost_cents, 0.0),
+                COALESCE(messages.cost_cents_effective, 0.0),
                 COALESCE(messages.cost_confidence, 'estimated'),
                 COALESCE(messages.git_branch, s.git_branch),
                 COALESCE(NULLIF(messages.surface, ''), 'unknown') AS surface
@@ -1020,7 +1020,7 @@ fn repo_usage_from_rollups(
                     COALESCE(SUM(message_count), 0) as cnt,
                     COALESCE(SUM(input_tokens), 0) as inp,
                     COALESCE(SUM(output_tokens), 0) as outp,
-                    COALESCE(SUM(cost_cents), 0.0) as cost
+                    COALESCE(SUM(cost_cents_effective), 0.0) as cost
              FROM {}
              WHERE {}
              GROUP BY repo
@@ -1116,7 +1116,7 @@ pub fn repo_usage_with_filters(
                 COUNT(*) as cnt,
                 COALESCE(SUM(input_tokens), 0) as inp,
                 COALESCE(SUM(output_tokens), 0) as outp,
-                COALESCE(SUM(cost_cents), 0.0) as cost
+                COALESCE(SUM(cost_cents_effective), 0.0) as cost
          FROM messages
          WHERE {}
          GROUP BY repo
@@ -1190,7 +1190,7 @@ pub fn non_repo_usage(
                 COUNT(*) AS cnt,
                 COALESCE(SUM(input_tokens), 0) AS inp,
                 COALESCE(SUM(output_tokens), 0) AS outp,
-                COALESCE(SUM(cost_cents), 0.0) AS cost
+                COALESCE(SUM(cost_cents_effective), 0.0) AS cost
          FROM messages
          WHERE {}
          GROUP BY cwd",
@@ -1363,7 +1363,7 @@ fn activity_chart_from_rollups(
                 COALESCE(SUM(message_count), 0) as cnt,
                 COALESCE(SUM(input_tokens), 0) as inp,
                 COALESCE(SUM(output_tokens), 0) as outp,
-                COALESCE(SUM(cost_cents), 0.0) as cost
+                COALESCE(SUM(cost_cents_effective), 0.0) as cost
          FROM {} {where_clause}
          GROUP BY bucket
          ORDER BY bucket",
@@ -1466,7 +1466,7 @@ pub fn activity_chart_with_filters(
         "SELECT {group_expr} as bucket, COUNT(*) as cnt,
                 COALESCE(SUM(input_tokens), 0) as inp,
                 COALESCE(SUM(output_tokens), 0) as outp,
-                COALESCE(SUM(cost_cents), 0.0) as cost
+                COALESCE(SUM(cost_cents_effective), 0.0) as cost
          FROM messages {where_clause}
          GROUP BY bucket
          ORDER BY bucket",
@@ -1576,7 +1576,7 @@ pub fn branch_cost_with_filters(
                 COALESCE(SUM(output_tokens), 0) as outp,
                 COALESCE(SUM(cache_read_tokens), 0) as cache_r,
                 COALESCE(SUM(cache_creation_tokens), 0) as cache_c,
-                COALESCE(SUM(cost_cents), 0.0) as cost
+                COALESCE(SUM(cost_cents_effective), 0.0) as cost
          FROM messages
          {where_clause}
          GROUP BY branch, repo
@@ -1655,7 +1655,7 @@ pub fn branch_cost_single(
                     COALESCE(SUM(output_tokens), 0) as outp,
                     COALESCE(SUM(cache_read_tokens), 0) as cache_r,
                     COALESCE(SUM(cache_creation_tokens), 0) as cache_c,
-                    COALESCE(SUM(cost_cents), 0.0) as cost
+                    COALESCE(SUM(cost_cents_effective), 0.0) as cost
              FROM messages
              {where_clause}
              GROUP BY COALESCE(repo_id, '')
@@ -1673,7 +1673,7 @@ pub fn branch_cost_single(
                     COALESCE(SUM(output_tokens), 0) as outp,
                     COALESCE(SUM(cache_read_tokens), 0) as cache_r,
                     COALESCE(SUM(cache_creation_tokens), 0) as cache_c,
-                    COALESCE(SUM(cost_cents), 0.0) as cost
+                    COALESCE(SUM(cost_cents_effective), 0.0) as cost
              FROM messages
              {where_clause}
              GROUP BY ?1
@@ -1830,7 +1830,7 @@ pub fn tag_stats_with_filters(
         format!(
             "UNION ALL
              SELECT '{k}' as key, '(untagged)' as value, 0 as session_count,
-                    COALESCE(SUM(m.cost_cents), 0.0) as total_cost_cents
+                    COALESCE(SUM(m.cost_cents_effective), 0.0) as total_cost_cents
              FROM messages m
              WHERE m.role = 'assistant' {date_filter}
                AND NOT EXISTS (
@@ -1859,7 +1859,7 @@ pub fn tag_stats_with_filters(
              )
              SELECT t.key, t.value,
                     COUNT(DISTINCT m.session_id) as session_count,
-                    COALESCE(SUM(m.cost_cents / mvc.n_values), 0.0) as total_cost_cents
+                    COALESCE(SUM(m.cost_cents_effective / mvc.n_values), 0.0) as total_cost_cents
              FROM tags t
              JOIN msg_val_counts mvc ON mvc.message_id = t.message_id
              JOIN messages m ON t.message_id = m.id
@@ -1873,7 +1873,7 @@ pub fn tag_stats_with_filters(
         format!(
             "SELECT t.key, t.value,
                     COUNT(DISTINCT m.session_id) as session_count,
-                    COALESCE(SUM(m.cost_cents), 0.0) as total_cost_cents
+                    COALESCE(SUM(m.cost_cents_effective), 0.0) as total_cost_cents
              FROM tags t
              JOIN messages m ON t.message_id = m.id
              {where_clause}
@@ -1948,7 +1948,7 @@ fn tag_stats_repo_from_messages(
         "SELECT '{key_label}' as key,
                 COALESCE(NULLIF(NULLIF(repo_id, ''), 'unknown'), '(untagged)') as value,
                 COUNT(DISTINCT session_id) as session_count,
-                COALESCE(SUM(cost_cents), 0.0) as total_cost_cents
+                COALESCE(SUM(cost_cents_effective), 0.0) as total_cost_cents
          FROM messages
          {where_clause}
          GROUP BY value
@@ -2028,7 +2028,7 @@ fn tag_stats_branch_from_messages(
                     '(untagged)'
                 ) as value,
                 COUNT(DISTINCT session_id) as session_count,
-                COALESCE(SUM(cost_cents), 0.0) as total_cost_cents
+                COALESCE(SUM(cost_cents_effective), 0.0) as total_cost_cents
          FROM messages
          {where_clause}
          GROUP BY value
@@ -2227,7 +2227,7 @@ pub fn ticket_cost_with_filters(
                     m.output_tokens,
                     m.cache_read_tokens,
                     m.cache_creation_tokens,
-                    m.cost_cents,
+                    m.cost_cents_effective AS cost_cents,
                     mvc.n_values,
                     COALESCE(ms.source_value, '') AS ticket_source
              FROM tags t
@@ -2333,7 +2333,7 @@ pub fn ticket_cost_with_filters(
                 COALESCE(SUM(m2.output_tokens), 0) AS outp,
                 COALESCE(SUM(m2.cache_read_tokens), 0) AS cache_r,
                 COALESCE(SUM(m2.cache_creation_tokens), 0) AS cache_c,
-                COALESCE(SUM(m2.cost_cents), 0.0) AS cost,
+                COALESCE(SUM(m2.cost_cents_effective), 0.0) AS cost,
                 '' AS top_branch,
                 '' AS top_repo,
                 '' AS ticket_source
@@ -2444,7 +2444,7 @@ pub fn ticket_cost_single(
                     m.output_tokens,
                     m.cache_read_tokens,
                     m.cache_creation_tokens,
-                    m.cost_cents,
+                    m.cost_cents_effective AS cost_cents,
                     mvc.n_values,
                     COALESCE(ms.source_value, '') AS ticket_source
              FROM tags t
@@ -2522,7 +2522,7 @@ pub fn ticket_cost_single(
                 COALESCE(m.repo_id, '') AS repo_value,
                 COUNT(DISTINCT m.session_id) AS sess,
                 COUNT(*) AS cnt,
-                COALESCE(SUM(m.cost_cents / mvc.n_values), 0.0) AS cost
+                COALESCE(SUM(m.cost_cents_effective / mvc.n_values), 0.0) AS cost
          FROM tags t
          JOIN msg_val_counts mvc ON mvc.message_id = t.message_id
          JOIN messages m ON m.id = t.message_id
@@ -2754,7 +2754,7 @@ pub fn activity_cost_with_filters(
                     m.output_tokens,
                     m.cache_read_tokens,
                     m.cache_creation_tokens,
-                    m.cost_cents,
+                    m.cost_cents_effective AS cost_cents,
                     mvc.n_values
              FROM tags t
              JOIN msg_val_counts mvc ON mvc.message_id = t.message_id
@@ -2836,7 +2836,7 @@ pub fn activity_cost_with_filters(
                 COALESCE(SUM(m2.output_tokens), 0) AS outp,
                 COALESCE(SUM(m2.cache_read_tokens), 0) AS cache_r,
                 COALESCE(SUM(m2.cache_creation_tokens), 0) AS cache_c,
-                COALESCE(SUM(m2.cost_cents), 0.0) AS cost,
+                COALESCE(SUM(m2.cost_cents_effective), 0.0) AS cost,
                 '' AS top_branch,
                 '' AS top_repo
          FROM messages m2
@@ -2930,7 +2930,7 @@ pub fn activity_cost_single(
                 COALESCE(SUM(m.output_tokens / mvc.n_values), 0) AS outp,
                 COALESCE(SUM(m.cache_read_tokens / mvc.n_values), 0) AS cache_r,
                 COALESCE(SUM(m.cache_creation_tokens / mvc.n_values), 0) AS cache_c,
-                COALESCE(SUM(m.cost_cents / mvc.n_values), 0.0) AS cost,
+                COALESCE(SUM(m.cost_cents_effective / mvc.n_values), 0.0) AS cost,
                 CASE WHEN COUNT(DISTINCT COALESCE(m.repo_id, '')) = 1
                      THEN COALESCE(MIN(m.repo_id), '')
                      ELSE '' END AS repo
@@ -2984,7 +2984,7 @@ pub fn activity_cost_single(
                 COALESCE(m.repo_id, '') AS repo_value,
                 COUNT(DISTINCT m.session_id) AS sess,
                 COUNT(*) AS cnt,
-                COALESCE(SUM(m.cost_cents / mvc.n_values), 0.0) AS cost
+                COALESCE(SUM(m.cost_cents_effective / mvc.n_values), 0.0) AS cost
          FROM tags t
          JOIN msg_val_counts mvc ON mvc.message_id = t.message_id
          JOIN messages m ON m.id = t.message_id
@@ -3202,7 +3202,7 @@ fn model_usage_from_rollups(
                 COALESCE(SUM(output_tokens), 0) as total_output,
                 COALESCE(SUM(cache_read_tokens), 0),
                 COALESCE(SUM(cache_creation_tokens), 0),
-                COALESCE(SUM(cost_cents), 0.0)
+                COALESCE(SUM(cost_cents_effective), 0.0)
          FROM {}
          WHERE {}
          GROUP BY m, p
@@ -3294,7 +3294,7 @@ pub fn model_usage_with_filters(
                 COALESCE(SUM(output_tokens), 0) as total_output,
                 COALESCE(SUM(cache_read_tokens), 0),
                 COALESCE(SUM(cache_creation_tokens), 0),
-                COALESCE(SUM(cost_cents), 0.0)
+                COALESCE(SUM(cost_cents_effective), 0.0)
          FROM messages
          {where_clause}
          GROUP BY m, p
@@ -3467,7 +3467,7 @@ fn assistant_cost_since_from_rollups(
         params.extend(providers.iter().cloned());
     }
     let sql = format!(
-        "SELECT COALESCE(SUM(cost_cents), 0.0)
+        "SELECT COALESCE(SUM(cost_cents_effective), 0.0)
          FROM {}
          WHERE {}",
         rollup_table(window.level),
@@ -3510,7 +3510,7 @@ pub fn statusline_stats(
     let cost_since = |since: &str| -> f64 {
         assistant_cost_since_from_rollups(conn, since, provider_filter).unwrap_or_else(|| {
             let mut sql = String::from(
-                "SELECT COALESCE(SUM(cost_cents), 0.0) FROM messages \
+                "SELECT COALESCE(SUM(cost_cents_effective), 0.0) FROM messages \
                      WHERE timestamp >= ? AND role = 'assistant'",
             );
             let mut bindings: Vec<String> = vec![since.to_string()];
@@ -3535,7 +3535,7 @@ pub fn statusline_stats(
     // Session cost: total cost for a specific session (optionally provider-scoped).
     let session_cost = normalized_session_id.as_ref().map(|sid| {
         let mut sql = String::from(
-            "SELECT COALESCE(SUM(cost_cents), 0.0) FROM messages \
+            "SELECT COALESCE(SUM(cost_cents_effective), 0.0) FROM messages \
              WHERE session_id = ? AND role = 'assistant'",
         );
         let mut bindings: Vec<String> = vec![sid.clone()];
@@ -3557,7 +3557,7 @@ pub fn statusline_stats(
     // instead of a silent cross-repo sum. See #347.
     let branch_cost = params.branch.as_ref().map(|branch| {
         let mut sql = String::from(
-            "SELECT COALESCE(SUM(cost_cents), 0.0) FROM messages \
+            "SELECT COALESCE(SUM(cost_cents_effective), 0.0) FROM messages \
              WHERE git_branch = ? AND role = 'assistant'",
         );
         let mut bindings: Vec<String> = vec![branch.clone()];
@@ -3578,7 +3578,7 @@ pub fn statusline_stats(
     // Project cost: total cost for messages in a specific directory.
     let project_cost = params.project_dir.as_ref().map(|dir| {
         let mut sql = String::from(
-            "SELECT COALESCE(SUM(cost_cents), 0.0) FROM messages \
+            "SELECT COALESCE(SUM(cost_cents_effective), 0.0) FROM messages \
              WHERE cwd = ? AND role = 'assistant'",
         );
         let mut bindings: Vec<String> = vec![dir.clone()];
@@ -3759,7 +3759,7 @@ fn provider_stats_from_rollups(
                 COALESCE(SUM(CASE WHEN role = 'assistant' THEN output_tokens ELSE 0 END), 0),
                 COALESCE(SUM(CASE WHEN role = 'assistant' THEN cache_creation_tokens ELSE 0 END), 0),
                 COALESCE(SUM(CASE WHEN role = 'assistant' THEN cache_read_tokens ELSE 0 END), 0),
-                COALESCE(SUM(CASE WHEN role = 'assistant' THEN cost_cents ELSE 0.0 END), 0.0)
+                COALESCE(SUM(CASE WHEN role = 'assistant' THEN cost_cents_effective ELSE 0.0 END), 0.0)
          FROM {}
          {}
          GROUP BY p
@@ -3888,7 +3888,7 @@ pub fn provider_stats_with_filters(
                 COALESCE(SUM(CASE WHEN role = 'assistant' THEN output_tokens ELSE 0 END), 0),
                 COALESCE(SUM(CASE WHEN role = 'assistant' THEN cache_creation_tokens ELSE 0 END), 0),
                 COALESCE(SUM(CASE WHEN role = 'assistant' THEN cache_read_tokens ELSE 0 END), 0),
-                COALESCE(SUM(CASE WHEN role = 'assistant' THEN cost_cents ELSE 0.0 END), 0.0)
+                COALESCE(SUM(CASE WHEN role = 'assistant' THEN cost_cents_effective ELSE 0.0 END), 0.0)
          FROM messages {}
          GROUP BY p ORDER BY asst_msgs DESC",
         where_clause
@@ -4032,7 +4032,7 @@ fn surface_stats_from_rollups(
                 COALESCE(SUM(CASE WHEN role = 'assistant' THEN output_tokens ELSE 0 END), 0),
                 COALESCE(SUM(CASE WHEN role = 'assistant' THEN cache_creation_tokens ELSE 0 END), 0),
                 COALESCE(SUM(CASE WHEN role = 'assistant' THEN cache_read_tokens ELSE 0 END), 0),
-                COALESCE(SUM(CASE WHEN role = 'assistant' THEN cost_cents ELSE 0.0 END), 0.0)
+                COALESCE(SUM(CASE WHEN role = 'assistant' THEN cost_cents_effective ELSE 0.0 END), 0.0)
          FROM {}
          {}
          GROUP BY s
@@ -4127,7 +4127,7 @@ pub fn surface_stats_with_filters(
                 COALESCE(SUM(CASE WHEN role = 'assistant' THEN output_tokens ELSE 0 END), 0),
                 COALESCE(SUM(CASE WHEN role = 'assistant' THEN cache_creation_tokens ELSE 0 END), 0),
                 COALESCE(SUM(CASE WHEN role = 'assistant' THEN cache_read_tokens ELSE 0 END), 0),
-                COALESCE(SUM(CASE WHEN role = 'assistant' THEN cost_cents ELSE 0.0 END), 0.0)
+                COALESCE(SUM(CASE WHEN role = 'assistant' THEN cost_cents_effective ELSE 0.0 END), 0.0)
          FROM messages {}
          GROUP BY s
          ORDER BY asst_msgs DESC, s ASC",
@@ -4387,7 +4387,7 @@ pub fn session_cost_curve_with_filters(
         "WITH session_stats AS (
              SELECT session_id,
                     COUNT(*) as msg_count,
-                    COALESCE(SUM(cost_cents), 0.0) as total_cost
+                    COALESCE(SUM(cost_cents_effective), 0.0) as total_cost
              FROM messages
              {where_clause}
              AND session_id IS NOT NULL
@@ -4492,7 +4492,7 @@ pub fn cost_confidence_stats_with_filters(
     let sql = format!(
         "SELECT COALESCE(cost_confidence, 'estimated') as conf,
                 COUNT(*) as cnt,
-                COALESCE(SUM(cost_cents), 0.0) as cost
+                COALESCE(SUM(cost_cents_effective), 0.0) as cost
          FROM messages {where_clause}
          GROUP BY conf
          ORDER BY cost DESC",
@@ -4580,7 +4580,7 @@ pub fn subagent_cost_stats_with_filters(
     let sql = format!(
         "SELECT CASE WHEN parent_uuid IS NOT NULL THEN 'subagent' ELSE 'main' END as category,
                 COUNT(*) as cnt,
-                COALESCE(SUM(cost_cents), 0.0) as cost,
+                COALESCE(SUM(cost_cents_effective), 0.0) as cost,
                 COALESCE(SUM(input_tokens), 0) as inp,
                 COALESCE(SUM(output_tokens), 0) as outp
          FROM messages {where_clause}
@@ -4940,7 +4940,7 @@ pub fn file_cost_with_filters(
                     m.output_tokens,
                     m.cache_read_tokens,
                     m.cache_creation_tokens,
-                    m.cost_cents,
+                    m.cost_cents_effective AS cost_cents,
                     mvc.n_values,
                     COALESCE(ms.source_value, '') AS file_source,
                     COALESCE(mt.ticket_value, '') AS ticket_value
@@ -5070,7 +5070,7 @@ pub fn file_cost_with_filters(
                 COALESCE(SUM(m2.output_tokens), 0) AS outp,
                 COALESCE(SUM(m2.cache_read_tokens), 0) AS cache_r,
                 COALESCE(SUM(m2.cache_creation_tokens), 0) AS cache_c,
-                COALESCE(SUM(m2.cost_cents), 0.0) AS cost,
+                COALESCE(SUM(m2.cost_cents_effective), 0.0) AS cost,
                 '' AS top_repo,
                 '' AS top_branch,
                 '' AS top_ticket,
@@ -5177,7 +5177,7 @@ pub fn file_cost_single(
                     m.output_tokens,
                     m.cache_read_tokens,
                     m.cache_creation_tokens,
-                    m.cost_cents,
+                    m.cost_cents_effective AS cost_cents,
                     mvc.n_values,
                     COALESCE(ms.source_value, '') AS file_source,
                     COALESCE(mc.confidence_value, '') AS file_confidence
@@ -5268,7 +5268,7 @@ pub fn file_cost_single(
                 COALESCE(m.repo_id, '') AS repo_value,
                 COUNT(DISTINCT m.session_id) AS sess,
                 COUNT(*) AS cnt,
-                COALESCE(SUM(m.cost_cents / mvc.n_values), 0.0) AS cost
+                COALESCE(SUM(m.cost_cents_effective / mvc.n_values), 0.0) AS cost
          FROM tags t
          JOIN msg_val_counts mvc ON mvc.message_id = t.message_id
          JOIN messages m ON m.id = t.message_id
@@ -5308,7 +5308,7 @@ pub fn file_cost_single(
          SELECT COALESCE(NULLIF(mt.ticket_value, ''), '{UNTAGGED_DIMENSION}') AS ticket_value,
                 COUNT(DISTINCT m.session_id) AS sess,
                 COUNT(*) AS cnt,
-                COALESCE(SUM(m.cost_cents / mvc.n_values), 0.0) AS cost
+                COALESCE(SUM(m.cost_cents_effective / mvc.n_values), 0.0) AS cost
          FROM tags t
          JOIN msg_val_counts mvc ON mvc.message_id = t.message_id
          JOIN messages m ON m.id = t.message_id

--- a/crates/budi-core/src/analytics/sessions.rs
+++ b/crates/budi-core/src/analytics/sessions.rs
@@ -510,12 +510,12 @@ pub fn session_list_with_filters(
                     MIN(m.timestamp) as started_at,
                     MAX(m.timestamp) as ended_at,
                     COUNT(*) as msg_count,
-                    COALESCE(SUM(m.cost_cents), 0.0) as cost,
+                    COALESCE(SUM(m.cost_cents_effective), 0.0) as cost,
                     (SELECT GROUP_CONCAT(sub.model, ',') FROM (
                          SELECT m2.model FROM messages m2
                          WHERE m2.session_id = m.session_id AND m2.role = 'assistant'
                            AND m2.model IS NOT NULL AND m2.model != '' AND SUBSTR(m2.model, 1, 1) != '<'
-                         GROUP BY m2.model ORDER BY SUM(m2.cost_cents) DESC
+                         GROUP BY m2.model ORDER BY SUM(m2.cost_cents_effective) DESC
                      ) sub) as models_csv,
                     COALESCE(MAX(m.provider), 'claude_code') as provider,
                     COALESCE(
@@ -528,7 +528,7 @@ pub fn session_list_with_filters(
                               AND m2.repo_id != ''
                               AND m2.repo_id != 'unknown'
                             GROUP BY m2.repo_id
-                            ORDER BY SUM(m2.cost_cents) DESC, COUNT(*) DESC, m2.repo_id ASC
+                            ORDER BY SUM(m2.cost_cents_effective) DESC, COUNT(*) DESC, m2.repo_id ASC
                             LIMIT 1
                         ),
                         MAX(s.repo_id)
@@ -542,7 +542,7 @@ pub fn session_list_with_filters(
                            AND m2.repo_id != ''
                            AND m2.repo_id != 'unknown'
                          GROUP BY m2.repo_id
-                         ORDER BY SUM(m2.cost_cents) DESC, COUNT(*) DESC, m2.repo_id ASC
+                         ORDER BY SUM(m2.cost_cents_effective) DESC, COUNT(*) DESC, m2.repo_id ASC
                      ) sub) as repo_ids_csv,
                     COALESCE(
                         (
@@ -553,7 +553,7 @@ pub fn session_list_with_filters(
                                         WHEN m2.git_branch LIKE 'refs/heads/%' THEN SUBSTR(m2.git_branch, 12)
                                         ELSE m2.git_branch
                                     END as branch_value,
-                                    SUM(m2.cost_cents) as branch_cost,
+                                    SUM(m2.cost_cents_effective) as branch_cost,
                                     COUNT(*) as branch_count
                                 FROM messages m2
                                 WHERE m2.session_id = m.session_id
@@ -579,7 +579,7 @@ pub fn session_list_with_filters(
                            AND m2.git_branch IS NOT NULL
                            AND m2.git_branch != ''
                          GROUP BY branch_value
-                         ORDER BY SUM(m2.cost_cents) DESC, COUNT(*) DESC, branch_value ASC
+                         ORDER BY SUM(m2.cost_cents_effective) DESC, COUNT(*) DESC, branch_value ASC
                      ) sub) as git_branches_csv,
                     COALESCE(SUM(m.input_tokens), 0) as inp,
                     COALESCE(SUM(m.output_tokens), 0) as outp,
@@ -703,12 +703,12 @@ pub fn session_detail(conn: &Connection, session_id: &str) -> Result<Option<Sess
                         END
                     ) as duration_ms,
                     COUNT(m.id) as msg_count,
-                    COALESCE(SUM(m.cost_cents), 0.0) as cost,
+                    COALESCE(SUM(m.cost_cents_effective), 0.0) as cost,
                     (SELECT GROUP_CONCAT(sub.model, ',') FROM (
                          SELECT m2.model FROM messages m2
                          WHERE m2.session_id = sid.session_id AND m2.role = 'assistant'
                            AND m2.model IS NOT NULL AND m2.model != '' AND SUBSTR(m2.model, 1, 1) != '<'
-                         GROUP BY m2.model ORDER BY SUM(m2.cost_cents) DESC
+                         GROUP BY m2.model ORDER BY SUM(m2.cost_cents_effective) DESC
                      ) sub) as models_csv,
                     COALESCE(MAX(m.provider), MAX(s.provider), 'claude_code') as provider,
                     COALESCE(
@@ -721,7 +721,7 @@ pub fn session_detail(conn: &Connection, session_id: &str) -> Result<Option<Sess
                               AND m2.repo_id != ''
                               AND m2.repo_id != 'unknown'
                             GROUP BY m2.repo_id
-                            ORDER BY SUM(m2.cost_cents) DESC, COUNT(*) DESC, m2.repo_id ASC
+                            ORDER BY SUM(m2.cost_cents_effective) DESC, COUNT(*) DESC, m2.repo_id ASC
                             LIMIT 1
                         ),
                         MAX(s.repo_id)
@@ -735,7 +735,7 @@ pub fn session_detail(conn: &Connection, session_id: &str) -> Result<Option<Sess
                            AND m2.repo_id != ''
                            AND m2.repo_id != 'unknown'
                          GROUP BY m2.repo_id
-                         ORDER BY SUM(m2.cost_cents) DESC, COUNT(*) DESC, m2.repo_id ASC
+                         ORDER BY SUM(m2.cost_cents_effective) DESC, COUNT(*) DESC, m2.repo_id ASC
                      ) sub) as repo_ids_csv,
                     COALESCE(
                         (
@@ -746,7 +746,7 @@ pub fn session_detail(conn: &Connection, session_id: &str) -> Result<Option<Sess
                                         WHEN m2.git_branch LIKE 'refs/heads/%' THEN SUBSTR(m2.git_branch, 12)
                                         ELSE m2.git_branch
                                     END as branch_value,
-                                    SUM(m2.cost_cents) as branch_cost,
+                                    SUM(m2.cost_cents_effective) as branch_cost,
                                     COUNT(*) as branch_count
                                 FROM messages m2
                                 WHERE m2.session_id = sid.session_id
@@ -772,7 +772,7 @@ pub fn session_detail(conn: &Connection, session_id: &str) -> Result<Option<Sess
                            AND m2.git_branch IS NOT NULL
                            AND m2.git_branch != ''
                          GROUP BY branch_value
-                         ORDER BY SUM(m2.cost_cents) DESC, COUNT(*) DESC, branch_value ASC
+                         ORDER BY SUM(m2.cost_cents_effective) DESC, COUNT(*) DESC, branch_value ASC
                      ) sub) as git_branches_csv,
                     COALESCE(SUM(m.input_tokens), 0) as inp,
                     COALESCE(SUM(m.output_tokens), 0) as outp,
@@ -1055,7 +1055,7 @@ pub fn session_messages_with_roles(
                 repo_id,
                 input_tokens, output_tokens,
                 cache_creation_tokens, cache_read_tokens,
-                COALESCE(cost_cents, 0.0),
+                COALESCE(cost_cents_effective, 0.0),
                 COALESCE(cost_confidence, 'estimated'),
                 git_branch,
                 request_id,
@@ -1132,7 +1132,7 @@ pub fn session_message_list(
             }
         }
         "tokens" => format!("(m.input_tokens + m.output_tokens) {dir}"),
-        "cost" => format!("COALESCE(m.cost_cents, 0.0) {dir}"),
+        "cost" => format!("COALESCE(m.cost_cents_effective, 0.0) {dir}"),
         "repo_id" => {
             if p.sort_asc {
                 format!("(m.repo_id IS NULL OR m.repo_id = '') ASC, m.repo_id {dir}")
@@ -1164,7 +1164,7 @@ pub fn session_message_list(
                 m.repo_id,
                 m.input_tokens, m.output_tokens,
                 m.cache_creation_tokens, m.cache_read_tokens,
-                COALESCE(m.cost_cents, 0.0),
+                COALESCE(m.cost_cents_effective, 0.0),
                 COALESCE(m.cost_confidence, 'estimated'),
                 m.git_branch,
                 m.request_id,
@@ -1233,7 +1233,7 @@ pub fn session_message_curve(
                     COALESCE(input_tokens, 0) as input_tokens,
                     COALESCE(output_tokens, 0) as output_tokens,
                     (COALESCE(cache_creation_tokens, 0) + COALESCE(cache_read_tokens, 0)) as cache_tokens,
-                    COALESCE(cost_cents, 0.0) as cost_cents
+                    COALESCE(cost_cents_effective, 0.0) as cost_cents
              FROM messages
              WHERE session_id = ?1 AND role = 'assistant'
          )
@@ -1274,7 +1274,7 @@ pub fn message_detail(conn: &Connection, message_id: &str) -> Result<Option<Mess
                 repo_id,
                 input_tokens, output_tokens,
                 cache_creation_tokens, cache_read_tokens,
-                COALESCE(cost_cents, 0.0),
+                COALESCE(cost_cents_effective, 0.0),
                 COALESCE(cost_confidence, 'estimated'),
                 git_branch,
                 request_id,

--- a/crates/budi-core/src/analytics/sync.rs
+++ b/crates/budi-core/src/analytics/sync.rs
@@ -937,11 +937,11 @@ mod tests {
         crate::migration::migrate(&conn).expect("migrate schema");
         conn.execute(
             "INSERT INTO messages
-             (id, role, timestamp, model, provider, input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens, cost_cents, cost_confidence)
+             (id, role, timestamp, model, provider, input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens, cost_cents_ingested, cost_cents_effective, cost_confidence)
              VALUES
-             ('m2', 'assistant', '2026-04-10T10:00:00Z', 'gpt-4o', 'openai', 10, 5, 0, 0, 1.0, 'proxy_estimated'),
-             ('m1', 'assistant', '2026-04-10T09:00:00Z', 'gpt-4o', 'openai', 10, 5, 0, 0, 1.0, 'proxy_estimated'),
-             ('m3', 'assistant', '2026-04-10T08:00:00Z', 'claude-sonnet-4-6', 'claude_code', 10, 5, 0, 0, 1.0, 'estimated')",
+             ('m2', 'assistant', '2026-04-10T10:00:00Z', 'gpt-4o', 'openai', 10, 5, 0, 0, 1.0, 1.0, 'proxy_estimated'),
+             ('m1', 'assistant', '2026-04-10T09:00:00Z', 'gpt-4o', 'openai', 10, 5, 0, 0, 1.0, 1.0, 'proxy_estimated'),
+             ('m3', 'assistant', '2026-04-10T08:00:00Z', 'claude-sonnet-4-6', 'claude_code', 10, 5, 0, 0, 1.0, 1.0, 'estimated')",
             [],
         )
         .expect("insert messages");
@@ -966,10 +966,10 @@ mod tests {
             "INSERT INTO messages
              (id, session_id, role, timestamp, model, provider,
               input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
-              cost_cents, cost_confidence)
+              cost_cents_ingested, cost_cents_effective, cost_confidence)
              VALUES
              ('a1', 's1', 'assistant', datetime('now'), 'claude-opus-4-6', 'claude_code',
-              100, 50, 0, 0, 5.0, 'exact')",
+              100, 50, 0, 0, 5.0, 5.0, 'exact')",
             [],
         )
         .expect("insert assistant message");
@@ -1011,10 +1011,10 @@ mod tests {
             "INSERT INTO messages
              (id, session_id, role, timestamp, model, provider,
               input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
-              cost_cents, cost_confidence)
+              cost_cents_ingested, cost_cents_effective, cost_confidence)
              VALUES
              ('a1', 's1', 'assistant', datetime('now'), 'claude-opus-4-6', 'claude_code',
-              100, 50, 0, 0, 5.0, 'exact')",
+              100, 50, 0, 0, 5.0, 5.0, 'exact')",
             [],
         )
         .expect("insert assistant message");
@@ -1053,10 +1053,10 @@ mod tests {
             "INSERT INTO messages
              (id, session_id, role, timestamp, model, provider,
               input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
-              cost_cents, cost_confidence)
+              cost_cents_ingested, cost_cents_effective, cost_confidence)
              VALUES
              ('a1', 's1', 'assistant', datetime('now'), 'claude-opus-4-6', 'claude_code',
-              100, 50, 0, 0, 5.0, 'exact')",
+              100, 50, 0, 0, 5.0, 5.0, 'exact')",
             [],
         )
         .expect("insert assistant message");

--- a/crates/budi-core/src/analytics/tests.rs
+++ b/crates/budi-core/src/analytics/tests.rs
@@ -174,7 +174,8 @@ fn rollups_track_message_updates_and_deletes() {
     conn.execute(
         "UPDATE messages
          SET output_tokens = 90,
-             cost_cents = 4.5
+             cost_cents_ingested = 4.5,
+             cost_cents_effective = 4.5
          WHERE id = 'rollup-msg-1'",
         [],
     )
@@ -368,10 +369,10 @@ fn cost_cents_baked_at_ingest() {
     CostEnricher.enrich(&mut msg);
     ingest_messages(&mut conn, &[msg], None).unwrap();
 
-    // Verify cost_cents was baked in: 1M input * $5/M + 100K output * $25/M = $5 + $2.50 = $7.50 = 750 cents
+    // Verify cost was baked in: 1M input * $5/M + 100K output * $25/M = $5 + $2.50 = $7.50 = 750 cents
     let cost_cents: f64 = conn
         .query_row(
-            "SELECT cost_cents FROM messages WHERE id = 'cost-test-1'",
+            "SELECT cost_cents_effective FROM messages WHERE id = 'cost-test-1'",
             [],
             |r| r.get(0),
         )
@@ -2097,18 +2098,18 @@ fn jsonl_dedup_matches_otel_by_fingerprint_within_window() {
     conn.execute(
         "INSERT INTO messages (id, session_id, role, timestamp, model, provider,
             input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
-            cost_cents, cost_confidence)
+            cost_cents_ingested, cost_cents_effective, cost_confidence)
          VALUES ('otel-a', 'sess-otel', 'assistant', '2026-03-25T00:00:01.050Z', 'claude-opus-4-6',
-                 'claude_code', 10, 5, 0, 0, 1.0, 'otel_exact')",
+                 'claude_code', 10, 5, 0, 0, 1.0, 1.0, 'otel_exact')",
         [],
     )
     .unwrap();
     conn.execute(
         "INSERT INTO messages (id, session_id, role, timestamp, model, provider,
             input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
-            cost_cents, cost_confidence)
+            cost_cents_ingested, cost_cents_effective, cost_confidence)
          VALUES ('otel-b', 'sess-otel', 'assistant', '2026-03-25T00:00:01.120Z', 'claude-opus-4-6',
-                 'claude_code', 900, 400, 5000, 50000, 7.3, 'otel_exact')",
+                 'claude_code', 900, 400, 5000, 50000, 7.3, 7.3, 'otel_exact')",
         [],
     )
     .unwrap();
@@ -2186,9 +2187,9 @@ fn jsonl_dedup_preserves_message_when_otel_candidates_are_ambiguous() {
         conn.execute(
             "INSERT INTO messages (id, session_id, role, timestamp, model, provider,
                 input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
-                cost_cents, cost_confidence)
+                cost_cents_ingested, cost_cents_effective, cost_confidence)
              VALUES (?1, 'sess-ambig', 'assistant', '2026-03-25T00:00:01.100Z', 'claude-opus-4-6',
-                     'claude_code', 1000, 500, 5000, 50000, 7.3, 'otel_exact')",
+                     'claude_code', 1000, 500, 5000, 50000, 7.3, 7.3, 'otel_exact')",
             params![id],
         )
         .unwrap();
@@ -2613,9 +2614,9 @@ fn session_visibility_reports_windows_and_flags_hidden_rows() {
     conn.execute(
         "INSERT INTO messages (id, session_id, role, timestamp, model, provider,
             input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
-            cost_cents, cost_confidence)
+            cost_cents_ingested, cost_cents_effective, cost_confidence)
          VALUES ('hidden-1', NULL, 'assistant', ?1, 'claude-opus-4-6',
-                 'claude_code', 1, 1, 0, 0, 0.1, 'proxy_estimated')",
+                 'claude_code', 1, 1, 0, 0, 0.1, 0.1, 'proxy_estimated')",
         params![(today_midnight + chrono::Duration::minutes(2)).to_rfc3339()],
     )
     .unwrap();
@@ -2657,9 +2658,9 @@ fn session_visibility_flags_mismatch_when_all_rows_missing_session_id() {
     conn.execute(
         "INSERT INTO messages (id, session_id, role, timestamp, model, provider,
             input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
-            cost_cents, cost_confidence)
+            cost_cents_ingested, cost_cents_effective, cost_confidence)
          VALUES ('hidden-1', NULL, 'assistant', ?1, 'claude-opus-4-6',
-                 'claude_code', 1, 1, 0, 0, 0.1, 'proxy_estimated')",
+                 'claude_code', 1, 1, 0, 0, 0.1, 0.1, 'proxy_estimated')",
         params![(today_midnight + chrono::Duration::minutes(1)).to_rfc3339()],
     )
     .unwrap();
@@ -2752,9 +2753,9 @@ fn session_list_ignores_empty_string_session_id() {
     conn.execute(
         "INSERT INTO messages (id, session_id, role, timestamp, model, provider,
             input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
-            cost_cents, cost_confidence)
+            cost_cents_ingested, cost_cents_effective, cost_confidence)
          VALUES ('empty-1', '', 'assistant', '2026-03-14T10:00:00+00:00',
-                 'claude-opus-4-6', 'claude_code', 1, 1, 0, 0, 0.1, 'proxy_estimated')",
+                 'claude-opus-4-6', 'claude_code', 1, 1, 0, 0, 0.1, 0.1, 'proxy_estimated')",
         [],
     )
     .unwrap();
@@ -7227,13 +7228,13 @@ fn backfill_preserves_already_populated_repo_and_branch() {
 fn status_snapshot_returns_consistent_data() {
     let conn = test_db();
     conn.execute(
-        "INSERT INTO messages (id, role, timestamp, model, provider, input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens, cost_cents)
-         VALUES ('m1', 'assistant', '2026-05-04T10:00:00Z', 'claude-sonnet-4-6', 'claude_code', 100000, 50000, 0, 0, 195.0)",
+        "INSERT INTO messages (id, role, timestamp, model, provider, input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens, cost_cents_ingested, cost_cents_effective)
+         VALUES ('m1', 'assistant', '2026-05-04T10:00:00Z', 'claude-sonnet-4-6', 'claude_code', 100000, 50000, 0, 0, 195.0, 195.0)",
         [],
     ).unwrap();
     conn.execute(
-        "INSERT INTO messages (id, role, timestamp, model, provider, input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens, cost_cents)
-         VALUES ('m2', 'user', '2026-05-04T10:00:01Z', 'claude-sonnet-4-6', 'claude_code', 0, 0, 0, 0, 0.0)",
+        "INSERT INTO messages (id, role, timestamp, model, provider, input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens, cost_cents_ingested, cost_cents_effective)
+         VALUES ('m2', 'user', '2026-05-04T10:00:01Z', 'claude-sonnet-4-6', 'claude_code', 0, 0, 0, 0, 0.0, 0.0)",
         [],
     ).unwrap();
 

--- a/crates/budi-core/src/cloud_sync.rs
+++ b/crates/budi-core/src/cloud_sync.rs
@@ -63,7 +63,16 @@ pub struct DailyRollupRecord {
     pub output_tokens: i64,
     pub cache_creation_tokens: i64,
     pub cache_read_tokens: i64,
-    pub cost_cents: f64,
+    /// Effective cost: what every read surface (CLI, statusline, extensions,
+    /// dashboard) displays. Defaults to the LiteLLM-priced `cost_cents_ingested`
+    /// at ingest; rewritten by the team-pricing worker (#731) once a cloud
+    /// price list is active. ADR-0094 §1.
+    #[serde(alias = "cost_cents")]
+    pub cost_cents_effective: f64,
+    /// LiteLLM-priced cost calculated at ingest time. ADR-0091 §5 immutable
+    /// (never overwritten after insert), as amended by ADR-0094 Rule D.
+    /// Sent so the cloud can populate its own `cost_cents_ingested` column.
+    pub cost_cents_ingested: f64,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -311,7 +320,8 @@ pub fn fetch_daily_rollups(
         let mut stmt = conn.prepare(
             "SELECT bucket_day, role, provider, model, repo_id, git_branch,
                     message_count, input_tokens, output_tokens,
-                    cache_creation_tokens, cache_read_tokens, cost_cents
+                    cache_creation_tokens, cache_read_tokens,
+                    cost_cents_effective, cost_cents_ingested
              FROM message_rollups_daily
              WHERE bucket_day > ?1 OR bucket_day = ?2
              ORDER BY bucket_day",
@@ -331,7 +341,8 @@ pub fn fetch_daily_rollups(
                 output_tokens: row.get(8)?,
                 cache_creation_tokens: row.get(9)?,
                 cache_read_tokens: row.get(10)?,
-                cost_cents: row.get(11)?,
+                cost_cents_effective: row.get(11)?,
+                cost_cents_ingested: row.get(12)?,
             })
         })?
         .filter_map(|r| r.ok())
@@ -341,7 +352,8 @@ pub fn fetch_daily_rollups(
         let mut stmt = conn.prepare(
             "SELECT bucket_day, role, provider, model, repo_id, git_branch,
                     message_count, input_tokens, output_tokens,
-                    cache_creation_tokens, cache_read_tokens, cost_cents
+                    cache_creation_tokens, cache_read_tokens,
+                    cost_cents_effective, cost_cents_ingested
              FROM message_rollups_daily
              ORDER BY bucket_day",
         )?;
@@ -360,7 +372,8 @@ pub fn fetch_daily_rollups(
                 output_tokens: row.get(8)?,
                 cache_creation_tokens: row.get(9)?,
                 cache_read_tokens: row.get(10)?,
-                cost_cents: row.get(11)?,
+                cost_cents_effective: row.get(11)?,
+                cost_cents_ingested: row.get(12)?,
             })
         })?
         .filter_map(|r| r.ok())
@@ -452,7 +465,7 @@ pub fn fetch_session_summaries(
                     COUNT(*) as msg_count,
                     SUM(input_tokens) as total_input,
                     SUM(output_tokens) as total_output,
-                    SUM(COALESCE(cost_cents, 0.0)) as total_cost
+                    SUM(COALESCE(cost_cents_effective, 0.0)) as total_cost
              FROM messages
              WHERE role = 'assistant'
              GROUP BY session_id
@@ -491,7 +504,7 @@ pub fn fetch_session_summaries(
                     COUNT(*) as msg_count,
                     SUM(input_tokens) as total_input,
                     SUM(output_tokens) as total_output,
-                    SUM(COALESCE(cost_cents, 0.0)) as total_cost
+                    SUM(COALESCE(cost_cents_effective, 0.0)) as total_cost
              FROM messages
              WHERE role = 'assistant'
              GROUP BY session_id
@@ -1184,9 +1197,10 @@ mod tests {
         // Insert a message to trigger the rollup trigger
         conn.execute(
             "INSERT INTO messages (id, role, timestamp, model, provider, repo_id, git_branch,
-                                   input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens, cost_cents)
+                                   input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
+                                   cost_cents_ingested, cost_cents_effective)
              VALUES ('msg-1', 'assistant', '2026-04-10T14:30:00Z', 'claude-sonnet-4-6', 'anthropic',
-                     'sha256:abc123', 'feature/PROJ-42-auth', 100, 200, 10, 50, 1.5)",
+                     'sha256:abc123', 'feature/PROJ-42-auth', 100, 200, 10, 50, 1.5, 1.5)",
             [],
         ).unwrap();
 
@@ -1245,8 +1259,9 @@ mod tests {
         for (msg_id, model, ts, input, output) in rows {
             conn.execute(
                 "INSERT INTO messages (id, session_id, role, timestamp, model, provider, repo_id, git_branch,
-                                       input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens, cost_cents)
-                 VALUES (?1, ?2, 'assistant', ?3, ?4, 'anthropic', 'sha256:pm', 'main', ?5, ?6, 0, 0, 0.1)",
+                                       input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
+                                       cost_cents_ingested, cost_cents_effective)
+                 VALUES (?1, ?2, 'assistant', ?3, ?4, 'anthropic', 'sha256:pm', 'main', ?5, ?6, 0, 0, 0.1, 0.1)",
                 params![msg_id, session_id, ts, model, input, output],
             )
             .unwrap();
@@ -1460,9 +1475,10 @@ mod tests {
 
         conn.execute(
             "INSERT INTO messages (id, role, timestamp, model, provider, repo_id, git_branch,
-                                   input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens, cost_cents)
+                                   input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
+                                   cost_cents_ingested, cost_cents_effective)
              VALUES ('msg-status-1', 'assistant', '2026-04-10T14:30:00Z', 'claude-sonnet-4-6', 'anthropic',
-                     'sha256:abc', 'main', 100, 200, 10, 50, 1.5)",
+                     'sha256:abc', 'main', 100, 200, 10, 50, 1.5, 1.5)",
             [],
         )
         .unwrap();
@@ -1505,7 +1521,8 @@ mod tests {
                     output_tokens: 500,
                     cache_creation_tokens: 100,
                     cache_read_tokens: 200,
-                    cost_cents: 2.5,
+                    cost_cents_effective: 2.5,
+                    cost_cents_ingested: 2.5,
                 }],
                 session_summaries: vec![],
             },
@@ -1528,6 +1545,18 @@ mod tests {
             json["payload"]["daily_rollups"][0]
                 .get("ticket_source")
                 .is_none()
+        );
+        // ADR-0094 §1: envelope carries both `cost_cents_effective` (read
+        // surface, may be overridden by team pricing) and `cost_cents_ingested`
+        // (LiteLLM-priced ingest cost, immutable per ADR-0091 §5 Rule D).
+        // Cloud uses `_ingested` to populate its own ingested column on insert.
+        assert_eq!(
+            json["payload"]["daily_rollups"][0]["cost_cents_effective"],
+            2.5
+        );
+        assert_eq!(
+            json["payload"]["daily_rollups"][0]["cost_cents_ingested"],
+            2.5
         );
     }
 
@@ -1633,9 +1662,10 @@ mod tests {
         // None here, so cloud ticket buckets disagreed with local CLI.
         conn.execute(
             "INSERT INTO messages (id, role, timestamp, model, provider, repo_id, git_branch,
-                                   input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens, cost_cents)
+                                   input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
+                                   cost_cents_ingested, cost_cents_effective)
              VALUES ('msg-num-1', 'assistant', '2026-04-10T14:30:00Z', 'claude-sonnet-4-6', 'anthropic',
-                     'sha256:num', 'feature/1234', 10, 20, 0, 0, 0.1)",
+                     'sha256:num', 'feature/1234', 10, 20, 0, 0, 0.1, 0.1)",
             [],
         )
         .unwrap();
@@ -1669,9 +1699,10 @@ mod tests {
         // Seed a rollup via the message trigger, plus an explicit session row.
         conn.execute(
             "INSERT INTO messages (id, role, timestamp, model, provider, repo_id, git_branch,
-                                   input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens, cost_cents)
+                                   input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
+                                   cost_cents_ingested, cost_cents_effective)
              VALUES ('msg-count-1', 'assistant', '2026-04-10T14:30:00Z', 'claude-sonnet-4-6', 'anthropic',
-                     'sha256:count', 'feature/PROJ-77-counts', 10, 20, 0, 0, 0.1)",
+                     'sha256:count', 'feature/PROJ-77-counts', 10, 20, 0, 0, 0.1, 0.1)",
             [],
         ).unwrap();
         conn.execute(
@@ -1713,9 +1744,10 @@ mod tests {
         let conn = crate::analytics::open_db_with_migration(&db_path).unwrap();
         conn.execute(
             "INSERT INTO messages (id, role, timestamp, model, provider, repo_id, git_branch,
-                                   input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens, cost_cents)
+                                   input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
+                                   cost_cents_ingested, cost_cents_effective)
              VALUES ('msg-int-1', 'assistant', '2026-04-10T14:30:00Z', 'claude-sonnet-4-6', 'anthropic',
-                     'sha256:int', 'main', 10, 20, 0, 0, 0.1)",
+                     'sha256:int', 'main', 10, 20, 0, 0, 0.1, 0.1)",
             [],
         )
         .unwrap();
@@ -1748,7 +1780,8 @@ mod tests {
             output_tokens: 20,
             cache_creation_tokens: 0,
             cache_read_tokens: 0,
-            cost_cents: 0.1,
+            cost_cents_effective: 0.1,
+            cost_cents_ingested: 0.1,
         }
     }
 

--- a/crates/budi-core/src/cost.rs
+++ b/crates/budi-core/src/cost.rs
@@ -156,10 +156,12 @@ pub fn estimate_cost_with_filters(
         .map(|s| s as &dyn rusqlite::types::ToSql)
         .collect();
 
-    // Use pre-computed SUM(cost_cents) for total_cost to match bar charts,
-    // and token-based calculation for the input/output/cache breakdown.
+    // Use pre-computed SUM(cost_cents_effective) for total_cost to match bar
+    // charts, and token-based calculation for the input/output/cache breakdown.
+    // ADR-0094 §1: every read surface reads `_effective`; until the team-pricing
+    // worker (#731) ships, `_effective = _ingested`.
     let sum_sql = format!(
-        "SELECT COALESCE(SUM(cost_cents), 0) FROM messages {}",
+        "SELECT COALESCE(SUM(cost_cents_effective), 0) FROM messages {}",
         where_clause
     );
     let sum_cost_cents: f64 = conn.query_row(&sum_sql, param_refs.as_slice(), |r| r.get(0))?;
@@ -275,8 +277,8 @@ mod tests {
         let conn = setup_db();
         // 1M input * $5/M = $5.00, 100K output * $25/M = $2.50, total = $7.50 = 750 cents
         conn.execute(
-            "INSERT INTO messages (id, role, timestamp, model, input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens, cost_cents)
-             VALUES (?1, 'assistant', '2026-03-21T00:00:00Z', 'claude-opus-4-6', ?2, ?3, ?4, ?5, ?6)",
+            "INSERT INTO messages (id, role, timestamp, model, input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens, cost_cents_ingested, cost_cents_effective)
+             VALUES (?1, 'assistant', '2026-03-21T00:00:00Z', 'claude-opus-4-6', ?2, ?3, ?4, ?5, ?6, ?6)",
             params!["msg1", 1_000_000i64, 100_000i64, 0i64, 0i64, 750.0],
         ).unwrap();
         let cost = estimate_cost_filtered(&conn, None, None, None).unwrap();
@@ -290,8 +292,8 @@ mod tests {
         let conn = setup_db();
         // total = 0.30 + 0.75 + 0.75 + 0.15 = $1.95 = 195 cents
         conn.execute(
-            "INSERT INTO messages (id, role, timestamp, model, input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens, cost_cents)
-             VALUES (?1, 'assistant', '2026-03-21T00:00:00Z', 'claude-sonnet-4-6', ?2, ?3, ?4, ?5, ?6)",
+            "INSERT INTO messages (id, role, timestamp, model, input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens, cost_cents_ingested, cost_cents_effective)
+             VALUES (?1, 'assistant', '2026-03-21T00:00:00Z', 'claude-sonnet-4-6', ?2, ?3, ?4, ?5, ?6, ?6)",
             params!["msg1", 100_000i64, 50_000i64, 200_000i64, 500_000i64, 195.0],
         ).unwrap();
         let cost = estimate_cost_filtered(&conn, None, None, None).unwrap();
@@ -309,14 +311,14 @@ mod tests {
         let conn = setup_db();
         // 1M input * $3/M = $3.00 = 300 cents each
         conn.execute(
-            "INSERT INTO messages (id, role, timestamp, model, input_tokens, output_tokens, cost_cents)
-             VALUES ('old', 'assistant', '2026-03-01T00:00:00Z', 'claude-sonnet-4-6', 1000000, 0, 300.0)",
+            "INSERT INTO messages (id, role, timestamp, model, input_tokens, output_tokens, cost_cents_ingested, cost_cents_effective)
+             VALUES ('old', 'assistant', '2026-03-01T00:00:00Z', 'claude-sonnet-4-6', 1000000, 0, 300.0, 300.0)",
             [],
         )
         .unwrap();
         conn.execute(
-            "INSERT INTO messages (id, role, timestamp, model, input_tokens, output_tokens, cost_cents)
-             VALUES ('new', 'assistant', '2026-03-21T00:00:00Z', 'claude-sonnet-4-6', 1000000, 0, 300.0)",
+            "INSERT INTO messages (id, role, timestamp, model, input_tokens, output_tokens, cost_cents_ingested, cost_cents_effective)
+             VALUES ('new', 'assistant', '2026-03-21T00:00:00Z', 'claude-sonnet-4-6', 1000000, 0, 300.0, 300.0)",
             [],
         )
         .unwrap();
@@ -332,20 +334,20 @@ mod tests {
         let conn = setup_db();
         // Opus 4.6: 100K input * $5/M = $0.50 = 50 cents
         conn.execute(
-            "INSERT INTO messages (id, role, timestamp, model, input_tokens, output_tokens, cost_cents)
-             VALUES ('m1', 'assistant', '2026-03-21T00:00:00Z', 'claude-opus-4-6', 100000, 0, 50.0)",
+            "INSERT INTO messages (id, role, timestamp, model, input_tokens, output_tokens, cost_cents_ingested, cost_cents_effective)
+             VALUES ('m1', 'assistant', '2026-03-21T00:00:00Z', 'claude-opus-4-6', 100000, 0, 50.0, 50.0)",
             [],
         ).unwrap();
         // Haiku 4.5: 100K input * $1/M = $0.10 = 10 cents
         conn.execute(
-            "INSERT INTO messages (id, role, timestamp, model, input_tokens, output_tokens, cost_cents)
-             VALUES ('m2', 'assistant', '2026-03-21T00:00:00Z', 'claude-haiku-4-5-20251001', 100000, 0, 10.0)",
+            "INSERT INTO messages (id, role, timestamp, model, input_tokens, output_tokens, cost_cents_ingested, cost_cents_effective)
+             VALUES ('m2', 'assistant', '2026-03-21T00:00:00Z', 'claude-haiku-4-5-20251001', 100000, 0, 10.0, 10.0)",
             [],
         ).unwrap();
         // Sonnet 4.6: 100K input * $3/M = $0.30 = 30 cents
         conn.execute(
-            "INSERT INTO messages (id, role, timestamp, model, input_tokens, output_tokens, cost_cents)
-             VALUES ('m3', 'assistant', '2026-03-21T00:00:00Z', 'claude-sonnet-4-6', 100000, 0, 30.0)",
+            "INSERT INTO messages (id, role, timestamp, model, input_tokens, output_tokens, cost_cents_ingested, cost_cents_effective)
+             VALUES ('m3', 'assistant', '2026-03-21T00:00:00Z', 'claude-sonnet-4-6', 100000, 0, 30.0, 30.0)",
             [],
         ).unwrap();
         let cost = estimate_cost_filtered(&conn, None, None, None).unwrap();
@@ -367,8 +369,8 @@ mod tests {
         let total_dollars = input_cost + cache_write_cost;
         let total_cents = total_dollars * 100.0;
         conn.execute(
-            "INSERT INTO messages (id, role, timestamp, model, input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens, cost_cents)
-             VALUES ('m1', 'assistant', '2026-03-21T00:00:00Z', 'claude-opus-4-6', 3, 0, 14873, 0, ?1)",
+            "INSERT INTO messages (id, role, timestamp, model, input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens, cost_cents_ingested, cost_cents_effective)
+             VALUES ('m1', 'assistant', '2026-03-21T00:00:00Z', 'claude-opus-4-6', 3, 0, 14873, 0, ?1, ?1)",
             params![total_cents],
         ).unwrap();
         let cost = estimate_cost_filtered(&conn, None, None, None).unwrap();
@@ -430,8 +432,8 @@ mod tests {
             expected_total_cents += cost_cents;
 
             conn.execute(
-                "INSERT INTO messages (id, role, timestamp, model, input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens, cost_cents)
-                 VALUES (?1, 'assistant', '2026-03-21T00:00:00Z', ?2, ?3, ?4, ?5, ?6, ?7)",
+                "INSERT INTO messages (id, role, timestamp, model, input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens, cost_cents_ingested, cost_cents_effective)
+                 VALUES (?1, 'assistant', '2026-03-21T00:00:00Z', ?2, ?3, ?4, ?5, ?6, ?7, ?7)",
                 params![*prefix, *model, *inp as i64, *out as i64, *cw as i64, *cr as i64, cost_cents],
             ).unwrap();
         }
@@ -489,8 +491,8 @@ mod tests {
         let conn = setup_db();
         let cost_cents = correct * 100.0;
         conn.execute(
-            "INSERT INTO messages (id, role, timestamp, model, input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens, cost_cents)
-             VALUES ('test', 'assistant', '2026-03-21T00:00:00Z', 'claude-opus-4-6', 3, 0, 16267, 9985, ?1)",
+            "INSERT INTO messages (id, role, timestamp, model, input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens, cost_cents_ingested, cost_cents_effective)
+             VALUES ('test', 'assistant', '2026-03-21T00:00:00Z', 'claude-opus-4-6', 3, 0, 16267, 9985, ?1, ?1)",
             params![cost_cents],
         ).unwrap();
         let result = estimate_cost_filtered(&conn, None, None, None).unwrap();
@@ -518,13 +520,13 @@ mod tests {
         // If stored as integer: 0 or 1 cent (up to 100% error)
         // If stored as f64: 0.5 cents exactly
         conn.execute(
-            "INSERT INTO messages (id, role, timestamp, model, input_tokens, output_tokens, cost_cents)
-             VALUES ('half', 'assistant', '2026-03-21T00:00:00Z', 'claude-opus-4-6', 0, 0, 0.5)",
+            "INSERT INTO messages (id, role, timestamp, model, input_tokens, output_tokens, cost_cents_ingested, cost_cents_effective)
+             VALUES ('half', 'assistant', '2026-03-21T00:00:00Z', 'claude-opus-4-6', 0, 0, 0.5, 0.5)",
             [],
         ).unwrap();
         let stored: f64 = conn
             .query_row(
-                "SELECT cost_cents FROM messages WHERE id = 'half'",
+                "SELECT cost_cents_effective FROM messages WHERE id = 'half'",
                 [],
                 |r| r.get(0),
             )
@@ -545,8 +547,8 @@ mod tests {
         // After fix: each stored as 0.0915 cents → total $0.09 (rounded at display)
         for i in 0..100 {
             conn.execute(
-                "INSERT INTO messages (id, role, timestamp, model, input_tokens, output_tokens, cost_cents)
-                 VALUES (?1, 'assistant', '2026-03-21T00:00:00Z', 'claude-opus-4-6', 3, 36, ?2)",
+                "INSERT INTO messages (id, role, timestamp, model, input_tokens, output_tokens, cost_cents_ingested, cost_cents_effective)
+                 VALUES (?1, 'assistant', '2026-03-21T00:00:00Z', 'claude-opus-4-6', 3, 36, ?2, ?2)",
                 params![format!("msg{}", i), 0.0915],
             ).unwrap();
         }
@@ -572,8 +574,8 @@ mod tests {
         // $25/M = $2.50 → components sum $7.50. The extra $2.50 is the
         // "other" bucket — thinking/fast-mode/web-search in real data.
         conn.execute(
-            "INSERT INTO messages (id, role, timestamp, model, input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens, cost_cents)
-             VALUES (?1, 'assistant', '2026-03-21T00:00:00Z', 'claude-opus-4-6', ?2, ?3, 0, 0, ?4)",
+            "INSERT INTO messages (id, role, timestamp, model, input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens, cost_cents_ingested, cost_cents_effective)
+             VALUES (?1, 'assistant', '2026-03-21T00:00:00Z', 'claude-opus-4-6', ?2, ?3, 0, 0, ?4, ?4)",
             params!["msg1", 1_000_000i64, 100_000i64, 1000.0],
         ).unwrap();
         let cost = estimate_cost_filtered(&conn, None, None, None).unwrap();
@@ -606,8 +608,8 @@ mod tests {
         // Stored `cost_cents` matches the recomputation exactly, so
         // `other_cost` should be zero.
         conn.execute(
-            "INSERT INTO messages (id, role, timestamp, model, input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens, cost_cents)
-             VALUES (?1, 'assistant', '2026-03-21T00:00:00Z', 'claude-opus-4-6', ?2, ?3, 0, 0, ?4)",
+            "INSERT INTO messages (id, role, timestamp, model, input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens, cost_cents_ingested, cost_cents_effective)
+             VALUES (?1, 'assistant', '2026-03-21T00:00:00Z', 'claude-opus-4-6', ?2, ?3, 0, 0, ?4, ?4)",
             params!["msg1", 1_000_000i64, 100_000i64, 750.0],
         ).unwrap();
         let cost = estimate_cost_filtered(&conn, None, None, None).unwrap();
@@ -627,8 +629,8 @@ mod tests {
         // only $5.00 at ingest time — `other_cost` should clamp at 0
         // rather than flip negative.
         conn.execute(
-            "INSERT INTO messages (id, role, timestamp, model, input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens, cost_cents)
-             VALUES (?1, 'assistant', '2026-03-21T00:00:00Z', 'claude-opus-4-6', ?2, ?3, 0, 0, ?4)",
+            "INSERT INTO messages (id, role, timestamp, model, input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens, cost_cents_ingested, cost_cents_effective)
+             VALUES (?1, 'assistant', '2026-03-21T00:00:00Z', 'claude-opus-4-6', ?2, ?3, 0, 0, ?4, ?4)",
             params!["msg1", 1_000_000i64, 100_000i64, 500.0],
         ).unwrap();
         let cost = estimate_cost_filtered(&conn, None, None, None).unwrap();

--- a/crates/budi-core/src/migration.rs
+++ b/crates/budi-core/src/migration.rs
@@ -137,6 +137,23 @@ fn detect_drift(conn: &Connection) -> Result<(Vec<String>, Vec<String>, Vec<Stri
     if !table_exists(conn, "pricing_manifests")? {
         added_columns.push("pricing_manifests".to_string());
     }
+    // #730 / ADR-0094 §1: dual-column cost shape on messages and both rollup
+    // tables. Missing either column on any of these tables is drift.
+    for table in [
+        "messages",
+        "message_rollups_hourly",
+        "message_rollups_daily",
+    ] {
+        if !table_exists(conn, table)? {
+            continue;
+        }
+        if !has_column(conn, table, "cost_cents_ingested")? {
+            added_columns.push(format!("{table}.cost_cents_ingested"));
+        }
+        if !has_column(conn, table, "cost_cents_effective")? {
+            added_columns.push(format!("{table}.cost_cents_effective"));
+        }
+    }
     if table_exists(conn, "messages")? && !has_column(conn, "messages", "surface")? {
         added_columns.push("messages.surface".to_string());
     }
@@ -207,7 +224,8 @@ fn create_current_schema(conn: &Connection) -> Result<()> {
             cwd                    TEXT,
             repo_id                TEXT,
             provider               TEXT DEFAULT 'claude_code',
-            cost_cents             REAL,
+            cost_cents_ingested    REAL NOT NULL DEFAULT 0,
+            cost_cents_effective   REAL,
             parent_uuid            TEXT,
             git_branch             TEXT,
             cost_confidence        TEXT DEFAULT 'estimated',
@@ -376,7 +394,8 @@ fn create_rollup_tables(conn: &Connection) -> Result<()> {
             output_tokens          INTEGER NOT NULL DEFAULT 0,
             cache_creation_tokens  INTEGER NOT NULL DEFAULT 0,
             cache_read_tokens      INTEGER NOT NULL DEFAULT 0,
-            cost_cents             REAL NOT NULL DEFAULT 0,
+            cost_cents_ingested    REAL NOT NULL DEFAULT 0,
+            cost_cents_effective   REAL NOT NULL DEFAULT 0,
             PRIMARY KEY(bucket_start, role, provider, model, repo_id, git_branch, surface)
         );
 
@@ -393,7 +412,8 @@ fn create_rollup_tables(conn: &Connection) -> Result<()> {
             output_tokens          INTEGER NOT NULL DEFAULT 0,
             cache_creation_tokens  INTEGER NOT NULL DEFAULT 0,
             cache_read_tokens      INTEGER NOT NULL DEFAULT 0,
-            cost_cents             REAL NOT NULL DEFAULT 0,
+            cost_cents_ingested    REAL NOT NULL DEFAULT 0,
+            cost_cents_effective   REAL NOT NULL DEFAULT 0,
             PRIMARY KEY(bucket_day, role, provider, model, repo_id, git_branch, surface)
         );
         ",
@@ -414,7 +434,8 @@ fn create_rollup_triggers(conn: &Connection) -> Result<()> {
             INSERT INTO message_rollups_hourly (
                 bucket_start, role, provider, model, repo_id, git_branch, surface,
                 message_count, input_tokens, output_tokens,
-                cache_creation_tokens, cache_read_tokens, cost_cents
+                cache_creation_tokens, cache_read_tokens,
+                cost_cents_ingested, cost_cents_effective
             )
             VALUES (
                 strftime('%Y-%m-%dT%H:00:00Z', NEW.timestamp),
@@ -443,7 +464,8 @@ fn create_rollup_triggers(conn: &Connection) -> Result<()> {
                 COALESCE(NEW.output_tokens, 0),
                 COALESCE(NEW.cache_creation_tokens, 0),
                 COALESCE(NEW.cache_read_tokens, 0),
-                COALESCE(NEW.cost_cents, 0.0)
+                COALESCE(NEW.cost_cents_ingested, 0.0),
+                COALESCE(NEW.cost_cents_effective, 0.0)
             )
             ON CONFLICT(bucket_start, role, provider, model, repo_id, git_branch, surface) DO UPDATE SET
                 message_count = message_count + excluded.message_count,
@@ -451,12 +473,14 @@ fn create_rollup_triggers(conn: &Connection) -> Result<()> {
                 output_tokens = output_tokens + excluded.output_tokens,
                 cache_creation_tokens = cache_creation_tokens + excluded.cache_creation_tokens,
                 cache_read_tokens = cache_read_tokens + excluded.cache_read_tokens,
-                cost_cents = cost_cents + excluded.cost_cents;
+                cost_cents_ingested = cost_cents_ingested + excluded.cost_cents_ingested,
+                cost_cents_effective = cost_cents_effective + excluded.cost_cents_effective;
 
             INSERT INTO message_rollups_daily (
                 bucket_day, role, provider, model, repo_id, git_branch, surface,
                 message_count, input_tokens, output_tokens,
-                cache_creation_tokens, cache_read_tokens, cost_cents
+                cache_creation_tokens, cache_read_tokens,
+                cost_cents_ingested, cost_cents_effective
             )
             VALUES (
                 strftime('%Y-%m-%d', NEW.timestamp),
@@ -485,7 +509,8 @@ fn create_rollup_triggers(conn: &Connection) -> Result<()> {
                 COALESCE(NEW.output_tokens, 0),
                 COALESCE(NEW.cache_creation_tokens, 0),
                 COALESCE(NEW.cache_read_tokens, 0),
-                COALESCE(NEW.cost_cents, 0.0)
+                COALESCE(NEW.cost_cents_ingested, 0.0),
+                COALESCE(NEW.cost_cents_effective, 0.0)
             )
             ON CONFLICT(bucket_day, role, provider, model, repo_id, git_branch, surface) DO UPDATE SET
                 message_count = message_count + excluded.message_count,
@@ -493,7 +518,8 @@ fn create_rollup_triggers(conn: &Connection) -> Result<()> {
                 output_tokens = output_tokens + excluded.output_tokens,
                 cache_creation_tokens = cache_creation_tokens + excluded.cache_creation_tokens,
                 cache_read_tokens = cache_read_tokens + excluded.cache_read_tokens,
-                cost_cents = cost_cents + excluded.cost_cents;
+                cost_cents_ingested = cost_cents_ingested + excluded.cost_cents_ingested,
+                cost_cents_effective = cost_cents_effective + excluded.cost_cents_effective;
         END;
 
         CREATE TRIGGER IF NOT EXISTS trg_messages_rollup_delete
@@ -502,7 +528,8 @@ fn create_rollup_triggers(conn: &Connection) -> Result<()> {
             INSERT INTO message_rollups_hourly (
                 bucket_start, role, provider, model, repo_id, git_branch, surface,
                 message_count, input_tokens, output_tokens,
-                cache_creation_tokens, cache_read_tokens, cost_cents
+                cache_creation_tokens, cache_read_tokens,
+                cost_cents_ingested, cost_cents_effective
             )
             VALUES (
                 strftime('%Y-%m-%dT%H:00:00Z', OLD.timestamp),
@@ -531,7 +558,8 @@ fn create_rollup_triggers(conn: &Connection) -> Result<()> {
                 -COALESCE(OLD.output_tokens, 0),
                 -COALESCE(OLD.cache_creation_tokens, 0),
                 -COALESCE(OLD.cache_read_tokens, 0),
-                -COALESCE(OLD.cost_cents, 0.0)
+                -COALESCE(OLD.cost_cents_ingested, 0.0),
+                -COALESCE(OLD.cost_cents_effective, 0.0)
             )
             ON CONFLICT(bucket_start, role, provider, model, repo_id, git_branch, surface) DO UPDATE SET
                 message_count = message_count + excluded.message_count,
@@ -539,7 +567,8 @@ fn create_rollup_triggers(conn: &Connection) -> Result<()> {
                 output_tokens = output_tokens + excluded.output_tokens,
                 cache_creation_tokens = cache_creation_tokens + excluded.cache_creation_tokens,
                 cache_read_tokens = cache_read_tokens + excluded.cache_read_tokens,
-                cost_cents = cost_cents + excluded.cost_cents;
+                cost_cents_ingested = cost_cents_ingested + excluded.cost_cents_ingested,
+                cost_cents_effective = cost_cents_effective + excluded.cost_cents_effective;
 
             DELETE FROM message_rollups_hourly
              WHERE bucket_start = strftime('%Y-%m-%dT%H:00:00Z', OLD.timestamp)
@@ -568,7 +597,8 @@ fn create_rollup_triggers(conn: &Connection) -> Result<()> {
             INSERT INTO message_rollups_daily (
                 bucket_day, role, provider, model, repo_id, git_branch, surface,
                 message_count, input_tokens, output_tokens,
-                cache_creation_tokens, cache_read_tokens, cost_cents
+                cache_creation_tokens, cache_read_tokens,
+                cost_cents_ingested, cost_cents_effective
             )
             VALUES (
                 strftime('%Y-%m-%d', OLD.timestamp),
@@ -597,7 +627,8 @@ fn create_rollup_triggers(conn: &Connection) -> Result<()> {
                 -COALESCE(OLD.output_tokens, 0),
                 -COALESCE(OLD.cache_creation_tokens, 0),
                 -COALESCE(OLD.cache_read_tokens, 0),
-                -COALESCE(OLD.cost_cents, 0.0)
+                -COALESCE(OLD.cost_cents_ingested, 0.0),
+                -COALESCE(OLD.cost_cents_effective, 0.0)
             )
             ON CONFLICT(bucket_day, role, provider, model, repo_id, git_branch, surface) DO UPDATE SET
                 message_count = message_count + excluded.message_count,
@@ -605,7 +636,8 @@ fn create_rollup_triggers(conn: &Connection) -> Result<()> {
                 output_tokens = output_tokens + excluded.output_tokens,
                 cache_creation_tokens = cache_creation_tokens + excluded.cache_creation_tokens,
                 cache_read_tokens = cache_read_tokens + excluded.cache_read_tokens,
-                cost_cents = cost_cents + excluded.cost_cents;
+                cost_cents_ingested = cost_cents_ingested + excluded.cost_cents_ingested,
+                cost_cents_effective = cost_cents_effective + excluded.cost_cents_effective;
 
             DELETE FROM message_rollups_daily
              WHERE bucket_day = strftime('%Y-%m-%d', OLD.timestamp)
@@ -638,7 +670,8 @@ fn create_rollup_triggers(conn: &Connection) -> Result<()> {
             INSERT INTO message_rollups_hourly (
                 bucket_start, role, provider, model, repo_id, git_branch, surface,
                 message_count, input_tokens, output_tokens,
-                cache_creation_tokens, cache_read_tokens, cost_cents
+                cache_creation_tokens, cache_read_tokens,
+                cost_cents_ingested, cost_cents_effective
             )
             VALUES (
                 strftime('%Y-%m-%dT%H:00:00Z', OLD.timestamp),
@@ -667,7 +700,8 @@ fn create_rollup_triggers(conn: &Connection) -> Result<()> {
                 -COALESCE(OLD.output_tokens, 0),
                 -COALESCE(OLD.cache_creation_tokens, 0),
                 -COALESCE(OLD.cache_read_tokens, 0),
-                -COALESCE(OLD.cost_cents, 0.0)
+                -COALESCE(OLD.cost_cents_ingested, 0.0),
+                -COALESCE(OLD.cost_cents_effective, 0.0)
             )
             ON CONFLICT(bucket_start, role, provider, model, repo_id, git_branch, surface) DO UPDATE SET
                 message_count = message_count + excluded.message_count,
@@ -675,7 +709,8 @@ fn create_rollup_triggers(conn: &Connection) -> Result<()> {
                 output_tokens = output_tokens + excluded.output_tokens,
                 cache_creation_tokens = cache_creation_tokens + excluded.cache_creation_tokens,
                 cache_read_tokens = cache_read_tokens + excluded.cache_read_tokens,
-                cost_cents = cost_cents + excluded.cost_cents;
+                cost_cents_ingested = cost_cents_ingested + excluded.cost_cents_ingested,
+                cost_cents_effective = cost_cents_effective + excluded.cost_cents_effective;
 
             DELETE FROM message_rollups_hourly
              WHERE bucket_start = strftime('%Y-%m-%dT%H:00:00Z', OLD.timestamp)
@@ -704,7 +739,8 @@ fn create_rollup_triggers(conn: &Connection) -> Result<()> {
             INSERT INTO message_rollups_daily (
                 bucket_day, role, provider, model, repo_id, git_branch, surface,
                 message_count, input_tokens, output_tokens,
-                cache_creation_tokens, cache_read_tokens, cost_cents
+                cache_creation_tokens, cache_read_tokens,
+                cost_cents_ingested, cost_cents_effective
             )
             VALUES (
                 strftime('%Y-%m-%d', OLD.timestamp),
@@ -733,7 +769,8 @@ fn create_rollup_triggers(conn: &Connection) -> Result<()> {
                 -COALESCE(OLD.output_tokens, 0),
                 -COALESCE(OLD.cache_creation_tokens, 0),
                 -COALESCE(OLD.cache_read_tokens, 0),
-                -COALESCE(OLD.cost_cents, 0.0)
+                -COALESCE(OLD.cost_cents_ingested, 0.0),
+                -COALESCE(OLD.cost_cents_effective, 0.0)
             )
             ON CONFLICT(bucket_day, role, provider, model, repo_id, git_branch, surface) DO UPDATE SET
                 message_count = message_count + excluded.message_count,
@@ -741,7 +778,8 @@ fn create_rollup_triggers(conn: &Connection) -> Result<()> {
                 output_tokens = output_tokens + excluded.output_tokens,
                 cache_creation_tokens = cache_creation_tokens + excluded.cache_creation_tokens,
                 cache_read_tokens = cache_read_tokens + excluded.cache_read_tokens,
-                cost_cents = cost_cents + excluded.cost_cents;
+                cost_cents_ingested = cost_cents_ingested + excluded.cost_cents_ingested,
+                cost_cents_effective = cost_cents_effective + excluded.cost_cents_effective;
 
             DELETE FROM message_rollups_daily
              WHERE bucket_day = strftime('%Y-%m-%d', OLD.timestamp)
@@ -770,7 +808,8 @@ fn create_rollup_triggers(conn: &Connection) -> Result<()> {
             INSERT INTO message_rollups_hourly (
                 bucket_start, role, provider, model, repo_id, git_branch, surface,
                 message_count, input_tokens, output_tokens,
-                cache_creation_tokens, cache_read_tokens, cost_cents
+                cache_creation_tokens, cache_read_tokens,
+                cost_cents_ingested, cost_cents_effective
             )
             VALUES (
                 strftime('%Y-%m-%dT%H:00:00Z', NEW.timestamp),
@@ -799,7 +838,8 @@ fn create_rollup_triggers(conn: &Connection) -> Result<()> {
                 COALESCE(NEW.output_tokens, 0),
                 COALESCE(NEW.cache_creation_tokens, 0),
                 COALESCE(NEW.cache_read_tokens, 0),
-                COALESCE(NEW.cost_cents, 0.0)
+                COALESCE(NEW.cost_cents_ingested, 0.0),
+                COALESCE(NEW.cost_cents_effective, 0.0)
             )
             ON CONFLICT(bucket_start, role, provider, model, repo_id, git_branch, surface) DO UPDATE SET
                 message_count = message_count + excluded.message_count,
@@ -807,12 +847,14 @@ fn create_rollup_triggers(conn: &Connection) -> Result<()> {
                 output_tokens = output_tokens + excluded.output_tokens,
                 cache_creation_tokens = cache_creation_tokens + excluded.cache_creation_tokens,
                 cache_read_tokens = cache_read_tokens + excluded.cache_read_tokens,
-                cost_cents = cost_cents + excluded.cost_cents;
+                cost_cents_ingested = cost_cents_ingested + excluded.cost_cents_ingested,
+                cost_cents_effective = cost_cents_effective + excluded.cost_cents_effective;
 
             INSERT INTO message_rollups_daily (
                 bucket_day, role, provider, model, repo_id, git_branch, surface,
                 message_count, input_tokens, output_tokens,
-                cache_creation_tokens, cache_read_tokens, cost_cents
+                cache_creation_tokens, cache_read_tokens,
+                cost_cents_ingested, cost_cents_effective
             )
             VALUES (
                 strftime('%Y-%m-%d', NEW.timestamp),
@@ -841,7 +883,8 @@ fn create_rollup_triggers(conn: &Connection) -> Result<()> {
                 COALESCE(NEW.output_tokens, 0),
                 COALESCE(NEW.cache_creation_tokens, 0),
                 COALESCE(NEW.cache_read_tokens, 0),
-                COALESCE(NEW.cost_cents, 0.0)
+                COALESCE(NEW.cost_cents_ingested, 0.0),
+                COALESCE(NEW.cost_cents_effective, 0.0)
             )
             ON CONFLICT(bucket_day, role, provider, model, repo_id, git_branch, surface) DO UPDATE SET
                 message_count = message_count + excluded.message_count,
@@ -849,7 +892,8 @@ fn create_rollup_triggers(conn: &Connection) -> Result<()> {
                 output_tokens = output_tokens + excluded.output_tokens,
                 cache_creation_tokens = cache_creation_tokens + excluded.cache_creation_tokens,
                 cache_read_tokens = cache_read_tokens + excluded.cache_read_tokens,
-                cost_cents = cost_cents + excluded.cost_cents;
+                cost_cents_ingested = cost_cents_ingested + excluded.cost_cents_ingested,
+                cost_cents_effective = cost_cents_effective + excluded.cost_cents_effective;
         END;
         ",
     )?;
@@ -889,13 +933,15 @@ fn backfill_rollup_tables(conn: &Connection) -> Result<()> {
                 COALESCE(output_tokens, 0) AS output_tokens,
                 COALESCE(cache_creation_tokens, 0) AS cache_creation_tokens,
                 COALESCE(cache_read_tokens, 0) AS cache_read_tokens,
-                COALESCE(cost_cents, 0.0) AS cost_cents
+                COALESCE(cost_cents_ingested, 0.0) AS cost_cents_ingested,
+                COALESCE(cost_cents_effective, 0.0) AS cost_cents_effective
             FROM messages
         )
         INSERT INTO message_rollups_hourly (
             bucket_start, role, provider, model, repo_id, git_branch, surface,
             message_count, input_tokens, output_tokens,
-            cache_creation_tokens, cache_read_tokens, cost_cents
+            cache_creation_tokens, cache_read_tokens,
+            cost_cents_ingested, cost_cents_effective
         )
         SELECT
             bucket_hour, role, provider, model, repo_id, git_branch, surface,
@@ -904,7 +950,8 @@ fn backfill_rollup_tables(conn: &Connection) -> Result<()> {
             COALESCE(SUM(output_tokens), 0),
             COALESCE(SUM(cache_creation_tokens), 0),
             COALESCE(SUM(cache_read_tokens), 0),
-            COALESCE(SUM(cost_cents), 0.0)
+            COALESCE(SUM(cost_cents_ingested), 0.0),
+            COALESCE(SUM(cost_cents_effective), 0.0)
         FROM normalized
         GROUP BY bucket_hour, role, provider, model, repo_id, git_branch, surface;
 
@@ -934,13 +981,15 @@ fn backfill_rollup_tables(conn: &Connection) -> Result<()> {
                 COALESCE(output_tokens, 0) AS output_tokens,
                 COALESCE(cache_creation_tokens, 0) AS cache_creation_tokens,
                 COALESCE(cache_read_tokens, 0) AS cache_read_tokens,
-                COALESCE(cost_cents, 0.0) AS cost_cents
+                COALESCE(cost_cents_ingested, 0.0) AS cost_cents_ingested,
+                COALESCE(cost_cents_effective, 0.0) AS cost_cents_effective
             FROM messages
         )
         INSERT INTO message_rollups_daily (
             bucket_day, role, provider, model, repo_id, git_branch, surface,
             message_count, input_tokens, output_tokens,
-            cache_creation_tokens, cache_read_tokens, cost_cents
+            cache_creation_tokens, cache_read_tokens,
+            cost_cents_ingested, cost_cents_effective
         )
         SELECT
             bucket_day, role, provider, model, repo_id, git_branch, surface,
@@ -949,7 +998,8 @@ fn backfill_rollup_tables(conn: &Connection) -> Result<()> {
             COALESCE(SUM(output_tokens), 0),
             COALESCE(SUM(cache_creation_tokens), 0),
             COALESCE(SUM(cache_read_tokens), 0),
-            COALESCE(SUM(cost_cents), 0.0)
+            COALESCE(SUM(cost_cents_ingested), 0.0),
+            COALESCE(SUM(cost_cents_effective), 0.0)
         FROM normalized
         GROUP BY bucket_day, role, provider, model, repo_id, git_branch, surface;
         ",
@@ -1102,14 +1152,14 @@ fn create_indexes(conn: &Connection) -> Result<()> {
         CREATE INDEX IF NOT EXISTS idx_tags_message ON tags(message_id);
         CREATE INDEX IF NOT EXISTS idx_tags_msg_key_val ON tags(message_id, key, value);
 
-        CREATE INDEX IF NOT EXISTS idx_messages_ts_cost ON messages(timestamp, cost_cents);
-        CREATE INDEX IF NOT EXISTS idx_messages_role_ts_cost ON messages(role, timestamp, cost_cents);
-        CREATE INDEX IF NOT EXISTS idx_messages_role_branch_cost ON messages(role, git_branch, cost_cents);
+        CREATE INDEX IF NOT EXISTS idx_messages_ts_cost ON messages(timestamp, cost_cents_effective);
+        CREATE INDEX IF NOT EXISTS idx_messages_role_ts_cost ON messages(role, timestamp, cost_cents_effective);
+        CREATE INDEX IF NOT EXISTS idx_messages_role_branch_cost ON messages(role, git_branch, cost_cents_effective);
         CREATE INDEX IF NOT EXISTS idx_messages_role_branch_ts ON messages(role, git_branch, timestamp);
         CREATE INDEX IF NOT EXISTS idx_messages_role_cwd ON messages(role, cwd);
         CREATE INDEX IF NOT EXISTS idx_messages_session_role ON messages(session_id, role);
         CREATE INDEX IF NOT EXISTS idx_messages_cwd_role ON messages(cwd, role);
-        CREATE INDEX IF NOT EXISTS idx_messages_session_role_cost ON messages(session_id, role, cost_cents);
+        CREATE INDEX IF NOT EXISTS idx_messages_session_role_cost ON messages(session_id, role, cost_cents_effective);
         CREATE INDEX IF NOT EXISTS idx_messages_dedup ON messages(session_id, model, role, cost_confidence, timestamp);
         CREATE INDEX IF NOT EXISTS idx_messages_request_id ON messages(request_id) WHERE request_id IS NOT NULL;
 
@@ -1360,6 +1410,97 @@ fn missing_reconcile_indexes(conn: &Connection) -> Result<Vec<String>> {
     Ok(missing)
 }
 
+/// #730 / ADR-0094 §1: migrate an existing v1 DB from the single `cost_cents`
+/// column to the dual `cost_cents_ingested` / `cost_cents_effective` pair.
+///
+/// Steps (per the ticket scope):
+/// 1. `ALTER TABLE … ADD COLUMN cost_cents_ingested REAL NOT NULL DEFAULT 0`
+/// 2. `UPDATE … SET cost_cents_ingested = cost_cents` (one-time copy)
+/// 3. `ALTER TABLE … RENAME COLUMN cost_cents TO cost_cents_effective`
+///
+/// Applied to `messages`, `message_rollups_hourly`, and `message_rollups_daily`.
+/// SQLite ≥ 3.25 automatically rewrites trigger bodies and index definitions
+/// that referenced the renamed column, but the rollup triggers reference the
+/// new `cost_cents_ingested` column (which didn't exist when they were
+/// authored) so the caller must drop + recreate them after this returns.
+///
+/// Returns the list of `table.column` strings the caller should surface in
+/// the [`SchemaReconcileReport`]. Idempotent: a second run reports no
+/// changes because every target column already exists.
+fn ensure_dual_cost_columns(conn: &Connection) -> Result<Vec<String>> {
+    let mut added: Vec<String> = Vec::new();
+
+    for table in [
+        "messages",
+        "message_rollups_hourly",
+        "message_rollups_daily",
+    ] {
+        if !table_exists(conn, table)? {
+            continue;
+        }
+        let has_effective = has_column(conn, table, "cost_cents_effective")?;
+        let has_ingested = has_column(conn, table, "cost_cents_ingested")?;
+        let has_legacy = has_column(conn, table, "cost_cents")?;
+
+        if has_effective && has_ingested {
+            continue;
+        }
+
+        // Drop rollup triggers up-front: they reference `NEW.cost_cents` /
+        // `OLD.cost_cents`, and once we rename or drop the column the
+        // trigger bodies become invalid. The caller recreates them with
+        // the dual-column shape via `create_rollup_triggers`.
+        conn.execute_batch(
+            "DROP TRIGGER IF EXISTS trg_messages_rollup_insert;
+             DROP TRIGGER IF EXISTS trg_messages_rollup_delete;
+             DROP TRIGGER IF EXISTS trg_messages_rollup_update;",
+        )?;
+
+        if !has_ingested {
+            // Rollups: NOT NULL DEFAULT 0 matches the existing rollup
+            // column shape and the spec. messages.cost_cents was
+            // nullable, but the new `_ingested` column is always
+            // NOT NULL DEFAULT 0 per ADR-0094 §1 — incoming NULL legacy
+            // rows get the column DEFAULT before the copy below.
+            conn.execute_batch(&format!(
+                "ALTER TABLE {table} ADD COLUMN cost_cents_ingested REAL NOT NULL DEFAULT 0;"
+            ))?;
+            added.push(format!("{table}.cost_cents_ingested"));
+        }
+
+        if has_legacy && !has_effective {
+            // Copy the legacy column's value (treating NULL as 0) into
+            // the new `_ingested` column so history is preserved
+            // verbatim. ADR-0091 §5 Rule D: `_ingested` is the
+            // ADR-0091-immutable column from this point forward.
+            conn.execute_batch(&format!(
+                "UPDATE {table} SET cost_cents_ingested = COALESCE(cost_cents, 0);"
+            ))?;
+            // Rename the legacy column. SQLite ≥ 3.25 rewrites trigger
+            // bodies and index definitions transparently, so existing
+            // `idx_messages_*_cost` indexes now reference the renamed
+            // column with no further action.
+            conn.execute_batch(&format!(
+                "ALTER TABLE {table} RENAME COLUMN cost_cents TO cost_cents_effective;"
+            ))?;
+            added.push(format!("{table}.cost_cents_effective"));
+        } else if !has_effective {
+            // No legacy column to rename (the table was created without
+            // any cost column — shouldn't happen in practice, but
+            // defensive): add it explicitly with the rollup-table
+            // semantics. Messages-table inserts always bind a value, so
+            // the NOT NULL default never gets exercised on the live
+            // path.
+            conn.execute_batch(&format!(
+                "ALTER TABLE {table} ADD COLUMN cost_cents_effective REAL NOT NULL DEFAULT 0;"
+            ))?;
+            added.push(format!("{table}.cost_cents_effective"));
+        }
+    }
+
+    Ok(added)
+}
+
 fn reconcile_schema(conn: &Connection) -> Result<SchemaReconcileReport> {
     let mut added_columns: Vec<String> = Vec::new();
     let mut removed_tables: Vec<String> = Vec::new();
@@ -1390,6 +1531,20 @@ fn reconcile_schema(conn: &Connection) -> Result<SchemaReconcileReport> {
         surface_column_added = true;
     }
 
+    // #730 / ADR-0094 §1: migrate `cost_cents` to the dual
+    // `cost_cents_ingested` / `cost_cents_effective` shape on
+    // messages and both rollup tables before the rollup-repair
+    // block below — `create_rollup_triggers` writes the new
+    // column names and would fail against a legacy single-column
+    // schema. If `ensure_dual_cost_columns` rewrites columns it
+    // also drops the legacy triggers so the recreate path below
+    // produces them with the dual-column shape.
+    let dual_cost_added = ensure_dual_cost_columns(conn)?;
+    let dual_cost_columns_added = !dual_cost_added.is_empty();
+    for entry in dual_cost_added {
+        added_columns.push(entry);
+    }
+
     let has_hourly_rollups = table_exists(conn, "message_rollups_hourly")?;
     let has_daily_rollups = table_exists(conn, "message_rollups_daily")?;
     let has_rollup_insert_trigger = trigger_exists(conn, "trg_messages_rollup_insert")?;
@@ -1401,7 +1556,8 @@ fn reconcile_schema(conn: &Connection) -> Result<SchemaReconcileReport> {
         || !has_rollup_insert_trigger
         || !has_rollup_delete_trigger
         || !has_rollup_update_trigger
-        || rollup_pk_outdated_pre;
+        || rollup_pk_outdated_pre
+        || dual_cost_columns_added;
     if rollup_pk_outdated_pre {
         // Pre-#701 rollup tables still carry the old PK. Drop them so
         // `ensure_rollup_schema` recreates with the surface-aware shape;
@@ -1908,5 +2064,183 @@ mod tests {
             .filter_map(|r| r.ok())
             .collect();
         assert_eq!(before, after, "backfill must be idempotent");
+    }
+
+    /// #730 / ADR-0094 §1: a pre-dual-cost v1 DB must gain
+    /// `cost_cents_ingested` on `messages` and both rollup tables, rename
+    /// the legacy `cost_cents` column to `cost_cents_effective`, and
+    /// preserve every existing row's stored value verbatim in both new
+    /// columns (since `_effective = _ingested` until the team-pricing
+    /// worker (#731) ships). The rollup triggers must be recreated with
+    /// the dual-column shape so subsequent message inserts populate both.
+    #[test]
+    fn reconcile_adds_dual_cost_columns_on_existing_v1_db() {
+        let conn = Connection::open_in_memory().unwrap();
+        migrate(&conn).unwrap();
+
+        // Simulate a pre-#730 v1 DB by dropping the new columns and
+        // creating a legacy `cost_cents` column on `messages` and the
+        // two rollup tables. The trigger bodies and several indexes
+        // reference the new columns; drop them so the legacy state is
+        // internally consistent.
+        conn.execute_batch(
+            "DROP TRIGGER IF EXISTS trg_messages_rollup_insert;
+             DROP TRIGGER IF EXISTS trg_messages_rollup_delete;
+             DROP TRIGGER IF EXISTS trg_messages_rollup_update;
+             DROP INDEX IF EXISTS idx_messages_ts_cost;
+             DROP INDEX IF EXISTS idx_messages_role_ts_cost;
+             DROP INDEX IF EXISTS idx_messages_role_branch_cost;
+             DROP INDEX IF EXISTS idx_messages_session_role_cost;
+             ALTER TABLE messages DROP COLUMN cost_cents_effective;
+             ALTER TABLE messages DROP COLUMN cost_cents_ingested;
+             ALTER TABLE messages ADD COLUMN cost_cents REAL;
+             ALTER TABLE message_rollups_hourly DROP COLUMN cost_cents_effective;
+             ALTER TABLE message_rollups_hourly DROP COLUMN cost_cents_ingested;
+             ALTER TABLE message_rollups_hourly ADD COLUMN cost_cents REAL NOT NULL DEFAULT 0;
+             ALTER TABLE message_rollups_daily DROP COLUMN cost_cents_effective;
+             ALTER TABLE message_rollups_daily DROP COLUMN cost_cents_ingested;
+             ALTER TABLE message_rollups_daily ADD COLUMN cost_cents REAL NOT NULL DEFAULT 0;
+             CREATE INDEX idx_messages_ts_cost ON messages(timestamp, cost_cents);
+             CREATE INDEX idx_messages_role_ts_cost ON messages(role, timestamp, cost_cents);
+             CREATE INDEX idx_messages_role_branch_cost ON messages(role, git_branch, cost_cents);
+             CREATE INDEX idx_messages_session_role_cost ON messages(session_id, role, cost_cents);",
+        )
+        .unwrap();
+        assert!(has_column(&conn, "messages", "cost_cents").unwrap());
+        assert!(!has_column(&conn, "messages", "cost_cents_effective").unwrap());
+        assert!(!has_column(&conn, "messages", "cost_cents_ingested").unwrap());
+
+        // Seed a row with a known cost so we can prove the value
+        // survives the rename + add-column path.
+        conn.execute(
+            "INSERT INTO messages (id, role, timestamp, model, provider, cost_cents)
+             VALUES ('m1', 'assistant', '2026-04-20T00:00:00Z', 'claude-opus-4-6',
+                     'claude_code', 12.34)",
+            [],
+        )
+        .unwrap();
+
+        let report = repair(&conn).unwrap();
+        assert!(
+            report
+                .added_columns
+                .iter()
+                .any(|c| c == "messages.cost_cents_ingested"),
+            "report should mention messages.cost_cents_ingested; got {:?}",
+            report.added_columns
+        );
+        assert!(
+            report
+                .added_columns
+                .iter()
+                .any(|c| c == "messages.cost_cents_effective"),
+            "report should mention messages.cost_cents_effective; got {:?}",
+            report.added_columns
+        );
+
+        assert!(has_column(&conn, "messages", "cost_cents_effective").unwrap());
+        assert!(has_column(&conn, "messages", "cost_cents_ingested").unwrap());
+        assert!(!has_column(&conn, "messages", "cost_cents").unwrap());
+        assert!(has_column(&conn, "message_rollups_hourly", "cost_cents_effective").unwrap());
+        assert!(has_column(&conn, "message_rollups_hourly", "cost_cents_ingested").unwrap());
+        assert!(has_column(&conn, "message_rollups_daily", "cost_cents_effective").unwrap());
+        assert!(has_column(&conn, "message_rollups_daily", "cost_cents_ingested").unwrap());
+
+        // ADR-0094 §1: `_effective` defaults to `_ingested` until a team
+        // price list rewrites it. The migration must copy the legacy
+        // value into both columns.
+        let (ingested, effective): (f64, f64) = conn
+            .query_row(
+                "SELECT cost_cents_ingested, cost_cents_effective FROM messages WHERE id = 'm1'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert!(
+            (ingested - 12.34).abs() < 1e-9,
+            "cost_cents_ingested preserves the legacy stored value; got {ingested}"
+        );
+        assert!(
+            (effective - 12.34).abs() < 1e-9,
+            "cost_cents_effective defaults to _ingested until team pricing ships (#731); got {effective}"
+        );
+
+        // Rollup triggers must be recreated with the dual-column shape.
+        // A fresh INSERT exercises them — both rollup columns must
+        // increment on the new row.
+        assert!(trigger_exists(&conn, "trg_messages_rollup_insert").unwrap());
+        conn.execute(
+            "INSERT INTO messages
+                (id, role, timestamp, model, provider,
+                 input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
+                 cost_cents_ingested, cost_cents_effective)
+             VALUES ('m2', 'assistant', '2026-04-21T00:00:00Z', 'claude-opus-4-6',
+                     'claude_code', 0, 0, 0, 0, 4.5, 4.5)",
+            [],
+        )
+        .unwrap();
+        let (rh_i, rh_e): (f64, f64) = conn
+            .query_row(
+                "SELECT SUM(cost_cents_ingested), SUM(cost_cents_effective)
+                 FROM message_rollups_daily WHERE bucket_day = '2026-04-21'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert!((rh_i - 4.5).abs() < 1e-9);
+        assert!((rh_e - 4.5).abs() < 1e-9);
+
+        // Idempotency: a second repair must not re-add the columns or
+        // rewrite the rollup contents.
+        let second = repair(&conn).unwrap();
+        assert!(
+            !second
+                .added_columns
+                .iter()
+                .any(|c| c.contains("cost_cents_")),
+            "second repair must not re-add dual cost columns; got {:?}",
+            second.added_columns
+        );
+    }
+
+    /// #730: `db check` must surface a missing `cost_cents_ingested` /
+    /// `cost_cents_effective` column on an otherwise-current v1 DB as
+    /// drift so `budi db check --fix` heals it without bumping the
+    /// schema version.
+    #[test]
+    fn check_detects_missing_dual_cost_columns() {
+        let conn = Connection::open_in_memory().unwrap();
+        migrate(&conn).unwrap();
+
+        // Drop only `cost_cents_ingested` to simulate an incomplete
+        // partial migration. The triggers reference it, so drop them
+        // too to keep the database internally consistent.
+        conn.execute_batch(
+            "DROP TRIGGER IF EXISTS trg_messages_rollup_insert;
+             DROP TRIGGER IF EXISTS trg_messages_rollup_delete;
+             DROP TRIGGER IF EXISTS trg_messages_rollup_update;
+             ALTER TABLE message_rollups_hourly DROP COLUMN cost_cents_ingested;
+             ALTER TABLE message_rollups_daily DROP COLUMN cost_cents_ingested;
+             ALTER TABLE messages DROP COLUMN cost_cents_ingested;",
+        )
+        .unwrap();
+
+        let report = check(&conn).unwrap();
+        assert!(
+            !report.migrated,
+            "additive drift must not request a destructive migration"
+        );
+        assert!(
+            report
+                .added_columns
+                .iter()
+                .any(|c| c == "messages.cost_cents_ingested"),
+            "check should report missing messages.cost_cents_ingested; got {:?}",
+            report.added_columns
+        );
+        assert!(
+            has_column(&conn, "messages", "cost_cents_effective").unwrap(),
+            "check must not modify the database"
+        );
     }
 }

--- a/crates/budi-core/src/pipeline/enrichers.rs
+++ b/crates/budi-core/src/pipeline/enrichers.rs
@@ -337,7 +337,12 @@ impl Enricher for IdentityEnricher {
 }
 
 // ---------------------------------------------------------------------------
-// CostEnricher — calculates cost_cents from tokens × pricing
+// CostEnricher — calculates cost_cents from tokens × pricing.
+//
+// ADR-0094 §1: the in-memory `msg.cost_cents` is the LiteLLM-priced number
+// (the `_ingested` value). At ingest the writer binds it into both
+// `cost_cents_ingested` and `cost_cents_effective` so `_effective = _ingested`
+// until the team-pricing worker (#731) rewrites `_effective`.
 // ---------------------------------------------------------------------------
 
 pub struct CostEnricher;

--- a/crates/budi-core/src/pricing/mod.rs
+++ b/crates/budi-core/src/pricing/mod.rs
@@ -899,9 +899,16 @@ pub fn backfill_unknown_rows(conn: &Connection, version: u32) -> Result<usize> {
         }
         if let PricingOutcome::Known { pricing, .. } = lookup(&model, &provider) {
             let cost = pricing.calculate_cost_cents(inp, out, cc, cr, 0, None, 0);
+            // ADR-0094 §1: write the new LiteLLM-priced number into both
+            // `_ingested` (this row's authoritative ingest-time value,
+            // previously stored as 0 with `pricing_source = 'unknown'`)
+            // and `_effective` (read surface). The team-pricing worker
+            // (#731) will subsequently rewrite `_effective` for team
+            // pricing without touching `_ingested`.
             tx.execute(
                 "UPDATE messages
-                    SET cost_cents = ?1,
+                    SET cost_cents_ingested = ?1,
+                        cost_cents_effective = ?1,
                         cost_confidence = 'estimated',
                         pricing_source = ?2
                   WHERE id = ?3
@@ -1067,9 +1074,9 @@ mod pricing_tests {
             "INSERT INTO messages
                 (id, role, timestamp, model, provider,
                  input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
-                 cost_cents, cost_confidence, pricing_source)
+                 cost_cents_ingested, cost_cents_effective, cost_confidence, pricing_source)
              VALUES (?1, 'assistant', '2026-04-20T00:00:00Z', ?2, ?3,
-                     100, 50, 0, 0, ?4, ?5, ?6)",
+                     100, 50, 0, 0, ?4, ?4, ?5, ?6)",
             rusqlite::params![
                 id,
                 model,
@@ -1084,7 +1091,7 @@ mod pricing_tests {
 
     fn cost_of(conn: &Connection, id: &str) -> f64 {
         conn.query_row(
-            "SELECT cost_cents FROM messages WHERE id = ?1",
+            "SELECT cost_cents_effective FROM messages WHERE id = ?1",
             rusqlite::params![id],
             |r| r.get(0),
         )

--- a/crates/budi-core/src/sync/copilot_chat_billing.rs
+++ b/crates/budi-core/src/sync/copilot_chat_billing.rs
@@ -426,7 +426,7 @@ fn apply_buckets(conn: &mut Connection, rows: &[BillingRow]) -> Result<usize> {
         // cleanly without a divide-by-zero.
         let existing_sum_cents: Option<f64> = tx
             .query_row(
-                "SELECT SUM(COALESCE(cost_cents, 0.0))
+                "SELECT SUM(COALESCE(cost_cents_effective, 0.0))
                  FROM messages
                  WHERE provider = ?1
                    AND model = ?2
@@ -444,9 +444,15 @@ fn apply_buckets(conn: &mut Connection, rows: &[BillingRow]) -> Result<usize> {
         }
 
         let scale = row.amount_in_cents / existing_sum_cents;
+        // ADR-0094 §1: GitHub Billing API gives us the authoritative
+        // ingest-time cost — what the user was actually billed. Scale both
+        // `_ingested` (immutable per ADR-0091 §5 Rule D, but the billing
+        // truths-up was already an exception to the substring-dispatch
+        // contract) and `_effective` (read surface).
         let updated = tx.execute(
             "UPDATE messages
-                SET cost_cents = COALESCE(cost_cents, 0.0) * ?1,
+                SET cost_cents_ingested = COALESCE(cost_cents_ingested, 0.0) * ?1,
+                    cost_cents_effective = COALESCE(cost_cents_effective, 0.0) * ?1,
                     cost_confidence = 'exact',
                     pricing_source = ?2
               WHERE provider = ?3
@@ -533,10 +539,10 @@ mod tests {
     ) {
         conn.execute(
             "INSERT INTO messages
-                (id, role, timestamp, model, provider, cost_cents,
+                (id, role, timestamp, model, provider, cost_cents_ingested, cost_cents_effective,
                  cost_confidence, pricing_source,
                  input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens)
-             VALUES (?1, 'assistant', ?2, ?3, 'copilot_chat', ?4,
+             VALUES (?1, 'assistant', ?2, ?3, 'copilot_chat', ?4, ?4,
                      'estimated', 'manifest:v1', 100, 10, 0, 0)",
             params![id, ts, model, cost_cents],
         )
@@ -698,15 +704,14 @@ mod tests {
         };
         apply_response(&mut conn, &response).unwrap();
 
-        let load =
-            |id: &str| -> (f64, String, String) {
-                conn.query_row(
-                "SELECT cost_cents, cost_confidence, pricing_source FROM messages WHERE id = ?1",
+        let load = |id: &str| -> (f64, String, String) {
+            conn.query_row(
+                "SELECT cost_cents_effective, cost_confidence, pricing_source FROM messages WHERE id = ?1",
                 params![id],
                 |r| Ok((r.get::<_, f64>(0)?, r.get::<_, String>(1)?, r.get::<_, String>(2)?)),
             )
             .unwrap()
-            };
+        };
 
         let (c1, conf1, src1) = load("m-1");
         let (c2, conf2, src2) = load("m-2");


### PR DESCRIPTION
## Summary

Lands ADR-0094 §1 phase 2 (local mirror) per #730. The local SQLite schema gains a dual `cost_cents_ingested` / `cost_cents_effective` column pair on `messages`, `message_rollups_hourly`, and `message_rollups_daily`, mirroring the cloud-side pattern.

- `cost_cents_ingested` — what Budi computed at ingest via `pricing::lookup` (ADR-0091); **never** overwritten after insert (ADR-0091 §5 Rule D as amended by ADR-0094).
- `cost_cents_effective` — what every CLI / statusline / extension / dashboard query reads. Defaults to `_ingested`; rewritten by the team-pricing worker in **#731** (next ticket).

No behavior change yet: writes set both columns to the same LiteLLM-priced value, so users without cloud sync see identical numbers to today.

Epic: #724
ADR: [docs/adr/0094-custom-team-pricing-and-effective-cost-recalculation.md](https://github.com/siropkin/budi/blob/main/docs/adr/0094-custom-team-pricing-and-effective-cost-recalculation.md)

## What changed

- **`migration.rs`** — `ensure_dual_cost_columns()` migrates legacy v1 DBs via `ALTER … ADD COLUMN cost_cents_ingested` → `UPDATE cost_cents_ingested = cost_cents` → `ALTER … RENAME COLUMN cost_cents TO cost_cents_effective`, applied to all three cost-bearing tables. SQLite ≥ 3.25 rewrites trigger bodies and indexes that referenced the renamed column transparently; the rollup triggers are dropped + recreated with the dual-column shape because they now reference `NEW.cost_cents_ingested`. Drift detection in `check()` reports missing columns so `budi db check --fix` heals partial migrations.
- **`pipeline/enrichers.rs`** — `CostEnricher` semantics unchanged: the in-memory `msg.cost_cents` is the `_ingested` value. Comment updated to reference ADR-0094.
- **`analytics/mod.rs`** — INSERT writes both columns; the cross-parse-dedup UPDATE writes both.
- **`analytics/{queries,sessions,sync,health,tests}.rs`** — every SQL read site reads `cost_cents_effective`; test INSERTs bind both columns.
- **`cost.rs`** — `SUM(cost_cents)` → `SUM(cost_cents_effective)`; test fixtures bind both columns.
- **`cloud_sync.rs`** — `DailyRollupRecord` carries both fields. Envelope rolls up both columns from `message_rollups_daily` and ships them so the cloud can populate its own `cost_cents_ingested` column on insert (cloud-side `_effective` recompute ships in the cloud ticket). Backward-compatible deserialization via `#[serde(alias = "cost_cents")]`.
- **`pricing/mod.rs`** — `backfill_unknown_rows` writes both columns when filling in `unknown` → `backfilled:vNNN` rows.
- **`sync/copilot_chat_billing.rs`** — billing-API truths-up scales both columns proportionally.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p budi-core` — 648 lib tests pass (incl. 12 migration tests)
- [x] `cargo test -p budi-cli` — 276 tests pass
- [x] New migration tests:
  - `reconcile_adds_dual_cost_columns_on_existing_v1_db` — legacy v1 → dual-column upgrade preserves stored values verbatim in both columns; rollup triggers recreated; idempotent on re-run.
  - `check_detects_missing_dual_cost_columns` — `db check` surfaces a missing `cost_cents_ingested` as drift without forcing a destructive migration.
- [x] Cloud-sync envelope test asserts both `cost_cents_effective` and `cost_cents_ingested` serialize.
- [ ] Manual: fresh `budi db check` reports no drift after a clean migrate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)