### PR TITLE
docs(#803): reconcile SOUL/AGENTS/CLAUDE/CONTRIBUTING audiences

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to budi
 
-Thanks for helping improve budi.
+Thanks for helping improve budi. This file covers contributor workflow (local checks, supply-chain policy, PR expectations). For end-user install/usage see [`README.md`](README.md); for architecture, data flow, release flow, and the daemon contract see [`SOUL.md`](SOUL.md).
 
 ## Prerequisites
 
@@ -78,31 +78,7 @@ See [`siropkin/budi-cloud`](https://github.com/siropkin/budi-cloud).
 
 ## Install locally
 
-```bash
-./scripts/install.sh    # builds release + installs to ~/.local/bin/
-budi --version
-```
-
-If scripts are blocked (for example by anti-virus), install to Cargo bin (`~/.cargo/bin`):
-
-```bash
-cargo install --path crates/budi-cli --bin budi --force --locked
-cargo install --path crates/budi-daemon --bin budi-daemon --force --locked
-budi --version
-budi init
-```
-
-Or build and copy binaries manually:
-
-```bash
-cargo build --release --locked
-mkdir -p ~/.local/bin
-cp target/release/budi target/release/budi-daemon ~/.local/bin/
-chmod +x ~/.local/bin/budi ~/.local/bin/budi-daemon
-rehash
-pkill -f "budi-daemon serve"   # graceful stop (avoid -9 unless stuck)
-budi init               # restarts daemon + re-syncs data
-```
+See [`SOUL.md` § Build & Test](SOUL.md#build--test) for `./scripts/install.sh`, the Cargo-bin fallback, and the rule about keeping `budi` + `budi-daemon` on the same build path.
 
 ## Filing issues and feature requests
 
@@ -160,7 +136,7 @@ The same `Provider` implementation powers both live tailing and `budi db import`
 
 ## Releasing
 
-Release automation is tag-driven (`.github/workflows/release.yml`) and expects a clean `main` branch.
+Release flow (stable vs. prerelease tags, Homebrew auto-bump, prerelease-then-promote loop) is documented in [`SOUL.md` § Release flow](SOUL.md#release-flow). Mechanical contributor commands:
 
 ```bash
 ./scripts/release.sh 7.0.0        # bump version + update Cargo.lock (clean tree required)
@@ -169,7 +145,7 @@ git commit -am "chore: bump version to 7.0.0"
 git push origin main v7.0.0       # CI + release workflows build and publish assets
 ```
 
-Post-push release checks:
+Post-push verification:
 
 ```bash
 gh release view v7.0.0 --repo siropkin/budi
@@ -177,17 +153,4 @@ gh release download v7.0.0 --repo siropkin/budi --pattern SHA256SUMS -D /tmp/bud
 cat /tmp/budi-release-check/SHA256SUMS
 ```
 
-Expected release artifacts:
-
-- `budi-v<version>-x86_64-unknown-linux-gnu.tar.gz`
-- `budi-v<version>-aarch64-unknown-linux-gnu.tar.gz`
-- `budi-v<version>-x86_64-apple-darwin.tar.gz`
-- `budi-v<version>-aarch64-apple-darwin.tar.gz`
-- `budi-v<version>-x86_64-pc-windows-msvc.zip`
-- `SHA256SUMS`
-
-Homebrew auto-update notes:
-
-- The release workflow updates `siropkin/homebrew-budi` after publishing assets. The `update-homebrew` job in `.github/workflows/release.yml` renders `homebrew/budi.rb` against the release `SHA256SUMS` and pushes `Formula/budi.rb` to the tap; no additional scripts are involved.
-- `HOMEBREW_TAP_TOKEN` must be configured in `siropkin/budi` repo secrets.
-- If the workflow ever fails to push, diagnose via the workflow logs and rerun the `update-homebrew` job. The one-shot tap-bootstrap runbook (used once on 2026-03-26 to create `siropkin/homebrew-budi`) is archived as a comment on [#365](https://github.com/siropkin/budi/issues/365#issuecomment-4292484508) for recovery scenarios where the tap repo itself has to be rebuilt from scratch.
+Expected artifacts: one tarball per `{x86_64,aarch64}-{unknown-linux-gnu,apple-darwin}` plus `x86_64-pc-windows-msvc.zip` and `SHA256SUMS`. The Homebrew tap (`siropkin/homebrew-budi`) is updated by the `update-homebrew` job in `.github/workflows/release.yml`; `HOMEBREW_TAP_TOKEN` must be configured in repo secrets. The one-shot tap-bootstrap runbook is archived on [#365](https://github.com/siropkin/budi/issues/365#issuecomment-4292484508).

--- a/README.md
+++ b/README.md
@@ -250,7 +250,14 @@ rm ~/.local/bin/budi ~/.local/bin/budi-daemon  # shell script install
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for local setup and PR workflow. Architecture and module boundaries are documented in [SOUL.md](SOUL.md). ADRs live in [`docs/adr/`](docs/adr/).
+Repository guidance is split across four top-level files so each has one audience:
+
+- [`README.md`](README.md) — end-user install, usage, and the daemon API surface (you are here).
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) — local quality checks, supply-chain policy, PR workflow.
+- [`SOUL.md`](SOUL.md) — canonical architecture, data flow, attribution contract, release flow, and AI-agent guidance.
+- [`AGENTS.md`](AGENTS.md) / [`CLAUDE.md`](CLAUDE.md) — thin compatibility pointers that redirect AI tooling to `SOUL.md`.
+
+ADRs live in [`docs/adr/`](docs/adr/).
 
 ### Running CI checks locally
 

--- a/SOUL.md
+++ b/SOUL.md
@@ -2,6 +2,17 @@
 
 Local-first cost analytics for AI coding agents (Claude Code, Codex CLI, Cursor, Copilot CLI). Tracks tokens, costs, and usage per message by tailing the JSONL transcript files those agents already write to disk (see [ADR-0089](docs/adr/0089-reverse-proxy-first-jsonl-tailing-as-sole-live-path.md)). Historical data from the same transcripts and the Cursor Usage API can be backfilled via `budi db import`. Optional cloud sync (disabled by default) pushes pre-aggregated daily rollups to a team dashboard — prompts, code, and responses never leave the machine (see [ADR-0083](docs/adr/0083-cloud-ingest-identity-and-privacy-contract.md)).
 
+This file is the **canonical AI-agent / architecture / product-identity reference**. [`AGENTS.md`](AGENTS.md) and [`CLAUDE.md`](CLAUDE.md) are thin compatibility pointers that redirect tools (OpenAI Codex / Claude Code / etc.) here. Contributor workflow lives in [`CONTRIBUTING.md`](CONTRIBUTING.md); end-user install/usage lives in [`README.md`](README.md).
+
+## Audience map
+
+| If you are… | Start here |
+|---|---|
+| An end user installing or using budi | [`README.md`](README.md) |
+| A contributor opening a PR | [`CONTRIBUTING.md`](CONTRIBUTING.md) — local quality checks, supply-chain policy, PR checklist |
+| An AI coding agent working in this repo | This file — [`AGENTS.md`](AGENTS.md) and [`CLAUDE.md`](CLAUDE.md) are pointer-only |
+| Looking for architecture, data flow, attribution contract, or release rationale | This file plus [`docs/adr/`](docs/adr/README.md) |
+
 Architecture highlights:
 
 - **JSONL tailing is the sole live ingestion path** ([ADR-0089](docs/adr/0089-reverse-proxy-first-jsonl-tailing-as-sole-live-path.md)). No proxy, no hooks, no OTEL. The 8.0/8.1 proxy was removed in 8.2; legacy `proxy_estimated` and `otel_exact` rows remain read-only in the DB for historical analytics.


### PR DESCRIPTION
## Summary

Closes #803 (part of #798).

Goal of the issue: each top-level guidance file should own one audience, with the others acting as thin pointers (the existing `CLAUDE.md → SOUL.md` pattern is the model). Deduplication pass, not a rewrite.

## What changed

- **`SOUL.md`**
  - New lede line names the pointer-only siblings (`AGENTS.md`, `CLAUDE.md`) and contrasts them with `CONTRIBUTING.md` (workflow) and `README.md` (end users).
  - New **Audience map** table mapping reader → entry-point file (acceptance criterion 2).
- **`README.md`**
  - Contributing section now links **all four** files with a one-line description of each (acceptance criterion 3).
- **`CONTRIBUTING.md`**
  - First paragraph now states the contributor-only scope and points to `README.md` / `SOUL.md` for the other audiences.
  - **`Install locally`** recipe removed (it duplicated `SOUL.md` § Build & Test) → replaced with a single-line pointer.
  - **`Releasing`** trimmed: contributor-facing commands stay; the tag/prerelease/Homebrew rationale now lives canonically in `SOUL.md` § Release flow.

`AGENTS.md` and `CLAUDE.md` were already thin pointers to `SOUL.md` and are left untouched.

## Acceptance check

- [x] No paragraph of guidance lives in two files (install + release content removed from `CONTRIBUTING.md`; pointer lines replace them).
- [x] Audience-map table added to `SOUL.md`.
- [x] `README.md` links to all four files with one-line descriptions.

## Test plan

- [x] `git diff --stat` shows changes scoped to the three intended files.
- [ ] Reviewer: open each of the four files and confirm the "where to go for what" routing matches the audience map.
- [ ] Reviewer: confirm no removed content lost any unique information (everything in the removed `CONTRIBUTING.md` install/release blocks is already in `SOUL.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)