### PR TITLE
fix(homebrew): drop redundant version line from formula template

### DIFF
--- a/homebrew/budi.rb
+++ b/homebrew/budi.rb
@@ -7,7 +7,6 @@
 class Budi < Formula
   desc "Local-first cost analytics for AI coding agents"
   homepage "https://github.com/siropkin/budi"
-  version "{{VERSION}}"
   license "MIT"
 
   on_macos do


### PR DESCRIPTION
## Summary
- Removes the `version "{{VERSION}}"` line from `homebrew/budi.rb`, the template that the release workflow renders into `siropkin/homebrew-budi`'s `Formula/budi.rb`.
- `brew audit --strict` (recently added to the tap in [siropkin/homebrew-budi#9](https://github.com/siropkin/homebrew-budi/pull/9)) treats an explicit `version` as redundant when the URL already encodes it (`…/releases/download/v8.4.6/…`).

## Why this matters
Every release since v8.4.3 has triggered a failing run on the tap's `tests` workflow with:

```
Stable: `version 8.4.6` is redundant with version scanned from URL
```

See e.g. https://github.com/siropkin/homebrew-budi/actions/runs/25712687915 (v8.4.6).

Homebrew still derives `version` from the URL after this change, so the formula's `test` block (`assert_match version.to_s, …`) keeps working unchanged.

## Test plan
- [ ] After this lands, cut the next release and confirm the regenerated `Formula/budi.rb` in `homebrew-budi` no longer has the `version` line.
- [ ] Confirm the `tests` workflow on `homebrew-budi` passes (`brew audit --strict --online siropkin/budi/budi`, `brew style`, `brew install`/`brew test` smoke tests on macOS + Ubuntu).

🤖 Generated with [Claude Code](https://claude.com/claude-code)