### PR TITLE
release: v8.4.8 — recognize older copilot-edit-sessions-nitrite.db filename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 8.4.8 — 2026-05-12
+
+8.4.8 is the second same-day hotfix on top of v8.4.6 / v8.4.7. The v8.4.7 fix combined the Xodus `projectName` extraction with Nitrite per-turn extraction, but the populated-entity probe still skipped session-dirs whose `.xd` carried only the `projectName` property (no `Xd*Session` marker) and whose Nitrite store used the older `copilot-edit-sessions-nitrite.db` filename — without the `chat-` prefix `NITRITE_DB_FILES` was looking for. Result: one of the three resolvable-on-disk JetBrains sessions (Verkada-Backend) stayed at `repo_id = NULL` even after the v8.4.7 dual-store fix. `api_version` stays at `3`.
+
+### Fixed
+
+- **JetBrains Copilot: recognize `copilot-edit-sessions-nitrite.db` (no `chat-` prefix)** (#766) — older plugin builds wrote the edit-session Nitrite store under the shorter filename. The post-release smoke test on v8.4.7 caught this when session `32REEy.../ic/chat-edit-sessions/` (Verkada-Backend) emitted zero rows even though its `.xd` carried `projectName=Verkada-Backend`. Added the legacy filename to `NITRITE_DB_FILES` so the populated-entity probe accepts it.
+
+### Cross-repo lockstep
+
+- No cross-repo changes required.
+
 ## 8.4.7 — 2026-05-12
 
 8.4.7 is a same-day hotfix for the v8.4.6 JetBrains parser. The 8.4.6 implementation treated the Xodus `.xd` log and the Nitrite `.db` store as mutually exclusive — the parser ran `extract_xodus_project_name` only when the populated-entity probe returned `.xd`, and `extract_nitrite_turn_ids` only when it returned a Nitrite file. Real dual-store session-dirs (the common shape post-migration) put `projectName` in `.xd` and `Nt*Turn` documents in `.nitrite.db`; the 8.4.6 code picked one and dropped the other, so every `surface=jetbrains` row landed with `repo_id = NULL` even when the .xd carried a clean `Verkada-Web`-style name. The post-release smoke test on a real DB caught this within minutes — 0 of 23 sessions populated `repo_id`. The parser now reads `00000000000.xd` and every `*.nitrite.db` in the session-dir independently and merges the results: per-turn UUIDs from Nitrite + `repo_id` / `git_branch` / `session_title` from Xodus land on the same `ParsedMessage`. `api_version` stays at `3`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,7 +175,7 @@ dependencies = [
 
 [[package]]
 name = "budi-cli"
-version = "8.4.7"
+version = "8.4.8"
 dependencies = [
  "anyhow",
  "budi-core",
@@ -195,7 +195,7 @@ dependencies = [
 
 [[package]]
 name = "budi-core"
-version = "8.4.7"
+version = "8.4.8"
 dependencies = [
  "anyhow",
  "chrono",
@@ -211,7 +211,7 @@ dependencies = [
 
 [[package]]
 name = "budi-daemon"
-version = "8.4.7"
+version = "8.4.8"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "8.4.7"
+version = "8.4.8"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"

--- a/crates/budi-core/src/providers/copilot_chat/jetbrains.rs
+++ b/crates/budi-core/src/providers/copilot_chat/jetbrains.rs
@@ -105,6 +105,13 @@ const NITRITE_DB_FILES: &[&str] = &[
     "copilot-chat-nitrite.db",
     "copilot-agent-sessions-nitrite.db",
     "copilot-chat-edit-sessions-nitrite.db",
+    // Older plugin builds write the edit-session store under a shorter
+    // name (no `chat-` prefix). Observed on real user DBs in v8.4.7's
+    // post-release smoke test where session dirs hold only
+    // `copilot-edit-sessions-nitrite.db` — without this entry the
+    // populated-entity probe skips them and the matching .xd's
+    // `projectName` never reaches the parser.
+    "copilot-edit-sessions-nitrite.db",
 ];
 
 /// Platform-specific roots that contain the per-IDE-slug session subtrees.


### PR DESCRIPTION
## Summary

Same-day second hotfix on top of v8.4.6 / v8.4.7. The v8.4.7 dual-store fix paired Xodus \`projectName\` extraction with Nitrite per-turn extraction, but the populated-entity probe still skipped session-dirs whose only Nitrite store used the older \`copilot-edit-sessions-nitrite.db\` filename (no \`chat-\` prefix). One of the three resolvable JetBrains sessions on the real-DB smoke test (Verkada-Backend) ended up at \`repo_id = NULL\` because of this gap.

Adds the legacy filename to \`NITRITE_DB_FILES\`. Workspace bumps to 8.4.8 + CHANGELOG entry.

## Test plan

- [x] \`cargo test -p budi-core --lib providers::copilot_chat::jetbrains\` — 26 pass.
- [x] \`cargo clippy --workspace --all-targets --locked -- -D warnings\` clean.
- [x] \`cargo fmt --all\` clean.
- [ ] Post-tag: brew upgrade picks 8.4.8 from the tap; sqlite shows 3 of 23 sessions with non-NULL \`repo_id\` (Verkada-Web, verkadalizer, Verkada-Backend — the upper bound for Phase 1's Xodus-only path on this DB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)