### PR TITLE
docs(#828): add GitHub release downloads badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![CI](https://github.com/siropkin/budi/actions/workflows/ci.yml/badge.svg)](https://github.com/siropkin/budi/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/siropkin/budi)](https://github.com/siropkin/budi/releases/latest)
+[![Downloads](https://img.shields.io/github/downloads/siropkin/budi/total?label=downloads)](https://github.com/siropkin/budi/releases)
 [![License](https://img.shields.io/github/license/siropkin/budi)](https://github.com/siropkin/budi/blob/main/LICENSE)
 [![GitHub stars](https://img.shields.io/github/stars/siropkin/budi?style=social)](https://github.com/siropkin/budi)
 


### PR DESCRIPTION
## Summary

- Adds a `Downloads` shields.io badge to README, linking to the releases page
- Surfaces cumulative GitHub release download counts (closest honest signal for a custom-tap project like budi)

Closes #828

## Test plan

- [ ] Badge renders correctly on the rendered README on GitHub
- [ ] Badge links to https://github.com/siropkin/budi/releases

🤖 Generated with [Claude Code](https://claude.com/claude-code)