### PR TITLE
test(#818): raise routes/pricing.rs coverage to ≥80%

### DIFF
--- a/crates/budi-daemon/src/routes/pricing.rs
+++ b/crates/budi-daemon/src/routes/pricing.rs
@@ -80,6 +80,43 @@ pub struct RecomputeQuery {
     pub force: bool,
 }
 
+/// Render a [`team_pricing::CliTickOutcome`] as the wire body returned
+/// by `POST /pricing/recompute`. Extracted so the per-variant JSON
+/// shapes are unit-testable without spinning up the team-pricing
+/// worker (which requires a cloud config + network).
+fn recompute_outcome_body(outcome: team_pricing::CliTickOutcome) -> Value {
+    match outcome {
+        team_pricing::CliTickOutcome::Updated(summary) => json!({
+            "ok": true,
+            "skipped": false,
+            "status": "updated",
+            "summary": summary,
+        }),
+        team_pricing::CliTickOutcome::Cleared(summary) => json!({
+            "ok": true,
+            "skipped": false,
+            "status": "cleared",
+            "summary": summary,
+        }),
+        team_pricing::CliTickOutcome::ForcedRecompute(summary) => json!({
+            "ok": true,
+            "skipped": false,
+            "status": "forced",
+            "summary": summary,
+        }),
+        team_pricing::CliTickOutcome::Unchanged => json!({
+            "ok": true,
+            "skipped": true,
+            "status": "unchanged",
+        }),
+        team_pricing::CliTickOutcome::NotConfigured => json!({
+            "ok": true,
+            "skipped": true,
+            "status": "not_configured",
+        }),
+    }
+}
+
 /// `POST /pricing/recompute` — loopback-only; immediately re-poll the
 /// team-pricing endpoint and recompute `messages.cost_cents_effective`.
 ///
@@ -94,37 +131,7 @@ pub async fn pricing_recompute(
     let force = q.force;
     let result = tokio::task::spawn_blocking(move || -> anyhow::Result<Value> {
         let outcome = team_pricing::run_tick_for_cli(force)?;
-        let body = match outcome {
-            team_pricing::CliTickOutcome::Updated(summary) => json!({
-                "ok": true,
-                "skipped": false,
-                "status": "updated",
-                "summary": summary,
-            }),
-            team_pricing::CliTickOutcome::Cleared(summary) => json!({
-                "ok": true,
-                "skipped": false,
-                "status": "cleared",
-                "summary": summary,
-            }),
-            team_pricing::CliTickOutcome::ForcedRecompute(summary) => json!({
-                "ok": true,
-                "skipped": false,
-                "status": "forced",
-                "summary": summary,
-            }),
-            team_pricing::CliTickOutcome::Unchanged => json!({
-                "ok": true,
-                "skipped": true,
-                "status": "unchanged",
-            }),
-            team_pricing::CliTickOutcome::NotConfigured => json!({
-                "ok": true,
-                "skipped": true,
-                "status": "not_configured",
-            }),
-        };
-        Ok(body)
+        Ok(recompute_outcome_body(outcome))
     })
     .await
     .map_err(|e| super::internal_error(anyhow::anyhow!("pricing recompute task panicked: {e}")))?;
@@ -136,6 +143,29 @@ pub async fn pricing_recompute(
             Json(json!({ "ok": false, "error": format!("{e:#}") })),
         )),
     }
+}
+
+/// Render a [`pricing_refresh::RefreshReport`] as the wire body
+/// returned by `POST /pricing/refresh`. The `rejected_upstream_rows`
+/// key is omitted when empty (ADR-0091 §2 amendment, 8.3.1 / #483) so
+/// older clients can keep deserializing the response without growing a
+/// field they don't yet know about.
+fn refresh_report_body(report: &pricing_refresh::RefreshReport) -> Value {
+    let mut body = json!({
+        "ok": true,
+        "version": report.version,
+        "known_model_count": report.known_model_count,
+        "backfilled_rows": report.backfilled_rows,
+    });
+    if !report.rejected_upstream_rows.is_empty()
+        && let Some(map) = body.as_object_mut()
+    {
+        map.insert(
+            "rejected_upstream_rows".to_string(),
+            serde_json::to_value(&report.rejected_upstream_rows).unwrap_or(json!([])),
+        );
+    }
+    body
 }
 
 /// `POST /pricing/refresh` — loopback-only; fire a manual refresh tick.
@@ -151,27 +181,7 @@ pub async fn pricing_refresh() -> Result<Json<Value>, (StatusCode, Json<Value>)>
         })?;
 
     match result {
-        Ok(report) => {
-            let mut body = json!({
-                "ok": true,
-                "version": report.version,
-                "known_model_count": report.known_model_count,
-                "backfilled_rows": report.backfilled_rows,
-            });
-            // ADR-0091 §2 amendment (8.3.1 / #483): surface row-level
-            // rejections on the refresh response so `budi pricing
-            // status --refresh` can print them on the spot.
-            // `skip-if-none` for older-client compatibility.
-            if !report.rejected_upstream_rows.is_empty()
-                && let Some(map) = body.as_object_mut()
-            {
-                map.insert(
-                    "rejected_upstream_rows".to_string(),
-                    serde_json::to_value(&report.rejected_upstream_rows).unwrap_or(json!([])),
-                );
-            }
-            Ok(Json(body))
-        }
+        Ok(report) => Ok(Json(refresh_report_body(&report))),
         Err(e) => Err((
             StatusCode::BAD_GATEWAY,
             Json(json!({
@@ -214,5 +224,244 @@ mod tests {
     fn recompute_query_rejects_numeric_bool_literals() {
         assert!(serde_urlencoded::from_str::<RecomputeQuery>("force=1").is_err());
         assert!(serde_urlencoded::from_str::<RecomputeQuery>("force=0").is_err());
+    }
+
+    // ─── #818 handler coverage tests ─────────────────────────────────────
+    //
+    // `routes::pricing` was at 11% line coverage on the 8.5.2 baseline
+    // (#804); the query parser above covered ~13 lines and every handler
+    // body was 0%. These tests exercise each handler's response shape on
+    // a tempdir-scoped HOME so they stay hermetic, with the JSON-body
+    // helpers (`recompute_outcome_body`, `refresh_report_body`) called
+    // directly so we can lock the per-variant wire contracts without
+    // needing the team-pricing worker / network upstream.
+
+    use budi_core::pricing::RejectedUpstreamRow;
+    use budi_core::pricing::team::RecomputeSummary;
+    use std::sync::Mutex;
+
+    /// Process-global `HOME` / `BUDI_HOME` are mutated to point at a
+    /// throw-away tempdir below. `cargo test` runs tests in parallel by
+    /// default, so without this mutex two tests would observe each
+    /// other's env writes between `set_var` and `remove_var`.
+    static HOME_MUTEX: Mutex<()> = Mutex::new(());
+
+    /// RAII guard that swaps `HOME` to a fresh tempdir for the duration
+    /// of one test and also clears `BUDI_HOME` (which, when set, takes
+    /// precedence over `HOME` inside `budi_home_dir`). Restores the
+    /// previous values on drop.
+    struct HomeGuard {
+        prev_home: Option<String>,
+        prev_budi_home: Option<String>,
+        // Owns the tempdir for the lifetime of the guard so it's not
+        // GC'd while the redirected `HOME` is active. Underscore-leading
+        // so the field can stay private without tripping `dead_code`.
+        _tmp: tempfile::TempDir,
+        _lock: std::sync::MutexGuard<'static, ()>,
+    }
+
+    impl HomeGuard {
+        fn new() -> Self {
+            let lock = HOME_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+            let tmp = tempfile::tempdir().expect("tempdir for HomeGuard");
+            let prev_home = std::env::var("HOME").ok();
+            let prev_budi_home = std::env::var("BUDI_HOME").ok();
+            unsafe { std::env::set_var("HOME", tmp.path()) };
+            unsafe { std::env::remove_var("BUDI_HOME") };
+            Self {
+                prev_home,
+                prev_budi_home,
+                _tmp: tmp,
+                _lock: lock,
+            }
+        }
+    }
+
+    impl Drop for HomeGuard {
+        fn drop(&mut self) {
+            match &self.prev_home {
+                Some(h) => unsafe { std::env::set_var("HOME", h) },
+                None => unsafe { std::env::remove_var("HOME") },
+            }
+            match &self.prev_budi_home {
+                Some(h) => unsafe { std::env::set_var("BUDI_HOME", h) },
+                None => unsafe { std::env::remove_var("BUDI_HOME") },
+            }
+        }
+    }
+
+    fn dummy_summary() -> RecomputeSummary {
+        RecomputeSummary {
+            list_version: 7,
+            rows_processed: 12,
+            rows_changed: 3,
+            before_total_cents: 100.0,
+            after_total_cents: 88.5,
+        }
+    }
+
+    #[test]
+    fn recompute_outcome_body_renders_updated_variant() {
+        let body = recompute_outcome_body(team_pricing::CliTickOutcome::Updated(dummy_summary()));
+        assert_eq!(body["ok"], true);
+        assert_eq!(body["skipped"], false);
+        assert_eq!(body["status"], "updated");
+        // `summary` is the serialized `RecomputeSummary` — lock the
+        // field names the CLI / dashboard depend on.
+        assert_eq!(body["summary"]["list_version"], 7);
+        assert_eq!(body["summary"]["rows_processed"], 12);
+        assert_eq!(body["summary"]["rows_changed"], 3);
+    }
+
+    #[test]
+    fn recompute_outcome_body_renders_cleared_variant() {
+        let body = recompute_outcome_body(team_pricing::CliTickOutcome::Cleared(dummy_summary()));
+        assert_eq!(body["status"], "cleared");
+        assert_eq!(body["skipped"], false);
+        assert!(body.get("summary").is_some());
+    }
+
+    #[test]
+    fn recompute_outcome_body_renders_forced_variant() {
+        let body = recompute_outcome_body(team_pricing::CliTickOutcome::ForcedRecompute(
+            dummy_summary(),
+        ));
+        assert_eq!(body["status"], "forced");
+        assert_eq!(body["skipped"], false);
+        assert!(body.get("summary").is_some());
+    }
+
+    #[test]
+    fn recompute_outcome_body_renders_unchanged_variant() {
+        let body = recompute_outcome_body(team_pricing::CliTickOutcome::Unchanged);
+        assert_eq!(body["ok"], true);
+        assert_eq!(body["skipped"], true);
+        assert_eq!(body["status"], "unchanged");
+        // No `summary` on the no-op path — the CLI keys off `skipped`.
+        assert!(body.get("summary").is_none());
+    }
+
+    #[test]
+    fn recompute_outcome_body_renders_not_configured_variant() {
+        let body = recompute_outcome_body(team_pricing::CliTickOutcome::NotConfigured);
+        assert_eq!(body["skipped"], true);
+        assert_eq!(body["status"], "not_configured");
+        assert!(body.get("summary").is_none());
+    }
+
+    #[test]
+    fn refresh_report_body_omits_rejected_rows_when_empty() {
+        // ADR-0091 §2 amendment: only emit `rejected_upstream_rows` when
+        // there's at least one entry, so v8.3.0 CLI consumers don't see
+        // a field they don't know about. Lock that here.
+        let report = pricing_refresh::RefreshReport {
+            version: 5,
+            known_model_count: 124,
+            backfilled_rows: 0,
+            rejected_upstream_rows: Vec::new(),
+        };
+        let body = refresh_report_body(&report);
+        assert_eq!(body["ok"], true);
+        assert_eq!(body["version"], 5);
+        assert_eq!(body["known_model_count"], 124);
+        assert_eq!(body["backfilled_rows"], 0);
+        assert!(body.get("rejected_upstream_rows").is_none());
+    }
+
+    #[test]
+    fn refresh_report_body_emits_rejected_rows_when_present() {
+        let report = pricing_refresh::RefreshReport {
+            version: 6,
+            known_model_count: 250,
+            backfilled_rows: 11,
+            rejected_upstream_rows: vec![RejectedUpstreamRow {
+                model_id: "wandb/Qwen3".to_string(),
+                reason: "$100000/M exceeds sanity ceiling".to_string(),
+            }],
+        };
+        let body = refresh_report_body(&report);
+        assert_eq!(body["version"], 6);
+        assert_eq!(body["backfilled_rows"], 11);
+        let rejected = body
+            .get("rejected_upstream_rows")
+            .expect("non-empty rejected_upstream_rows must be surfaced");
+        assert_eq!(rejected[0]["model_id"], "wandb/Qwen3");
+        assert!(
+            rejected[0]["reason"]
+                .as_str()
+                .unwrap()
+                .contains("sanity ceiling")
+        );
+    }
+
+    /// `GET /pricing/status` always includes the LiteLLM `PricingState`
+    /// fields plus a `team_pricing` object — the dashboard / CLI probe
+    /// `team_pricing.active` to decide whether to render the section.
+    /// With a fresh tempdir HOME and no `team::install`, the active flag
+    /// must be false.
+    #[tokio::test]
+    async fn pricing_status_returns_body_with_inactive_team_pricing_key() {
+        let _guard = HomeGuard::new();
+        let Json(body) = pricing_status().await.expect("status handler must succeed");
+        // PricingState fields are surfaced flat at the top level.
+        assert!(
+            body.get("source_label").is_some(),
+            "status must include `source_label` from PricingState"
+        );
+        // team_pricing is always present, even when inactive (#732).
+        let tp = body
+            .get("team_pricing")
+            .expect("team_pricing key must always be present");
+        assert_eq!(tp["active"], false);
+    }
+
+    /// With no `cloud.toml` configured, `team_pricing::run_tick_for_cli`
+    /// returns `NotConfigured` before touching the DB or network. The
+    /// handler must surface that as `{ ok: true, skipped: true, status:
+    /// "not_configured" }`.
+    #[tokio::test]
+    async fn pricing_recompute_without_cloud_config_returns_not_configured() {
+        let _guard = HomeGuard::new();
+        let Json(body) = pricing_recompute(Query(RecomputeQuery { force: false }))
+            .await
+            .expect("recompute handler must not error on the not_configured path");
+        assert_eq!(body["ok"], true);
+        assert_eq!(body["skipped"], true);
+        assert_eq!(body["status"], "not_configured");
+    }
+
+    /// `force=true` cannot promote a NotConfigured outcome — the worker
+    /// short-circuits on missing `api_key` before evaluating `force`.
+    /// Pin the same response shape on the force path so a future
+    /// refactor doesn't silently start running a recompute against an
+    /// unconfigured org.
+    #[tokio::test]
+    async fn pricing_recompute_force_without_cloud_config_still_returns_not_configured() {
+        let _guard = HomeGuard::new();
+        let Json(body) = pricing_recompute(Query(RecomputeQuery { force: true }))
+            .await
+            .expect("recompute handler must not error on the not_configured path");
+        assert_eq!(body["status"], "not_configured");
+    }
+
+    /// Wire `pricing_recompute` into a router and drive a malformed
+    /// query through `oneshot` to exercise the `axum::Query` extractor's
+    /// 400 path. The handler body is never entered.
+    #[tokio::test]
+    async fn router_rejects_malformed_recompute_query_with_400() {
+        use axum::Router;
+        use axum::body::Body;
+        use axum::http::{Request, StatusCode};
+        use axum::routing::post;
+        use tower::ServiceExt;
+
+        let app: Router = Router::new().route("/pricing/recompute", post(pricing_recompute));
+        // `force=1` is the v8.4.3 regression shape — `serde`'s strict
+        // bool deserializer rejects it, axum maps that to a 400.
+        let req = Request::post("/pricing/recompute?force=1")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
     }
 }


### PR DESCRIPTION
Closes #818.

## Summary

- Extract two pure helpers from `routes::pricing` (`recompute_outcome_body`, `refresh_report_body`) so each `POST /pricing/*` response shape can be unit-tested without spinning up the team-pricing worker / network upstream.
- Add handler-level tests for `GET /pricing/status` and the `NotConfigured` recompute path behind a `HomeGuard` (process-global `HOME`/`BUDI_HOME` redirected to a fresh tempdir, serialized via a local `Mutex`).
- Drive the malformed-query path through `axum::Router::oneshot` so the `axum::Query` extractor's 400 branch is exercised end-to-end (pins the v8.4.3 `force=1` regression at the router level too — the existing `recompute_query_rejects_numeric_bool_literals` test only locked the serde side).
- Lock the ADR-0091 §2 amendment (#483) contract: `rejected_upstream_rows` is omitted from the refresh body when empty, present when non-empty.

## Coverage

`crates/budi-daemon/src/routes/pricing.rs`: **11.0% → 82.93%** (`cargo llvm-cov`).

```
routes/pricing.rs   411   57   86.13%   37   7   81.08%   287   49   82.93%
```

Above the issue's ≥70% acceptance target.

## Test plan

- [x] `cargo test -p budi-daemon routes::pricing` — 13 tests pass
- [x] `cargo test --workspace --locked -- --test-threads=1` — full suite green
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p budi-daemon --all-targets --locked -- -D warnings`
- [x] `cargo llvm-cov -p budi-daemon --summary-only -- --test-threads=1` confirms ≥70% for `routes/pricing.rs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)