### PR TITLE
ci(release): inline prerelease check in job-level if (env context unavailable)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -257,7 +257,12 @@ jobs:
     # Prerelease tags don't bump the tap — `brew upgrade siropkin/budi/budi`
     # users stay on the last stable. Promote an rc to a stable tag from the
     # same SHA when it passes smoke and this job will fire then.
-    if: ${{ env.IS_PRERELEASE != 'true' }}
+    #
+    # NB: the `env:` context isn't available in job-level `if:` expressions
+    # (only `github.*`, `needs.*`, `inputs.*`, `vars.*`), so we recompute
+    # the same `contains(..., '-')` check inline rather than referencing
+    # `env.IS_PRERELEASE`.
+    if: ${{ !contains((github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.ref_name), '-') }}
     steps:
       - name: Checkout budi repo
         uses: actions/checkout@v5


### PR DESCRIPTION
## Summary

Same-session followup on #776. The \`update-homebrew\` job's \`if:\` referenced \`env.IS_PRERELEASE\`, but the \`env:\` context isn't available in job-level \`if:\` expressions — only \`github.*\`, \`needs.*\`, \`inputs.*\`, \`vars.*\` are.

Result: every tag push to v8.4.8-rc.1 (and any future tag) failed YAML validation with \`Unrecognized named-value: env\` and produced a 0-second failure run with no jobs scheduled.

Fix: inline the same \`contains(..., '-')\` expression we use to compute \`env.IS_PRERELEASE\`, so the job-level gate works under the \`github.*\` context. \`env.IS_PRERELEASE\` stays for step-level use (\`action-gh-release\`'s \`prerelease:\` input — step-level context where env is available).

## Test plan

- [ ] After merge, delete + re-push tag \`v8.4.8-rc.1\` and verify the workflow runs cleanly: build all 5 platforms, publish prerelease, skip the homebrew-tap update job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)