### PR TITLE
release: v8.4.7 — combine Xodus + Nitrite on dual-store JetBrains dirs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 8.4.7 — 2026-05-12
+
+8.4.7 is a same-day hotfix for the v8.4.6 JetBrains parser. The 8.4.6 implementation treated the Xodus `.xd` log and the Nitrite `.db` store as mutually exclusive — the parser ran `extract_xodus_project_name` only when the populated-entity probe returned `.xd`, and `extract_nitrite_turn_ids` only when it returned a Nitrite file. Real dual-store session-dirs (the common shape post-migration) put `projectName` in `.xd` and `Nt*Turn` documents in `.nitrite.db`; the 8.4.6 code picked one and dropped the other, so every `surface=jetbrains` row landed with `repo_id = NULL` even when the .xd carried a clean `Verkada-Web`-style name. The post-release smoke test on a real DB caught this within minutes — 0 of 23 sessions populated `repo_id`. The parser now reads `00000000000.xd` and every `*.nitrite.db` in the session-dir independently and merges the results: per-turn UUIDs from Nitrite + `repo_id` / `git_branch` / `session_title` from Xodus land on the same `ParsedMessage`. `api_version` stays at `3`.
+
+### Fixed
+
+- **JetBrains Copilot: combine Xodus projectName and Nitrite per-turn extraction on dual-store session-dirs** (#766, #764) — `parse_session_dir` previously ran `populated_store_in` and then used its single return value to decide between the two extraction paths. The result was that every dual-store agent-session (Xodus carrying the populated-entity marker, Nitrite carrying the per-turn documents) emitted either a one-row placeholder with repo enrichment *or* a per-turn batch without it, never both. Now the parser reads each store unconditionally — `.xd` for `projectName`, each `*.nitrite.db` for `Nt(Agent|Edit)?Turn` UUIDs — and merges the results onto every emitted row. New regression test `dual_store_session_combines_xodus_repo_with_nitrite_turns` covers the wire shape.
+
+### Cross-repo lockstep
+
+- No cross-repo changes required.
+
 ## 8.4.6 — 2026-05-11
 
 8.4.6 is the patch that closes the JetBrains-as-first-class-host story for real. v8.4.3 said JetBrains was a first-class surface; v8.4.5 fixed the parser bail-out that left every Nitrite-only session emitting zero rows. The v8.4.5 post-release smoke test then surfaced the remaining four cuts — and this release lands all four. The headline fix is **per-turn rows on JetBrains**: the Nitrite parser previously emitted one assistant-role placeholder per session, so fresh prompts inside an existing session never materialized as new rows; the parser now byte-walks `Nt(Agent|Edit)?Turn` document boundaries and emits one row per turn UUID. Sibling fixes light the rest of the dashboard up: the Billing API reconciler now dollarizes zero-token JetBrains placeholders evenly across the bucket's rows (pre-#765 it short-circuited on zero existing-sum and left `cost_30d` for `surface=jetbrains` permanently at \$0); the dashboard's Repo column finally renders real project names for JetBrains sessions thanks to a Xodus-log `projectName` byte-scan; and on every upgrade across a wire-shape change boundary, the daemon now resets its cloud-sync watermark automatically so historical rows re-upload under the new shape — no more `POST /cloud/reset` as undocumented institutional knowledge. `api_version` stays at `3`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,7 +175,7 @@ dependencies = [
 
 [[package]]
 name = "budi-cli"
-version = "8.4.6"
+version = "8.4.7"
 dependencies = [
  "anyhow",
  "budi-core",
@@ -195,7 +195,7 @@ dependencies = [
 
 [[package]]
 name = "budi-core"
-version = "8.4.6"
+version = "8.4.7"
 dependencies = [
  "anyhow",
  "chrono",
@@ -211,7 +211,7 @@ dependencies = [
 
 [[package]]
 name = "budi-daemon"
-version = "8.4.6"
+version = "8.4.7"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "8.4.6"
+version = "8.4.7"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"

--- a/crates/budi-core/src/providers/copilot_chat/jetbrains.rs
+++ b/crates/budi-core/src/providers/copilot_chat/jetbrains.rs
@@ -262,17 +262,19 @@ pub(super) fn parse_session_dir(session_dir: &Path) -> Vec<ParsedMessage> {
         .as_deref()
         .map(|s| s.trim_end_matches("-sessions").to_string());
 
-    // #766: pull the IntelliJ project name + resolved repo/branch out of
-    // the Xodus log. The result is shared across every row this session
-    // emits (one row per turn for Nitrite, one row per session for the
-    // legacy .xd path). Nitrite-only sessions fall through to
-    // `repo_id = None` until Phase 2 lands the `NtAgentWorkingSetItem`
-    // decoder.
-    let (project_name, repo_resolution) = if store_path
-        .file_name()
-        .and_then(|s| s.to_str())
-        .is_some_and(|name| name == "00000000000.xd")
-        && let Ok(bytes) = std::fs::read(&store_path)
+    // #766: pull the IntelliJ project name + resolved repo/branch from
+    // the Xodus log regardless of which store the populated-entity probe
+    // picked. Dual-store sessions on disk write `XdChatSession.projectName`
+    // into `00000000000.xd` *and* `Nt*Turn` documents into the matching
+    // `*.nitrite.db` — the two stores are complementary, not alternative
+    // shapes of the same data. The original 8.4.6 implementation treated
+    // them as mutually exclusive (repo only set when .xd was the
+    // "populated" store, turn extraction only when Nitrite was), so every
+    // dual-store session emitted either a one-row placeholder with
+    // `repo_id` or a per-turn batch without it. Now we try both
+    // unconditionally and combine.
+    let xd_candidate = session_dir.join("00000000000.xd");
+    let (project_name, repo_resolution) = if let Ok(bytes) = std::fs::read(&xd_candidate)
         && let Some(project_name) = extract_xodus_project_name(&bytes)
     {
         let resolution = resolve_project_workspace(&project_name);
@@ -281,21 +283,26 @@ pub(super) fn parse_session_dir(session_dir: &Path) -> Vec<ParsedMessage> {
         (None, None)
     };
 
-    // #764: Phase 1 per-turn extraction for Nitrite stores. Walk the
-    // serialized `Nt(Agent|Edit)?Turn` documents for their `uuid` field
-    // and emit one assistant `ParsedMessage` per turn. Tokens stay zero;
-    // cost reconciliation flows through `crate::sync::copilot_chat_billing`
-    // (#765's even-distribution path is what dollarizes these rows).
-    let nitrite_turns = if store_path
-        .file_name()
-        .and_then(|s| s.to_str())
-        .is_some_and(|n| NITRITE_DB_FILES.contains(&n))
-        && let Ok(bytes) = std::fs::read(&store_path)
+    // #764: Phase 1 per-turn extraction. Walk every `*.nitrite.db` in
+    // the session dir for `Nt(Agent|Edit)?Turn` documents and collect
+    // their `uuid` fields. Combine across all Nitrite files because a
+    // single session-dir can carry both `copilot-chat-nitrite.db` and
+    // `copilot-agent-sessions-nitrite.db` post-migration.
+    let mut nitrite_turns: Vec<String> = Vec::new();
     {
-        extract_nitrite_turn_ids(&bytes)
-    } else {
-        Vec::new()
-    };
+        let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+        for filename in NITRITE_DB_FILES {
+            let candidate = session_dir.join(filename);
+            let Ok(bytes) = std::fs::read(&candidate) else {
+                continue;
+            };
+            for turn_id in extract_nitrite_turn_ids(&bytes) {
+                if seen.insert(turn_id.clone()) {
+                    nitrite_turns.push(turn_id);
+                }
+            }
+        }
+    }
 
     let build_msg = |uuid: String, request_id: Option<String>| -> ParsedMessage {
         let mut msg = ParsedMessage {
@@ -1169,6 +1176,65 @@ mod tests {
             1,
             "duplicate uuids must collapse, got {extracted:?}"
         );
+    }
+
+    /// Regression coverage for the v8.4.6 dual-store bug: when a
+    /// session-dir holds both a populated `.xd` (with `projectName`) and
+    /// a populated `.nitrite.db` (with `Nt*Turn` documents), the parser
+    /// must combine the two — Nitrite supplies per-turn UUIDs, Xodus
+    /// supplies the repo enrichment that lands on every per-turn row.
+    /// The pre-fix 8.4.6 implementation read whichever store the
+    /// populated-entity probe returned and ignored the other, so every
+    /// `surface=jetbrains` row landed with `repo_id = NULL` even on
+    /// sessions whose .xd carried a clean `Verkada-Web`-style project
+    /// name.
+    #[test]
+    fn dual_store_session_combines_xodus_repo_with_nitrite_turns() {
+        let tmp = std::env::temp_dir().join("budi-jetbrains-dual-combined");
+        let _ = std::fs::remove_dir_all(&tmp);
+        let session_dir = tmp.join("iu/chat-agent-sessions/sess-dual-combined");
+        std::fs::create_dir_all(&session_dir).unwrap();
+
+        // Synthetic .xd with the projectName property + value record. The
+        // resolve_project_workspace probe will return None on most CI
+        // hosts (no `~/_projects/budi-test-fake-name/.git`), so the
+        // assertion focuses on `session_title` and the row count — those
+        // two cover the wire shape that flows to the cloud and the
+        // dashboard's Repo column fallback.
+        let mut xd = Vec::new();
+        xd.extend_from_slice(b"XdAgentSession");
+        xd.extend_from_slice(b"\x86\x86\x8e\x8cprojectName\x00\x04");
+        xd.extend_from_slice(b"\x86\x99\x90\x82\x00\x04\x82budi-test-fake-name\x00");
+        std::fs::write(session_dir.join("00000000000.xd"), &xd).unwrap();
+
+        // Synthetic Nitrite with one NtAgentTurn + uuid pair.
+        let uuid = "11afee98-04f2-4da1-a282-3fc0d14e9054";
+        let mut nit = Vec::new();
+        nit.extend_from_slice(b"H:2,blockSize:1000,format:3,version:f\n");
+        nit.extend_from_slice(&[0u8; 64]);
+        nit.extend_from_slice(b"NtAgentTurn");
+        nit.extend_from_slice(b"\xac\xed\x00\x05");
+        nit.extend_from_slice(b"t\x00\x04uuid");
+        nit.extend_from_slice(b"t\x00\x24");
+        nit.extend_from_slice(uuid.as_bytes());
+        nit.extend_from_slice(b"\x00trailer\x00");
+        std::fs::write(session_dir.join("copilot-agent-sessions-nitrite.db"), &nit).unwrap();
+
+        let parsed = parse_session_dir(&session_dir);
+        // One row per Nitrite turn — the Xodus probe doesn't add a
+        // separate placeholder, it only enriches.
+        assert_eq!(parsed.len(), 1, "expected one per-turn row, got {parsed:?}");
+        // The Xodus-derived project name lands on the per-turn row's
+        // `session_title` even when the filesystem-probe step fails to
+        // resolve a `.git` checkout, so the dashboard renders the
+        // IntelliJ name instead of a sea of `(unknown)`.
+        assert_eq!(
+            parsed[0].session_title.as_deref(),
+            Some("budi-test-fake-name"),
+            "Xodus project name must reach the per-turn row's session_title"
+        );
+
+        let _ = std::fs::remove_dir_all(&tmp);
     }
 
     /// #764: sessions whose only Nitrite documents are sessions (not


### PR DESCRIPTION
## Summary

Same-day hotfix on top of v8.4.6 — the v8.4.6 \`parse_session_dir\` treated Xodus \`.xd\` and Nitrite \`*.db\` as mutually-exclusive stores, so dual-store session-dirs always emitted either a one-row placeholder with \`repo_id\` *or* per-turn rows without it, never both. The post-release smoke test on the real DB caught this: 0 of 23 \`surface=jetbrains\` sessions populated \`repo_id\` despite multiple sessions having a clean \`Verkada-Web\` projectName in their .xd.

\`parse_session_dir\` now reads \`00000000000.xd\` unconditionally for the projectName and every \`*.nitrite.db\` in the session-dir for per-turn UUIDs, then merges: per-turn rows carry \`repo_id\` / \`git_branch\` / \`session_title\` from Xodus.

Includes the workspace.package bump to 8.4.7, Cargo.lock relock, and a CHANGELOG entry documenting the dual-store bug + the same-day hotfix.

## Test plan

- [x] \`cargo test -p budi-core --lib providers::copilot_chat::jetbrains\` — 26 pass (one new regression test: \`dual_store_session_combines_xodus_repo_with_nitrite_turns\`).
- [x] \`cargo test --workspace --lib\` — 713 pass.
- [x] \`cargo clippy --workspace --all-targets --locked -- -D warnings\` clean.
- [x] \`cargo fmt --all\` clean.
- [ ] Post-tag: brew upgrade picks 8.4.7 from the auto-bumped tap; sqlite shows \`surface=jetbrains\` sessions with non-NULL repo_id for the 4 sessions whose .xd contains projectName + a resolvable local project dir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)