### PR TITLE
ci: enforce cargo-machete + cargo-udeps on PRs (#808)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,11 @@ jobs:
           cargo install cargo-audit --quiet
           cargo audit
 
+      - name: Unused dependencies (cargo-machete)
+        run: |
+          cargo install cargo-machete --locked --quiet
+          cargo machete
+
       - name: Validate shell script syntax
         run: |
           set -euo pipefail
@@ -238,6 +243,30 @@ jobs:
 
       - name: Run cargo-deny
         run: cargo deny --all-features check
+
+  # Unused-dependency scan via `cargo udeps` (issue #808).
+  #
+  # Requires the nightly toolchain. Allowed to fail initially so nightly
+  # flakiness doesn't block PRs; the warning still shows up on the Checks
+  # tab. Promote to a required check once a few clean runs have landed.
+  udeps:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Install Rust nightly toolchain
+        uses: dtolnay/rust-toolchain@nightly
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+
+      - name: Install cargo-udeps
+        run: cargo install cargo-udeps --locked
+
+      - name: Run cargo-udeps
+        run: cargo +nightly udeps --workspace --all-targets
 
   ci-success:
     if: always()

--- a/README.md
+++ b/README.md
@@ -252,7 +252,25 @@ rm ~/.local/bin/budi ~/.local/bin/budi-daemon  # shell script install
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for local setup and PR workflow. Architecture and module boundaries are documented in [SOUL.md](SOUL.md). ADRs live in [`docs/adr/`](docs/adr/).
 
-Quick validation: `cargo fmt --all && cargo clippy --workspace --all-targets --locked -- -D warnings && cargo test --workspace --locked`
+### Running CI checks locally
+
+The six checks CI runs on every PR (issue #808):
+
+```bash
+cargo fmt --all -- --check                                       # formatting
+cargo clippy --workspace --all-targets --locked -- -D warnings   # lints
+cargo test --workspace --locked                                  # tests
+cargo +nightly udeps --workspace --all-targets                   # unused deps (needs nightly)
+cargo machete                                                    # unused deps (secondary pass)
+cargo deny --all-features check                                  # supply-chain policy
+```
+
+One-time install of the supporting tools:
+
+```bash
+rustup toolchain install nightly                # for cargo-udeps
+cargo install cargo-udeps cargo-machete cargo-deny --locked
+```
 
 ## License
 


### PR DESCRIPTION
Closes #808.

## Summary

- Adds `cargo machete` to the existing `rust-checks` job as a required check (cheap, stable, no nightly toolchain).
- Adds a new `udeps` job on the nightly toolchain with `continue-on-error: true` — visible on the Checks tab but non-blocking while we feel out nightly flakiness, per the issue spec ("allowed-to-fail initially if nightly flakiness is a worry, but the warning has to be visible"). Promote to required after a few clean runs.
- README gains a "Running CI checks locally" snippet listing all six required-or-visible checks (fmt, clippy, test, udeps, machete, deny) plus the one-time tool-install command.

## Six checks per #808 acceptance

| # | Check | Where | Status |
|---|-------|-------|--------|
| 1 | `cargo fmt --all -- --check` | `rust-checks` | required (existing) |
| 2 | `cargo clippy --workspace --all-targets -- -D warnings` | `rust-checks` + `macos-build` | required (existing) |
| 3 | `cargo +nightly udeps --workspace` | new `udeps` job | visible, non-blocking (new) |
| 4 | `cargo machete` | `rust-checks` | required (new) |
| 5 | `cargo test --workspace` | `rust-checks` + `macos-build` + `windows-build` | required (existing) |
| 6 | `cargo deny check` | `supply-chain` | non-blocking (existing, promotion tracked by #409) |

## Test plan

- [ ] CI green on this PR.
- [ ] `cargo machete` step passes (verified locally: "didn't find any unused dependencies").
- [ ] `udeps` job runs and surfaces output on the Checks tab even if it reports findings (must not block).
- [ ] README snippet renders correctly on GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)