### PR TITLE
docs(adr-0093): retire-with #789 annotations on JetBrains Phase 1/2 byte-walkers

### DIFF
--- a/crates/budi-core/src/providers/copilot_chat/jetbrains.rs
+++ b/crates/budi-core/src/providers/copilot_chat/jetbrains.rs
@@ -278,7 +278,11 @@ pub(super) fn parse_session_dir(session_dir: &Path) -> Vec<ParsedMessage> {
 
     // #766: pull the IntelliJ project name + resolved repo/branch from
     // the Xodus log regardless of which store the populated-entity probe
-    // picked. Dual-store sessions on disk write `XdChatSession.projectName`
+    // picked. retire-with: #789 — this Phase 1 byte-walker block goes
+    // away when the Phase 3 MVStore/Xodus decoder lands. See #807,
+    // ADR-0093 §"Amendment 2026-05-14".
+    //
+    // Dual-store sessions on disk write `XdChatSession.projectName`
     // into `00000000000.xd` *and* `Nt*Turn` documents into the matching
     // `*.nitrite.db` — the two stores are complementary, not alternative
     // shapes of the same data. The original 8.4.6 implementation treated
@@ -298,7 +302,12 @@ pub(super) fn parse_session_dir(session_dir: &Path) -> Vec<ParsedMessage> {
     };
 
     // #778: Phase 2 fallback for agent-only Nitrite sessions whose `.xd` log
-    // is absent or carries no `projectName`. Sweeps every Nitrite store in
+    // is absent or carries no `projectName`. retire-with: #789 — Phase 2
+    // resolved 0 additional sessions on real data; the Phase 3 MVStore
+    // decoder is expected to subsume this entire block. See #807,
+    // ADR-0093 §"Amendment 2026-05-14".
+    //
+    // Sweeps every Nitrite store in
     // the session dir for `file://` URIs (today written into the
     // `currentFileUri` JSON blob inside `NtAgentTurn.stringContent` by
     // recent Copilot Chat plugin builds), computes their longest common
@@ -429,6 +438,12 @@ pub(super) fn parse_session_dir(session_dir: &Path) -> Vec<ParsedMessage> {
 
 /// #766: pull the JetBrains project name out of the Xodus log's
 /// `XdChatSession.projectName` property by byte-scanning.
+///
+/// retire-with: #789 — this byte-walker is a low-cost fast-path that
+/// resolved 3 of 23 sessions on the 8.4.8 smoke-test machine. It survives
+/// only until the Phase 3 MVStore + Java-serialization decoder lands and
+/// proves it can subsume the heuristic. Disposition decision recorded in
+/// #807 and ADR-0093 §"Amendment 2026-05-14".
 ///
 /// The Xodus log writes a schema header near the start of the file that
 /// declares each property name once with a 1-byte property ID
@@ -701,6 +716,13 @@ const NITRITE_TURN_MARKERS: &[&[u8]] = &[b"NtTurn", b"NtAgentTurn", b"NtEditTurn
 /// #778: Phase 2 workspace-path extractor for the JetBrains Copilot Nitrite
 /// store.
 ///
+/// retire-with: #789 — Phase 2 added zero additional resolutions on the
+/// 8.4.8 smoke-test machine (95 of 98 surveyed Nitrite DBs carried no
+/// `file://` token at all). It is kept here only to avoid a regression-
+/// risking delete in a pre-Phase-3 release; the Phase 3 MVStore decoder
+/// is expected to subsume this path entirely. Disposition decision
+/// recorded in #807 and ADR-0093 §"Amendment 2026-05-14".
+///
 /// The original Phase 1 ticket assumed `NtAgentWorkingSetItem` documents
 /// would carry literal `file://...` URIs in a top-level `stringContent`
 /// TC_STRING. A survey of 98 real Nitrite DBs from the 8.4.8 smoke-test
@@ -840,6 +862,10 @@ struct Phase2WorkspaceResolution {
 /// Always returns a [`Phase2WorkspaceResolution`]: when resolution fails,
 /// the struct still carries the recovered `common_prefix` (when one
 /// existed) and a `failure_reason` for the caller to log. See #788.
+///
+/// retire-with: #789 — companion to `extract_nitrite_workspace_paths`;
+/// retires alongside the Phase 2 byte-walker once the Phase 3 decoder
+/// can supply richer per-turn workspace evidence.
 fn resolve_phase2_workspace(paths: &[String]) -> Phase2WorkspaceResolution {
     if paths.is_empty() {
         return Phase2WorkspaceResolution {

--- a/docs/adr/0093-copilot-chat-jetbrains-storage-shape.md
+++ b/docs/adr/0093-copilot-chat-jetbrains-storage-shape.md
@@ -184,3 +184,43 @@ The Phase 2 byte-walker only fires on sessions that happen to carry a `currentFi
 The #778 ticket asked for "≥ 12 of 23" sessions resolved post-Phase-2. The honest delivered bar against this data shape is **+1 session** beyond Phase 1 — the one additional agent session that happens to carry a `currentFileUri` snapshot for a repo not already covered by Phase 1. The data simply does not contain enough `file://` tokens to reach the speculative bar. Sessions that do not write a `currentFileUri` cleanly fall through to the Phase 1 `projectName` heuristic (where present) or remain with `repo_id = NULL` (the honest "we don't know" signal — the dashboard renders `Repo: (unknown)` rather than guessing).
 
 Fixture: `crates/budi-core/src/providers/copilot_chat/fixtures/jetbrains_nitrite_working_set_phase2/` (size-preserving redacted from a real session, see the matching `.shape.md`).
+
+## Amendment 2026-05-14 — #807: Phase 1 / Phase 2 byte-walker disposition
+
+The 8.5.2 polish release (umbrella #798) prompted a keep-vs-retire decision for the two byte-walker phases shipped in v8.4.x / v8.5.0, ahead of the Phase 3 MVStore + Java-serialization decoder planned for 8.6.0 (#789).
+
+The data the decision rests on (from the 8.4.8 smoke-test machine):
+
+- **Phase 1** (PR #766, Xodus `XdChatSession.projectName` byte-scan): resolved 3 of 23 `surface=jetbrains` sessions.
+- **Phase 2** (PR #778, Nitrite `currentFileUri` JSON-blob byte-scan): resolved 0 *additional* sessions over Phase 1 in the production capture (the §"Amendment 2026-05-12" "+1 session" figure was the honest hypothetical against the data shape — it was not observed end-to-end in the post-#778 smoke run).
+
+### Decision
+
+Both byte-walkers are **retired conditionally** — kept in tree, but every entry-point function, struct, and call-site block carries a `retire-with: #789` annotation so the Phase 3 implementor knows exactly what gets deleted when the real decoder lands. Rationale per phase:
+
+- **Phase 1**: real value (3-of-23) as a low-cost fast-path. Even after Phase 3 ships, it may remain useful if the decoder is heavier than the heuristic on cold caches; the call is deferred to whoever lands #789. Until then, do not delete.
+- **Phase 2**: marginal-to-zero value, but deleting it now without re-running the original smoke capture risks an unmeasured regression on the +1 hypothetical session (or on any future plugin version whose default-on `currentFileUri` snapshot shape we haven't seen yet). The Phase 3 decoder will subsume it; deletion belongs in that PR, not this one.
+
+### What the annotation contract is
+
+A `retire-with: #789` comment promises:
+
+1. The annotated function/block is **eligible** for deletion in the PR that closes #789.
+2. The Phase 3 implementor is **not obligated** to delete it — they may keep it as a fast-path if it earns its keep against the decoded baseline. The "retire-with" is a permission to delete, not a mandate.
+3. Removing an annotation without deleting the code requires a fresh ADR amendment explaining why the heuristic graduated from "retire-with" to "permanent".
+
+### Annotated surfaces (Phase 1)
+
+- `extract_xodus_project_name` (function-level rustdoc)
+- the `xd_candidate` block inside `parse_session_dir`
+
+### Annotated surfaces (Phase 2)
+
+- `extract_nitrite_workspace_paths` (function-level rustdoc)
+- `resolve_phase2_workspace` (function-level rustdoc — companion resolver)
+- the `phase2` block inside `parse_session_dir`
+
+### What this amendment does not promise
+
+- No smoke-test re-run was performed for this release. The resolution numbers are quoted from the 8.4.8 and #778 captures, not freshly measured against 8.5.1. Re-measurement happens as part of the Phase 3 PR, against the same fixture set, so the decoder's delta over the heuristics is honestly comparable.
+- Phase 1 and Phase 2 are not "frozen": small fixes (e.g. new path-safe terminator bytes, fixture additions) remain in scope. The retire-with annotation marks the *block*, not the *behavior* — bug-fixes inside an annotated block do not need a fresh ADR amendment.


### PR DESCRIPTION
Closes #807. Part of #798 (8.5.2 polish release).

## Decision

Both JetBrains byte-walkers shipped in v8.4.x / v8.5.0 are **retired conditionally** — kept in tree with `retire-with: #789` annotations on every entry-point function, struct, and call-site block so the Phase 3 MVStore + Java-serialization decoder (#789) can sweep them cleanly.

| Phase | PR    | Real-world value (8.4.8 smoke test)               | Disposition                  |
|-------|-------|---------------------------------------------------|------------------------------|
| 1     | #766  | 3 of 23 sessions resolved via Xodus `projectName` | `retire-with: #789`          |
| 2     | #778  | 0 additional sessions on production capture       | `retire-with: #789`          |

### Why not "retire now"

The issue's acceptance criteria for "retire now" required a smoke-test re-run against the original 23-session capture. That capture is not reproducible in this PR, so a delete here would be unmeasured. Phase 3 lands in 8.6.0 and is the right place to remove the heuristics — it will re-measure resolution numbers against the same fixture set, making the decoder's delta over the heuristics honestly comparable.

### Annotation contract (per the ADR amendment)

`retire-with: #789` means:
1. The block is **eligible** for deletion in the PR that closes #789.
2. The Phase 3 implementor is **not obligated** to delete — they may keep a heuristic as a fast-path if it earns its keep against the decoded baseline.
3. Graduating from "retire-with" to "permanent" requires a fresh ADR amendment.

## Changes

- `crates/budi-core/src/providers/copilot_chat/jetbrains.rs` — annotations at `extract_xodus_project_name`, `extract_nitrite_workspace_paths`, `resolve_phase2_workspace`, and the matching call-site blocks in `parse_session_dir`.
- `docs/adr/0093-copilot-chat-jetbrains-storage-shape.md` — new `Amendment 2026-05-14 — #807` section codifying the disposition + annotation contract.

## Test plan

- [x] `cargo fmt --all` clean.
- [x] `cargo test -p budi-core --lib providers::copilot_chat::jetbrains` — 42 passed, 0 failed (no behavior changes).
- [ ] Phase 3 implementor (when #789 lands) sweeps annotated blocks in the same PR or explicitly graduates them via ADR-0093 amendment.

## Non-goals

- No behavior changes. Pure documentation + code-comment annotations.
- No smoke-test re-run — deferred to the Phase 3 PR where numbers are honestly comparable against the decoded baseline.
- The Phase 3 decoder itself remains scoped to #789 / 8.6.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)