### PR TITLE
fix(analytics): /statusline honors ?surface= filter (#748)

### DIFF
--- a/crates/budi-core/src/analytics/queries.rs
+++ b/crates/budi-core/src/analytics/queries.rs
@@ -3419,6 +3419,30 @@ pub struct StatuslineParams {
     /// the comma-list form. See ADR-0088 §7 (post-#648).
     #[serde(default, deserialize_with = "deserialize_provider_filter")]
     pub provider: Vec<String>,
+    /// Host environment filter — `vscode`, `cursor`, `jetbrains`, `terminal`,
+    /// `unknown`. Comma-separated, same shape as `provider`. Added in #748
+    /// after `/analytics/statusline` was missed by the original #702 surface
+    /// rollout — the JetBrains widget was reading the global rollup instead
+    /// of `surface=jetbrains` rows. Empty filter is unscoped (all surfaces).
+    #[serde(default, deserialize_with = "deserialize_surface_filter")]
+    pub surface: Vec<String>,
+}
+
+fn deserialize_surface_filter<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::Deserialize;
+    let raw: Option<String> = Option::deserialize(deserializer)?;
+    let parsed: Vec<String> = raw
+        .as_deref()
+        .unwrap_or_default()
+        .split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
+        .collect();
+    Ok(normalize_surfaces(&parsed))
 }
 
 fn deserialize_provider_filter<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
@@ -3453,6 +3477,7 @@ fn assistant_cost_since_from_rollups(
     conn: &Connection,
     since: &str,
     providers: &[String],
+    surfaces: &[String],
 ) -> Option<f64> {
     if !rollups_available(conn) {
         return None;
@@ -3465,6 +3490,15 @@ fn assistant_cost_since_from_rollups(
         let placeholders = vec!["?"; providers.len()].join(", ");
         conditions.push(format!("provider IN ({placeholders})"));
         params.extend(providers.iter().cloned());
+    }
+    if !surfaces.is_empty() {
+        let placeholders = vec!["?"; surfaces.len()].join(", ");
+        // Mirror the COALESCE/lowercase normalization the rest of the
+        // analytics layer uses (see `normalized_surface_expr`) so a row
+        // with `surface = NULL` or `''` still matches `?surface=unknown`.
+        let expr = normalized_surface_expr("surface");
+        conditions.push(format!("{expr} IN ({placeholders})"));
+        params.extend(surfaces.iter().cloned());
     }
     let sql = format!(
         "SELECT COALESCE(SUM(cost_cents_effective), 0.0)
@@ -3494,6 +3528,7 @@ pub fn statusline_stats(
     params: &StatuslineParams,
 ) -> Result<StatuslineStats> {
     let provider_filter: &[String] = &params.provider;
+    let surface_filter: &[String] = &params.surface;
 
     // Helper: append `provider IN (?, ?, ...)` to `sql` and the matching
     // bindings, using whatever placeholder syntax the caller is already using.
@@ -3507,21 +3542,37 @@ pub fn statusline_stats(
         bindings.extend(provider_filter.iter().cloned());
     };
 
+    // #748: surface filter mirrors the provider filter. The COALESCE-
+    // normalized expression matches `?surface=unknown` against NULL / empty
+    // rows, consistent with the rest of the analytics layer.
+    let push_surface_in = |sql: &mut String, bindings: &mut Vec<String>| {
+        if surface_filter.is_empty() {
+            return;
+        }
+        let placeholders = vec!["?"; surface_filter.len()].join(", ");
+        let expr = normalized_surface_expr("surface");
+        sql.push_str(&format!(" AND {expr} IN ({placeholders})"));
+        bindings.extend(surface_filter.iter().cloned());
+    };
+
     let cost_since = |since: &str| -> f64 {
-        assistant_cost_since_from_rollups(conn, since, provider_filter).unwrap_or_else(|| {
-            let mut sql = String::from(
-                "SELECT COALESCE(SUM(cost_cents_effective), 0.0) FROM messages \
+        assistant_cost_since_from_rollups(conn, since, provider_filter, surface_filter)
+            .unwrap_or_else(|| {
+                let mut sql = String::from(
+                    "SELECT COALESCE(SUM(cost_cents_effective), 0.0) FROM messages \
                      WHERE timestamp >= ? AND role = 'assistant'",
-            );
-            let mut bindings: Vec<String> = vec![since.to_string()];
-            push_provider_in(&mut sql, &mut bindings);
-            let refs: Vec<&dyn rusqlite::types::ToSql> = bindings
-                .iter()
-                .map(|s| s as &dyn rusqlite::types::ToSql)
-                .collect();
-            conn.query_row(&sql, refs.as_slice(), |r| r.get::<_, f64>(0))
-                .unwrap_or(0.0)
-        }) / 100.0
+                );
+                let mut bindings: Vec<String> = vec![since.to_string()];
+                push_provider_in(&mut sql, &mut bindings);
+                push_surface_in(&mut sql, &mut bindings);
+                let refs: Vec<&dyn rusqlite::types::ToSql> = bindings
+                    .iter()
+                    .map(|s| s as &dyn rusqlite::types::ToSql)
+                    .collect();
+                conn.query_row(&sql, refs.as_slice(), |r| r.get::<_, f64>(0))
+                    .unwrap_or(0.0)
+            })
+            / 100.0
     };
 
     let cost_1d = cost_since(since_1d);
@@ -3540,6 +3591,7 @@ pub fn statusline_stats(
         );
         let mut bindings: Vec<String> = vec![sid.clone()];
         push_provider_in(&mut sql, &mut bindings);
+        push_surface_in(&mut sql, &mut bindings);
         let refs: Vec<&dyn rusqlite::types::ToSql> = bindings
             .iter()
             .map(|s| s as &dyn rusqlite::types::ToSql)
@@ -3566,6 +3618,7 @@ pub fn statusline_stats(
             bindings.push(repo.to_string());
         }
         push_provider_in(&mut sql, &mut bindings);
+        push_surface_in(&mut sql, &mut bindings);
         let refs: Vec<&dyn rusqlite::types::ToSql> = bindings
             .iter()
             .map(|s| s as &dyn rusqlite::types::ToSql)
@@ -3583,6 +3636,7 @@ pub fn statusline_stats(
         );
         let mut bindings: Vec<String> = vec![dir.clone()];
         push_provider_in(&mut sql, &mut bindings);
+        push_surface_in(&mut sql, &mut bindings);
         let refs: Vec<&dyn rusqlite::types::ToSql> = bindings
             .iter()
             .map(|s| s as &dyn rusqlite::types::ToSql)
@@ -3595,11 +3649,14 @@ pub fn statusline_stats(
     // Active provider: most recent provider seen in the 1d window, after the
     // provider filter is applied. Under multi-provider this is the provider
     // with the most recent traffic — host-scoped click-through routes to its
-    // dashboard (ADR-0088 §7 post-#648).
+    // dashboard (ADR-0088 §7 post-#648). #748: also honor surface filter so
+    // a JetBrains-scoped statusline doesn't surface a Claude Code CLI as
+    // "active" when the JetBrains rollup is empty.
     let active_provider: Option<String> = {
         let mut sql = String::from("SELECT provider FROM messages WHERE timestamp >= ?");
         let mut bindings: Vec<String> = vec![since_1d.to_string()];
         push_provider_in(&mut sql, &mut bindings);
+        push_surface_in(&mut sql, &mut bindings);
         sql.push_str(" ORDER BY timestamp DESC LIMIT 1");
         let refs: Vec<&dyn rusqlite::types::ToSql> = bindings
             .iter()

--- a/crates/budi-core/src/analytics/tests.rs
+++ b/crates/budi-core/src/analytics/tests.rs
@@ -1596,6 +1596,174 @@ fn statusline_stats_aggregates_across_multiple_providers() {
     );
 }
 
+/// #748: `/analytics/statusline?surface=<name>` must honor the filter the
+/// same way `/analytics/messages` does (added in #702). The original v8.4.3
+/// rollout missed this endpoint, so the JetBrains widget showed the global
+/// rollup (typically dominated by Claude Code CLI usage) instead of
+/// `surface=jetbrains` rows. Pin the wire contract on every numeric field
+/// plus `active_provider`.
+#[test]
+fn statusline_stats_with_surface_filter_scopes_every_field() {
+    let mut conn = test_db();
+
+    let mk =
+        |uuid: &str, session: &str, surface: &str, provider: &str, cost_cents: f64, ts: &str| {
+            ParsedMessage {
+                uuid: uuid.to_string(),
+                session_id: Some(session.to_string()),
+                timestamp: ts.parse().unwrap(),
+                cwd: Some("/proj/a".to_string()),
+                role: "assistant".to_string(),
+                model: Some("m".to_string()),
+                input_tokens: 100,
+                output_tokens: 50,
+                cache_creation_tokens: 0,
+                cache_read_tokens: 0,
+                git_branch: Some("main".to_string()),
+                repo_id: Some("repo-1".to_string()),
+                provider: provider.to_string(),
+                cost_cents: Some(cost_cents),
+                session_title: None,
+                parent_uuid: None,
+                user_name: None,
+                machine_name: None,
+                cost_confidence: "exact".to_string(),
+                pricing_source: None,
+                request_id: None,
+                speed: None,
+                cache_creation_1h_tokens: 0,
+                web_search_requests: 0,
+                prompt_category: None,
+                prompt_category_source: None,
+                prompt_category_confidence: None,
+                tool_names: Vec::new(),
+                tool_use_ids: Vec::new(),
+                tool_files: Vec::new(),
+                tool_outcomes: Vec::new(),
+                cwd_source: None,
+                surface: Some(surface.to_string()),
+            }
+        };
+
+    let msgs = vec![
+        mk(
+            "cc-term",
+            "cc-sess",
+            "terminal",
+            "claude_code",
+            900.0,
+            "2026-04-15T10:00:00Z",
+        ),
+        mk(
+            "cop-jb",
+            "jb-sess",
+            "jetbrains",
+            "copilot_chat",
+            300.0,
+            "2026-04-15T11:00:00Z",
+        ),
+        mk(
+            "cop-vsc",
+            "vsc-sess",
+            "vscode",
+            "copilot_chat",
+            500.0,
+            "2026-04-15T11:30:00Z",
+        ),
+    ];
+    ingest_messages(&mut conn, &msgs, None).unwrap();
+
+    let since_1d = "2026-04-15T00:00:00Z";
+    let since_7d = "2026-04-10T00:00:00Z";
+    let since_30d = "2026-03-20T00:00:00Z";
+
+    // No filter: blended global rollup. Pre-fix daemon returned exactly this
+    // value regardless of `?surface=`.
+    let global = statusline_stats(
+        &conn,
+        since_1d,
+        since_7d,
+        since_30d,
+        &StatuslineParams::default(),
+    )
+    .unwrap();
+    assert_eq!(global.cost_1d, 17.0);
+
+    // `?surface=jetbrains` → only the JetBrains row contributes; the global
+    // 17.0 must not bleed through.
+    let jb = statusline_stats(
+        &conn,
+        since_1d,
+        since_7d,
+        since_30d,
+        &StatuslineParams {
+            surface: vec!["jetbrains".to_string()],
+            session_id: Some("jb-sess".to_string()),
+            branch: Some("main".to_string()),
+            project_dir: Some("/proj/a".to_string()),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(jb.cost_1d, 3.0);
+    assert_eq!(jb.cost_7d, 3.0);
+    assert_eq!(jb.cost_30d, 3.0);
+    assert_eq!(jb.session_cost, Some(3.0));
+    assert_eq!(jb.branch_cost, Some(3.0));
+    assert_eq!(jb.project_cost, Some(3.0));
+    assert_eq!(jb.active_provider.as_deref(), Some("copilot_chat"));
+
+    // `?surface=vscode` returns the vscode row only — copilot_chat shows
+    // through as the active provider but cost_30d does not blend with
+    // jetbrains' copilot_chat row.
+    let vsc = statusline_stats(
+        &conn,
+        since_1d,
+        since_7d,
+        since_30d,
+        &StatuslineParams {
+            surface: vec!["vscode".to_string()],
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(vsc.cost_1d, 5.0);
+    assert_eq!(vsc.active_provider.as_deref(), Some("copilot_chat"));
+
+    // Unknown surface name → zero rows, no error. Matches `?provider=mars`.
+    let unknown = statusline_stats(
+        &conn,
+        since_1d,
+        since_7d,
+        since_30d,
+        &StatuslineParams {
+            surface: vec!["mars".to_string()],
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(unknown.cost_1d, 0.0);
+    assert_eq!(unknown.cost_30d, 0.0);
+    assert!(unknown.active_provider.is_none());
+
+    // Composing surface with provider: the intersection wins. `surface=vscode`
+    // ∩ `provider=claude_code` → no rows.
+    let intersected = statusline_stats(
+        &conn,
+        since_1d,
+        since_7d,
+        since_30d,
+        &StatuslineParams {
+            surface: vec!["vscode".to_string()],
+            provider: vec!["claude_code".to_string()],
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(intersected.cost_1d, 0.0);
+    assert!(intersected.active_provider.is_none());
+}
+
 /// R1.3 (#650): comma-list parsing for the statusline `?provider=` query
 /// param. `?provider=cursor` keeps the 8.1 single-provider behavior;
 /// `?provider=cursor,copilot_chat` is the host-scoped form. Empty / absent


### PR DESCRIPTION
## Summary

- Add `surface: Vec<String>` to `StatuslineParams`, comma-separated on the wire (same shape as `provider`), normalized via the existing `normalize_surfaces` helper.
- Wire the filter into every numeric field (`cost_{1d,7d,30d}`, `session_cost`, `branch_cost`, `project_cost`) plus `active_provider`.
- Extend `assistant_cost_since_from_rollups` so the daily/hourly rollup fast path also honors the filter (otherwise a surface-scoped query would fall back to a messages-table scan).

## Why

The original #702 surface rollout retrofitted `/analytics/messages`, `/analytics/sessions`, and the breakdown routes but missed `/analytics/statusline`. The JetBrains widget shipped in budi-jetbrains 0.1.2 received the global rollup (typically dominated by Claude Code CLI usage) instead of `surface=jetbrains` rows — the widget felt broken from the user's perspective, claiming to show "JetBrains spend" while actually showing total cross-IDE spend.

Closes #748

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo test --workspace --lib` — 685 passed (1 new regression test, 4 surfaces × 5 numeric fields covered).
- [x] `cargo clippy --workspace --all-targets` — clean.
- [x] New test `statusline_stats_with_surface_filter_scopes_every_field` covers: known surface scopes every field; unknown surface returns zero; surface ∩ provider intersection wins.
- [ ] Manual: `curl 'http://127.0.0.1:7878/analytics/statusline?surface=jetbrains'` on a multi-IDE machine returns only JetBrains-host rows.