### PR TITLE
fix(team-pricing): treat ureq Ok(304) as Unchanged (#747)

### DIFF
--- a/crates/budi-daemon/src/workers/team_pricing.rs
+++ b/crates/budi-daemon/src/workers/team_pricing.rs
@@ -300,6 +300,15 @@ fn fetch_pricing(
         .call();
     match result {
         Ok(mut response) => {
+            // #747: ureq's `call()` returns `Ok` for 304 in this workspace's
+            // pinned version (304 is not a 4xx/5xx). The body is empty, so
+            // `read_json()` would surface an EOF parse error to the user.
+            // Short-circuit before touching the body. The matching 304 arm
+            // on the `Err` side stays as defense-in-depth in case a future
+            // ureq bump flips the classification.
+            if response.status() == 304 {
+                return Ok(FetchOutcome::Unchanged);
+            }
             let pricing: TeamPricing = response
                 .body_mut()
                 .read_json()
@@ -400,6 +409,45 @@ mod tests {
         let interval = resolve_interval();
         unsafe { std::env::remove_var(REFRESH_INTERVAL_ENV) };
         assert_eq!(interval, DEFAULT_REFRESH_INTERVAL);
+    }
+
+    /// Spawn a one-shot TCP server that replies with the canned response and
+    /// returns its `http://127.0.0.1:PORT` endpoint. Keeps the test free of
+    /// any new test-only dependency — the existing workspace already exposes
+    /// `std::net` and `std::thread`.
+    fn spawn_one_shot_server(response: &'static [u8]) -> String {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+        let port = listener.local_addr().unwrap().port();
+        std::thread::spawn(move || {
+            use std::io::{Read, Write};
+            let (mut stream, _) = listener.accept().expect("accept");
+            // Drain the request — the daemon will send GET headers + CRLFCRLF.
+            // We don't need the bytes, just to read past them so the kernel
+            // delivers our write back as the response.
+            let mut buf = [0u8; 1024];
+            let _ = stream.read(&mut buf);
+            stream.write_all(response).expect("write response");
+        });
+        format!("http://127.0.0.1:{port}")
+    }
+
+    /// #747: prior to this fix, ureq's `call()` returned `Ok` for a 304
+    /// response in the pinned version, which then tripped `read_json()` on
+    /// the empty body and surfaced an EOF parse error to the user every
+    /// hourly tick. Assert the worker now reports `Unchanged` instead.
+    #[test]
+    fn fetch_pricing_treats_ok_304_as_unchanged() {
+        let endpoint = spawn_one_shot_server(
+            b"HTTP/1.1 304 Not Modified\r\n\
+              Content-Length: 0\r\n\
+              Connection: close\r\n\
+              \r\n",
+        );
+        let outcome = fetch_pricing(&endpoint, "test-key", 7).expect("304 must not error");
+        assert!(
+            matches!(outcome, FetchOutcome::Unchanged),
+            "got {outcome:?}"
+        );
     }
 
     /// When `BUDI_PRICING_REFRESH=0` is set, `run()` must exit quickly


### PR DESCRIPTION
## Summary

- Short-circuit on `response.status() == 304` inside the `Ok` arm of `fetch_pricing` before calling `read_json()` on the empty body.
- Keep the `Err(StatusCode(304))` arm as defense-in-depth in case a future ureq bump reclassifies 304.
- Add a regression test using a one-shot TCP server (no new dev-dependency) that replays a real 304 response and asserts `FetchOutcome::Unchanged`.

## Why

ureq's `call()` in the pinned version returns `Ok` for 304 (it's not in the 4xx/5xx error set), so the worker fell through to `read_json()` on the empty body and surfaced an EOF parse error to the user every hourly tick after the first successful install. The matching `Err(StatusCode(304))` arm was effectively dead code in this build, which is why the failure escaped CI: no test exercised the actual `ureq` 304 path.

Combined with #745 / #746, the v8.4.3 worker stopped recomputing after the first successful install for every cloud-linked user.

Closes #747

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo test --workspace --lib` — 684 passed
- [x] New test `fetch_pricing_treats_ok_304_as_unchanged` — exercises the real ureq client against a hand-crafted 304 response.
- [ ] Manual: against `app.getbudi.dev` with `since_version` matching the active list, confirm the worker logs `team-pricing unchanged (304 or version match)` at debug instead of `parse team-pricing response: EOF`.