### PR TITLE
ci(release): support prerelease tags (vX.Y.Z-rc.N) that skip the tap bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,11 +3,16 @@ name: Release
 on:
   push:
     tags:
+      # Matches `vMAJOR.MINOR.PATCH` and `vMAJOR.MINOR.PATCH-SUFFIX` (prereleases).
+      # Stable tags trigger the full pipeline; prerelease tags (anything with a
+      # `-` in the version, e.g. `v8.4.8-rc.1`) publish artifacts as a
+      # GitHub "Pre-release" and *skip* the Homebrew tap auto-bump so
+      # `brew install siropkin/budi/budi` keeps pointing at the latest stable.
       - "v[0-9]*"
   workflow_dispatch:
     inputs:
       tag:
-        description: "Release tag to publish (example: v2.0.0)"
+        description: "Release tag to publish (example: v2.0.0 or v2.0.0-rc.1)"
         required: true
         type: string
 
@@ -18,6 +23,10 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.ref_name }}
+  # `true` for prerelease tags (vX.Y.Z-rc.N, vX.Y.Z-beta.N, …). Drives both
+  # the GitHub release's `prerelease` flag and the gate on the Homebrew tap
+  # update so users on `brew upgrade` never get pulled onto an rc.
+  IS_PRERELEASE: ${{ contains((github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.ref_name), '-') }}
 
 jobs:
   ci-check:
@@ -59,7 +68,14 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          # Strip the `vX.Y.Z` prefix; for prereleases (`vX.Y.Z-rc.N`) also
+          # strip the suffix so we only compare the semver base against
+          # Cargo.toml. The workspace stays pinned to the *target* stable
+          # version across an entire prerelease cycle — bump it once when
+          # cutting the first rc, then promote the same SHA to the stable
+          # tag at the end.
           expected_version="${RELEASE_TAG#v}"
+          expected_base="${expected_version%%-*}"
           actual_version="$(awk -F'\"' '/^version = \"[0-9]+\.[0-9]+\.[0-9]+\"$/ {print $2; exit}' Cargo.toml)"
           if [[ -z "${actual_version}" ]]; then
             echo "::error::Unable to read workspace version from Cargo.toml"
@@ -67,8 +83,10 @@ jobs:
           fi
           echo "release_tag=${RELEASE_TAG}"
           echo "workspace_version=${actual_version}"
-          if [[ "${actual_version}" != "${expected_version}" ]]; then
-            echo "::error::Tag ${RELEASE_TAG} does not match Cargo version ${actual_version}. Expected tag v${actual_version}."
+          echo "expected_base=${expected_base}"
+          echo "is_prerelease=${IS_PRERELEASE}"
+          if [[ "${actual_version}" != "${expected_base}" ]]; then
+            echo "::error::Tag ${RELEASE_TAG} (base ${expected_base}) does not match Cargo version ${actual_version}. Expected tag v${actual_version} or v${actual_version}-<suffix>."
             exit 1
           fi
 
@@ -222,6 +240,11 @@ jobs:
         with:
           tag_name: ${{ env.RELEASE_TAG }}
           generate_release_notes: true
+          # Tags containing a `-` (rc/beta/alpha suffix) publish as a
+          # GitHub "Pre-release" — they keep the "Latest" badge on the
+          # most recent stable tag and are excluded from the auto-update
+          # discovery path the CLI uses.
+          prerelease: ${{ env.IS_PRERELEASE == 'true' }}
           files: |
             dist/*.tar.gz
             dist/*.zip
@@ -231,6 +254,10 @@ jobs:
     name: Update Homebrew tap
     runs-on: ubuntu-latest
     needs: publish-release
+    # Prerelease tags don't bump the tap — `brew upgrade siropkin/budi/budi`
+    # users stay on the last stable. Promote an rc to a stable tag from the
+    # same SHA when it passes smoke and this job will fire then.
+    if: ${{ env.IS_PRERELEASE != 'true' }}
     steps:
       - name: Checkout budi repo
         uses: actions/checkout@v5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 8.4.8 — 2026-05-12
+
+8.4.8 is the second same-day hotfix on top of v8.4.6 / v8.4.7. The v8.4.7 fix combined the Xodus `projectName` extraction with Nitrite per-turn extraction, but the populated-entity probe still skipped session-dirs whose `.xd` carried only the `projectName` property (no `Xd*Session` marker) and whose Nitrite store used the older `copilot-edit-sessions-nitrite.db` filename — without the `chat-` prefix `NITRITE_DB_FILES` was looking for. Result: one of the three resolvable-on-disk JetBrains sessions (Verkada-Backend) stayed at `repo_id = NULL` even after the v8.4.7 dual-store fix. `api_version` stays at `3`.
+
+### Fixed
+
+- **JetBrains Copilot: recognize `copilot-edit-sessions-nitrite.db` (no `chat-` prefix)** (#766) — older plugin builds wrote the edit-session Nitrite store under the shorter filename. The post-release smoke test on v8.4.7 caught this when session `32REEy.../ic/chat-edit-sessions/` (Verkada-Backend) emitted zero rows even though its `.xd` carried `projectName=Verkada-Backend`. Added the legacy filename to `NITRITE_DB_FILES` so the populated-entity probe accepts it.
+
+### Cross-repo lockstep
+
+- No cross-repo changes required.
+
 ## 8.4.7 — 2026-05-12
 
 8.4.7 is a same-day hotfix for the v8.4.6 JetBrains parser. The 8.4.6 implementation treated the Xodus `.xd` log and the Nitrite `.db` store as mutually exclusive — the parser ran `extract_xodus_project_name` only when the populated-entity probe returned `.xd`, and `extract_nitrite_turn_ids` only when it returned a Nitrite file. Real dual-store session-dirs (the common shape post-migration) put `projectName` in `.xd` and `Nt*Turn` documents in `.nitrite.db`; the 8.4.6 code picked one and dropped the other, so every `surface=jetbrains` row landed with `repo_id = NULL` even when the .xd carried a clean `Verkada-Web`-style name. The post-release smoke test on a real DB caught this within minutes — 0 of 23 sessions populated `repo_id`. The parser now reads `00000000000.xd` and every `*.nitrite.db` in the session-dir independently and merges the results: per-turn UUIDs from Nitrite + `repo_id` / `git_branch` / `session_title` from Xodus land on the same `ParsedMessage`. `api_version` stays at `3`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,7 +175,7 @@ dependencies = [
 
 [[package]]
 name = "budi-cli"
-version = "8.4.7"
+version = "8.4.8"
 dependencies = [
  "anyhow",
  "budi-core",
@@ -195,7 +195,7 @@ dependencies = [
 
 [[package]]
 name = "budi-core"
-version = "8.4.7"
+version = "8.4.8"
 dependencies = [
  "anyhow",
  "chrono",
@@ -211,7 +211,7 @@ dependencies = [
 
 [[package]]
 name = "budi-daemon"
-version = "8.4.7"
+version = "8.4.8"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "8.4.7"
+version = "8.4.8"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"

--- a/SOUL.md
+++ b/SOUL.md
@@ -513,6 +513,15 @@ Key points:
 - `crates/budi-cli/src/commands/pricing.rs` — `budi pricing` / `budi pricing status` (read-only) + `budi pricing sync` (network refresh; mirrors `cloud sync`). Both accept `--format json`.
 <!-- budi-cursor and budi-cloud live in their own repos: siropkin/budi-cursor, siropkin/budi-cloud -->
 
+## Release flow
+
+Tags drive the entire pipeline; `Cargo.toml` is the source of truth for the workspace version.
+
+- **Stable releases**: tag `vX.Y.Z`. `.github/workflows/release.yml` builds tarballs for all five platforms, publishes a GitHub release with `prerelease: false`, and auto-bumps `siropkin/homebrew-budi/Formula/budi.rb`. `brew upgrade siropkin/budi/budi` picks the new version up within a few minutes.
+- **Prereleases (rc / beta)**: tag `vX.Y.Z-rc.N` (any tag with a `-` suffix counts). Same workflow, but the GitHub release is marked `prerelease: true` *and* the Homebrew tap bump is skipped — `brew upgrade` users stay on the last stable. Use this for "local smoke before promoting to public" loops: cut `v8.4.8-rc.1`, `-rc.2`, … from the same branch, swap the binary in by hand (`curl` the prerelease tarball and replace `/opt/homebrew/Cellar/budi/<stable>/bin/budi-daemon`), and only tag the clean `vX.Y.Z` once the candidate passes the real-DB smoke. `Cargo.toml` stays at the *target* stable (`X.Y.Z`) across the entire prerelease cycle — `verify_tag_version` strips the `-suffix` before comparing.
+- **One commit, two tags**: promoting an rc is a tag-only operation — re-tag the same SHA as `vX.Y.Z` and the workflow republishes with the stable-release gate (prerelease: false, tap bump on).
+- **Inspecting which tag did what**: every release-workflow run logs `is_prerelease=…` in the `verify_tag_version` step output. Cross-reference with `gh release view vX.Y.Z[-rc.N] --json prerelease,assets` to confirm the GitHub release was published with the right flag.
+
 ## Dev notes
 
 - **Before committing**, always run `cargo fmt --all` and `cargo clippy` to catch formatting and lint issues. CI enforces `cargo fmt --all -- --check` and will reject unformatted code.

--- a/crates/budi-core/src/providers/copilot_chat/jetbrains.rs
+++ b/crates/budi-core/src/providers/copilot_chat/jetbrains.rs
@@ -105,6 +105,13 @@ const NITRITE_DB_FILES: &[&str] = &[
     "copilot-chat-nitrite.db",
     "copilot-agent-sessions-nitrite.db",
     "copilot-chat-edit-sessions-nitrite.db",
+    // Older plugin builds write the edit-session store under a shorter
+    // name (no `chat-` prefix). Observed on real user DBs in v8.4.7's
+    // post-release smoke test where session dirs hold only
+    // `copilot-edit-sessions-nitrite.db` — without this entry the
+    // populated-entity probe skips them and the matching .xd's
+    // `projectName` never reaches the parser.
+    "copilot-edit-sessions-nitrite.db",
 ];
 
 /// Platform-specific roots that contain the per-IDE-slug session subtrees.


### PR DESCRIPTION
## Summary

Adds Option-A prerelease support to the release workflow:

- Stable \`vX.Y.Z\` tags: unchanged — publish GitHub release with \`prerelease: false\`, auto-bump \`siropkin/homebrew-budi/Formula/budi.rb\`.
- Prerelease tags \`vX.Y.Z-*\` (\`-rc.N\`, \`-beta.N\`, anything with a \`-\`): publish GitHub release with \`prerelease: true\` and **skip** the \`update-homebrew\` job. \`brew upgrade siropkin/budi/budi\` users stay on the last stable while maintainers swap the binary in by hand for smoke-testing.
- \`Cargo.toml\` stays at the target stable across an entire prerelease cycle — \`verify_tag_version\` strips the \`-suffix\` before comparing against the workspace version.

Documented in \`SOUL.md\` under a new "Release flow" section. Paired with a tap-side PR documenting the convention (link follows).

## Why

The post-release smoke test on v8.4.6 caught a real bug that needed v8.4.7, and v8.4.7 caught another that wanted v8.4.8 — burning two public versions for fixes that could have iterated as \`v8.4.8-rc.N\` against the same Cargo.toml without nudging \`brew upgrade\` users along for the ride.

## Test plan

- [ ] After merge, tag \`v8.4.8-rc.1\` from the #775 SHA. Verify:
  - Release workflow logs \`is_prerelease=true\`.
  - GH release page marks v8.4.8-rc.1 as "Pre-release" (latest badge stays on v8.4.7).
  - \`siropkin/homebrew-budi/Formula/budi.rb\` is **not** modified.
  - \`brew info siropkin/budi/budi\` still reports 8.4.7 as stable.
- [ ] Smoke-test the rc binary against the real DB; on pass, tag \`v8.4.8\` from the same SHA, verify the tap bumps and \`brew upgrade siropkin/budi/budi\` lands 8.4.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)