### PR TITLE
fix(doctor): document v1.1 cursor-sessions.json contract + surface field (#780)

### DIFF
--- a/crates/budi-cli/src/commands/doctor.rs
+++ b/crates/budi-cli/src/commands/doctor.rs
@@ -2784,6 +2784,29 @@ mod tests {
     }
 
     #[test]
+    fn merge_hint_extensions_accepts_v1_1_surface_field_for_vscode_host() {
+        // ADR-0086 §3.4 v1.1 schema (#780): the host-aware extension writes
+        // the same `cursor-sessions.json` regardless of host and tags the
+        // host via an optional `surface` field. The daemon-side loader is
+        // permissive — `surface` is purely informational on this path and
+        // must not interfere with `installed_extensions` merging.
+        let mut hints = HostExtensionHints::default();
+        let doc = serde_json::json!({
+            "active_session_id": "abc",
+            "updated_at": "2026-05-06T20:00:00Z",
+            "surface": "vscode",
+            "installed_extensions": {
+                "copilot_chat": ["github.copilot-chat"]
+            }
+        });
+        merge_hint_extensions(&mut hints, doc);
+        assert_eq!(
+            hints.extensions_for("copilot_chat"),
+            Some(&vec!["github.copilot-chat".to_string()])
+        );
+    }
+
+    #[test]
     fn read_session_hint_file_returns_none_for_missing_or_invalid() {
         // Missing file.
         assert!(

--- a/docs/adr/0086-extraction-boundaries.md
+++ b/docs/adr/0086-extraction-boundaries.md
@@ -155,9 +155,9 @@ Release workflow (`.github/workflows/release.yml`) also builds the extension bef
 #### 3.4 Session Tracking File
 
 **Current state:**
-- `~/.local/share/budi/cursor-sessions.json` is written by hook events (daemon side) and watched by the Cursor extension (file watch) to track the active session.
+- `~/.local/share/budi/cursor-sessions.json` is written by the host-aware extension and consumed by `budi` (the daemon reads it as an optional UX hints file in `doctor`, not as a workspace-resolution oracle). Workspace / repo / branch attribution is per-message and is set by the parsers at ingest time (`repo_id` is resolved by `crate::repo_id::resolve_repo_id`); the file is purely a UX signal layer.
 
-**Untangling impact:** This is a well-defined file contract. The daemon writes it; the extension reads it. No code sharing involved. The contract is:
+**Wire contract — v1:**
 
 ```json
 {
@@ -166,7 +166,31 @@ Release workflow (`.github/workflows/release.yml`) also builds the extension bef
 }
 ```
 
-This file format must be documented and stable before extraction. Changes to the format require a version bump.
+**Wire contract — v1.1 (2026-05-12, [#780](https://github.com/siropkin/budi/issues/780), companion to [siropkin/budi-cursor#64](https://github.com/siropkin/budi-cursor/issues/64)):**
+
+The same extension binary may run inside **Cursor** *or* **VS Code** when installed via the VS Code Marketplace / Open VSX. The host is determined by the extension at runtime (`vscode.env.appName`). To keep one canonical wire file for the host-aware extension, **the file path stays `cursor-sessions.json` regardless of host** and grows an optional `surface` field carrying the host id:
+
+```json
+{
+  "active_session_id": "uuid-string",
+  "updated_at": "ISO-8601",
+  "surface": "vscode",
+  "installed_extensions": {
+    "copilot_chat": ["github.copilot-chat"]
+  }
+}
+```
+
+Rules:
+
+1. **Filename stays `cursor-sessions.json`.** The name is a historical artifact; it does not imply the host. Decision rationale: option (A) of #780 ("keep one file, key on content") was picked over (B) "two filenames" because the daemon's per-message workspace resolver already keys on file *content* (`messages.surface`, `repo_id`, `git_branch` columns), not on this file's name. A second filename would have required no daemon work either way — but it would have forced two file watches in the extension and split the doctor permissive-merge logic for no gain.
+2. **`surface` is optional.** Allowed values: `cursor`, `vscode`. Unknown / missing values are treated as `cursor` for backward compatibility with budi-cursor 1.x writers. Future hosts add new values.
+3. **The daemon is permissive.** `budi doctor`'s loader (`read_session_hint_file` / `merge_hint_extensions` in `crates/budi-cli/src/commands/doctor.rs`) ignores any field it does not recognise. For backward compatibility a second filename `vscode-sessions.json` is *also* read at the same path; the contents of both are merged. This is a compatibility carve-out — the host-aware extension should write only `cursor-sessions.json` going forward.
+4. **No version bump needed.** The schema is purely additive — `surface` is optional, ignored when absent, and does not invalidate v1 writers. Both v1 and v1.1 documents coexist on the same path.
+
+**Acceptance signal:** `GET /analytics/statusline?surface=vscode` returns the per-VS-Code rollup based on the `messages.surface` column populated at ingest time (covered by tests in `crates/budi-core/src/analytics/tests.rs` for surface-filter scoping). The wire-contract file itself is consumed only for installed-extension hints in `budi doctor` — its `surface` field is informational, not load-bearing on the analytics path.
+
+This file format must be documented and stable before extraction. Future breaking changes (rename, removal of `active_session_id`, schema bump) require a version bump and an ADR amendment.
 
 #### 3.5 Config File Ownership
 

--- a/docs/adr/0088-8x-local-developer-first-product-contract.md
+++ b/docs/adr/0088-8x-local-developer-first-product-contract.md
@@ -130,6 +130,10 @@ Classification should improve through **simple, explainable, local-first methods
 - **Onboarding (#228):** Scope is strictly local: install / init / doctor / first-run success. The cross-surface local→cloud linking UX is **not** part of #228 — it is owned by #235 in R3. This split is intentional: keep R2 about "does Budi feel good on one machine?" and keep R3 about "does Budi feel good across machine and cloud?".
 - **Statusline (#224):** See §4. Default stays quiet, provider-scoped, `1d` / `7d` / `30d`.
 
+**`cursor-onboarding.json` (forward-looking, [#780](https://github.com/siropkin/budi/issues/780)):**
+
+The host-aware extension may emit a sibling `~/.local/share/budi/cursor-onboarding.json` containing local-counter state (e.g. install timestamps, first-run flags, per-host onboarding progress) that `budi doctor` reads to render a sharper onboarding check. Path naming mirrors the `cursor-sessions.json` story (ADR-0086 §3.4): the filename stays `cursor-onboarding.json` regardless of host; an optional `surface` field inside the JSON tags the host (`cursor` | `vscode` | future). Daemon-side readers stay permissive (silently ignore unknown fields) and treat absent `surface` as `cursor` for backward compatibility. No daemon reader exists yet — this is forward-looking; the contract is reserved here so the extension can land it without further ADR churn. A future ADR will pin the field list when the doctor check is implemented.
+
 ### 7. Surface alignment rules for R3 (amended for 8.4)
 
 **Host-scoped vs. provider-scoped surfaces.** Every user-visible surface in 8.x is one of:


### PR DESCRIPTION
## Summary

- Pins the wire contract for `~/.local/share/budi/cursor-sessions.json` v1.1 so the host-aware budi-cursor extension (siropkin/budi-cursor#64) can land cleanly without a daemon-side resolver change.
- Option (A) of #780: keep one filename, tag the host via an optional `surface` field inside the JSON (`cursor` | `vscode`), unknown values fall back to `cursor` for backward compatibility with 1.x writers.
- ADR-0086 §3.4 amended with the v1.1 schema, rules, and acceptance signal.
- ADR-0088 §6 reserves the `cursor-onboarding.json` mirror story (forward-looking — no daemon reader yet) so the extension can ship local-counter state without further ADR churn.
- New doctor test confirms the `surface` field is silently accepted alongside `installed_extensions` (the loader was already permissive — this locks the contract in code).

## Why no daemon resolver change

The daemon's per-message workspace/repo/branch attribution is set at parse time from the parser-resolved `repo_id` and recorded into the `messages.surface` / `messages.repo_id` / `messages.git_branch` columns. `cursor-sessions.json` is only consumed by `budi doctor` as a UX hints file (installed-extensions list), not as a workspace-resolution oracle. So option (A) is a pure documentation move plus a regression-locking test.

Acceptance signal `GET /analytics/statusline?surface=vscode` already returns correct per-VS-Code totals from the `messages.surface` column (covered by existing analytics tests at `crates/budi-core/src/analytics/tests.rs`).

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings`
- [x] `cargo test --workspace --lib` — 713 pass
- [x] New `merge_hint_extensions_accepts_v1_1_surface_field_for_vscode_host` test passes

## Companion

- siropkin/budi-cursor#64 — host-aware surface detection in the extension. This PR lands the daemon-side contract so the extension change can pick it up whenever it's ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)