### PR TITLE
fix(cli): pricing recompute sends true/false, not 1/0 (#745)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,6 +225,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "tempfile",
  "tokio",
  "tower",

--- a/crates/budi-cli/src/client.rs
+++ b/crates/budi-cli/src/client.rs
@@ -501,12 +501,15 @@ impl DaemonClient {
     /// when `list_version` is unchanged (the worker would otherwise
     /// short-circuit). #732.
     pub fn pricing_recompute(&self, force: bool) -> Result<Value> {
+        // #745: the daemon route uses serde's strict bool deserializer, which
+        // only accepts the literal strings "true" / "false". A numeric
+        // 0 / 1 (the older convention) trips 400 Bad Request.
         let resp = self
             .client
             .post(format!(
                 "{}/pricing/recompute?force={}",
                 self.base_url,
-                if force { "1" } else { "0" }
+                if force { "true" } else { "false" }
             ))
             .timeout(std::time::Duration::from_secs(120))
             .send()

--- a/crates/budi-daemon/Cargo.toml
+++ b/crates/budi-daemon/Cargo.toml
@@ -26,5 +26,6 @@ ureq.workspace = true
 
 [dev-dependencies]
 http-body-util = "0.1"
+serde_urlencoded = "0.7"
 tempfile = "3"
 tower = { version = "0.5", features = ["util"] }

--- a/crates/budi-daemon/src/routes/pricing.rs
+++ b/crates/budi-daemon/src/routes/pricing.rs
@@ -181,3 +181,38 @@ pub async fn pricing_refresh() -> Result<Json<Value>, (StatusCode, Json<Value>)>
         )),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// #745: the CLI used to send `?force=0|1`, but serde's strict bool
+    /// deserializer only accepts the literal strings `true` / `false`.
+    /// Pin the wire contract on the daemon side so a future CLI bump
+    /// can't silently regress it again.
+    #[test]
+    fn recompute_query_accepts_true_false_literals() {
+        let true_q: RecomputeQuery =
+            serde_urlencoded::from_str("force=true").expect("force=true must parse");
+        assert!(true_q.force);
+
+        let false_q: RecomputeQuery =
+            serde_urlencoded::from_str("force=false").expect("force=false must parse");
+        assert!(!false_q.force);
+
+        let missing_q: RecomputeQuery =
+            serde_urlencoded::from_str("").expect("missing force must default");
+        assert!(!missing_q.force);
+    }
+
+    /// Numeric `0` / `1` are explicitly *not* part of the wire shape — the
+    /// CLI shipped a regression in v8.4.3 doing exactly that and produced a
+    /// 400 the user couldn't recover from. Keep this test failing-loud so
+    /// the bad shape can't be re-introduced without an opt-in custom
+    /// deserializer.
+    #[test]
+    fn recompute_query_rejects_numeric_bool_literals() {
+        assert!(serde_urlencoded::from_str::<RecomputeQuery>("force=1").is_err());
+        assert!(serde_urlencoded::from_str::<RecomputeQuery>("force=0").is_err());
+    }
+}


### PR DESCRIPTION
## Summary

- Switch the CLI's `pricing_recompute` URL builder to emit `?force=true|false` instead of `?force=1|0`.
- Add two daemon-side `RecomputeQuery` tests pinning the wire contract: `true`/`false` parse; numeric `1`/`0` fail to parse.

## Why

The daemon's `RecomputeQuery` uses serde's strict bool deserializer (only `"true"`/`"false"` literals). The CLI shipped numeric `1`/`0` in v8.4.3 (#743), so every `budi pricing recompute` invocation came back with a 400 and an unhelpful serde error — the only documented escape hatch between hourly worker ticks was broken.

Two unit tests pin the wire contract so a future CLI bump can't silently re-introduce the mismatch.

Closes #745

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo test --workspace --lib` — 684 passed
- [x] New `recompute_query_accepts_true_false_literals` + `recompute_query_rejects_numeric_bool_literals` tests both green.
- [ ] Manual: `budi pricing recompute` and `budi pricing recompute --force` both return 200.