### PR TITLE
feat(#804): coverage baseline with cargo-llvm-cov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,6 +244,41 @@ jobs:
       - name: Run cargo-deny
         run: cargo deny --all-features check
 
+  # Coverage baseline via `cargo llvm-cov` (issue #804).
+  #
+  # Non-blocking for now — the point is visibility, not a target. Runs the
+  # same `scripts/coverage.sh` contributors run locally, so drift between
+  # local and CI numbers stays small. Single-threaded test execution is
+  # required (see docs/quality/coverage-baseline-8.5.2.md for the why).
+  coverage:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+
+      - name: Install cargo-llvm-cov
+        run: cargo install cargo-llvm-cov --locked
+
+      - name: Run coverage
+        run: scripts/coverage.sh --lcov target/coverage/lcov.info
+
+      - name: Upload LCOV artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-lcov
+          path: target/coverage/lcov.info
+          if-no-files-found: warn
+
   # Unused-dependency scan via `cargo udeps` (issue #808).
   #
   # Requires the nightly toolchain. Allowed to fail initially so nightly

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,22 @@ To mirror CI exactly for formatting, use:
 cargo fmt --all -- --check
 ```
 
+### Coverage (optional)
+
+Coverage is a visibility tool, not a gate. The 8.5.2 baseline is captured in
+[`docs/quality/coverage-baseline-8.5.2.md`](docs/quality/coverage-baseline-8.5.2.md).
+To reproduce it locally:
+
+```bash
+cargo install cargo-llvm-cov --locked
+rustup component add llvm-tools-preview
+scripts/coverage.sh          # text summary
+scripts/coverage.sh --html   # also writes target/coverage/html/index.html
+```
+
+The same script runs in the non-blocking `coverage` CI job, which uploads an
+LCOV artifact for editor integrations.
+
 ### Supply-chain policy (`cargo-deny`)
 
 The workspace ships a [`deny.toml`](deny.toml) that pins a permissive license

--- a/docs/quality/coverage-baseline-8.5.2.md
+++ b/docs/quality/coverage-baseline-8.5.2.md
@@ -1,0 +1,127 @@
+# Coverage baseline — 8.5.2
+
+Captured by `cargo-llvm-cov` (v0.8.7) against `cargo test --workspace --locked --test-threads=1`. Tracks issue #804.
+
+- **Tool**: `cargo-llvm-cov` (LLVM source-based instrumentation).
+- **Command**: `scripts/coverage.sh` → `cargo llvm-cov --workspace --summary-only -- --test-threads=1`.
+- **Date captured**: 2026-05-14, against `main`.
+- **Test runner constraint**: `--test-threads=1` is required. A few worker tests in `budi-daemon` (`workers::pricing_refresh`, `workers::team_pricing`) mutate process-wide env vars under a `std::sync::Mutex`. Under parallelism, one panicking test poisons the lock and the next thread observes `PoisonError` rather than the real condition. Single-threaded test execution sidesteps the race without changing the tests. (Follow-up: rework the env-mutation tests to scope env per-process or use a `parking_lot::Mutex` that does not poison on panic — separate issue.)
+
+## Headline numbers
+
+| Metric    | Total | Missed | Covered |
+| --------- | ----: | -----: | ------: |
+| Regions   | 58,024 | 21,064 | **63.70%** |
+| Functions | 3,512  | 1,218  | **65.32%** |
+| Lines     | 37,633 | 13,505 | **64.11%** |
+
+No branch coverage is reported — llvm-cov does not emit branch counts for Rust today.
+
+## Reading the table
+
+- `Lines (cov)` = source lines actually executed at least once during the test run.
+- `Regions` = compiler-instrumented basic blocks; usually the strictest of the three measures.
+- `Functions` = item-level coverage; "uncovered" includes derived items the tests never touch (e.g. `Debug` for a struct only printed on error paths).
+
+Coverage numbers are an interest-rate, not a quality score. A 90% line-coverage module with no assertions on the hot path can still ship bugs; a 40% module that fully exercises its public contract can be sound. The numbers below are starting points for *gap analysis*, not targets.
+
+## Per-file coverage (line %)
+
+Sorted by coverage ascending. Files at 100% (only `pipeline/emit.rs`) omitted for brevity. Lines columns are absolute counts from llvm-cov.
+
+| File | Lines | Missed | Cover |
+| --- | ---: | ---: | ---: |
+| `budi-daemon/src/routes/analytics.rs` | 1,025 | 1,012 | **1.27%** |
+| `budi-cli/src/commands/update.rs` | 556 | 526 | 5.40% |
+| `budi-daemon/src/routes/pricing.rs` | 136 | 121 | 11.03% |
+| `budi-cli/src/commands/db.rs` | 107 | 90 | 15.89% |
+| `budi-cli/src/commands/sessions.rs` | 418 | 333 | 20.33% |
+| `budi-cli/src/daemon.rs` | 496 | 395 | 20.36% |
+| `budi-cli/src/commands/uninstall.rs` | 584 | 455 | 22.09% |
+| `budi-cli/src/commands/init.rs` | 392 | 299 | 23.72% |
+| `budi-daemon/src/routes/hooks.rs` | 713 | 531 | 25.53% |
+| `budi-cli/src/commands/stats/mod.rs` | 1,547 | 1,140 | 26.31% |
+| `budi-cli/src/commands/cloud.rs` | 691 | 481 | 30.39% |
+| `budi-cli/src/commands/status.rs` | 137 | 92 | 32.85% |
+| `budi-cli/src/client.rs` | 1,057 | 705 | 33.30% |
+| `budi-cli/src/commands/autostart.rs` | 124 | 83 | 33.06% |
+| `budi-core/src/providers/claude_code.rs` | 88 | 56 | 36.36% |
+| `budi-cli/src/commands/integrations.rs` | 782 | 437 | 44.12% |
+| `budi-cli/src/commands/import.rs` | 313 | 167 | 46.65% |
+| `budi-core/src/providers/cursor/mod.rs` | 1,486 | 758 | 48.99% |
+| `budi-core/src/analytics/sync.rs` | 906 | 471 | 48.01% |
+| `budi-cli/src/commands/pricing.rs` | 526 | 261 | 50.38% |
+| `budi-daemon/src/workers/cloud_sync.rs` | 157 | 69 | 56.05% |
+| `budi-daemon/src/workers/pricing_refresh.rs` | 323 | 155 | 52.01% |
+| `budi-daemon/src/workers/team_pricing.rs` | 253 | 118 | 53.36% |
+| `budi-daemon/src/routes/cloud.rs` | 366 | 150 | 59.02% |
+| `budi-core/src/analytics/queries/summary.rs` | 800 | 271 | 66.12% |
+| `budi-core/src/analytics/queries/dimensions.rs` | 1,147 | 310 | 72.97% |
+| `budi-core/src/analytics/sessions.rs` | 855 | 199 | 76.73% |
+| `budi-core/src/cloud_sync/mod.rs` | 669 | 210 | 68.61% |
+| `budi-daemon/src/main.rs` | 600 | 206 | 65.67% |
+| `budi-cli/src/commands/statusline.rs` | 811 | 282 | 65.23% |
+| `budi-core/src/analytics/health.rs` | 703 | 162 | 76.96% |
+| `budi-core/src/analytics/queries/breakdowns.rs` | 756 | 122 | 83.86% |
+| `budi-core/src/providers/jetbrains_ai_assistant.rs` | 329 | 55 | 83.28% |
+| `budi-core/src/providers/copilot.rs` | 406 | 69 | 83.00% |
+| `budi-core/src/providers/codex.rs` | 378 | 61 | 83.86% |
+| `budi-core/src/migration.rs` | 1,833 | 84 | 95.42% |
+| `budi-core/src/jsonl.rs` | 594 | 23 | 96.13% |
+| `budi-core/src/pipeline/mod.rs` | 810 | 25 | 96.91% |
+| `budi-core/src/pipeline/enrichers.rs` | 686 | 51 | 92.57% |
+| `budi-core/src/pipeline/emit.rs` | 161 | 0 | 100.00% |
+
+For the full per-file listing run `scripts/coverage.sh` locally.
+
+## Top-10 gap list
+
+Ranked by (low coverage) × (blast radius — defined per #804 as anything in `crates/budi-core/src/{providers,pipeline,pricing,cloud_sync,migration}` plus public HTTP surfaces in `budi-daemon/src/routes/`). Each entry says where the gap is and what the follow-up plan is.
+
+1. **`budi-daemon/src/routes/analytics.rs` — 1.27%** — the entire HTTP analytics surface is essentially untested at the route layer. The underlying query modules (`analytics/queries/*`) cover the SQL/shape logic, but request validation, error mapping, pagination, and `connect_info` gating live in the route module. **Follow-up**: #816 (8.5.2).
+2. **`budi-core/src/providers/cursor/mod.rs` — 49.0%** — the largest provider module (1,486 lines), and the one with the most volatile upstream contract (see ADR-0090). Today's tests focus on parser happy-path. **Follow-up**: #819 — deferred to 8.6.0 because closing it needs fixtures for each ADR-0090 variant.
+3. **`budi-daemon/src/routes/hooks.rs` — 25.5%** — `surface_for_path` and `collect_health_sources` are well tested; the actual handler bodies are not. The surface is on the proxy hot path. **Follow-up**: #817 (8.5.2).
+4. **`budi-cli/src/commands/stats/mod.rs` — 26.3%** — recently split out of the legacy mega-module (#813). Stat formatting is the main user-visible surface. **Follow-up**: #821 (8.5.2) — golden-output tests for the formatter functions; the IO orchestration can stay uncovered for now.
+5. **`budi-cli/src/client.rs` — 33.3%** — daemon-client glue: HTTP request construction, error mapping, retry policy. **Follow-up**: #822 (8.5.2) — mock-server tests.
+6. **`budi-cli/src/commands/cloud.rs` — 30.4%** — the cloud CLI subcommands. Cloud is alpha (R4) — coverage will follow the feature work. **Note**: covered by R4 follow-ups, no separate gap issue needed.
+7. **`budi-daemon/src/routes/pricing.rs` — 11.0%** — small surface (136 lines). `recompute_query_*` tests cover the query parser. **Follow-up**: #818 (8.5.2).
+8. **`budi-core/src/providers/claude_code.rs` — 36.4%** — small file (88 lines), but the provider for our flagship surface. **Follow-up**: #820 (8.5.2) — quick win, fixture-based.
+9. **`budi-cli/src/commands/init.rs` — 23.7%** — onboarding flow; touches filesystem, `gh`, daemon start. Hard to unit-test cleanly. **Note**: covered by existing install-script e2e tests in CI; no unit-test gap issue.
+10. **`budi-core/src/analytics/sync.rs` — 48.0%** — cloud-sync producer (mints sync chunks). Adjacent to `cloud_sync/mod.rs`. **Follow-up**: #823 (8.5.2).
+
+### Items deliberately not on the gap list
+
+- **`budi-cli/src/commands/update.rs` (5.40%)** — self-update path. Hits GitHub releases and writes to `$PATH`. The on-disk swap is exercised by the release-flow e2e in CI; the rest is best left as integration coverage. No unit-test gap issue.
+- **`budi-cli/src/commands/db.rs` (15.9%)** and **`budi-cli/src/commands/uninstall.rs` (22.1%)** — destructive maintenance commands; already exercised by `scripts/install.sh` / `scripts/uninstall.sh` smoke tests in CI.
+- **`budi-cli/src/commands/sessions.rs` (20.3%)** and **`budi-cli/src/daemon.rs` (20.4%)** — thin CLI shells that delegate into well-covered core modules.
+
+### Already well covered
+
+- `budi-core/src/pipeline/` — `emit.rs` 100%, `mod.rs` 96.9%, `enrichers.rs` 92.6%. ADR-0089 contract is well exercised.
+- `budi-core/src/migration.rs` — 95.4%.
+- `budi-core/src/jsonl.rs` — 96.1%.
+- `budi-core/src/providers/copilot_chat/` — `mod.rs` 87.7%, `jetbrains.rs` 93.1%. ADR-0092 contract well exercised.
+- `budi-core/src/pricing/` — 88–93% across the three files.
+
+## Reproducing locally
+
+```bash
+# install once
+cargo install cargo-llvm-cov --locked
+rustup component add llvm-tools-preview
+
+# text summary
+scripts/coverage.sh
+
+# also produce browsable HTML at target/coverage/html/index.html
+scripts/coverage.sh --html
+
+# also write an LCOV file (for editor integrations)
+scripts/coverage.sh --lcov target/coverage/lcov.info
+```
+
+CI runs the same `scripts/coverage.sh` in the `coverage` job (non-blocking; see `.github/workflows/ci.yml`).
+
+## Why not a percentage target
+
+Per #804: a target would push contributors toward easy-coverage gains (testing trivial getters) and away from the gap list above. The acceptance criterion for 8.5.2 is **visibility**, not a number. A target may be reconsidered for 8.6.x once the top-10 gaps are closed; gating in CI is explicitly out of scope here.

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Run llvm-cov coverage across the workspace.
+#
+# Usage:
+#   scripts/coverage.sh              # text summary
+#   scripts/coverage.sh --html       # also write HTML report to target/coverage
+#   scripts/coverage.sh --lcov FILE  # also write LCOV file
+#
+# Tests are forced single-threaded because a handful of pricing/team-pricing
+# tests mutate process-wide env vars under a mutex; parallel test threads
+# trip a PoisonError when one panics first. `cargo test` runs them serially
+# in CI today via the same flag implicitly via test-level locks, but llvm-cov
+# re-execs the instrumented binary and needs the flag spelled out.
+
+set -euo pipefail
+
+EMIT_HTML=0
+LCOV_PATH=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --html) EMIT_HTML=1 ;;
+    --lcov) LCOV_PATH="${2:?--lcov requires a path}"; shift ;;
+    -h|--help)
+      sed -n '2,11p' "$0"
+      exit 0
+      ;;
+    *)
+      echo "unknown flag: $1" >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+if ! command -v cargo-llvm-cov >/dev/null 2>&1; then
+  echo "cargo-llvm-cov not installed. Install with:" >&2
+  echo "    cargo install cargo-llvm-cov --locked" >&2
+  echo "    rustup component add llvm-tools-preview" >&2
+  exit 1
+fi
+
+cargo llvm-cov --workspace --summary-only -- --test-threads=1
+
+if [ "$EMIT_HTML" = "1" ]; then
+  cargo llvm-cov --workspace --html --output-dir target/coverage -- --test-threads=1
+  echo "HTML report: target/coverage/html/index.html"
+fi
+
+if [ -n "$LCOV_PATH" ]; then
+  cargo llvm-cov --workspace --lcov --output-path "$LCOV_PATH" -- --test-threads=1
+  echo "LCOV report: $LCOV_PATH"
+fi

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -47,6 +47,7 @@ if [ "$EMIT_HTML" = "1" ]; then
 fi
 
 if [ -n "$LCOV_PATH" ]; then
+  mkdir -p "$(dirname "$LCOV_PATH")"
   cargo llvm-cov --workspace --lcov --output-path "$LCOV_PATH" -- --test-threads=1
   echo "LCOV report: $LCOV_PATH"
 fi


### PR DESCRIPTION
Closes #804.

## Summary

- Adds `scripts/coverage.sh` — wraps `cargo llvm-cov --workspace --summary-only -- --test-threads=1`. Single-thread is required because two `budi-daemon` worker test modules mutate process-wide env vars under a `std::sync::Mutex`; one panic poisons the lock under parallelism. Supports `--html` and `--lcov FILE` for HTML reports and editor integration.
- Adds a non-blocking `coverage` CI job that runs the same script and uploads an LCOV artifact. Pattern mirrors the existing `udeps` job (#808).
- Adds `docs/quality/coverage-baseline-8.5.2.md` with workspace totals, a per-file table sorted ascending by line coverage, and a top-10 gap list. Each gap entry links a filed follow-up issue or notes why no issue was opened.
- Adds an optional "Coverage" subsection to `CONTRIBUTING.md`.

## Baseline numbers

| Metric    | Total  | Cover |
| --------- | -----: | ----: |
| Regions   | 58,024 | 63.70% |
| Functions | 3,512  | 65.32% |
| Lines     | 37,633 | 64.11% |

## Follow-up issues filed

8.5.2 milestone: #816 (analytics routes), #817 (hooks routes), #818 (pricing routes), #820 (claude_code provider), #821 (stats formatter), #822 (cli client), #823 (analytics sync).

8.6.0 milestone: #819 (cursor provider — needs ADR-0090 fixtures, non-mechanical).

`cloud.rs` and `init.rs` are explicitly noted in the doc as "covered by existing tests / R4 work, no separate gap issue".

## Acceptance for #804

- [x] `scripts/coverage.sh` runs locally and in CI (non-blocking)
- [x] Baseline markdown committed
- [x] Top-10 gap list either has issues filed or a one-line "covered, no gap" note
- [x] No coverage-percentage target introduced (out of scope per #804)
- [x] No CI gating introduced (out of scope per #804)

## Test plan

- [x] `cargo fmt --all -- --check` passes locally
- [x] `bash -n scripts/coverage.sh` and `scripts/coverage.sh --help` work
- [x] `scripts/coverage.sh` produces the table reproduced in the baseline doc
- [ ] CI `coverage` job runs to completion (verify on this PR)

## Risks

- The `coverage` CI job is `continue-on-error: true`, matching `udeps` — failures will not block merges. The PR description mentions promoting to a required check once a few clean runs land, but that's a follow-up decision, not part of this PR.
- `--test-threads=1` slows coverage runs (~22s vs ~16s parallel locally). Acceptable for a non-blocking CI job. The underlying mutex-poison flakiness is filed as a note in the baseline doc and is a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)