### PR TITLE
fix(autostart): respawn daemon on clean SIGTERM via KeepAlive=true (#790)

### DIFF
--- a/crates/budi-cli/src/daemon.rs
+++ b/crates/budi-cli/src/daemon.rs
@@ -266,10 +266,10 @@ fn launchctl_kickstart_target() -> String {
 /// #611: when a launchd LaunchAgent is registered, route the post-update
 /// restart through `launchctl kickstart -k gui/$UID/dev.getbudi.budi-daemon`
 /// so the fresh daemon is reparented to launchd. Without this, the macOS
-/// branch falls into the raw-spawn fallback and the LaunchAgent stays in
-/// `state = not running` after a clean exit (KeepAlive.SuccessfulExit=false),
-/// silently orphaning the supervisor and producing ingestion gaps until
-/// the next login. Sibling to `try_systemd_user_restart` for Linux (#582).
+/// branch falls into the raw-spawn fallback, orphaning the supervisor
+/// until launchd's KeepAlive eventually respawns the daemon (#790 made
+/// that respawn reliable for clean exits; this kickstart avoids the
+/// throttle wait). Sibling to `try_systemd_user_restart` for Linux (#582).
 #[cfg(target_os = "macos")]
 fn try_launchctl_kickstart() -> bool {
     if matches!(

--- a/crates/budi-core/src/autostart.rs
+++ b/crates/budi-core/src/autostart.rs
@@ -227,10 +227,7 @@ fn generate_launchd_plist(daemon_bin: &Path, host: &str, port: u16, log_path: &P
     <key>RunAtLoad</key>
     <true/>
     <key>KeepAlive</key>
-    <dict>
-        <key>SuccessfulExit</key>
-        <false/>
-    </dict>
+    <true/>
     <key>ThrottleInterval</key>
     <integer>10</integer>
     <key>StandardOutPath</key>
@@ -532,8 +529,13 @@ mod tests {
         assert!(plist.contains("<string>127.0.0.1</string>"));
         assert!(plist.contains("<string>7878</string>"));
         assert!(plist.contains("<key>RunAtLoad</key>"));
-        assert!(plist.contains("<key>KeepAlive</key>"));
+        // #790: KeepAlive must be plain <true/> so launchd respawns on ANY
+        // exit (including clean SIGTERM), not the SuccessfulExit=false dict
+        // form which only restarts on non-zero exits.
+        assert!(plist.contains("<key>KeepAlive</key>\n    <true/>"));
+        assert!(!plist.contains("<key>SuccessfulExit</key>"));
         assert!(plist.contains("<key>ThrottleInterval</key>"));
+        assert!(plist.contains("<integer>10</integer>"));
         assert!(plist.contains("<string>/Users/test/Library/Logs/budi-daemon.log</string>"));
     }
 


### PR DESCRIPTION
## Summary

Closes #790.

The shipped launchd plist used `KeepAlive.SuccessfulExit=false`, which restarts the daemon only on a non-zero exit. `budi-daemon` exits cleanly (code 0) on SIGTERM, sleep/wake, `brew upgrade`, and any panic it drains from — so any clean shutdown left the LaunchAgent in `state = not running` permanently. The CLI's empty-payload fallback then silently rendered `$0.00 1d · $0.00 7d · $0.00 30d` until next login.

Switch `KeepAlive` to plain `<true/>` so launchd respawns on any exit. `ThrottleInterval = 10` stays in place to bound a hard-crashing daemon. Existing installs pick up the new plist on `budi autostart install`, which already overwrites the file unconditionally before reloading.

## Changes

- `crates/budi-core/src/autostart.rs`: plist generator now emits `<key>KeepAlive</key><true/>`; assertion in `launchd_plist_contains_expected_fields` tightened to reject the old dict form.
- `crates/budi-cli/src/daemon.rs`: refreshed the post-update `launchctl kickstart` doc comment so it no longer cites the removed `SuccessfulExit=false` behavior.

## Test plan

- [x] `cargo test -p budi-core --lib autostart::` (4 passed)
- [x] `cargo build --workspace`
- [x] `cargo fmt --all -- --check`
- [ ] Manual repro on a real Mac: install, `pkill -TERM budi-daemon`, wait ~15s, confirm `curl http://127.0.0.1:7878/healthz` recovers (launchd respawns within ~10s of throttle interval).

## Out of scope (deferred to follow-up issues)

The bonus follow-ups in #790 — making `budi doctor`'s `daemon health` check fail loud when the supervisor reports running but the listener is unreachable, and changing the Claude statusline to render `budi --` on empty payloads — are intentionally not included here so this PR stays focused on the launchd plist regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)