### PR TITLE
fix(pricing): repair NULL cost_cents_effective rows (#746)

### DIFF
--- a/crates/budi-core/src/migration.rs
+++ b/crates/budi-core/src/migration.rs
@@ -1469,60 +1469,73 @@ fn ensure_dual_cost_columns(conn: &Connection) -> Result<Vec<String>> {
         let has_ingested = has_column(conn, table, "cost_cents_ingested")?;
         let has_legacy = has_column(conn, table, "cost_cents")?;
 
-        if has_effective && has_ingested {
-            continue;
+        let needs_migration = !has_effective || !has_ingested;
+
+        if needs_migration {
+            // Drop rollup triggers up-front: they reference `NEW.cost_cents`
+            // / `OLD.cost_cents`, and once we rename or drop the column the
+            // trigger bodies become invalid. The caller recreates them with
+            // the dual-column shape via `create_rollup_triggers`.
+            conn.execute_batch(
+                "DROP TRIGGER IF EXISTS trg_messages_rollup_insert;
+                 DROP TRIGGER IF EXISTS trg_messages_rollup_delete;
+                 DROP TRIGGER IF EXISTS trg_messages_rollup_update;",
+            )?;
+
+            if !has_ingested {
+                // Rollups: NOT NULL DEFAULT 0 matches the existing rollup
+                // column shape and the spec. messages.cost_cents was
+                // nullable, but the new `_ingested` column is always
+                // NOT NULL DEFAULT 0 per ADR-0094 §1 — incoming NULL legacy
+                // rows get the column DEFAULT before the copy below.
+                conn.execute_batch(&format!(
+                    "ALTER TABLE {table} ADD COLUMN cost_cents_ingested REAL NOT NULL DEFAULT 0;"
+                ))?;
+                added.push(format!("{table}.cost_cents_ingested"));
+            }
+
+            if has_legacy && !has_effective {
+                // Copy the legacy column's value (treating NULL as 0) into
+                // the new `_ingested` column so history is preserved
+                // verbatim. ADR-0091 §5 Rule D: `_ingested` is the
+                // ADR-0091-immutable column from this point forward.
+                conn.execute_batch(&format!(
+                    "UPDATE {table} SET cost_cents_ingested = COALESCE(cost_cents, 0);"
+                ))?;
+                // Rename the legacy column. SQLite ≥ 3.25 rewrites trigger
+                // bodies and index definitions transparently, so existing
+                // `idx_messages_*_cost` indexes now reference the renamed
+                // column with no further action.
+                conn.execute_batch(&format!(
+                    "ALTER TABLE {table} RENAME COLUMN cost_cents TO cost_cents_effective;"
+                ))?;
+                added.push(format!("{table}.cost_cents_effective"));
+            } else if !has_effective {
+                // No legacy column to rename (the table was created without
+                // any cost column — shouldn't happen in practice, but
+                // defensive): add it explicitly with the rollup-table
+                // semantics. Messages-table inserts always bind a value, so
+                // the NOT NULL default never gets exercised on the live
+                // path.
+                conn.execute_batch(&format!(
+                    "ALTER TABLE {table} ADD COLUMN cost_cents_effective REAL NOT NULL DEFAULT 0;"
+                ))?;
+                added.push(format!("{table}.cost_cents_effective"));
+            }
         }
 
-        // Drop rollup triggers up-front: they reference `NEW.cost_cents` /
-        // `OLD.cost_cents`, and once we rename or drop the column the
-        // trigger bodies become invalid. The caller recreates them with
-        // the dual-column shape via `create_rollup_triggers`.
-        conn.execute_batch(
-            "DROP TRIGGER IF EXISTS trg_messages_rollup_insert;
-             DROP TRIGGER IF EXISTS trg_messages_rollup_delete;
-             DROP TRIGGER IF EXISTS trg_messages_rollup_update;",
-        )?;
-
-        if !has_ingested {
-            // Rollups: NOT NULL DEFAULT 0 matches the existing rollup
-            // column shape and the spec. messages.cost_cents was
-            // nullable, but the new `_ingested` column is always
-            // NOT NULL DEFAULT 0 per ADR-0094 §1 — incoming NULL legacy
-            // rows get the column DEFAULT before the copy below.
-            conn.execute_batch(&format!(
-                "ALTER TABLE {table} ADD COLUMN cost_cents_ingested REAL NOT NULL DEFAULT 0;"
-            ))?;
-            added.push(format!("{table}.cost_cents_ingested"));
-        }
-
-        if has_legacy && !has_effective {
-            // Copy the legacy column's value (treating NULL as 0) into
-            // the new `_ingested` column so history is preserved
-            // verbatim. ADR-0091 §5 Rule D: `_ingested` is the
-            // ADR-0091-immutable column from this point forward.
-            conn.execute_batch(&format!(
-                "UPDATE {table} SET cost_cents_ingested = COALESCE(cost_cents, 0);"
-            ))?;
-            // Rename the legacy column. SQLite ≥ 3.25 rewrites trigger
-            // bodies and index definitions transparently, so existing
-            // `idx_messages_*_cost` indexes now reference the renamed
-            // column with no further action.
-            conn.execute_batch(&format!(
-                "ALTER TABLE {table} RENAME COLUMN cost_cents TO cost_cents_effective;"
-            ))?;
-            added.push(format!("{table}.cost_cents_effective"));
-        } else if !has_effective {
-            // No legacy column to rename (the table was created without
-            // any cost column — shouldn't happen in practice, but
-            // defensive): add it explicitly with the rollup-table
-            // semantics. Messages-table inserts always bind a value, so
-            // the NOT NULL default never gets exercised on the live
-            // path.
-            conn.execute_batch(&format!(
-                "ALTER TABLE {table} ADD COLUMN cost_cents_effective REAL NOT NULL DEFAULT 0;"
-            ))?;
-            added.push(format!("{table}.cost_cents_effective"));
-        }
+        // #746: the original rename above preserved the legacy NULLs into
+        // `cost_cents_effective`, which then crashes `recompute_messages`
+        // when it reads the column as a non-nullable f64. Backfill NULLs
+        // from `_ingested` per ADR-0094 §1 ("`_effective` is never
+        // legitimately NULL"). Idempotent — matches zero rows on
+        // subsequent runs, and also recovers users whose DBs already
+        // shipped past the broken migration without forcing a fresh
+        // install.
+        conn.execute_batch(&format!(
+            "UPDATE {table} SET cost_cents_effective = cost_cents_ingested \
+                WHERE cost_cents_effective IS NULL;"
+        ))?;
     }
 
     Ok(added)
@@ -2235,6 +2248,62 @@ mod tests {
                 .any(|c| c.contains("cost_cents_")),
             "second repair must not re-add dual cost columns; got {:?}",
             second.added_columns
+        );
+    }
+
+    /// #746: a user who shipped past the original #730 rename keeps the
+    /// pre-migration NULL rows in `cost_cents_effective` (the rename
+    /// preserves nulls). Running `repair` on that DB must backfill the
+    /// NULLs from `_ingested` so the recompute loop stops crashing.
+    /// Idempotent — a second pass touches zero rows.
+    #[test]
+    fn reconcile_backfills_null_effective_on_already_migrated_db() {
+        let conn = Connection::open_in_memory().unwrap();
+        migrate(&conn).unwrap();
+
+        // Insert a row in the post-migration shape but force `_effective`
+        // back to NULL, mimicking history that came through the broken
+        // rename without ever being recomputed.
+        conn.execute(
+            "INSERT INTO messages (id, role, timestamp, model, provider,
+                                   input_tokens, output_tokens,
+                                   cost_cents_ingested, cost_cents_effective)
+             VALUES ('legacy','assistant','2026-04-22T00:00:00Z','claude-opus-4-6','claude_code',
+                     0, 100, 9.75, NULL)",
+            [],
+        )
+        .unwrap();
+
+        let null_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM messages WHERE cost_cents_effective IS NULL",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(null_count, 1, "seed precondition");
+
+        repair(&conn).unwrap();
+
+        let null_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM messages WHERE cost_cents_effective IS NULL",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(null_count, 0, "repair must backfill NULL _effective rows");
+
+        let eff: f64 = conn
+            .query_row(
+                "SELECT cost_cents_effective FROM messages WHERE id='legacy'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!(
+            (eff - 9.75).abs() < 1e-9,
+            "_effective must mirror _ingested after backfill; got {eff}"
         );
     }
 

--- a/crates/budi-core/src/pricing/team.rs
+++ b/crates/budi-core/src/pricing/team.rs
@@ -356,10 +356,14 @@ pub fn recompute_messages(
     };
 
     let Some(pricing) = pricing else {
+        // `!=` returns NULL (not TRUE) when one side is NULL, so the
+        // legacy filter skipped pre-#730 NULL rows and the worker silently
+        // no-op'd them (#746). The `IS NULL` clause picks those rows up.
         let changed = conn.execute(
             "UPDATE messages
                 SET cost_cents_effective = cost_cents_ingested
-              WHERE cost_cents_effective != cost_cents_ingested",
+              WHERE cost_cents_effective IS NULL
+                 OR cost_cents_effective != cost_cents_ingested",
             [],
         )?;
         summary.rows_changed = changed as i64;
@@ -393,7 +397,11 @@ pub fn recompute_messages(
         let cache_creation_t: i64 = r.get(5)?;
         let cache_read_t: i64 = r.get(6)?;
         let ingested: f64 = r.get(7)?;
-        let current_eff: f64 = r.get(8)?;
+        // #746: pre-#730 history can still carry NULL `_effective` rows if the
+        // user's DB shipped past the rename before the backfill landed. Read
+        // as Option<f64> so the loop survives those rows; the NULL case below
+        // schedules an unconditional write to repair them.
+        let current_eff: Option<f64> = r.get(8)?;
 
         let new_eff = if let Some(model_str) = model.as_deref() {
             let provider_str = provider.as_deref().unwrap_or("");
@@ -412,7 +420,13 @@ pub fn recompute_messages(
             ingested
         };
 
-        if (new_eff - current_eff).abs() > 1e-9 {
+        let needs_update = match current_eff {
+            Some(c) => (new_eff - c).abs() > 1e-9,
+            // NULL → row predates the dual-cost migration backfill;
+            // always rewrite so the column becomes a real number.
+            None => true,
+        };
+        if needs_update {
             updates.push((id, new_eff));
         }
     }
@@ -621,6 +635,37 @@ mod tests {
             .unwrap();
         // 1M input × $2.91/MTok + 1M output × $14.55/MTok = $17.46 = 1746 cents.
         assert!((eff - 1746.0).abs() < 1e-6, "got {eff}");
+    }
+
+    // #746: pre-#730 history can carry NULL `_effective` rows if the DB
+    // shipped past the rename before the backfill landed. The recompute
+    // loop used to read the column as `f64` and crash with "Invalid column
+    // type Null"; assert it now (a) survives the read, and (b) repairs
+    // the NULL into a real number.
+    #[test]
+    fn recompute_repairs_null_effective_rows() {
+        let conn = crate::analytics::open_db_with_migration(std::path::Path::new(":memory:"))
+            .expect("open db");
+        conn.execute(
+            "INSERT INTO messages (id, role, timestamp, model, provider,
+                                   input_tokens, output_tokens,
+                                   cost_cents_ingested, cost_cents_effective)
+             VALUES ('legacy','assistant','2026-05-11T00:00:00Z','claude-sonnet-4-5-x','claude_code',
+                     0, 100, 7.0, NULL)",
+            [],
+        )
+        .expect("seed legacy NULL row");
+
+        let summary = recompute_messages(&conn, None).expect("recompute survives NULL");
+        assert_eq!(summary.rows_changed, 1, "NULL row must be rewritten");
+        let eff: Option<f64> = conn
+            .query_row(
+                "SELECT cost_cents_effective FROM messages WHERE id='legacy'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(eff, Some(7.0), "NULL should be repaired to _ingested");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Backfill `cost_cents_effective` from `cost_cents_ingested` whenever the former is NULL during reconcile, recovering users whose DBs already shipped past the broken #730 rename.
- Make `recompute_messages` survive NULL `_effective` rows: read as `Option<f64>`, treat NULL as "always rewrite", and patch the no-pricing fast path's NULL-propagating `!=` filter.

## Why

The original #730 rename preserved legacy NULLs into `cost_cents_effective`, which then crashed `recompute_messages` on `r.get::<f64>(8)` and silently no-op'd the worker's SQL UPDATE (`!=` is NULL-propagating, so NULL rows never matched). Result: `budi pricing recompute` 500s for any DB with pre-pricing-manifest history, and the hourly worker stays a no-op for the same DBs — the v8.4.3 "team-pricing end-to-end" narrative was false for the user base it actually targets.

ADR-0094 §1 says `_effective` is never legitimately NULL — this PR enforces that invariant on both the migration path and the recompute path.

Closes #746

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo test --workspace --lib` — 684 passed (2 new regression tests)
- [x] New test `reconcile_backfills_null_effective_on_already_migrated_db`: seeds a NULL row in the post-migration shape, runs `repair`, asserts the NULL is healed to `_ingested`.
- [x] New test `recompute_repairs_null_effective_rows`: seeds a NULL row, runs `recompute_messages(None)`, asserts no panic and the row is rewritten.
- [ ] Manual: against a real pre-#730 DB (~120K NULL rows), confirm `curl -X POST 'http://127.0.0.1:7878/pricing/recompute?force=true'` returns 200 and `SELECT SUM(cost_cents_effective IS NULL) FROM messages` is 0.