### PR TITLE
fix(jetbrains): backfill sessions.title by re-running the parser (#779 followup)

### DIFF
--- a/crates/budi-core/src/analytics/sync.rs
+++ b/crates/budi-core/src/analytics/sync.rs
@@ -592,12 +592,16 @@ fn cleanup_legacy_auto_tags(conn: &mut Connection) -> usize {
 /// Sources:
 /// - Claude Code: first user prompt from the JSONL transcript file.
 /// - Cursor: composer name from state.vscdb `allComposers`.
-/// - Copilot Chat (`jetbrains`): most-frequent `session_title` tag across
-///   the session's messages. The parser already emits this tag for every
-///   row (#766 sets it to the resolved `projectName`; #757 falls back to
-///   the session-type label `chat` / `chat-agent` / `chat-edit` /
-///   `bg-agent`). Pure DB-side backfill — no file reads, no 30-day
-///   recency window, so historical sessions also get a title.
+/// - Copilot Chat (`jetbrains`): `ParsedMessage.session_title` from the
+///   JetBrains parser — re-derived by walking the session dirs on disk.
+///   The title is either the resolved IntelliJ `projectName` (#766 Phase
+///   1, #778 Phase 2) or the session-type fallback (`chat`, `chat-agent`,
+///   `chat-edit`, `bg-agent`). Runs across every historical row (no
+///   30-day recency cap) so the dashboard's historical sessions also
+///   light up. The parser's `session_title` field never reached the
+///   tags table on its own — the constant in `tag_keys.rs::SESSION_TITLE`
+///   exists but no enricher emits it — so the backfill re-runs the parser
+///   to derive the title from the source of truth (the session dirs).
 fn backfill_session_titles(conn: &mut Connection) -> usize {
     let rows: Vec<(String, String)> = {
         let mut stmt = match conn.prepare(
@@ -636,54 +640,31 @@ fn backfill_session_titles(conn: &mut Connection) -> usize {
         titles.extend(collect_cursor_titles(&cursor_ids));
     }
 
+    // #779: JetBrains Copilot title backfill. Always-on across every row
+    // that needs a title — no `started_at` window because the parser is
+    // cheap (one byte-scan per session dir) and historical jetbrains
+    // sessions remain visible in the dashboard. Gated by the
+    // `title IS NULL OR title = ''` predicate in the UPDATE below so
+    // idempotent calls are no-ops after the first pass.
+    let jetbrains_titles =
+        crate::providers::copilot_chat::jetbrains::collect_jetbrains_session_titles();
+
     let tx = match conn.transaction() {
         Ok(t) => t,
         Err(_) => return 0,
     };
     let mut count = 0usize;
-    for (sid, title) in &titles {
+    for (sid, title) in titles.iter().chain(jetbrains_titles.iter()) {
         if tx
             .execute(
                 "UPDATE sessions SET title = ?2 WHERE id = ?1 AND (title IS NULL OR title = '')",
                 rusqlite::params![sid, title],
             )
-            .is_ok()
+            .map(|n| n > 0)
+            .unwrap_or(false)
         {
             count += 1;
         }
-    }
-    // #779: JetBrains Copilot title backfill. Pure SQL — pulls the
-    // most-frequent `session_title` tag across the session's messages
-    // into `sessions.title`. Idempotent (the `title IS NULL OR title = ''`
-    // predicate becomes empty after the first pass). Runs across every
-    // historical jetbrains row, not just the last 30 days, because the
-    // dashboard renders historical sessions and the parser-emitted tag
-    // is already on every row.
-    if let Ok(updated) = tx.execute(
-        "UPDATE sessions
-            SET title = (
-                SELECT t.value FROM tags t
-                JOIN messages m ON m.id = t.message_id
-                WHERE m.session_id = sessions.id
-                  AND t.key = 'session_title'
-                  AND t.value <> ''
-                GROUP BY t.value
-                ORDER BY COUNT(*) DESC, t.value ASC
-                LIMIT 1
-            )
-          WHERE provider = 'copilot_chat'
-            AND surface = 'jetbrains'
-            AND (title IS NULL OR title = '')
-            AND EXISTS (
-                SELECT 1 FROM tags t2
-                JOIN messages m2 ON m2.id = t2.message_id
-                WHERE m2.session_id = sessions.id
-                  AND t2.key = 'session_title'
-                  AND t2.value <> ''
-            )",
-        [],
-    ) {
-        count += updated;
     }
     if tx.commit().is_err() {
         return 0;
@@ -1096,107 +1077,45 @@ mod tests {
         assert_eq!(count, 0, "should not backfill when session has no category");
     }
 
-    // #779: backfill `sessions.title` for `surface=jetbrains` rows from
-    // the parser-emitted `session_title` tag. The parser already writes
-    // this tag on every message (`projectName` when #766/#778 resolves
-    // one, falling back to `chat`/`chat-agent`/`chat-edit`/`bg-agent` per
-    // session type) — the gap was purely promotion to the column.
+    // #779: backfill `sessions.title` for `surface=jetbrains` rows by
+    // re-deriving the title from the JetBrains parser's `session_title`
+    // field via `collect_jetbrains_session_titles`. The parser emits
+    // either the resolved IntelliJ `projectName` (#766 Phase 1, #778
+    // Phase 2) or the session-type fallback (`chat`, `chat-agent`, etc.)
+    // — but it never reached the DB on its own (the `SESSION_TITLE`
+    // tag-keys constant exists but no enricher writes it). The backfill
+    // re-runs the parser to derive the title from the source of truth.
+    //
+    // This in-process unit test cannot stand up real JetBrains session
+    // dirs (the helper walks `~/.config/github-copilot/`), so the
+    // coverage here is limited to the no-op-on-already-titled guard.
+    // The end-to-end behaviour is verified by the smoke-test step of the
+    // release flow against a real DB on the smoke-test machine.
     #[test]
-    fn backfill_jetbrains_session_titles_promotes_most_frequent_tag() {
-        let mut conn = rusqlite::Connection::open_in_memory().expect("in-memory db");
-        crate::migration::migrate(&conn).expect("migrate");
-
-        // Three sessions: one resolved to `Verkada-Web`, one to the
-        // `chat-agent` fallback, one already has a title (must not change).
-        conn.execute_batch(
-            "INSERT INTO sessions (id, provider, surface, title) VALUES
-                ('s-resolved', 'copilot_chat', 'jetbrains', NULL),
-                ('s-fallback', 'copilot_chat', 'jetbrains', ''),
-                ('s-already',  'copilot_chat', 'jetbrains', 'do not touch');",
-        )
-        .expect("insert sessions");
-
-        // Per-turn rows for each session, all with `session_title` tags.
-        let assistant_row = |id: &str, sess: &str| {
-            format!(
-                "INSERT INTO messages
-                 (id, session_id, role, timestamp, model, provider,
-                  input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
-                  cost_cents_ingested, cost_cents_effective, cost_confidence, surface)
-                 VALUES
-                 ('{id}', '{sess}', 'assistant', datetime('now'), 'gpt-4o', 'copilot_chat',
-                  0, 0, 0, 0, 0.0, 0.0, 'estimated', 'jetbrains');"
-            )
-        };
-        conn.execute_batch(&format!(
-            "{}{}{}{}{}",
-            assistant_row("m-resolved-1", "s-resolved"),
-            assistant_row("m-resolved-2", "s-resolved"),
-            assistant_row("m-fallback-1", "s-fallback"),
-            assistant_row("m-already-1", "s-already"),
-            "INSERT INTO tags (message_id, key, value) VALUES
-                ('m-resolved-1', 'session_title', 'Verkada-Web'),
-                ('m-resolved-2', 'session_title', 'Verkada-Web'),
-                ('m-fallback-1', 'session_title', 'chat-agent'),
-                ('m-already-1',  'session_title', 'chat');"
-        ))
-        .expect("insert messages + tags");
-
-        let updated = backfill_session_titles(&mut conn);
-        assert!(
-            updated >= 2,
-            "expected at least the two empty-title rows to flip, got {updated}"
-        );
-
-        let title = |id: &str| -> Option<String> {
-            conn.query_row(
-                "SELECT title FROM sessions WHERE id = ?1",
-                rusqlite::params![id],
-                |r| r.get(0),
-            )
-            .ok()
-        };
-        assert_eq!(title("s-resolved").as_deref(), Some("Verkada-Web"));
-        assert_eq!(title("s-fallback").as_deref(), Some("chat-agent"));
-        // Pre-existing title is preserved — the WHERE predicate excludes it.
-        assert_eq!(title("s-already").as_deref(), Some("do not touch"));
-
-        // Idempotency: a second backfill pass updates nothing.
-        let second = backfill_session_titles(&mut conn);
-        assert_eq!(second, 0, "second pass should be a no-op");
-    }
-
-    /// A `surface=jetbrains` session whose messages carry no
-    /// `session_title` tag at all (theoretical — the parser always emits
-    /// one — but exercises the `EXISTS` guard) must not be set to NULL.
-    #[test]
-    fn backfill_jetbrains_session_titles_skips_sessions_without_tags() {
+    fn backfill_session_titles_preserves_existing_title() {
         let mut conn = rusqlite::Connection::open_in_memory().expect("in-memory db");
         crate::migration::migrate(&conn).expect("migrate");
 
         conn.execute(
-            "INSERT INTO sessions (id, provider, surface) VALUES ('s-empty', 'copilot_chat', 'jetbrains')",
+            "INSERT INTO sessions (id, provider, surface, title)
+                VALUES ('s-untouched', 'copilot_chat', 'jetbrains', 'do not touch')",
             [],
         )
         .expect("insert session");
-        conn.execute(
-            "INSERT INTO messages
-             (id, session_id, role, timestamp, model, provider,
-              input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
-              cost_cents_ingested, cost_cents_effective, cost_confidence, surface)
-             VALUES
-             ('m-empty', 's-empty', 'assistant', datetime('now'), 'gpt-4o', 'copilot_chat',
-              0, 0, 0, 0, 0.0, 0.0, 'estimated', 'jetbrains')",
-            [],
-        )
-        .expect("insert message without session_title tag");
 
         let _ = backfill_session_titles(&mut conn);
-        let title: Option<String> = conn
-            .query_row("SELECT title FROM sessions WHERE id = 's-empty'", [], |r| {
-                r.get(0)
-            })
-            .unwrap_or(None);
-        assert!(title.is_none(), "title should remain NULL");
+
+        let preserved: Option<String> = conn
+            .query_row(
+                "SELECT title FROM sessions WHERE id = 's-untouched'",
+                [],
+                |r| r.get(0),
+            )
+            .ok();
+        assert_eq!(
+            preserved.as_deref(),
+            Some("do not touch"),
+            "pre-existing title must be preserved by the WHERE predicate"
+        );
     }
 }

--- a/crates/budi-core/src/providers/copilot_chat.rs
+++ b/crates/budi-core/src/providers/copilot_chat.rs
@@ -22,7 +22,7 @@ use sha2::{Digest, Sha256};
 use crate::jsonl::ParsedMessage;
 use crate::provider::{DiscoveredFile, Provider};
 
-mod jetbrains;
+pub mod jetbrains;
 
 /// Canonical provider id. ADR-0093 §1: JetBrains is a host of the same
 /// Copilot Chat provider as VS Code — the `surface` dimension carries the

--- a/crates/budi-core/src/providers/copilot_chat/jetbrains.rs
+++ b/crates/budi-core/src/providers/copilot_chat/jetbrains.rs
@@ -912,6 +912,38 @@ fn deterministic_uuid(session_id: &str, path: &str) -> String {
     )
 }
 
+/// #779: walk every JetBrains-side session dir under the active config
+/// roots and return a `(session_id, title)` map suitable for backfilling
+/// `sessions.title`. The title is the parser's `ParsedMessage.session_title`
+/// — either the resolved IntelliJ `projectName` (Phase 1 #766 or Phase 2
+/// #778) or the session-type label fallback (`chat`, `chat-agent`,
+/// `chat-edit`, `bg-agent`). Cheap (one byte-scan per session dir);
+/// idempotent — callers should still gate on `title IS NULL OR title = ''`
+/// at write time so a manual-rename in the cloud isn't overwritten.
+///
+/// Returns an empty map when no JetBrains config root exists on this host.
+pub fn collect_jetbrains_session_titles() -> std::collections::HashMap<String, String> {
+    let session_dirs = discover_session_dirs(&jetbrains_config_roots());
+    let mut out = std::collections::HashMap::new();
+    for dir in session_dirs {
+        let Some(sid) = dir.file_name().and_then(|s| s.to_str()) else {
+            continue;
+        };
+        let parsed = parse_session_dir(&dir);
+        let Some(first) = parsed.into_iter().next() else {
+            continue;
+        };
+        let Some(title) = first.session_title else {
+            continue;
+        };
+        if title.is_empty() {
+            continue;
+        }
+        out.insert(sid.to_string(), title);
+    }
+    out
+}
+
 /// Discover JetBrains-side sessions, parse each, run the resulting messages
 /// through the pipeline, and ingest them. Side-effect path called from
 /// `CopilotChatProvider::sync_direct` so the JetBrains rows land in the


### PR DESCRIPTION
## Summary

v8.5.0-rc.1 smoke surfaced that the pure-SQL backfill that landed in #779 silently no-ops on real data. The original ticket assumed a \`session_title\` tag is emitted on every JetBrains message — but no enricher in the pipeline emits one. The parser sets \`ParsedMessage.session_title\`, the constant in \`tag_keys.rs::SESSION_TITLE\` exists, but the tag never reaches the DB.

## Fix

- Expose \`collect_jetbrains_session_titles()\` from the JetBrains parser module. It walks the session dirs and returns \`(session_id, title)\` for every session whose parser run produces a non-empty \`session_title\` (either the resolved IntelliJ \`projectName\` or the session-type fallback).
- The backfill calls this directly and writes to \`sessions.title\` for any row that matches the existing \`title IS NULL OR title = ''\` predicate.
- Removes the pure-SQL UPDATE that depended on the non-existent tag.
- Replaces the synthetic-tag-based unit tests with a simpler "pre-existing title is preserved" test; end-to-end behaviour is verified by the v8.5.0 smoke against the real DB.

## Test plan

- [x] \`cargo fmt --all\`
- [x] \`cargo clippy --workspace --all-targets --locked -- -D warnings\`
- [x] \`cargo test --workspace --lib\` — 727 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)