### PR TITLE
fix(schema): cost_cents_effective NOT NULL on messages (#755)

### DIFF
--- a/crates/budi-core/src/analytics/mod.rs
+++ b/crates/budi-core/src/analytics/mod.rs
@@ -500,8 +500,13 @@ pub fn ingest_messages_with_sync(
         // ADR-0094 §1: write the same value into both `cost_cents_ingested`
         // (immutable per ADR-0091 §5 Rule D) and `cost_cents_effective`
         // (read surface). The team-pricing worker (#731) rewrites only
-        // `_effective`; until it ships `_effective = _ingested`.
+        // `_effective`; until it ships `_effective = _ingested`. #755:
+        // `_effective` is never legitimately NULL — user rows (no LLM
+        // spend) bind 0.0, same as `_ingested`. The schema enforces
+        // `NOT NULL DEFAULT 0` so any future bind that skips the column
+        // still lands a 0 instead of a NULL.
         let cost_cents_ingested = cost_cents.unwrap_or(0.0);
+        let cost_cents_effective = cost_cents.unwrap_or(0.0);
         let inserted = tx.execute(
             "INSERT OR IGNORE INTO messages
              (id, session_id, role, timestamp, model,
@@ -526,7 +531,7 @@ pub fn ingest_messages_with_sync(
                 msg.repo_id,
                 msg.provider,
                 cost_cents_ingested,
-                cost_cents,
+                cost_cents_effective,
                 msg.parent_uuid,
                 git_branch,
                 msg.cost_confidence,

--- a/crates/budi-core/src/analytics/tests.rs
+++ b/crates/budi-core/src/analytics/tests.rs
@@ -7600,3 +7600,85 @@ fn session_prompt_category_tracks_latest_value() {
         "session should track the latest prompt_category"
     );
 }
+
+/// #755: ADR-0094 §1 declares `cost_cents_effective` is never legitimately
+/// NULL. Before the fix, the ingest path bound the raw `Option<f64>` to the
+/// column, so any row without a cost (every `role=user` prompt) wrote a
+/// NULL into `_effective`. Regression: a user row with `cost_cents=None`
+/// must round-trip as `_effective = 0.0`, and the schema's NOT NULL
+/// constraint must reject any attempt to write NULL directly.
+#[test]
+fn ingest_user_row_writes_zero_not_null_into_effective() {
+    let mut conn = test_db();
+    let msg = ParsedMessage {
+        uuid: "user-no-cost".to_string(),
+        session_id: Some("s-755".to_string()),
+        timestamp: "2026-05-12T01:54:25Z".parse().unwrap(),
+        cwd: Some("/tmp/proj".to_string()),
+        role: "user".to_string(),
+        model: None,
+        input_tokens: 0,
+        output_tokens: 0,
+        cache_creation_tokens: 0,
+        cache_read_tokens: 0,
+        git_branch: None,
+        repo_id: None,
+        provider: "claude_code".to_string(),
+        cost_cents: None,
+        session_title: None,
+        parent_uuid: None,
+        user_name: None,
+        machine_name: None,
+        cost_confidence: "estimated".to_string(),
+        pricing_source: None,
+        request_id: None,
+        speed: None,
+        cache_creation_1h_tokens: 0,
+        web_search_requests: 0,
+        prompt_category: None,
+        prompt_category_source: None,
+        prompt_category_confidence: None,
+        tool_names: Vec::new(),
+        tool_use_ids: Vec::new(),
+        tool_files: Vec::new(),
+        tool_outcomes: Vec::new(),
+        cwd_source: None,
+        surface: None,
+    };
+    ingest_messages(&mut conn, &[msg], None).unwrap();
+
+    let (ingested, effective): (f64, f64) = conn
+        .query_row(
+            "SELECT cost_cents_ingested, cost_cents_effective
+               FROM messages WHERE id = 'user-no-cost'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(ingested, 0.0);
+    assert_eq!(effective, 0.0);
+
+    let null_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM messages WHERE cost_cents_effective IS NULL",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(null_count, 0);
+
+    // Schema invariant: direct NULL writes must be rejected.
+    let err = conn.execute(
+        "INSERT INTO messages (id, role, timestamp, provider,
+                               input_tokens, output_tokens,
+                               cache_creation_tokens, cache_read_tokens,
+                               cost_cents_ingested, cost_cents_effective)
+         VALUES ('null-write', 'user', '2026-05-12T01:55:00Z', 'claude_code',
+                 0, 0, 0, 0, 0, NULL)",
+        [],
+    );
+    assert!(
+        err.is_err(),
+        "schema must reject NULL cost_cents_effective writes"
+    );
+}

--- a/crates/budi-core/src/migration.rs
+++ b/crates/budi-core/src/migration.rs
@@ -228,7 +228,7 @@ fn create_current_schema(conn: &Connection) -> Result<()> {
             repo_id                TEXT,
             provider               TEXT DEFAULT 'claude_code',
             cost_cents_ingested    REAL NOT NULL DEFAULT 0,
-            cost_cents_effective   REAL,
+            cost_cents_effective   REAL NOT NULL DEFAULT 0,
             parent_uuid            TEXT,
             git_branch             TEXT,
             cost_confidence        TEXT DEFAULT 'estimated',
@@ -2260,6 +2260,24 @@ mod tests {
     fn reconcile_backfills_null_effective_on_already_migrated_db() {
         let conn = Connection::open_in_memory().unwrap();
         migrate(&conn).unwrap();
+
+        // #755 tightened the live schema to `cost_cents_effective REAL NOT
+        // NULL DEFAULT 0`, so the test has to recreate the legacy nullable
+        // shape before it can seed the NULL row that the backfill is
+        // supposed to repair. Drop the indexes that reference the column,
+        // drop the column, and re-add as plain `REAL`.
+        conn.execute_batch(
+            "DROP TRIGGER IF EXISTS trg_messages_rollup_insert;
+             DROP TRIGGER IF EXISTS trg_messages_rollup_delete;
+             DROP TRIGGER IF EXISTS trg_messages_rollup_update;
+             DROP INDEX IF EXISTS idx_messages_ts_cost;
+             DROP INDEX IF EXISTS idx_messages_role_ts_cost;
+             DROP INDEX IF EXISTS idx_messages_role_branch_cost;
+             DROP INDEX IF EXISTS idx_messages_session_role_cost;
+             ALTER TABLE messages DROP COLUMN cost_cents_effective;
+             ALTER TABLE messages ADD COLUMN cost_cents_effective REAL;",
+        )
+        .unwrap();
 
         // Insert a row in the post-migration shape but force `_effective`
         // back to NULL, mimicking history that came through the broken

--- a/crates/budi-core/src/pricing/team.rs
+++ b/crates/budi-core/src/pricing/team.rs
@@ -573,6 +573,26 @@ mod tests {
         assert!((result - 1800.0).abs() < 1e-6, "got {result}");
     }
 
+    /// #755: tests that need to simulate the pre-fix nullable shape of
+    /// `messages.cost_cents_effective` (so they can seed a legacy NULL row)
+    /// drop the indexes that reference the column, drop the column itself,
+    /// and re-add it as plain nullable `REAL`. The fresh-install schema
+    /// declares `NOT NULL DEFAULT 0`, which we reverse here.
+    fn revert_effective_to_legacy_nullable(conn: &rusqlite::Connection) {
+        conn.execute_batch(
+            "DROP TRIGGER IF EXISTS trg_messages_rollup_insert;
+             DROP TRIGGER IF EXISTS trg_messages_rollup_delete;
+             DROP TRIGGER IF EXISTS trg_messages_rollup_update;
+             DROP INDEX IF EXISTS idx_messages_ts_cost;
+             DROP INDEX IF EXISTS idx_messages_role_ts_cost;
+             DROP INDEX IF EXISTS idx_messages_role_branch_cost;
+             DROP INDEX IF EXISTS idx_messages_session_role_cost;
+             ALTER TABLE messages DROP COLUMN cost_cents_effective;
+             ALTER TABLE messages ADD COLUMN cost_cents_effective REAL;",
+        )
+        .expect("revert column to legacy nullable shape");
+    }
+
     #[test]
     fn install_and_snapshot_roundtrip() {
         install(Some(sample_pricing()));
@@ -642,10 +662,16 @@ mod tests {
     // loop used to read the column as `f64` and crash with "Invalid column
     // type Null"; assert it now (a) survives the read, and (b) repairs
     // the NULL into a real number.
+    //
+    // #755 tightened the column to NOT NULL DEFAULT 0 on fresh installs,
+    // so this test has to simulate the legacy nullable-column shape by
+    // dropping the constraint via `DROP COLUMN`/`ADD COLUMN` before
+    // seeding the NULL row.
     #[test]
     fn recompute_repairs_null_effective_rows() {
         let conn = crate::analytics::open_db_with_migration(std::path::Path::new(":memory:"))
             .expect("open db");
+        revert_effective_to_legacy_nullable(&conn);
         conn.execute(
             "INSERT INTO messages (id, role, timestamp, model, provider,
                                    input_tokens, output_tokens,


### PR DESCRIPTION
## Summary

- Schema: `messages.cost_cents_effective` is now `REAL NOT NULL DEFAULT 0` on fresh installs — any future INSERT that forgets the column gets a real 0; any explicit NULL bind is rejected.
- Ingest path: bind `cost_cents.unwrap_or(0.0)` into `_effective`, mirroring the existing bind for `_ingested`. User-role rows no longer write NULL.
- Defense-in-depth recompute (#750) kept; two legacy-NULL repair tests updated to recreate the nullable column shape before seeding.

Fixes #755.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo test --workspace --lib` — 686 passed, 0 failed
- [x] New regression `ingest_user_row_writes_zero_not_null_into_effective` asserts: (a) user-row INSERT through the production path writes `_effective = 0.0`, (b) direct NULL INSERT is rejected by the schema.
- [ ] Post-merge smoke: `SELECT SUM(cost_cents_effective IS NULL) FROM messages` stays at 0 after 10+ min of mixed Claude Code activity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)