### PR TITLE
docs(review/8.5.2): provider module review pass (#799)

### DIFF
--- a/docs/review/8.5.2/README.md
+++ b/docs/review/8.5.2/README.md
@@ -1,0 +1,73 @@
+# 8.5.2 provider review pass
+
+Tracking: [#799](https://github.com/siropkin/budi/issues/799) (part of [#798](https://github.com/siropkin/budi/issues/798))
+
+Per-provider review notes for the 8.5.2 polish release:
+
+- [claude_code](./claude_code.md) — 140 LOC; reference shape.
+- [codex](./codex.md) — 528 LOC; contract-drift guardrails missing.
+- [copilot](./copilot.md) — 558 LOC; `copilot_cli` provider id; redundant `Option` on yaml parser.
+- [copilot_chat](./copilot_chat.md) — 4,335 LOC (incl. JetBrains submodule); best ADR discipline.
+- [cursor](./cursor.md) — 3,128 LOC; three ingestion paths; best operator-diagnostics surface.
+- [jetbrains_ai_assistant](./jetbrains_ai_assistant.md) — 524 LOC; no workspace attribution.
+
+## Top 3 takeaways across all providers
+
+1. **Five hand-rolled `deterministic_uuid` formatters.**
+   Every provider has its own SHA-256-to-UUID-shape helper with subtly
+   different namespacing and only cursor sets the RFC 4122 v4/variant
+   bits. Cost: ~80 LOC duplication, inconsistent UUID shape across the
+   tree. Fix: a shared `crate::util::uuid::deterministic_from(domain,
+   &[bytes])` helper that always emits RFC 4122 v4. Tracking: #800.
+2. **Contract-drift discipline is uneven.** `copilot_chat` is the
+   model — pinned to ADR-0092, `MIN_API_VERSION` bumps in lockstep,
+   `log_unknown_shape_once` with a `(path, shape_signature)` dedup,
+   real-world fixtures committed per version. The other four providers
+   (`codex`, `copilot_cli`, `cursor`'s bubble shape, `jetbrains_ai_assistant`)
+   each tail an undocumented upstream **with no ADR pin, no version
+   constant, and no unknown-shape warn**. A silent upstream rename will
+   emit zero rows and no signal until users complain. Fix: the
+   copilot_chat pattern is reusable; apply it to each remaining
+   provider, ideally one ADR per surface (ADR-0090 is precedent for
+   Cursor; codex / copilot_cli / jetbrains_ai_assistant want siblings).
+   Track as 8.6.x prep, not 8.5.2 scope.
+3. **`ParsedMessage` struct-literal duplication is the biggest
+   cleanup target.** `ParsedMessage { … 27 fields … }` literals appear
+   13 times across the providers/, with most fields holding the same
+   uniform defaults (`tool_*: Vec::new()`, `parent_uuid: None`,
+   `pricing_source: None`, `cost_confidence: "estimated"`). Combined
+   with magic-string `cost_confidence` values (`"estimated"`, `"exact"`,
+   `"n/a"`, `""`), this is ~600 LOC of duplication. Fix:
+   `ParsedMessage::for_provider(id)` constructor that pre-fills defaults
+   + a `CostConfidence` enum on the field. Tracking: #800.
+
+## Cross-cutting follow-up bundle (target: #800 "split mega-modules")
+
+- Shared `deterministic_uuid` (#800 / new ticket).
+- Shared `for_each_complete_line` line-walker (#800).
+- `CostConfidence` enum on `ParsedMessage` (#800).
+- `ParsedMessage::for_provider(id)` constructor (#800).
+- Shared `percent_decode` helper (copilot_chat + jetbrains.rs both
+  carry one).
+- Single `read_git_head_branch` in `crate::repo_id` (cursor.rs and
+  copilot_chat/jetbrains.rs both have one).
+
+## 8.5.2-scoped fixes
+
+Nothing in this review **requires** a behavior change inside the 8.5.2
+window. Each provider is correct on today's upstream shapes. The
+follow-ups above are deliberately punted to 8.6.x or to the other
+8.5.2 tickets (#800 code-organization, #804 coverage, #805 test
+organization). One small candidate — `copilot.rs::parse_workspace_yaml`
+returning `Some(default)` when nothing parses — is a near-trivial fix
+that could ride into 8.5.2 with the rest of #799's followups; left as
+optional.
+
+## Scope explicitly out
+
+- Refactors > 200 LOC per provider — each becomes its own ticket.
+- Behavior changes affecting the data contract — each needs an ADR
+  amendment.
+- The `retire-with: #789` byte-walkers in `copilot_chat/jetbrains.rs` —
+  disposition already decided in ADR-0093 §"Amendment 2026-05-14"
+  (#807), kept in tree for 8.5.x.

--- a/docs/review/8.5.2/claude_code.md
+++ b/docs/review/8.5.2/claude_code.md
@@ -1,0 +1,60 @@
+# `claude_code` provider — 8.5.2 review pass
+
+- **Module**: `crates/budi-core/src/providers/claude_code.rs` (140 LOC, no submodules)
+- **Tracking**: #799
+- **ADRs**: [0089](../../adr/0089-reverse-proxy-first-jsonl-tailing-as-sole-live-path.md)
+
+## Shape
+
+The smallest provider in the tree. The `Provider` trait impl is a thin
+delegation: `parse_file` calls `jsonl::parse_transcript`, `discover_files`
+walks `~/.claude/projects/**/*.jsonl`, `watch_roots` returns the same
+projects directory.
+
+This is the reference shape ADR-0089 anticipates for any agent whose
+transcript format the central `jsonl` module already understands.
+
+## Adherence to ADRs
+
+- **ADR-0089 §1**: ✓ — `discover_files`, `parse_file`, `watch_roots` all
+  implemented. No `sync_direct` override (correct — Claude Code has no
+  Usage API equivalent).
+- **ADR-0089 §6** (daemon outage safety): ✓ — pure file-tail path.
+
+## Observations
+
+### Minor
+
+- `discover_jsonl_files` is `pub(crate)` but the only caller is this
+  module's own `discover_files` (`rg -n 'discover_jsonl_files'` confirms a
+  single external-to-this-fn call). Could be private (`fn` without the
+  `pub(crate)` modifier). Net cleanup: one keyword.
+- `collect_jsonl_recursive` caps recursion at `depth > 4` with no comment
+  explaining why `4` (codex caps at `5`, copilot_chat at `8`). Either
+  add a one-line rationale or factor a shared cap constant.
+- The two unit tests build directories under `std::env::temp_dir()` with
+  best-effort cleanup. Standard Rust convention prefers `tempfile::TempDir`
+  so a panic mid-test still cleans up. This is a small papercut, not a
+  bug — the same pattern is used across the other providers, so a
+  separate "providers: tempdir hygiene" pass would address them all at
+  once rather than one-off here.
+
+### No issues found
+
+- No tracing-noise concerns (the file emits no `tracing::*` calls — work
+  delegated to `jsonl`).
+- No magic numbers in the parser path itself (parsing lives in `jsonl`).
+- No public API leakage — `ClaudeCodeProvider` is the only `pub` symbol.
+- Module doc-comment is accurate and current.
+
+## Concrete follow-up
+
+- **Drop `pub(crate)` on `discover_jsonl_files`** — net one-line cleanup,
+  belongs in #800 (code organization) or as a tiny standalone PR.
+- **Justify or extract the depth cap** — same pattern recurs in codex
+  and copilot_chat; track in #800.
+- **Move tempdir-based tests to `tempfile::TempDir`** — provider-wide;
+  belongs in #805 (test organization).
+
+No 8.5.2-scoped fixes required. The provider is healthy and the right
+shape for the reference pattern.

--- a/docs/review/8.5.2/codex.md
+++ b/docs/review/8.5.2/codex.md
@@ -1,0 +1,100 @@
+# `codex` provider — 8.5.2 review pass
+
+- **Module**: `crates/budi-core/src/providers/codex.rs` (528 LOC, single file)
+- **Tracking**: #799
+- **ADRs**: [0089](../../adr/0089-reverse-proxy-first-jsonl-tailing-as-sole-live-path.md)
+
+## Shape
+
+Tails OpenAI Codex Desktop + Codex CLI transcripts at
+`~/.codex/sessions/` and `~/.codex/archived_sessions/`. Per-line walker
+keys off `session_meta` (cwd / git_branch / session_id), `turn_context`
+(model), and `event_msg.payload.type == "token_count"` (usage rollup).
+
+Self-contained — no shared transcript-walker with the other providers.
+
+## Adherence to ADRs
+
+- **ADR-0089 §1**: ✓ — both root directories declared as watch roots;
+  parse path is file-only.
+- **ADR-0089 §4** (attribution from transcript): ✓ — cwd and git_branch
+  pulled out of `session_meta` rather than headers.
+- No provider-specific ADR. The `session_meta` / `turn_context` /
+  `event_msg.token_count` envelope **is** an undocumented contract owned
+  by OpenAI Codex; no pin against drift today. See "Contract-drift
+  discipline" below.
+
+## Observations
+
+### Worth fixing (defer follow-up tickets)
+
+1. **No fixture and no `MIN_API_VERSION`.** Unlike copilot_chat
+   (ADR-0092 §2.6), Codex has no monotonic version constant that surfaces
+   in `budi doctor` when the parser shape needs review. A silent change
+   to Codex's `last_token_usage` shape would just produce zero rows. Two
+   options: (a) commit a real-world capture under
+   `src/providers/codex/fixtures/` plus a tiny `MIN_API_VERSION`, or
+   (b) add a `codex_unknown_record_shape` warn-once analogous to
+   `log_unknown_shape_once` in copilot_chat.rs:2108. Either is cheap.
+   Punt to 8.6.x: file follow-up.
+2. **Surface attribution is hardcoded to `TERMINAL`** (codex.rs:314).
+   The module doc-comment says "covers both Codex Desktop and Codex
+   CLI" — Codex Desktop is an Electron app, not a terminal session.
+   The current attribution is wrong for the Desktop arm. Two fixes:
+   tighten the doc-comment (CLI-only) or distinguish at parse time
+   (e.g. by directory name — `~/.codex/sessions/` is CLI, the Desktop
+   arm writes elsewhere). Worth a separate ticket because it changes a
+   surface tag.
+3. **`role: "assistant"` hardcoded on every emitted row** (codex.rs:286).
+   Token-count events are *summary* rows, not assistant turns. The same
+   pattern lands in copilot_cli and jetbrains_ai_assistant — it's
+   consistent across the lightweight providers — but it conflates "this
+   turn finished with these tokens" with "the assistant said something".
+   Worth thinking about a `summary` role at the provider trait level
+   in 8.6.x. Out of scope for 8.5.2.
+
+### Minor
+
+- `deterministic_uuid` (codex.rs:124-141) hand-rolls a UUID-shape string
+  out of SHA-256 bytes. This duplicates verbatim into copilot.rs:134-149,
+  with a longer-prefixed variant in copilot_chat.rs:1329 / .rs:2078,
+  another shape in jetbrains.rs:986 / .rs:1006, and a more
+  RFC-4122-compliant version in cursor.rs:952. **Five hand-rolled
+  UUID-shape formatters in the providers/ tree.** Worth a shared
+  `crate::uuid::deterministic_from(domain, &[bytes])` helper. Tracking
+  in #800.
+- `collect_jsonl_recursive` (codex.rs:106) caps depth at `> 5`; claude_code
+  uses `4`, copilot_chat uses `8`. No rationale per cap. See claude_code
+  review.
+- The per-line walker pattern (codex.rs:170-218 — `pos`/`offset` byte
+  accounting + `for line in remaining.lines()`) is duplicated almost
+  verbatim into copilot.rs:209-264, jetbrains_ai_assistant.rs:187-227,
+  and cursor.rs:2257-2269. Single shared `for_each_complete_line(content,
+  start_offset, |line, offset| { ... })` would deduplicate ~40 LOC ×
+  four sites. Tracking in #800.
+- `cost_confidence: "estimated"` is a magic string (codex.rs:300). Same
+  string ("estimated" / "exact" / "n/a" / `""` empty) is scattered across
+  every provider. A `CostConfidence` enum with a `Display` impl belongs
+  on `ParsedMessage` itself; tracking in #800.
+- `ParsedMessage { … 27 fields … }` struct-literal (codex.rs:281-315) is
+  another sweep candidate — see the copilot review.
+
+### No issues found
+
+- ADR-0089 watch_roots semantics correct (both `sessions/` and
+  `archived_sessions/` returned when present, missing roots filtered).
+- Test coverage is broad: token-count happy path, null-info skip,
+  zero-tokens skip, incremental offset, watch_roots variants. Good baseline.
+- No `tracing::warn!` spam.
+
+## Concrete follow-up
+
+- **Fixture + `MIN_API_VERSION` for Codex** — paired with the
+  unknown-shape warn-once. Track via 8.5.2 successor (8.6.x).
+- **Decide Desktop vs CLI surface** — small ticket, paired ADR
+  amendment-free since this provider isn't pinned to an ADR yet.
+- **De-dup `deterministic_uuid` / `for_each_complete_line` /
+  `CostConfidence` magic strings** — bundle into #800.
+
+No 8.5.2-scoped behavior change required. The provider works correctly
+on today's Codex format; the gaps are forward-looking guardrails.

--- a/docs/review/8.5.2/copilot.md
+++ b/docs/review/8.5.2/copilot.md
@@ -1,0 +1,84 @@
+# `copilot_cli` provider — 8.5.2 review pass
+
+- **Module**: `crates/budi-core/src/providers/copilot.rs` (558 LOC, single file)
+- **Tracking**: #799
+- **ADRs**: [0089](../../adr/0089-reverse-proxy-first-jsonl-tailing-as-sole-live-path.md)
+- **Note**: `provider_id = "copilot_cli"`, distinct from the
+  VS Code-family `copilot_chat` provider (ADR-0092 §1).
+
+## Shape
+
+Tails the standalone GitHub Copilot CLI's `~/.copilot/session-state/<sid>/
+events.jsonl`. Per-line walker matches on `assistant.turn_start` (model
+hint) and `assistant.usage` (token rollup). Workspace metadata
+(`cwd`, `git_branch`) is pulled out of a sibling `workspace.yaml` via a
+hand-rolled mini-parser.
+
+`COPILOT_HOME` env override is supported (well-placed for tests and
+operator overrides).
+
+## Adherence to ADRs
+
+- **ADR-0089 §1**: ✓ — `watch_roots` returns `~/.copilot/session-state/`
+  (recursive watcher picks up new `<sid>/events.jsonl` automatically).
+- **ADR-0089 §4** (attribution from transcript): ✓ — cwd and git_branch
+  flow from the on-disk YAML, not from headers.
+
+## Observations
+
+### Worth fixing
+
+1. **`parse_workspace_yaml` always returns `Some(WorkspaceMetadata)`**
+   (copilot.rs:164-184) — even when no fields matched. The `Option`
+   wrapper is a redundant API; either return `WorkspaceMetadata` (always
+   meaningful — default = `cwd: None, git_branch: None`), or actually
+   return `None` when nothing was parsed. Small leak, easy fix.
+2. **No fixture / `MIN_API_VERSION` / unknown-shape warn-once.** Same
+   gap as the Codex review — the `assistant.usage` and
+   `assistant.turn_start` shapes are an undocumented GitHub contract.
+   `parse_usage_event` (copilot.rs:269) already defensively reads either
+   `data.input_tokens` or `data.usage.input_tokens` — that fallback is a
+   contract-drift accommodation that *should* be pinned in an ADR. Punt
+   to 8.6.x: file follow-up.
+3. **`COPILOT_HOME` env override not user-documented.** Only the module
+   doc-comment mentions it. If we want users to discover it, surface in
+   `SOUL.md` or `--help`. If we don't, the doc-comment is fine.
+
+### Minor
+
+- `deterministic_uuid` (copilot.rs:134) is identical to codex.rs:124 —
+  cut and paste. See "Cross-cutting findings" in `claude_code.md` /
+  codex review for the shared-helper proposal (#800).
+- `parse_copilot_transcript` (copilot.rs:194-267) line-walker byte
+  accounting matches codex/jetbrains_ai_assistant/cursor verbatim. Same
+  shared-helper opportunity.
+- `parse_usage_event` returns a `ParsedMessage` with the same 27-field
+  struct literal as everywhere else (copilot.rs:308-342). Half the
+  fields are uniform defaults that could land in a
+  `ParsedMessage::for_provider("copilot_cli")` constructor.
+- `cost_confidence: "estimated"` magic string (copilot.rs:327).
+- `surface: TERMINAL` hardcoded (copilot.rs:341) — correct (this *is*
+  a CLI), but the constant lives at `crate::surface::TERMINAL`; the
+  `to_string()` round-trip is wasteful. Same pattern in codex. Worth a
+  `pub const TERMINAL: &str` → `surface: TERMINAL.into()` once and for
+  all in a separate sweep.
+
+### No issues found
+
+- Workspace-yaml mini-parser correctly trims both `"..."` and `'...'`
+  quote forms. Comment justifies the no-serde_yaml choice.
+- Tests cover both bare and `data.usage.*`-nested shapes, plus zero-token
+  skip + incremental offset.
+- ADR-0089 watch_roots correct (returns empty when dir missing, doesn't
+  panic).
+
+## Concrete follow-up
+
+- **`parse_workspace_yaml` return-type cleanup** — single-line fix,
+  could land in 8.5.2 with the test update.
+- **Fixture + `MIN_API_VERSION` for Copilot CLI** — paired with the
+  `data.usage.*` fallback ADR. Track in 8.6.x.
+- **Shared helpers** (`deterministic_uuid`, line walker,
+  `CostConfidence`) — bundle into #800.
+
+No 8.5.2-scoped behavior change required.

--- a/docs/review/8.5.2/copilot_chat.md
+++ b/docs/review/8.5.2/copilot_chat.md
@@ -1,0 +1,157 @@
+# `copilot_chat` provider — 8.5.2 review pass
+
+- **Modules**:
+  - `crates/budi-core/src/providers/copilot_chat.rs` (4,335 LOC; prod 2,145 / tests 2,190)
+  - `crates/budi-core/src/providers/copilot_chat/jetbrains.rs` (2,042 LOC; prod ~1,103 / tests ~939)
+- **Tracking**: #799
+- **ADRs**: [0092](../../adr/0092-copilot-chat-data-contract.md), [0093](../../adr/0093-copilot-chat-jetbrains-storage-shape.md), [0089](../../adr/0089-reverse-proxy-first-jsonl-tailing-as-sole-live-path.md)
+
+## Shape
+
+By far the largest provider in the tree and also the one with the
+highest engineering discipline. Three responsibilities sit under one
+provider id:
+
+1. **VS Code-family local tail** (copilot_chat.rs): five
+   `workspaceStorage` / `globalStorage` subpath shapes per ADR-0092 §2.2,
+   a JSON Pointer mutation-log reducer per §2.3 v4, four full-pair
+   token shapes plus one output-only fallback per §2.3.
+2. **GitHub Billing API reconciliation** (delegated to
+   `crate::sync::copilot_chat_billing` from `sync_direct`).
+3. **JetBrains host ingest** (copilot_chat/jetbrains.rs): byte-scans
+   over Xodus log + Nitrite stores per ADR-0093.
+
+## Adherence to ADRs
+
+- **ADR-0092 §1 (provider id)**: ✓ — `pub const PROVIDER_ID = "copilot_chat"`.
+- **ADR-0092 §2.1, §2.2 (path roots)**: ✓ — all five VS Code variants,
+  remote/dev-container roots, dual-publisher casing (`GitHub` /
+  `github`) all enumerated. `is_session_storage_dir_name` enforces the
+  §2.2 directory-name allowlist (#684).
+- **ADR-0092 §2.3 (token shapes)**: ✓ — four full-pair shapes
+  (`extract_tokens_vscode_delta`, `_copilot_cli`, `_legacy`,
+  `_feb_2026`) plus the v3 output-only fallback (`_completion_only`).
+  Reducer logic (`apply_mutation`, `set_at_path`, `append_at_path`)
+  matches the v4 spec.
+- **ADR-0092 §2.4 (model id resolution)**: ✓ — three-step fallback in
+  `extract_model_id` (resolvedModel → modelId → `agent.id` table).
+  §2.4.1 `agent.id` table lives in `resolve_auto_model_id`
+  (copilot_chat.rs:1816-1831); five entries, matches the ADR table.
+- **ADR-0092 §2.6 (parser tolerance + `MIN_API_VERSION`)**: ✓ —
+  `MIN_API_VERSION = 5` (copilot_chat.rs:93), bumped in lockstep with
+  each amendment. `log_unknown_shape_once` (copilot_chat.rs:2108)
+  warns once per `(file_path, shape_signature)` per daemon run.
+- **ADR-0093 §2-4 (JetBrains discovery + dual-store probe)**: ✓ — both
+  Xodus `.xd` and Nitrite `.db` accepted; #757 amendment honored
+  (jetbrains.rs:592-609). Phase 1 (`extract_xodus_project_name`,
+  jetbrains.rs:464) and Phase 2 (`extract_nitrite_workspace_paths`,
+  jetbrains.rs:752) byte-walkers both carry the `retire-with: #789`
+  annotation contract per ADR-0093 §"Amendment 2026-05-14".
+- **ADR-0089 §1**: ✓ — file watcher only; `sync_direct` is a side
+  effect (billing pull + JetBrains binary-store sweep), returns `None`
+  so the dispatcher still runs the file path.
+
+## Observations
+
+### Where the discipline shines
+
+The pattern other providers should copy:
+
+- **Tight ADR/code lockstep**: every "amendment" section in ADR-0092
+  has a matching `// vN (...)` block in the `MIN_API_VERSION` doc-comment
+  (copilot_chat.rs:36-92). When a fifth shape lands, the contract and
+  the code never disagree.
+- **Warn-once with a structured signature** keeps daemon-log noise
+  bounded without losing the signal an operator needs.
+- **Fixture-pinned envelope shapes**: `vscode_chat_0_47_0.jsonl`,
+  `vscode_chat_0_47_0.expected.json`, `vscode_chat_0_47_0_v5.jsonl`,
+  `jetbrains_copilot_1_5_53_243_empty_session/`, etc., all sanitized but
+  shape-preserving. The other providers have no equivalent.
+
+### Worth fixing (defer follow-up tickets)
+
+1. **`build_message` + `build_messages_for_request` duplicate ~150 LOC
+   of struct-literal construction.** Both build one optional user row
+   and one assistant row from a record, both produce two near-identical
+   `ParsedMessage { … }` literals (copilot_chat.rs:1235-1283 vs
+   1455-1503; 1290-1324 vs 1511-1545). The only differences:
+   - Emit-key shape (`requestId`-based vs `idx`-based)
+   - Tool-data presence
+   - Timestamp-extractor choice
+   One generic builder `build_messages(path, record, _, role_picker,
+   uuid_seed, &enrichment)` would collapse both. Tracking in #800.
+2. **`apply_mutation` / `set_at_path` / `append_at_path` is a from-scratch
+   JSON Pointer reducer in 100 LOC** (copilot_chat.rs:1047-1193). Works
+   correctly and is well-tested, but if any future provider needs the
+   same pattern, it belongs as a `crate::json_pointer_reducer` helper.
+   Not a 8.5.2 fix; tracking note for whenever a second use-case lands.
+3. **Two private `percent_decode` implementations in the same module
+   tree** (copilot_chat.rs:602 + jetbrains.rs:812). Both target the
+   same RFC 3986 surface, both for `file://` URIs. One shared private
+   helper in a `super` module is the obvious cleanup. Tracking in #800.
+4. **The whole file is read from disk on every `parse_file` tick**
+   (copilot_chat.rs:814 — `std::fs::read_to_string(path)`). The
+   in-line comment justifies this against the v4 reducer requirement.
+   The comment also flags the missing "per-session last-processed line
+   index" cache; for long sessions this is a real CPU cost. Worth
+   measuring (via `cargo flamegraph` against a few-MB session file)
+   before deciding whether to land the cache. Tracking note.
+5. **Tests live inline alongside ~2,200 LOC of production code.** Both
+   submodules cross the threshold #805 sets (split-into-sibling-test-modules).
+
+### Minor
+
+- `deterministic_uuid` and `deterministic_uuid_for_key` are two near-
+  identical SHA-256 → UUID-shape formatters (copilot_chat.rs:1329 vs
+  2078). With a shared helper (#800) both collapse.
+- `extract_timestamp` (copilot_chat.rs:2044) walks four JSON Pointer
+  candidates. The four are spelled out in a local `candidates` array —
+  could promote to a `const` so a fifth shape lands as a one-line edit.
+- `editor_context_cwd_hint_from_state` (copilot_chat.rs:710) does
+  ad-hoc string parsing of an editor-context English sentence. Comment
+  explains why; honest. Worth a tracking note if Copilot Chat ever
+  changes the wording.
+- `cost_confidence: "estimated"` / `"n/a"` magic strings (4 sites in this
+  file). Same enum proposal as the other providers.
+
+### JetBrains-specific (jetbrains.rs)
+
+1. **`resolve_project_workspace` probes hardcoded home-dir paths**
+   (jetbrains.rs:533-549): `~/_projects/<name>`, `~/projects/<name>`,
+   `~/<name>`. The `~/_projects/` prefix is the maintainer's personal
+   convention (and yes — this repo lives in
+   `/Users/ivan.seredkin/_projects/budi/`). On a fresh developer's
+   machine these probes will miss every time. Worth either (a) widening
+   to a configurable list, or (b) deleting the heuristic when Phase 3
+   (#789) lands. Since the whole block is marked
+   `retire-with: #789` per ADR-0093, the latter is the path.
+2. **Three `#[cfg(test)]` blocks at lines 1103, 1109, 1117** —
+   `empty_fixture_dir` helper, the inner test module declaration, and
+   the real `mod tests`. Reads cleanly but the layering is unusual;
+   worth a quick comment or a merge.
+3. **`byte_find` / `byte_contains`** (jetbrains.rs:572, 622) reimplement
+   `slice::windows(n).position(...)` / `.any(...)`. Std is fast enough
+   for the 10-30 KB inputs documented in the comment. Cleanup, not a
+   bug.
+4. **`read_git_head_branch` is a parallel to
+   `cursor::resolve_git_branch_from_head`** (cursor.rs:1880). Two
+   different files, same function. Shared `crate::repo_id::head_branch()`
+   would land both. Tracking in #800.
+
+## Concrete follow-up
+
+- **Test-organization split** — paired with #805, this is a single PR
+  per submodule that moves the inline tests into
+  `copilot_chat/tests.rs` and `copilot_chat/jetbrains/tests.rs`. Net
+  ~3,100 LOC of test code out of two production files.
+- **Build-message dedup** — needs a careful pass because the two
+  builders differ in tool-data routing; not a 8.5.2 fix.
+- **JetBrains hard-coded `~/_projects/` workspace probe** — retire
+  alongside the `retire-with: #789` block when Phase 3 lands; **do not
+  delete in 8.5.2** per ADR-0093 §"Amendment 2026-05-14" #807 disposition.
+- **Profile `read_to_string` cost on long sessions** — measurement
+  ticket, not a fix.
+
+No 8.5.2-scoped behavior change required. The provider is the
+healthiest in the tree on contract-drift discipline; the cleanups are
+all forward-looking.

--- a/docs/review/8.5.2/cursor.md
+++ b/docs/review/8.5.2/cursor.md
@@ -1,0 +1,133 @@
+# `cursor` provider — 8.5.2 review pass
+
+- **Module**: `crates/budi-core/src/providers/cursor.rs` (3,128 LOC; prod 2,284 / tests 843)
+- **Tracking**: #799
+- **ADRs**: [0089](../../adr/0089-reverse-proxy-first-jsonl-tailing-as-sole-live-path.md), [0090](../../adr/0090-cursor-usage-api-contract.md)
+
+## Shape
+
+The provider with the most ingestion paths — three:
+
+1. **`cursorDiskKV` bubbles** (preferred, #553) — exact per-message
+   tokens + model from the local `state.vscdb`, no network call.
+2. **Cursor Usage API** (`/api/dashboard/get-filtered-usage-events`) —
+   supplementary signal for overage attribution, exact `cost_cents`.
+3. **JSONL transcripts** under `~/.cursor/projects/*/agent-transcripts/`
+   — fallback for older sessions and machines without auth.
+
+Plus a hefty "session repair" suite (`run_cursor_repairs`,
+`repair_cursor_workspace_metadata`, `backfill_cursor_session_ids`) that
+patches historical rows in SQL.
+
+## Adherence to ADRs
+
+- **ADR-0089 §1**: ✓ — `watch_roots` returns the JSONL projects dir
+  only. State.vscdb and the Usage API are pull-mode via `sync_direct`.
+- **ADR-0089 §7** (Usage API pull-only, not a watch root): ✓ —
+  `combine_cursor_sync_results` returns `None` from `sync_direct`
+  when both arms are unavailable so the file fallback still runs.
+- **ADR-0090** (Usage API contract): ✓ — JWT extraction
+  (`extract_cursor_auth`), pagination with watermark
+  (`fetch_usage_events`, `paginate_all` logic), pricing-source tagging
+  (`pricing::COLUMN_VALUE_UPSTREAM_API`).
+- **ADR-0090 §2026-04-23 amendment** (bubbles primary, API
+  supplementary): ✓ — `sync_from_bubbles` runs first, `sync_from_usage_api`
+  runs after; combiner merges.
+
+## Observations
+
+### Where the discipline shines
+
+- **`CursorAuthIssue` enum + `reason_tag()` + `human_message()`**
+  (cursor.rs:410-488). Best-in-class operator diagnostics in the tree.
+  Seven typed reasons each map to (a) a stable wire-contract tag for
+  log grepping, (b) a human-readable message that names the fix. Pinned
+  by a test that the reason tags don't drift (cursor.rs:2296-).
+  **This is the template the other providers should follow** for any
+  "configured but not working" failure-mode surface.
+- **Watermark separation**: `cursor-bubbles` and `cursor-api-usage` are
+  intentionally distinct `sync_state` keys (cursor.rs:42-53). Both
+  paths advance independently; correctly justified inline.
+- **JWT exp claim heuristic** (cursor.rs:378-392): `> 1_700_000_000_000`
+  to distinguish ms from s. Magic but defensible (10^12 ≈ Nov 2023 in
+  ms vs year 56,000 in s). Worth a date comment so the next reader
+  doesn't have to derive it.
+
+### Worth fixing (defer follow-up tickets)
+
+1. **No `MIN_API_VERSION` on the Usage API or bubble shapes.** Both
+   are documented in ADR-0090, but neither has the `MIN_API_VERSION` /
+   `*_unknown_shape` guardrails copilot_chat ships. The bubble path
+   does have `warn_bubble_schema_once` (cursor.rs:1231) — but that's a
+   single bit ("we warned once for this process"), not a per-shape dedup.
+   If Cursor renames `tokenCount.inputTokens` to `tokens.input` in a
+   future release, the SQL would emit zero rows and the warn would
+   fire once and never again. Worth tightening to the
+   `(file_path, shape_signature)`-style dedup copilot_chat uses.
+2. **Silent `let _ = conn.execute(...)`** sprinkled through the SQL
+   repair code (cursor.rs:1692, 1725, 1793, 1803). The intent is "this
+   is best-effort, don't fail the sync" — fair — but a single
+   `tracing::debug!` on the error would let operators trace why a
+   particular row didn't repair. Worth a one-line per-site fix.
+3. **`repair_cursor_workspace_metadata` does sequential prepared
+   statements without a per-old_cwd transaction wrapper**
+   (cursor.rs:1768-1812). If the second `conn.execute` fails after the
+   first succeeds, the row lands in a half-repaired state. The outer
+   loop already iterates per `old_cwd`; wrapping each iteration in a
+   transaction makes each row atomic without changing the per-row
+   semantics. Small ticket.
+4. **`base64url_decode` is hand-rolled** (cursor.rs:247-295) with a
+   compile-time lookup table. Works fine; if any other path in the
+   tree later needs JWT parsing, it deserves to live in
+   `crate::util::base64`.
+5. **Three-path provider with three ingestion code paths is the most
+   complex in the tree** — the comment block at the top of the module
+   gives a one-line summary, but a state-flow diagram (or a
+   pretty-printed call graph in this review's successor) would help
+   future readers. Worth tracking against #800.
+
+### Minor
+
+- `deterministic_cursor_message_uuid` (cursor.rs:952) is the most
+  RFC-4122-compliant UUID formatter in the providers/ tree (sets the
+  v4/variant bits). The other providers' deterministic-UUID helpers do
+  not. If the shared helper proposed in #800 lands, this implementation
+  is the one to keep.
+- `find_matching_session` uses a `±5s` clock-skew window
+  (`CLOCK_SKEW_MS`, cursor.rs:731). Documented; reasonable.
+- `bubble_to_parsed_message` (cursor.rs:1416) leaves `cwd` / `git_branch`
+  / `repo_id` as `None` and patches them later via
+  `attach_session_context_to_bubbles`. The dance is correct but
+  indirect; a comment at the `None` site explaining "filled by
+  attach_session_context_to_bubbles after composer-header merge" would
+  save future debugging.
+- `cost_confidence: String::new()` (cursor.rs:1533) — empty string as
+  a sentinel that the `CostEnricher` interprets later. Three valid
+  values plus a sentinel; an enum on `ParsedMessage` would be cleaner.
+- `surface: Some(crate::surface::CURSOR.to_string())` repeated four
+  times — same `to_string()`-of-a-const pattern as the other providers.
+
+### No issues found
+
+- ADR-0090 path-discovery cross-product correct (macOS / Linux /
+  Windows variants).
+- Composer-header merge logic (`load_composer_header_contexts` →
+  `load_session_contexts`) correctly prefers local Cursor windows over
+  hook-derived timestamps. Reasoning is justified inline.
+- `total_cents` validation in `parse_usage_event` (cursor.rs:565-586)
+  has thoughtful clamping for negative / >$1000 / >$50 values, with
+  tracing warnings rather than silent drops.
+
+## Concrete follow-up
+
+- **`MIN_API_VERSION` + `(path, shape)` warn-once for bubbles** —
+  small ticket, paired with an ADR-0090 amendment if the bubble shape
+  ever shifts.
+- **Surface SQL repair errors at `debug` level** — one-line per site.
+- **Transaction-per-row for `repair_cursor_workspace_metadata`** — small
+  refactor.
+- **Document the three-path flow** — track in #800 or a dedicated
+  cursor walkthrough doc.
+
+No 8.5.2-scoped behavior change required. The operator-diagnostics
+quality on the auth path is a model to copy elsewhere.

--- a/docs/review/8.5.2/jetbrains_ai_assistant.md
+++ b/docs/review/8.5.2/jetbrains_ai_assistant.md
@@ -1,0 +1,105 @@
+# `jetbrains_ai_assistant` provider — 8.5.2 review pass
+
+- **Module**: `crates/budi-core/src/providers/jetbrains_ai_assistant.rs` (524 LOC; prod 345 / tests 179)
+- **Tracking**: #799
+- **ADRs**: [0089](../../adr/0089-reverse-proxy-first-jsonl-tailing-as-sole-live-path.md)
+- **Note**: distinct from `copilot_chat`'s JetBrains host (ADR-0093).
+  This is JetBrains' own Anthropic-backed AI Assistant product
+  (`com.intellij.ml.llm`), billed through JetBrains AI subscriptions,
+  surface tag is shared (`jetbrains`).
+
+## Shape
+
+Tails Anthropic-shaped JSONL transcripts under
+`<JetBrains config root>/<Product><Year>/aiAssistant/chats/*.jsonl`.
+Per-line walker tracks `current_model` from `message_start` events and
+emits one `ParsedMessage` per `message_stop` event.
+
+## Adherence to ADRs
+
+- **ADR-0089 §1**: ✓ — pure file-tail; `watch_roots` returns each
+  chat dir discovered via filesystem listing (no closed allowlist).
+- **ADR-0089 §4** (attribution from transcript): ⚠ — the
+  Anthropic-style event stream doesn't carry `cwd` or `git_branch`
+  itself, so every row emits with `cwd: None`, `git_branch: None`,
+  `repo_id: None` (jetbrains_ai_assistant.rs:295-303). See "Worth
+  fixing" #1 below.
+
+## Observations
+
+### Worth fixing (defer follow-up tickets)
+
+1. **No workspace/repo attribution.** Every emitted row has `cwd`,
+   `git_branch`, `repo_id` set to `None`. Unlike Cursor, there's no
+   `attach_session_context_to_*` step that patches them after the fact.
+   The result on the dashboard: JetBrains AI Assistant cost lands in
+   the "(unknown)" repo bucket regardless of which project the user
+   was working in. Two possible signals to fish out:
+   - Sibling files in the chat dir (some IDE plugins write project
+     hints next to the transcript).
+   - The chat dir's parent dir path (`IntelliJIdea2025.3` vs
+     `WebStorm2026.1`) carries IDE-flavor info but not project info.
+   Worth a discovery ticket: capture a real-world session to see what
+   else is on disk.
+2. **Synthetic fixture only.** `fixtures/synthetic_session_v1.jsonl`
+   is hand-crafted; the module doc-comment explicitly says "open
+   questions for a real-world capture." Same gap as the codex /
+   copilot_cli reviews: capture a real session and pin a fixture +
+   `MIN_API_VERSION`. Should pair with a tracking issue under
+   ADR-0093-style "JetBrains AI Assistant Data Contract".
+3. **No `MIN_API_VERSION`, no unknown-shape warn-once.** If JetBrains
+   changes the `usage.*` key names in a plugin update, the parser will
+   silently drop rows. Same fix pattern as codex / copilot_cli.
+4. **`uuid: id.clone()` and `request_id: Some(id)` are the same
+   value** (jetbrains_ai_assistant.rs:292 + :312). Two fields hold
+   one piece of data. If this is intentional (e.g. `request_id` is
+   meant to be a separate field once the event stream exposes it),
+   add a comment. Otherwise drop the duplication.
+
+### Minor
+
+- `deterministic_uuid` (jetbrains_ai_assistant.rs:328-343) is a
+  fourth-or-fifth hand-rolled UUID formatter — see #800 sweep proposal.
+  Keyed on `(session_id, timestamp_nanos)`, which means two
+  `message_stop` events with the exact same nanosecond timestamp would
+  collide. Vanishingly unlikely; worth a note.
+- Per-line walker (jetbrains_ai_assistant.rs:187-227) duplicates the
+  byte-accounting pattern from codex / copilot / cursor. Same shared
+  helper proposal.
+- `cost_confidence: "estimated"` magic string (jetbrains_ai_assistant.rs:310).
+- `role: "assistant"` hardcoded on every row, same as codex /
+  copilot_cli — token-rollup events aren't really "assistant turns"
+  but the analytics taxonomy treats them as such.
+- Two-test discovery coverage is good (presence + absence cases).
+- `discover_chat_dirs` uses `std::env::temp_dir()` for tests with
+  best-effort cleanup — same papercut as the other providers.
+
+### No issues found
+
+- Platform-specific roots (macOS / Linux / Windows / fallback) are
+  correctly cfg-gated.
+- Cross-platform `vec![]` returns when target isn't macOS/Linux/Windows
+  rather than panicking — good defensive shape.
+- `parse_message_stop` correctly inherits `current_model` from the
+  paired `message_start`, with a fallback to the literal event value.
+- Tests cover: synthetic happy-path (3 turns, with/without cache),
+  zero-token skip, model inheritance, fallback-session-id, incremental
+  offset (including partial-trailing-line), malformed-line tolerance.
+  Good baseline.
+
+## Concrete follow-up
+
+- **Capture a real-world session** under
+  `src/providers/jetbrains_ai_assistant/fixtures/` and add
+  `MIN_API_VERSION` + unknown-shape warn-once. Track in 8.6.x.
+- **Workspace attribution** — discovery ticket for what's on disk
+  near the chat transcript. Until then, JetBrains AI rows land in
+  the unknown-repo bucket.
+- **Drop the `uuid == request_id` duplication** or comment why both
+  exist.
+- **Shared `deterministic_uuid` / line-walker / `CostConfidence`** —
+  bundle into #800.
+
+No 8.5.2-scoped behavior change required. The provider is small and
+clean; the gap is in coverage (real fixture, workspace signal) rather
+than correctness.


### PR DESCRIPTION
## Summary

- Adds per-provider review notes under `docs/review/8.5.2/` for `claude_code`, `codex`, `copilot` (CLI), `copilot_chat` (incl. JetBrains submodule), `cursor`, and `jetbrains_ai_assistant`.
- Closes the acceptance criteria of #799: one review note per provider + a `README.md` summary block with the top-3 cross-cutting takeaways.
- Observation-only: no source code touched.

## Top 3 takeaways (full text in `docs/review/8.5.2/README.md`)

1. **Five hand-rolled `deterministic_uuid` formatters.** Subtly different namespacing across providers; only `cursor` sets the RFC 4122 v4/variant bits. Fix: shared helper in `crate::util::uuid`. Track in #800.
2. **Contract-drift discipline is uneven.** `copilot_chat` is the model (ADR-0092 + `MIN_API_VERSION` + warn-once + real-world fixtures). The other four (`codex`, `copilot_cli`, `cursor` bubbles, `jetbrains_ai_assistant`) tail an undocumented upstream with no equivalent guard-rails. Punt to 8.6.x: one ADR per surface.
3. **`ParsedMessage` struct-literal duplication is the biggest cleanup target.** 13 sites × 27 fields × mostly-uniform defaults = ~600 LOC of duplication. Fix: `ParsedMessage::for_provider(id)` constructor + a `CostConfidence` enum. Track in #800.

## Out of scope

Per #799: no behaviour changes inside 8.5.2; no refactors > 200 LOC per provider (those become their own tickets); no ADR-affecting changes to the data contract.

## Test plan

- [x] Review docs render correctly on GitHub
- [x] All six providers covered (`claude_code`, `codex`, `copilot`, `copilot_chat`, `cursor`, `jetbrains_ai_assistant`)
- [x] README links resolve

Closes #799.

🤖 Generated with [Claude Code](https://claude.com/claude-code)