### PR TITLE
feat(daemon): GET /health/sources endpoint (#735)

### DIFF
--- a/crates/budi-daemon/src/main.rs
+++ b/crates/budi-daemon/src/main.rs
@@ -177,6 +177,7 @@ fn build_router(app_state: AppState, host_allowlist: routes::HostAllowlist) -> R
         .route("/favicon.ico", get(h::favicon))
         .route("/health", get(h::health))
         .route("/health/integrations", get(h::health_integrations))
+        .route("/health/sources", get(h::health_sources))
         .route("/health/check-update", get(h::health_check_update))
         .route("/sync/status", get(h::sync_status))
         .route("/cloud/status", get(routes::cloud::cloud_status))

--- a/crates/budi-daemon/src/routes/hooks.rs
+++ b/crates/budi-daemon/src/routes/hooks.rs
@@ -284,6 +284,133 @@ pub async fn health() -> Json<HealthResponse> {
     })
 }
 
+/// Query parameters for `GET /health/sources` (#735).
+///
+/// `?surface=<id>` narrows the response to a single surface — the
+/// filtered shape the JetBrains plugin's "Detected sources" row
+/// consumes today (siropkin/budi-jetbrains#36). Omitting the param
+/// returns every surface in the grouped shape; the plugin doesn't
+/// consume the unfiltered form yet, but the contract is documented
+/// here so future hosts can rely on it.
+#[derive(Debug, serde::Deserialize)]
+pub struct HealthSourcesParams {
+    pub surface: Option<String>,
+}
+
+#[derive(Debug, serde::Serialize)]
+pub struct HealthSourcesByGroup {
+    pub surface: String,
+    pub paths: Vec<String>,
+}
+
+#[derive(Debug, serde::Serialize)]
+#[serde(untagged)]
+pub enum HealthSourcesResponse {
+    Filtered { surface: String, paths: Vec<String> },
+    Grouped { surfaces: Vec<HealthSourcesByGroup> },
+}
+
+/// `GET /health/sources?surface=<id>` (#735).
+///
+/// Returns the on-disk paths the daemon's tailer is currently watching,
+/// grouped by surface (`vscode` / `cursor` / `jetbrains` / `terminal` /
+/// `unknown`). Source of truth is each enabled provider's
+/// [`budi_core::provider::Provider::watch_roots`] — the same call the
+/// tailer's reconcile loop runs every backstop tick. We deliberately
+/// re-query on each request: `watch_roots` is filesystem-sensitive
+/// (cheap `is_dir`/`exists` checks, no JSONL parse), and reflecting
+/// directories that have materialized since the last tailer tick is
+/// what makes this endpoint "live" from a host extension's point of
+/// view.
+///
+/// Surface inference mirrors the ingest path: providers that bind to a
+/// single host get [`budi_core::surface::default_for_provider`], and
+/// `copilot_chat` (whose watch roots span VS Code, Cursor, and
+/// JetBrains storage) gets [`budi_core::surface::infer_copilot_chat_surface`]
+/// per path so each root is bucketed correctly.
+pub async fn health_sources(
+    axum::extract::Query(params): axum::extract::Query<HealthSourcesParams>,
+) -> Result<Json<HealthSourcesResponse>, (StatusCode, Json<serde_json::Value>)> {
+    let result = tokio::task::spawn_blocking(move || collect_health_sources(params.surface))
+        .await
+        .map_err(|e| internal_error(anyhow::anyhow!("{e}")))?;
+    Ok(Json(result))
+}
+
+fn surface_for_path(provider_name: &str, path: &Path) -> &'static str {
+    if provider_name == "copilot_chat" {
+        budi_core::surface::infer_copilot_chat_surface(path)
+    } else {
+        budi_core::surface::default_for_provider(provider_name)
+    }
+}
+
+/// Collect tailed paths from every enabled provider, mirroring the
+/// snapshot logic the tailer uses at boot
+/// (`workers::tailer::run`). Broken out as a pure function (no
+/// `axum::Json`, no env coupling) so the response shape can be
+/// unit-tested directly.
+fn collect_health_sources(surface_filter: Option<String>) -> HealthSourcesResponse {
+    let agents_config = budi_core::config::load_agents_config();
+    let providers: Vec<Box<dyn budi_core::provider::Provider>> = match &agents_config {
+        Some(cfg) => budi_core::provider::all_providers()
+            .into_iter()
+            .filter(|p| cfg.is_agent_enabled(p.name()))
+            .collect(),
+        None => budi_core::provider::all_providers(),
+    };
+    let routes: Vec<(String, std::path::PathBuf)> = providers
+        .iter()
+        .flat_map(|p| {
+            let name = p.name().to_string();
+            p.watch_roots()
+                .into_iter()
+                .map(move |root| (name.clone(), root))
+        })
+        .collect();
+
+    let normalized_filter = surface_filter
+        .as_deref()
+        .map(|s| s.trim().to_ascii_lowercase())
+        .filter(|s| !s.is_empty());
+
+    if let Some(filter) = normalized_filter {
+        let mut paths: Vec<String> = routes
+            .into_iter()
+            .filter(|(name, path)| surface_for_path(name, path) == filter)
+            .map(|(_, path)| path.to_string_lossy().to_string())
+            .collect();
+        paths.sort();
+        paths.dedup();
+        return HealthSourcesResponse::Filtered {
+            surface: filter,
+            paths,
+        };
+    }
+
+    let mut by_surface: std::collections::BTreeMap<&'static str, Vec<String>> =
+        std::collections::BTreeMap::new();
+    for (name, path) in routes {
+        let surface = surface_for_path(&name, &path);
+        by_surface
+            .entry(surface)
+            .or_default()
+            .push(path.to_string_lossy().to_string());
+    }
+    let surfaces = by_surface
+        .into_iter()
+        .map(|(surface, mut paths)| {
+            paths.sort();
+            paths.dedup();
+            HealthSourcesByGroup {
+                surface: surface.to_string(),
+                paths,
+            }
+        })
+        .collect();
+    HealthSourcesResponse::Grouped { surfaces }
+}
+
 pub async fn health_check_update()
 -> Result<Json<super::analytics::CheckUpdateResponse>, (StatusCode, Json<serde_json::Value>)> {
     use super::analytics::CheckUpdateResponse;
@@ -576,7 +703,11 @@ pub async fn sync_status(State(state): State<AppState>) -> Json<SyncStatusRespon
 
 #[cfg(test)]
 mod tests {
-    use super::{manifest_has_cursor_extension, output_has_cursor_extension};
+    use super::{
+        HealthSourcesResponse, manifest_has_cursor_extension, output_has_cursor_extension,
+        surface_for_path,
+    };
+    use std::path::Path;
 
     #[test]
     fn cursor_extension_cli_output_detection_handles_versioned_lines() {
@@ -595,6 +726,97 @@ mod tests {
         assert!(!manifest_has_cursor_extension(
             r#"[{"identifier":{"id":"ms-python.python"}}]"#
         ));
+    }
+
+    #[test]
+    fn surface_for_path_maps_single_host_providers_via_default() {
+        // Path is irrelevant for non-copilot_chat providers — they bind to
+        // a single host so `default_for_provider` decides.
+        let p = Path::new("/anywhere/whatever.jsonl");
+        assert_eq!(surface_for_path("claude_code", p), "terminal");
+        assert_eq!(surface_for_path("cursor", p), "cursor");
+        assert_eq!(surface_for_path("codex", p), "terminal");
+        assert_eq!(surface_for_path("copilot_cli", p), "terminal");
+        assert_eq!(surface_for_path("jetbrains_ai_assistant", p), "jetbrains");
+    }
+
+    #[test]
+    fn surface_for_path_classifies_copilot_chat_per_path() {
+        // copilot_chat's watch roots span three hosts; surface comes from
+        // the path itself per ADR-0092 §2.1.
+        let cursor = Path::new("/Users/u/Library/Application Support/Cursor/User/workspaceStorage");
+        let vscode = Path::new("/Users/u/Library/Application Support/Code/User/workspaceStorage");
+        let jetbrains = Path::new("/Users/u/Library/Application Support/JetBrains/IdeaIC2026.1");
+        assert_eq!(surface_for_path("copilot_chat", cursor), "cursor");
+        assert_eq!(surface_for_path("copilot_chat", vscode), "vscode");
+        assert_eq!(surface_for_path("copilot_chat", jetbrains), "jetbrains");
+    }
+
+    #[test]
+    fn collect_health_sources_filtered_returns_only_matching_surface() {
+        let filtered = super::collect_health_sources(Some("jetbrains".to_string()));
+        match filtered {
+            HealthSourcesResponse::Filtered { surface, paths } => {
+                assert_eq!(surface, "jetbrains");
+                // Every returned path must classify as jetbrains.
+                for path in &paths {
+                    let p = Path::new(path);
+                    // The path's owning provider can be either
+                    // jetbrains_ai_assistant or copilot_chat; both produce
+                    // the jetbrains surface.
+                    let jb_ai = surface_for_path("jetbrains_ai_assistant", p) == "jetbrains";
+                    let copilot = surface_for_path("copilot_chat", p) == "jetbrains";
+                    assert!(
+                        jb_ai || copilot,
+                        "path {path} does not map to jetbrains surface"
+                    );
+                }
+            }
+            HealthSourcesResponse::Grouped { .. } => panic!("expected filtered shape"),
+        }
+    }
+
+    #[test]
+    fn collect_health_sources_blank_surface_is_treated_as_unfiltered() {
+        // `?surface=` (empty value) should fall through to the grouped
+        // shape, not 404 / return nothing — mirrors the issue contract.
+        let resp = super::collect_health_sources(Some("   ".to_string()));
+        match resp {
+            HealthSourcesResponse::Grouped { .. } => {}
+            HealthSourcesResponse::Filtered { .. } => {
+                panic!("blank surface filter should fall through to grouped shape")
+            }
+        }
+    }
+
+    #[test]
+    fn collect_health_sources_grouped_omits_unknown_surfaces() {
+        // Grouped shape is allowed to include any of the canonical
+        // surfaces; the only invariant we can assert without mocking the
+        // filesystem is that each entry is a valid canonical surface and
+        // its `paths` is sorted+deduped.
+        let resp = super::collect_health_sources(None);
+        match resp {
+            HealthSourcesResponse::Grouped { surfaces } => {
+                let canonical = ["vscode", "cursor", "jetbrains", "terminal", "unknown"];
+                for group in &surfaces {
+                    assert!(
+                        canonical.contains(&group.surface.as_str()),
+                        "non-canonical surface returned: {}",
+                        group.surface
+                    );
+                    let mut sorted = group.paths.clone();
+                    sorted.sort();
+                    sorted.dedup();
+                    assert_eq!(
+                        sorted, group.paths,
+                        "paths must be sorted + deduped for surface {}",
+                        group.surface
+                    );
+                }
+            }
+            HealthSourcesResponse::Filtered { .. } => panic!("expected grouped shape"),
+        }
     }
 }
 

--- a/scripts/e2e/test_735_health_sources_endpoint.sh
+++ b/scripts/e2e/test_735_health_sources_endpoint.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# End-to-end regression for issue #735: verify
+# `GET /health/sources?surface=<id>` returns the on-disk paths the daemon
+# is currently tailing for the requested surface, and that the unfiltered
+# form returns every surface in the grouped shape.
+#
+# Contract pinned (from the issue body):
+#   GET /health/sources?surface=jetbrains
+#   → 200 { "surface": "jetbrains", "paths": ["/abs/...", "/abs/..."] }
+#   GET /health/sources
+#   → 200 { "surfaces": [ { "surface": "...", "paths": [...] }, ... ] }
+#
+# The plugin caps the response at 64 KB and times out at 3 s; we don't
+# replay those caps here (they're plugin-side), but we do assert the
+# happy-path response shape and surface filtering using a JetBrains
+# AI Assistant `aiAssistant/chats/` directory seeded under a temp HOME.
+#
+# Negative-path: drop the route registration in
+# `crates/budi-daemon/src/main.rs` and this script must fail with the
+# `404 Not Found` branch.
+set -euo pipefail
+
+export NO_COLOR="${NO_COLOR:-1}"
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BUDI_DAEMON="$ROOT/target/release/budi-daemon"
+
+if [[ ! -x "$BUDI_DAEMON" ]]; then
+  echo "error: release binary not built. run \`cargo build --release\` first." >&2
+  exit 2
+fi
+
+TMPDIR_ROOT="$(mktemp -d -t budi-e2e-735-XXXXXX)"
+export HOME="$TMPDIR_ROOT"
+
+# Seed a JetBrains AI Assistant chats dir so the JetBrains provider's
+# watch_roots() returns a non-empty path. macOS + Linux both probe
+# `${HOME}/Library/Application Support/JetBrains/<Product><Year>/aiAssistant/chats`
+# or `${HOME}/.config/JetBrains/<Product><Year>/aiAssistant/chats`; seed
+# both so the test works on either OS.
+JB_MAC_DIR="$HOME/Library/Application Support/JetBrains/IdeaIC2026.1/aiAssistant/chats"
+JB_LINUX_DIR="$HOME/.config/JetBrains/IdeaIC2026.1/aiAssistant/chats"
+mkdir -p "$JB_MAC_DIR" "$JB_LINUX_DIR"
+
+DAEMON_PORT=17935
+
+cleanup() {
+  local status=$?
+  { kill "${DAEMON_PID:-}" 2>/dev/null || true; } >/dev/null 2>&1
+  pkill -f "budi-daemon serve --host 127.0.0.1 --port $DAEMON_PORT" >/dev/null 2>&1 || true
+  if [[ "${KEEP_TMP:-0}" == "1" ]]; then
+    echo "[e2e] leaving tmp: $TMPDIR_ROOT"
+  else
+    rm -rf "$TMPDIR_ROOT"
+  fi
+  exit $status
+}
+trap cleanup EXIT INT TERM
+
+echo "[e2e] HOME=$HOME"
+
+echo "[e2e] starting budi-daemon on :$DAEMON_PORT"
+RUST_LOG=warn \
+  "$BUDI_DAEMON" serve \
+    --host 127.0.0.1 \
+    --port $DAEMON_PORT \
+    >"$TMPDIR_ROOT/daemon.log" 2>&1 &
+DAEMON_PID=$!
+
+for _ in {1..50}; do
+  if curl -s -o /dev/null -w "%{http_code}" --max-time 1 "http://127.0.0.1:$DAEMON_PORT/health" | grep -q "^200"; then
+    break
+  fi
+  sleep 0.1
+done
+
+if ! curl -s -o /dev/null -w "%{http_code}" --max-time 1 "http://127.0.0.1:$DAEMON_PORT/health" | grep -q "^200"; then
+  echo "[e2e] FAIL: daemon /health did not return 200 in time" >&2
+  tail -n 60 "$TMPDIR_ROOT/daemon.log" >&2 || true
+  exit 1
+fi
+
+echo "[e2e] querying /health/sources?surface=jetbrains"
+FILTERED_BODY="$TMPDIR_ROOT/sources-jetbrains.json"
+HTTP_CODE="$(curl -s -o "$FILTERED_BODY" -w "%{http_code}" --max-time 3 \
+  "http://127.0.0.1:$DAEMON_PORT/health/sources?surface=jetbrains")"
+if [[ "$HTTP_CODE" != "200" ]]; then
+  echo "[e2e] FAIL: expected 200 from /health/sources?surface=jetbrains, got $HTTP_CODE" >&2
+  cat "$FILTERED_BODY" >&2 || true
+  exit 1
+fi
+
+# Response shape: { "surface": "jetbrains", "paths": [...] }
+python3 - "$FILTERED_BODY" <<'PY'
+import json
+import sys
+path = sys.argv[1]
+with open(path) as f:
+    body = json.load(f)
+if body.get("surface") != "jetbrains":
+    print(f"[e2e] FAIL: surface field is {body.get('surface')!r}, want 'jetbrains'", file=sys.stderr)
+    sys.exit(1)
+paths = body.get("paths")
+if not isinstance(paths, list):
+    print(f"[e2e] FAIL: paths is not a list: {paths!r}", file=sys.stderr)
+    sys.exit(1)
+if not paths:
+    print("[e2e] FAIL: expected at least one jetbrains path; got empty list", file=sys.stderr)
+    sys.exit(1)
+for p in paths:
+    if not isinstance(p, str) or not p.startswith("/"):
+        print(f"[e2e] FAIL: path entry not an absolute string: {p!r}", file=sys.stderr)
+        sys.exit(1)
+print(f"[e2e] OK: filtered jetbrains response has {len(paths)} path(s)")
+PY
+
+echo "[e2e] querying /health/sources (unfiltered)"
+GROUPED_BODY="$TMPDIR_ROOT/sources-all.json"
+HTTP_CODE="$(curl -s -o "$GROUPED_BODY" -w "%{http_code}" --max-time 3 \
+  "http://127.0.0.1:$DAEMON_PORT/health/sources")"
+if [[ "$HTTP_CODE" != "200" ]]; then
+  echo "[e2e] FAIL: expected 200 from /health/sources, got $HTTP_CODE" >&2
+  cat "$GROUPED_BODY" >&2 || true
+  exit 1
+fi
+
+# Response shape: { "surfaces": [ { "surface": "...", "paths": [...] }, ... ] }
+python3 - "$GROUPED_BODY" <<'PY'
+import json
+import sys
+path = sys.argv[1]
+with open(path) as f:
+    body = json.load(f)
+surfaces = body.get("surfaces")
+if not isinstance(surfaces, list):
+    print(f"[e2e] FAIL: surfaces is not a list: {surfaces!r}", file=sys.stderr)
+    sys.exit(1)
+canonical = {"vscode", "cursor", "jetbrains", "terminal", "unknown"}
+found_jb = False
+for group in surfaces:
+    if group.get("surface") not in canonical:
+        print(f"[e2e] FAIL: non-canonical surface {group.get('surface')!r}", file=sys.stderr)
+        sys.exit(1)
+    if not isinstance(group.get("paths"), list):
+        print(f"[e2e] FAIL: paths for {group.get('surface')!r} is not a list", file=sys.stderr)
+        sys.exit(1)
+    if group["surface"] == "jetbrains" and group["paths"]:
+        found_jb = True
+if not found_jb:
+    print("[e2e] FAIL: grouped response did not include jetbrains paths", file=sys.stderr)
+    sys.exit(1)
+print(f"[e2e] OK: grouped response has {len(surfaces)} surface group(s)")
+PY
+
+echo "[e2e] querying /health/sources?surface=does-not-exist"
+EMPTY_BODY="$TMPDIR_ROOT/sources-empty.json"
+HTTP_CODE="$(curl -s -o "$EMPTY_BODY" -w "%{http_code}" --max-time 3 \
+  "http://127.0.0.1:$DAEMON_PORT/health/sources?surface=does-not-exist")"
+if [[ "$HTTP_CODE" != "200" ]]; then
+  echo "[e2e] FAIL: expected 200 from unknown-surface query, got $HTTP_CODE" >&2
+  cat "$EMPTY_BODY" >&2 || true
+  exit 1
+fi
+python3 - "$EMPTY_BODY" <<'PY'
+import json
+import sys
+path = sys.argv[1]
+with open(path) as f:
+    body = json.load(f)
+if body.get("surface") != "does-not-exist":
+    print(f"[e2e] FAIL: surface field is {body.get('surface')!r}", file=sys.stderr)
+    sys.exit(1)
+if body.get("paths") != []:
+    print(f"[e2e] FAIL: expected empty paths for unknown surface; got {body.get('paths')!r}", file=sys.stderr)
+    sys.exit(1)
+print("[e2e] OK: unknown surface yields empty paths")
+PY
+
+echo "[e2e] PASS"


### PR DESCRIPTION
## Summary

- Add `GET /health/sources?surface=<id>` to the daemon's public HTTP surface, returning the on-disk paths the tailer is currently watching for the requested surface — the contract the JetBrains plugin already speaks (siropkin/budi-jetbrains#36).
- Unfiltered form (`GET /health/sources`) returns every surface grouped under `{ "surfaces": [ { "surface", "paths" }, ... ] }`, sorted + deduped.
- Source of truth is each enabled provider's `Provider::watch_roots()`, the same call the tailer's reconcile loop runs every backstop tick. Surface inference reuses `budi_core::surface` so copilot_chat roots get classified per-path (VS Code / Cursor / JetBrains) while single-host providers fall through to `default_for_provider`.

Closes #735.

## Test plan

- [x] `cargo test -p budi-daemon -- collect_health surface_for_path` (5 new unit tests for filter / blank-surface fallthrough / canonical-surface invariants).
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.
- [x] `bash scripts/e2e/test_735_health_sources_endpoint.sh` — boots the release daemon under a temp HOME seeded with a JetBrains AI Assistant chats dir and asserts the filtered + grouped + unknown-surface response shapes.
- [x] Negative-path verified by removing the `/health/sources` route registration in `main.rs` — the e2e test fails with the expected 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)