### PR TITLE
fix(cloud_sync): surface real 422 body, classify schema mismatches (#756)

### DIFF
--- a/crates/budi-core/src/cloud_sync.rs
+++ b/crates/budi-core/src/cloud_sync.rs
@@ -696,12 +696,117 @@ pub enum SyncResult {
     Success(IngestResponse),
     /// Auth failure (401) — should stop syncing and prompt re-auth.
     AuthFailure,
-    /// Schema mismatch (422) — log warning, don't retry until updated.
-    SchemaMismatch(String),
+    /// 422 — server rejected the envelope. #756: the body is captured
+    /// verbatim and classified so the daemon/CLI can show the right
+    /// recovery advice. The previous shape dropped the body and assumed
+    /// every 422 was a schema-version mismatch; the v8.4.4 smoke test
+    /// proved that wrong (the cloud's `validateIngestMetrics` rejected
+    /// the `cost_cents` rename with a non-version 422 and budi told the
+    /// user to "update budi" when the cloud was the lagging side).
+    SchemaMismatch(SchemaMismatch),
     /// Transient error (429/5xx/network) — should retry with backoff.
     TransientError(String),
     /// Nothing to sync (empty payload).
     EmptyPayload,
+}
+
+/// #756: structured 422 outcome. Wraps the server's exact response body
+/// plus a classification of *why* the cloud rejected it. The daemon
+/// renders the body verbatim and chooses the recovery advice from
+/// [`SchemaMismatchKind`] (so a "cloud is lagging" 422 stops telling the
+/// user to update budi when budi isn't the problem).
+#[derive(Debug, Clone)]
+pub struct SchemaMismatch {
+    pub body: String,
+    pub kind: SchemaMismatchKind,
+}
+
+/// #756: classification of a 422 from the cloud ingest endpoint.
+///
+/// The cloud's `validateIngestMetrics` produces two distinct shapes of
+/// 422 — one that names `schema_version` directly, and a catch-all for
+/// per-field validation (`cost_cents must be a finite, non-negative
+/// number`, `device_id must be a UUID`, etc.). Only the first kind
+/// implies "the client is older than the cloud and needs to update", so
+/// the daemon needs to know which it is before printing recovery advice.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SchemaMismatchKind {
+    /// Body matched `Unsupported schema_version: <c>. Expected one of:
+    /// [<min>, …, <max>]` and the client version is below the minimum
+    /// accepted version. The user should update budi.
+    ClientTooOld { client: u32, expected_min: u32 },
+    /// Body matched the same pattern, but the client version is above
+    /// the maximum the cloud accepts. The cloud is the lagging side;
+    /// no amount of `brew upgrade budi` will help. Telling the user to
+    /// update budi here was the exact failure flagged in #749's body.
+    CloudTooOld { client: u32, expected_max: u32 },
+    /// Body did not match the schema_version pattern at all — usually a
+    /// per-field validation error from the cloud's envelope validator.
+    /// Surface the body verbatim and do not pretend it is a version
+    /// issue.
+    NotSchemaRelated,
+}
+
+/// #756: parse the cloud's 422 response body for a schema_version
+/// mismatch and classify it against the client's current schema_version.
+/// Returns [`SchemaMismatchKind::NotSchemaRelated`] when the body
+/// doesn't match the expected pattern.
+///
+/// The cloud emits the pattern `Unsupported schema_version: <c>.
+/// Expected one of: [<v1>, <v2>, …]` (see siropkin/budi-cloud
+/// `validateEnvelope`). We pull out the integer client version and the
+/// list to decide whether the client is below or above the accepted
+/// set.
+pub fn classify_schema_mismatch(body: &str, client_schema_version: u32) -> SchemaMismatchKind {
+    let Some(prefix) = body.find("Unsupported schema_version:") else {
+        return SchemaMismatchKind::NotSchemaRelated;
+    };
+    let tail = &body[prefix + "Unsupported schema_version:".len()..];
+    let Some(dot) = tail.find('.') else {
+        return SchemaMismatchKind::NotSchemaRelated;
+    };
+    let client_str = tail[..dot].trim();
+    let Ok(_client_from_body) = client_str.parse::<u32>() else {
+        return SchemaMismatchKind::NotSchemaRelated;
+    };
+    // We trust the *client's* known version over whatever the cloud echoed
+    // back (the wire could carry a typo, future cloud format change, etc.).
+    let client = client_schema_version;
+
+    let after_dot = &tail[dot + 1..];
+    let Some(open) = after_dot.find('[') else {
+        return SchemaMismatchKind::NotSchemaRelated;
+    };
+    let Some(close) = after_dot[open..].find(']') else {
+        return SchemaMismatchKind::NotSchemaRelated;
+    };
+    let list_str = &after_dot[open + 1..open + close];
+    let expected: Vec<u32> = list_str
+        .split(',')
+        .filter_map(|s| s.trim().parse::<u32>().ok())
+        .collect();
+    if expected.is_empty() {
+        return SchemaMismatchKind::NotSchemaRelated;
+    }
+    let min = *expected.iter().min().unwrap();
+    let max = *expected.iter().max().unwrap();
+    if client < min {
+        SchemaMismatchKind::ClientTooOld {
+            client,
+            expected_min: min,
+        }
+    } else if client > max {
+        SchemaMismatchKind::CloudTooOld {
+            client,
+            expected_max: max,
+        }
+    } else {
+        // The body claims the client's schema_version is unsupported
+        // but the parsed expected set contains it. The daemon shouldn't
+        // be hitting this arm at all; treat as a generic rejection so
+        // the body is at least surfaced verbatim.
+        SchemaMismatchKind::NotSchemaRelated
+    }
 }
 
 /// Validate that the endpoint is HTTPS. ADR-0083 §4: "The daemon refuses to sync
@@ -801,8 +906,15 @@ pub fn send_sync_envelope(endpoint: &str, api_key: &str, envelope: &SyncEnvelope
 
     let url = format!("{endpoint}/v1/ingest");
 
+    // #756: ureq's default classifies any 4xx/5xx as
+    // `Err(Error::StatusCode(n))` and drops the response body, which is
+    // exactly what we need to read to surface the cloud's real rejection
+    // message. Disable the auto-error so the response always reaches us
+    // and we can branch on `status()` while still owning the body.
+    // Mirrors the post-#751 pattern in `workers/team_pricing.rs`.
     let agent: ureq::Agent = ureq::Agent::config_builder()
         .timeout_global(Some(Duration::from_secs(30)))
+        .http_status_as_error(false)
         .build()
         .into();
 
@@ -812,19 +924,35 @@ pub fn send_sync_envelope(endpoint: &str, api_key: &str, envelope: &SyncEnvelope
         .send_json(envelope);
 
     match result {
-        Ok(mut response) => match response.body_mut().read_json::<IngestResponse>() {
-            Ok(resp) => SyncResult::Success(resp),
-            Err(e) => SyncResult::TransientError(format!("Failed to parse response: {e}")),
-        },
-        Err(ureq::Error::StatusCode(401)) => SyncResult::AuthFailure,
-        Err(ureq::Error::StatusCode(422)) => {
-            SyncResult::SchemaMismatch("Server returned 422".to_string())
-        }
-        Err(ureq::Error::StatusCode(status)) if status == 429 || status >= 500 => {
-            SyncResult::TransientError(format!("Server returned {status}"))
-        }
-        Err(ureq::Error::StatusCode(status)) => {
-            SyncResult::TransientError(format!("Server returned {status}"))
+        Ok(mut response) => {
+            let status = response.status().as_u16();
+            if (200..300).contains(&status) {
+                match response.body_mut().read_json::<IngestResponse>() {
+                    Ok(resp) => SyncResult::Success(resp),
+                    Err(e) => SyncResult::TransientError(format!("Failed to parse response: {e}")),
+                }
+            } else if status == 401 {
+                SyncResult::AuthFailure
+            } else if status == 422 {
+                let body = response
+                    .body_mut()
+                    .read_to_string()
+                    .unwrap_or_else(|_| String::new());
+                let kind = classify_schema_mismatch(&body, envelope.schema_version);
+                SyncResult::SchemaMismatch(SchemaMismatch { body, kind })
+            } else if status == 429 || status >= 500 {
+                SyncResult::TransientError(format!("Server returned {status}"))
+            } else {
+                let body = response
+                    .body_mut()
+                    .read_to_string()
+                    .unwrap_or_else(|_| String::new());
+                if body.is_empty() {
+                    SyncResult::TransientError(format!("Server returned {status}"))
+                } else {
+                    SyncResult::TransientError(format!("Server returned {status}: {body}"))
+                }
+            }
         }
         Err(e) => SyncResult::TransientError(format!("Network error: {e}")),
     }
@@ -1025,6 +1153,64 @@ pub fn backoff_delay(attempt: u32, retry_max_seconds: u64) -> Duration {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// #756: schema_version mismatch where the client is below the cloud's
+    /// accepted set should classify as ClientTooOld — the only path where
+    /// "update budi" advice is correct.
+    #[test]
+    fn classify_schema_mismatch_client_too_old() {
+        let body = "Unsupported schema_version: 1. Expected one of: [2, 3]. Update your client.";
+        let kind = classify_schema_mismatch(body, 1);
+        assert_eq!(
+            kind,
+            SchemaMismatchKind::ClientTooOld {
+                client: 1,
+                expected_min: 2,
+            }
+        );
+    }
+
+    /// #756: when the client is *above* the cloud's accepted set (the
+    /// failure mode flagged in #749's body — a fresh release shipped a
+    /// schema bump faster than the cloud deployed), the daemon must call
+    /// out the cloud as the lagging side instead of telling the user to
+    /// update budi.
+    #[test]
+    fn classify_schema_mismatch_cloud_too_old() {
+        let body = "Unsupported schema_version: 3. Expected one of: [1, 2]";
+        let kind = classify_schema_mismatch(body, 3);
+        assert_eq!(
+            kind,
+            SchemaMismatchKind::CloudTooOld {
+                client: 3,
+                expected_max: 2,
+            }
+        );
+    }
+
+    /// #756: a 422 body that doesn't mention `schema_version` is per-field
+    /// validation (the exact failure mode from the v8.4.4 smoke test —
+    /// `daily_rollups[0].cost_cents must be a finite, non-negative
+    /// number`). Classifier returns NotSchemaRelated; the daemon
+    /// surfaces the body verbatim and skips the "update budi" advice.
+    #[test]
+    fn classify_schema_mismatch_non_schema_body() {
+        let body = "daily_rollups[0].cost_cents must be a finite, non-negative number; got null";
+        let kind = classify_schema_mismatch(body, 2);
+        assert_eq!(kind, SchemaMismatchKind::NotSchemaRelated);
+    }
+
+    /// #756: a malformed schema_version error (missing `Expected one of`
+    /// list, garbled integer, etc.) falls back to NotSchemaRelated so the
+    /// daemon doesn't crash on cloud format drift — the body is still
+    /// surfaced verbatim.
+    #[test]
+    fn classify_schema_mismatch_malformed_falls_back() {
+        let kind = classify_schema_mismatch("Unsupported schema_version: oops.", 2);
+        assert_eq!(kind, SchemaMismatchKind::NotSchemaRelated);
+        let kind = classify_schema_mismatch("Unsupported schema_version: 2.", 2);
+        assert_eq!(kind, SchemaMismatchKind::NotSchemaRelated);
+    }
 
     #[test]
     fn extract_ticket_basic() {

--- a/crates/budi-daemon/src/routes/cloud.rs
+++ b/crates/budi-daemon/src/routes/cloud.rs
@@ -15,7 +15,7 @@ use axum::Json;
 use axum::extract::State;
 use axum::http::StatusCode;
 use budi_core::analytics;
-use budi_core::cloud_sync::{self, SyncResult, SyncTickReport};
+use budi_core::cloud_sync::{self, SchemaMismatchKind, SyncResult, SyncTickReport};
 use budi_core::config::{self, CloudConfig};
 use serde_json::{Value, json};
 
@@ -267,19 +267,23 @@ fn report_to_json(report: SyncTickReport) -> Value {
             "Authentication failed (401). Check `api_key` in ~/.config/budi/cloud.toml."
                 .to_string(),
         ),
-        SyncResult::SchemaMismatch(msg) if chunks_succeeded > 0 => (
+        SyncResult::SchemaMismatch(mismatch) if chunks_succeeded > 0 => (
             false,
             RESULT_SCHEMA_MISMATCH,
             format!(
-                "Server rejected chunk {} of {chunks_total} as schema-incompatible (422) after confirming {chunks_succeeded}. Update budi to resume syncing. Detail: {msg}",
+                "Server rejected chunk {} of {chunks_total} with 422 after confirming {chunks_succeeded}. {} Detail: {}",
                 chunks_succeeded + 1,
+                schema_mismatch_advice(&mismatch.kind),
+                mismatch.body,
             ),
         ),
-        SyncResult::SchemaMismatch(msg) => (
+        SyncResult::SchemaMismatch(mismatch) => (
             false,
             RESULT_SCHEMA_MISMATCH,
             format!(
-                "Server rejected the payload as schema-incompatible (422). Update budi to resume syncing. Detail: {msg}"
+                "Server rejected the payload with 422. {} Detail: {}",
+                schema_mismatch_advice(&mismatch.kind),
+                mismatch.body,
             ),
         ),
         SyncResult::TransientError(msg) if chunks_succeeded > 0 => (
@@ -309,6 +313,41 @@ fn report_to_json(report: SyncTickReport) -> Value {
         "chunks_total": chunks_total,
         "chunks_succeeded": chunks_succeeded,
     })
+}
+
+/// #756: render the recovery advice for a 422 based on which side of the
+/// schema_version split the client is on. Returns a complete sentence so
+/// callers can splat it into a status message verbatim.
+///
+/// - `ClientTooOld`: the user's local budi is older than the cloud accepts.
+///   Tell them to update. This is the only path where "update budi" is right.
+/// - `CloudTooOld`: the cloud is the lagging side (e.g. a recent CLI release
+///   shipped a `schema_version` bump that hasn't reached the deployed cloud
+///   yet). Updating budi locally would make it worse; point at the
+///   maintainers instead. This is the exact failure mode flagged in #749's
+///   body.
+/// - `NotSchemaRelated`: the 422 is from per-field validation
+///   (`cost_cents must be a finite, non-negative number`, etc.) or some
+///   other business rule. The body is the diagnostic; don't pretend it's
+///   a version issue.
+fn schema_mismatch_advice(kind: &SchemaMismatchKind) -> String {
+    match kind {
+        SchemaMismatchKind::ClientTooOld {
+            client,
+            expected_min,
+        } => format!(
+            "Client schema_version {client} is below the minimum the cloud accepts ({expected_min}). Update budi to resume syncing."
+        ),
+        SchemaMismatchKind::CloudTooOld {
+            client,
+            expected_max,
+        } => format!(
+            "Cloud is older than this client (client schema_version {client}, cloud max {expected_max}). Updating budi locally will not help — wait for the cloud to catch up or ping the maintainers."
+        ),
+        SchemaMismatchKind::NotSchemaRelated => {
+            "The cloud rejected the envelope; check the server detail below before assuming budi is out of date.".to_string()
+        }
+    }
 }
 
 #[cfg(test)]
@@ -409,5 +448,73 @@ mod tests {
         let msg = body["message"].as_str().unwrap();
         assert!(msg.contains("chunk 3 of 5"), "got: {msg}");
         assert!(msg.contains("after confirming 2"), "got: {msg}");
+    }
+
+    /// #756: a 422 caused by per-field validation (the failure mode
+    /// from the v8.4.4 smoke test where the cloud rejected the
+    /// `cost_cents` rename) must surface the body verbatim and must
+    /// NOT tell the user to "update budi" — the client wasn't the
+    /// lagging side. Mirrors acceptance criterion 2 on #756.
+    #[test]
+    fn report_to_json_422_field_validation_does_not_say_update_budi() {
+        use budi_core::cloud_sync::{SchemaMismatch, SchemaMismatchKind};
+        let report = SyncTickReport {
+            result: SyncResult::SchemaMismatch(SchemaMismatch {
+                body: "daily_rollups[0].cost_cents must be a finite, non-negative number".into(),
+                kind: SchemaMismatchKind::NotSchemaRelated,
+            }),
+            endpoint: "https://app.getbudi.dev".into(),
+            envelope_rollups: 1,
+            envelope_sessions: 0,
+            server_records_upserted: None,
+            server_watermark: None,
+            chunks_total: 1,
+            chunks_succeeded: 0,
+        };
+        let body = report_to_json(report);
+        let msg = body["message"].as_str().unwrap();
+        assert!(
+            msg.contains("cost_cents must be a finite"),
+            "server body must round-trip into the message: {msg}"
+        );
+        assert!(
+            !msg.contains("Update budi"),
+            "non-schema 422 must not advise updating budi: {msg}"
+        );
+    }
+
+    /// #756: when the client is *above* the cloud's accepted set, the
+    /// message must call out the cloud as the lagging side, not blame
+    /// budi. This is the exact regression the original #749 body
+    /// flagged.
+    #[test]
+    fn report_to_json_422_cloud_too_old_blames_cloud() {
+        use budi_core::cloud_sync::{SchemaMismatch, SchemaMismatchKind};
+        let report = SyncTickReport {
+            result: SyncResult::SchemaMismatch(SchemaMismatch {
+                body: "Unsupported schema_version: 3. Expected one of: [1, 2]".into(),
+                kind: SchemaMismatchKind::CloudTooOld {
+                    client: 3,
+                    expected_max: 2,
+                },
+            }),
+            endpoint: "https://app.getbudi.dev".into(),
+            envelope_rollups: 1,
+            envelope_sessions: 0,
+            server_records_upserted: None,
+            server_watermark: None,
+            chunks_total: 1,
+            chunks_succeeded: 0,
+        };
+        let body = report_to_json(report);
+        let msg = body["message"].as_str().unwrap();
+        assert!(
+            msg.contains("Cloud is older than this client"),
+            "msg should call out cloud, not budi: {msg}"
+        );
+        assert!(
+            !msg.contains("Update budi"),
+            "cloud-too-old 422 must not advise updating budi: {msg}"
+        );
     }
 }

--- a/crates/budi-daemon/src/workers/cloud_sync.rs
+++ b/crates/budi-daemon/src/workers/cloud_sync.rs
@@ -133,9 +133,16 @@ pub async fn run(db_path: PathBuf, initial_config: CloudConfig, cloud_syncing: A
                 tracing::error!("Cloud sync: authentication failed (401)");
                 continue; // Skip normal sleep, handled at loop top
             }
-            Ok(SyncResult::SchemaMismatch(msg)) => {
+            Ok(SyncResult::SchemaMismatch(mismatch)) => {
                 schema_mismatch = true;
-                tracing::error!("Cloud sync: schema mismatch (422): {msg}");
+                // #756: log the server's actual body and our classification
+                // so on-call doesn't have to guess whether budi or the
+                // cloud is the lagging side.
+                tracing::error!(
+                    kind = ?mismatch.kind,
+                    "Cloud sync: server returned 422: {}",
+                    mismatch.body,
+                );
                 continue; // Skip normal sleep, handled at loop top
             }
             Ok(SyncResult::TransientError(msg)) => {


### PR DESCRIPTION
## Summary

- `send_sync_envelope` now reads the cloud's 422 body verbatim (ureq agent uses `http_status_as_error(false)`, mirroring the post-#751 team-pricing pattern).
- `SyncResult::SchemaMismatch(String)` → `SyncResult::SchemaMismatch(SchemaMismatch { body, kind })` with three kinds: `ClientTooOld` (the only place "update budi" is correct), `CloudTooOld` (call out the cloud, fix flagged in #749's body), and `NotSchemaRelated` (per-field validation — surface the body verbatim).
- CLI message in `routes/cloud.rs` branches on the kind via a new `schema_mismatch_advice()` helper.

Fixes #756.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo test --workspace --lib` — 690 passed, 0 failed
- [x] Classifier unit tests cover ClientTooOld, CloudTooOld, NotSchemaRelated, and malformed bodies.
- [x] End-to-end route tests assert (a) per-field 422s round-trip the body and do NOT say "Update budi", (b) cloud-too-old 422s call out the cloud as the lagging side.
- [ ] Post-merge smoke: real 422 against the live cloud surfaces the actual body text in the daemon log + CLI message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)