### PR TITLE
docs(#832): soften 'team-only' framing for cloud dashboard in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 brew install siropkin/budi/budi && budi init
 ```
 
-Everything stays on your machine by default. Optional cloud sync pushes aggregated daily metrics to a team dashboard — prompts, code, and responses never leave your machine.
+Everything stays on your machine by default. Optional cloud sync pushes aggregated daily metrics to a cloud dashboard — prompts, code, and responses never leave your machine.
 
 <p align="center">
   <img src="assets/demo.gif" alt="budi CLI demo" width="800">
@@ -21,7 +21,7 @@ Everything stays on your machine by default. Optional cloud sync pushes aggregat
 <details>
 <summary>Cloud dashboard screenshots</summary>
 
-**Overview** — team-wide cost visibility
+**Overview** — cost visibility across your projects and team
 <p align="center">
   <img src="assets/dashboard-overview.png" alt="budi dashboard — cost overview" width="800">
 </p>
@@ -31,7 +31,7 @@ Everything stays on your machine by default. Optional cloud sync pushes aggregat
   <img src="assets/dashboard-repos.png" alt="budi repos" width="800">
 </p>
 
-**Sessions** — recent sessions across the team
+**Sessions** — recent sessions across your machines and team
 <p align="center">
   <img src="assets/dashboard-sessions.png" alt="budi sessions" width="800">
 </p>
@@ -45,7 +45,7 @@ Everything stays on your machine by default. Optional cloud sync pushes aggregat
 - **Repo, branch, and ticket breakdown** — know which project, PR branch, or ticket is driving spend
 - **Session health** — detects context bloat, cache degradation, and cost acceleration with actionable tips
 - **Live status line** in Claude Code, Cursor, and VS Code showing rolling 1d / 7d / 30d spend (VS Code aggregates over Copilot Chat + any other detected provider)
-- **Team dashboard** at [app.getbudi.dev](https://app.getbudi.dev) — optional sync sends only aggregated metrics; prompts and code never leave your machine
+- **Cloud dashboard** at [app.getbudi.dev](https://app.getbudi.dev) — for solo developers and teams; optional sync sends only aggregated metrics, prompts and code never leave your machine
 - **~6 MB Rust binary**, zero config required, minimal footprint
 
 ## Ecosystem
@@ -53,7 +53,7 @@ Everything stays on your machine by default. Optional cloud sync pushes aggregat
 | | |
 |---|---|
 | **[budi](https://github.com/siropkin/budi)** ← you are here | Core Rust daemon and CLI |
-| **[budi-cloud](https://github.com/siropkin/budi-cloud)** | Team dashboard and ingest API at [app.getbudi.dev](https://app.getbudi.dev) |
+| **[budi-cloud](https://github.com/siropkin/budi-cloud)** | Cloud dashboard and ingest API at [app.getbudi.dev](https://app.getbudi.dev) — for solo developers and teams |
 | **[budi-cursor](https://github.com/siropkin/budi-cursor)** | VS Code / Cursor status bar extension |
 | **[budi-jetbrains](https://github.com/siropkin/budi-jetbrains)** | JetBrains IDE status bar plugin (Kotlin) — [Marketplace listing](https://plugins.jetbrains.com/plugin/31662-budi) |
 | **[homebrew-budi](https://github.com/siropkin/homebrew-budi)** | Homebrew tap for `brew install siropkin/budi/budi` |
@@ -369,7 +369,7 @@ Data views accept `--period today|week|month|all` (or relative like `7d`, `2w`, 
 | Multi-agent support | **Yes** (Claude Code, Codex CLI, Cursor, Copilot CLI, Copilot Chat) | Claude Code only | Claude Code only |
 | Live local transcript tailing | **Yes** | No | No |
 | Cost history | **Per-message + daily** | Per-session | Current session only |
-| Cloud team dashboard | **Yes** ([app.getbudi.dev](https://app.getbudi.dev)) | No | No |
+| Cloud dashboard | **Yes** ([app.getbudi.dev](https://app.getbudi.dev)) | No | No |
 | Status line + session health | **Yes** (with actionable tips) | No | No |
 | Cost attribution (branch/ticket/file) | **Yes** | No | No |
 | Privacy | Local-first, optional cloud sync (aggregates only) | Local | Built-in |


### PR DESCRIPTION
## Summary

- Drops "team-only" framing from the README so solo developers aren't implicitly excluded from the cloud product.
- Updates the two spots called out in #832 (ecosystem row, comparison table) plus three nearby lines that carried the same framing (tagline, dashboard screenshot captions, feature bullet).

Closes #832.

## Changes

- `README.md:15` — "team dashboard" → "cloud dashboard" in the privacy tagline.
- `README.md:24` — Overview caption: "team-wide cost visibility" → "cost visibility across your projects and team".
- `README.md:34` — Sessions caption: "across the team" → "across your machines and team".
- `README.md:48` — Feature bullet: **Team dashboard** → **Cloud dashboard**, with explicit "for solo developers and teams".
- `README.md:56` — Ecosystem row: "Team dashboard" → "Cloud dashboard … for solo developers and teams".
- `README.md:372` — Comparison table row: "Cloud team dashboard" → "Cloud dashboard".

## Test plan

- [x] `git diff` review — only README copy touched, no code/links changed
- [ ] Render README on GitHub to confirm tables and formatting still look right

🤖 Generated with [Claude Code](https://claude.com/claude-code)