### PR TITLE
chore(#806): dead-code sweep — narrow unreachable_pub (alt. to #812)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 8.5.2 — unreleased
+
+8.5.2 is the polish-release umbrella tracked by #798. No user-visible behaviour changes. `api_version` stays at `3`.
+
+### Internal — 8.5.2
+
+- **Dead code sweep: `cargo-udeps`, `cargo-machete`, `clippy -W unreachable_pub -W dead_code`** (#806) — workspace-wide hygiene pass for the 8.5.2 release. `cargo machete` and `cargo +nightly udeps --workspace --all-targets` both report clean. `cargo clippy --workspace --all-targets -- -W dead_code -W unreachable_pub` reported 255 `unreachable_pub` items across the binary crates (`budi-cli`, `budi-daemon`) and the workspace-private `budi-core` library; all were mechanically narrowed to `pub(crate)` via `clippy --fix`, since neither crate has external API consumers. The surviving `#[allow(dead_code)]` annotations now carry one-line explanations (added one for `PlatformFamily` in `crates/budi-core/src/legacy_proxy.rs`, whose variants are constructed via cfg-gated branches that look dead per-target but are required for cross-platform tests). One redundant `#[allow(dead_code)]` was dropped from `parse_session_dir_for_tests` in `crates/budi-core/src/providers/copilot_chat/jetbrains.rs` since it is exercised by the sibling test module. No `#[deprecated]` items, no `#[cfg(feature = "...")]` gates, and no unused workspace dependencies were found.
+
+### Cross-repo lockstep
+
+- No cross-repo changes required.
+
 ## 8.5.1 — 2026-05-13
 
 8.5.1 is the v8.5.0 followup release that closes the four post-release smoke-test cuts surfaced on 2026-05-12: an autostart regression that left the macOS LaunchAgent in `not running` after any clean shutdown (statusline silently rendered `$0.00`), a Copilot Chat tailer noise source that made a healthy parser look like a shape regression in `budi doctor`, a JetBrains Phase 2 resolver gap where extracted `file://` URIs landed with `repo_id = NULL` and no diagnostic, and a longstanding pipeline gap where the `session_title` constant existed but no enricher emitted it — forcing the v8.5.0 backfill to re-walk session dirs on every sync tick. `api_version` stays at `3`.

--- a/crates/budi-cli/src/client.rs
+++ b/crates/budi-cli/src/client.rs
@@ -159,7 +159,7 @@ fn parse_needs_migration_error(body: &str) -> Option<String> {
 /// and `POST /sync/reset`. Used by `budi db import` to render the final
 /// per-agent breakdown (#440).
 #[derive(Debug, Clone, serde::Deserialize)]
-pub struct SyncResponse {
+pub(crate) struct SyncResponse {
     pub files_synced: usize,
     pub messages_ingested: usize,
     #[serde(default)]
@@ -179,7 +179,7 @@ pub struct SyncResponse {
 /// tripping the dead-code lint for the unused ones.
 #[derive(Debug, Clone, serde::Deserialize)]
 #[allow(dead_code)]
-pub struct SyncStatusResponse {
+pub(crate) struct SyncStatusResponse {
     pub syncing: bool,
     #[serde(default)]
     pub last_sync_completed_at: Option<String>,
@@ -202,7 +202,7 @@ pub struct SyncStatusResponse {
 /// CLI can render the optional `fallback_reason` on stderr without
 /// digging through raw JSON.
 #[derive(Debug, Clone, serde::Deserialize)]
-pub struct ResolvedSession {
+pub(crate) struct ResolvedSession {
     pub session_id: String,
     /// `"current"` if the cwd-encoded transcript dir resolved
     /// directly; `"latest"` if we fell back to the newest DB session.
@@ -218,7 +218,7 @@ pub struct ResolvedSession {
 
 /// Thin HTTP client that talks to budi-daemon.
 #[derive(Clone)]
-pub struct DaemonClient {
+pub(crate) struct DaemonClient {
     base_url: String,
     client: Client,
 }
@@ -245,7 +245,7 @@ where
 
 impl DaemonClient {
     /// Create a new client, auto-starting the daemon if needed.
-    pub fn connect() -> Result<Self> {
+    pub(crate) fn connect() -> Result<Self> {
         let config = Self::load_config();
         let base_url = config.daemon_base_url();
         let repo_root = std::env::current_dir()
@@ -345,20 +345,20 @@ impl DaemonClient {
 
     /// `POST /sync/all` — run a quick 30-day sync and return the typed
     /// per-agent report. Used by `budi db import` (no `--force`).
-    pub fn history(&self) -> Result<SyncResponse> {
+    pub(crate) fn history(&self) -> Result<SyncResponse> {
         self.sync_request(|| self.send_sync_post("sync/all"))
     }
 
     /// `POST /sync/reset` — clear sync state and re-ingest all history from
     /// scratch. Used by `budi db import --force`.
-    pub fn sync_reset(&self) -> Result<SyncResponse> {
+    pub(crate) fn sync_reset(&self) -> Result<SyncResponse> {
         self.sync_request(|| self.send_sync_post("sync/reset"))
     }
 
     /// `GET /sync/status` — typed snapshot. The `progress` field is populated
     /// only while a sync is in flight (see `/sync/status` handler).
     /// `budi db import` polls this every ~2 s to render live per-agent progress.
-    pub fn sync_status(&self) -> Result<SyncStatusResponse> {
+    pub(crate) fn sync_status(&self) -> Result<SyncStatusResponse> {
         let resp = self
             .client
             .get(format!("{}/sync/status", self.base_url))
@@ -368,7 +368,7 @@ impl DaemonClient {
         Ok(resp.json()?)
     }
 
-    pub fn check(&self) -> Result<Value> {
+    pub(crate) fn check(&self) -> Result<Value> {
         let resp = self
             .client
             .get(format!("{}/admin/check", self.base_url))
@@ -379,7 +379,7 @@ impl DaemonClient {
         Ok(resp.json()?)
     }
 
-    pub fn repair(&self) -> Result<Value> {
+    pub(crate) fn repair(&self) -> Result<Value> {
         let resp = self
             .client
             .post(format!("{}/admin/repair", self.base_url))
@@ -398,7 +398,7 @@ impl DaemonClient {
     /// surfaced as `anyhow` errors via [`check_response`]; a successful HTTP
     /// status still encodes per-result outcomes (`auth_failure`,
     /// `transient_error`, …) in `result`.
-    pub fn cloud_sync(&self) -> Result<Value> {
+    pub(crate) fn cloud_sync(&self) -> Result<Value> {
         let resp = self
             .client
             .post(format!("{}/cloud/sync", self.base_url))
@@ -414,7 +414,7 @@ impl DaemonClient {
     ///
     /// Returns the same `{ok, result, removed, message}` shape on success
     /// and a 409 `busy` error when the worker / a manual sync are mid-flight.
-    pub fn cloud_reset(&self) -> Result<Value> {
+    pub(crate) fn cloud_reset(&self) -> Result<Value> {
         let resp = self
             .client
             .post(format!("{}/cloud/reset", self.base_url))
@@ -427,7 +427,7 @@ impl DaemonClient {
 
     /// `GET /cloud/status` — read cloud sync readiness and watermarks.
     /// Never blocks on the network; the daemon only reads local state.
-    pub fn cloud_status(&self) -> Result<Value> {
+    pub(crate) fn cloud_status(&self) -> Result<Value> {
         let resp = self
             .client
             .get(format!("{}/cloud/status", self.base_url))
@@ -440,7 +440,7 @@ impl DaemonClient {
     /// `GET /pricing/status` — snapshot of the in-memory pricing manifest
     /// (layer, version, known model count, unknown models seen). Backs
     /// `budi pricing status` (ADR-0091 §8).
-    pub fn pricing_status(&self) -> Result<Value> {
+    pub(crate) fn pricing_status(&self) -> Result<Value> {
         let resp = self
             .client
             .get(format!("{}/pricing/status", self.base_url))
@@ -463,7 +463,7 @@ impl DaemonClient {
     /// so the caller sees the structured body; the CLI in
     /// `cmd_pricing_status` already distinguishes `body.ok == true`
     /// from `body.ok == false` on the rendering side.
-    pub fn pricing_refresh(&self) -> Result<Value> {
+    pub(crate) fn pricing_refresh(&self) -> Result<Value> {
         let resp = self
             .client
             .post(format!("{}/pricing/refresh", self.base_url))
@@ -500,7 +500,7 @@ impl DaemonClient {
     /// `budi pricing recompute`. `force=true` runs the recompute even
     /// when `list_version` is unchanged (the worker would otherwise
     /// short-circuit). #732.
-    pub fn pricing_recompute(&self, force: bool) -> Result<Value> {
+    pub(crate) fn pricing_recompute(&self, force: bool) -> Result<Value> {
         // #745: the daemon route uses serde's strict bool deserializer, which
         // only accepts the literal strings "true" / "false". A numeric
         // 0 / 1 (the older convention) trips 400 Bad Request.
@@ -520,7 +520,7 @@ impl DaemonClient {
 
     // ─── Analytics ───────────────────────────────────────────────────
 
-    pub fn summary(
+    pub(crate) fn summary(
         &self,
         since: Option<&str>,
         until: Option<&str>,
@@ -550,7 +550,7 @@ impl DaemonClient {
         Ok(resp.json()?)
     }
 
-    pub fn cost(
+    pub(crate) fn cost(
         &self,
         since: Option<&str>,
         until: Option<&str>,
@@ -581,7 +581,7 @@ impl DaemonClient {
     }
 
     /// Single-call snapshot of summary + cost + providers (#619).
-    pub fn status_snapshot(
+    pub(crate) fn status_snapshot(
         &self,
         since: Option<&str>,
         until: Option<&str>,
@@ -611,7 +611,7 @@ impl DaemonClient {
         Ok(resp.json()?)
     }
 
-    pub fn projects(
+    pub(crate) fn projects(
         &self,
         since: Option<&str>,
         until: Option<&str>,
@@ -645,7 +645,7 @@ impl DaemonClient {
 
     /// Fetch per-cwd-basename breakdown of non-repo work for the
     /// `--include-non-repo` view on `budi stats --projects` (#442).
-    pub fn non_repo(
+    pub(crate) fn non_repo(
         &self,
         since: Option<&str>,
         until: Option<&str>,
@@ -669,7 +669,7 @@ impl DaemonClient {
         Ok(resp.json()?)
     }
 
-    pub fn branches(
+    pub(crate) fn branches(
         &self,
         since: Option<&str>,
         until: Option<&str>,
@@ -701,7 +701,7 @@ impl DaemonClient {
         Ok(resp.json()?)
     }
 
-    pub fn branch_detail(
+    pub(crate) fn branch_detail(
         &self,
         branch: &str,
         repo_id: Option<&str>,
@@ -741,7 +741,7 @@ impl DaemonClient {
     /// `GET /analytics/tickets` — per-ticket cost roll-up. Matches the
     /// daemon's `TicketListParams` shape (date window + dimension filters +
     /// limit). Used by `budi stats --tickets`.
-    pub fn tickets(
+    pub(crate) fn tickets(
         &self,
         since: Option<&str>,
         until: Option<&str>,
@@ -776,7 +776,7 @@ impl DaemonClient {
     /// `GET /analytics/tickets/{id}` — single-ticket detail with per-branch
     /// breakdown. Returns `Ok(None)` for an unknown ticket id (mirrors
     /// `branch_detail`).
-    pub fn ticket_detail(
+    pub(crate) fn ticket_detail(
         &self,
         ticket_id: &str,
         repo_id: Option<&str>,
@@ -815,7 +815,7 @@ impl DaemonClient {
     /// `GET /analytics/activities` — per-activity cost roll-up. Used by
     /// `budi stats --activities`. Mirrors `tickets` so operators can swap
     /// `--tickets` / `--activities` without learning a new query shape.
-    pub fn activities(
+    pub(crate) fn activities(
         &self,
         since: Option<&str>,
         until: Option<&str>,
@@ -850,7 +850,7 @@ impl DaemonClient {
     /// `GET /analytics/activities/{name}` — single-activity detail with
     /// per-branch breakdown. Returns `Ok(None)` for an unknown activity
     /// (mirrors `ticket_detail`).
-    pub fn activity_detail(
+    pub(crate) fn activity_detail(
         &self,
         activity: &str,
         repo_id: Option<&str>,
@@ -888,7 +888,7 @@ impl DaemonClient {
 
     /// `GET /analytics/files` — per-file cost roll-up. Used by
     /// `budi stats --files`. Mirrors `tickets` / `activities`.
-    pub fn files(
+    pub(crate) fn files(
         &self,
         since: Option<&str>,
         until: Option<&str>,
@@ -922,7 +922,7 @@ impl DaemonClient {
 
     /// `GET /analytics/files/{path}` — single-file detail with per-branch
     /// and per-ticket breakdowns. Returns `Ok(None)` for an unknown file.
-    pub fn file_detail(
+    pub(crate) fn file_detail(
         &self,
         file_path: &str,
         repo_id: Option<&str>,
@@ -958,7 +958,7 @@ impl DaemonClient {
         Ok(Some(serde_json::from_value(val)?))
     }
 
-    pub fn models(
+    pub(crate) fn models(
         &self,
         since: Option<&str>,
         until: Option<&str>,
@@ -990,7 +990,7 @@ impl DaemonClient {
         Ok(resp.json()?)
     }
 
-    pub fn tags(
+    pub(crate) fn tags(
         &self,
         key: Option<&str>,
         since: Option<&str>,
@@ -1018,7 +1018,7 @@ impl DaemonClient {
         Ok(resp.json()?)
     }
 
-    pub fn providers(
+    pub(crate) fn providers(
         &self,
         since: Option<&str>,
         until: Option<&str>,
@@ -1047,7 +1047,7 @@ impl DaemonClient {
     /// `GET /analytics/surfaces` — per-host-environment breakdown (#702).
     /// Mirror of [`Self::providers`] keyed on the surface axis. Returns one
     /// row per surface present in the window; empty surfaces are excluded.
-    pub fn surfaces(
+    pub(crate) fn surfaces(
         &self,
         since: Option<&str>,
         until: Option<&str>,
@@ -1074,7 +1074,7 @@ impl DaemonClient {
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub fn sessions(
+    pub(crate) fn sessions(
         &self,
         since: Option<&str>,
         until: Option<&str>,
@@ -1130,7 +1130,7 @@ impl DaemonClient {
         Ok(resp.json()?)
     }
 
-    pub fn session_detail(&self, session_id: &str) -> Result<Option<SessionListEntry>> {
+    pub(crate) fn session_detail(&self, session_id: &str) -> Result<Option<SessionListEntry>> {
         let resp = self
             .client
             .get(format!(
@@ -1146,7 +1146,7 @@ impl DaemonClient {
         Ok(Some(resp.json()?))
     }
 
-    pub fn session_tags(&self, session_id: &str) -> Result<Vec<SessionTag>> {
+    pub(crate) fn session_tags(&self, session_id: &str) -> Result<Vec<SessionTag>> {
         let resp = self
             .client
             .get(format!(
@@ -1163,7 +1163,11 @@ impl DaemonClient {
     /// server-side resolution for the `current` and `latest` literal
     /// session tokens (#603). Returns the resolved session id plus
     /// an optional `fallback_reason` line the CLI prints on stderr.
-    pub fn resolve_session_token(&self, token: &str, cwd: Option<&str>) -> Result<ResolvedSession> {
+    pub(crate) fn resolve_session_token(
+        &self,
+        token: &str,
+        cwd: Option<&str>,
+    ) -> Result<ResolvedSession> {
         let mut params: Vec<(&str, &str)> = vec![("token", token)];
         if let Some(c) = cwd {
             params.push(("cwd", c));
@@ -1178,7 +1182,7 @@ impl DaemonClient {
         Ok(resp.json()?)
     }
 
-    pub fn session_health(&self, session_id: Option<&str>) -> Result<SessionHealth> {
+    pub(crate) fn session_health(&self, session_id: Option<&str>) -> Result<SessionHealth> {
         let mut params: Vec<(&str, &str)> = Vec::new();
         if let Some(s) = session_id {
             params.push(("session_id", s));

--- a/crates/budi-cli/src/commands/autostart.rs
+++ b/crates/budi-cli/src/commands/autostart.rs
@@ -7,7 +7,7 @@ use crate::StatsFormat;
 use crate::daemon;
 
 /// `budi autostart status` — show current autostart state.
-pub fn cmd_autostart_status(format: StatsFormat) -> Result<()> {
+pub(crate) fn cmd_autostart_status(format: StatsFormat) -> Result<()> {
     if matches!(format, StatsFormat::Json) {
         return cmd_autostart_status_json();
     }
@@ -95,7 +95,7 @@ fn autostart_platform_tag() -> &'static str {
 }
 
 /// `budi autostart install` — install the autostart service.
-pub fn cmd_autostart_install() -> Result<()> {
+pub(crate) fn cmd_autostart_install() -> Result<()> {
     let green = super::ansi("\x1b[32m");
     let yellow = super::ansi("\x1b[33m");
     let reset = super::ansi("\x1b[0m");
@@ -132,7 +132,7 @@ pub fn cmd_autostart_install() -> Result<()> {
 }
 
 /// `budi autostart uninstall` — remove the autostart service.
-pub fn cmd_autostart_uninstall() -> Result<()> {
+pub(crate) fn cmd_autostart_uninstall() -> Result<()> {
     let green = super::ansi("\x1b[32m");
     let reset = super::ansi("\x1b[0m");
 

--- a/crates/budi-cli/src/commands/cloud.rs
+++ b/crates/budi-cli/src/commands/cloud.rs
@@ -50,7 +50,7 @@ const DEFAULT_CLOUD_ENDPOINT: &str = "https://app.getbudi.dev";
 /// hard-erroring. Non-TTY callers still need `--force` as the explicit
 /// escape hatch; the error copy now names the existing org so the user
 /// recognizes what they're about to replace.
-pub fn cmd_cloud_init(
+pub(crate) fn cmd_cloud_init(
     api_key: Option<String>,
     force: bool,
     yes: bool,
@@ -510,7 +510,7 @@ fn describe_source(src: IdentitySource) -> &'static str {
 /// build) and then the regular sync runs. Cloud-side dedup keeps the
 /// re-upload safe even when records overlap with rows the cloud
 /// already has.
-pub fn cmd_cloud_sync(format: StatsFormat, full: bool, yes: bool) -> Result<()> {
+pub(crate) fn cmd_cloud_sync(format: StatsFormat, full: bool, yes: bool) -> Result<()> {
     let client = DaemonClient::connect()?;
 
     let reset_removed = if full {
@@ -576,7 +576,7 @@ fn render_full_reset_preamble(removed: usize) {
 }
 
 /// `budi cloud status` — report cloud sync readiness and last-synced-at.
-pub fn cmd_cloud_status(format: StatsFormat) -> Result<()> {
+pub(crate) fn cmd_cloud_status(format: StatsFormat) -> Result<()> {
     let client = DaemonClient::connect()?;
     let body = client.cloud_status()?;
 
@@ -601,7 +601,7 @@ pub fn cmd_cloud_status(format: StatsFormat) -> Result<()> {
 /// background tick would — that way a manual reset can never race a
 /// concurrent envelope build that already read the about-to-be-deleted
 /// watermark.
-pub fn cmd_cloud_reset(yes: bool, format: StatsFormat) -> Result<()> {
+pub(crate) fn cmd_cloud_reset(yes: bool, format: StatsFormat) -> Result<()> {
     let cfg = load_cloud_config();
     if !confirm_reset(&cfg, yes)? {
         if matches!(format, StatsFormat::Json) {

--- a/crates/budi-cli/src/commands/db.rs
+++ b/crates/budi-cli/src/commands/db.rs
@@ -40,7 +40,7 @@ use crate::commands::ansi;
 /// scripts (`budi db check && deploy`) can branch on the result. Repair
 /// mode (`/admin/repair`) is the old `db repair` behaviour: applies the
 /// migration, fixes additive drift, and prints a green ✓.
-pub fn cmd_db_check(fix: bool) -> Result<()> {
+pub(crate) fn cmd_db_check(fix: bool) -> Result<()> {
     let client = DaemonClient::connect()?;
     let result = if fix {
         client.repair()?
@@ -146,7 +146,7 @@ const DB_ALIAS_NUDGE_MARKER: &str = "db-alias-nudge";
 /// from 8.2.x. The file is a single-line UTC-date marker with no data;
 /// failure to remove it (missing budi home, permission denied) is
 /// silently ignored so this never fails an upgrade.
-pub fn remove_db_alias_nudge_marker() {
+pub(crate) fn remove_db_alias_nudge_marker() {
     if let Ok(home) = config::budi_home_dir() {
         let _ = fs::remove_file(home.join(DB_ALIAS_NUDGE_MARKER));
     }

--- a/crates/budi-cli/src/commands/doctor/mod.rs
+++ b/crates/budi-cli/src/commands/doctor/mod.rs
@@ -13,7 +13,7 @@ use serde::Serialize;
 use crate::StatsFormat;
 use crate::daemon::{daemon_health, ensure_daemon_running, resolve_daemon_binary};
 
-pub fn cmd_doctor(
+pub(crate) fn cmd_doctor(
     repo_root: Option<PathBuf>,
     deep: bool,
     quiet: bool,

--- a/crates/budi-cli/src/commands/import.rs
+++ b/crates/budi-cli/src/commands/import.rs
@@ -37,7 +37,7 @@ const POLL_INTERVAL: Duration = Duration::from_millis(2_000);
 /// `json`: emit a structured per-agent summary on stdout instead of the
 /// text table. Progress chatter is suppressed in JSON mode so stdout stays
 /// parseable.
-pub fn cmd_import(force: bool, json: bool) -> Result<()> {
+pub(crate) fn cmd_import(force: bool, json: bool) -> Result<()> {
     let client = DaemonClient::connect()?;
     let quiet = json;
     let is_tty = std::io::stdout().is_terminal();

--- a/crates/budi-cli/src/commands/init.rs
+++ b/crates/budi-cli/src/commands/init.rs
@@ -8,7 +8,7 @@ use budi_core::provider::Provider;
 
 use crate::daemon::ensure_daemon_running;
 
-pub fn cmd_init(no_integrations: bool, no_daemon: bool) -> Result<()> {
+pub(crate) fn cmd_init(no_integrations: bool, no_daemon: bool) -> Result<()> {
     clean_duplicate_binaries();
     check_daemon_binary_and_version();
 

--- a/crates/budi-cli/src/commands/integrations.rs
+++ b/crates/budi-cli/src/commands/integrations.rs
@@ -15,7 +15,7 @@ use serde_json::{Value, json};
 )]
 #[clap(rename_all = "kebab-case")]
 #[serde(rename_all = "kebab-case")]
-pub enum IntegrationComponent {
+pub(crate) enum IntegrationComponent {
     #[value(skip)]
     ClaudeCodeHooks,
     #[value(skip)]
@@ -28,7 +28,7 @@ pub enum IntegrationComponent {
 }
 
 impl IntegrationComponent {
-    pub fn display_name(self) -> &'static str {
+    pub(crate) fn display_name(self) -> &'static str {
         match self {
             Self::ClaudeCodeHooks => "Claude Code hooks",
             Self::ClaudeCodeOtel => "Claude Code OTEL",
@@ -39,7 +39,7 @@ impl IntegrationComponent {
         }
     }
 
-    pub fn is_removed_surface(self) -> bool {
+    pub(crate) fn is_removed_surface(self) -> bool {
         matches!(
             self,
             Self::ClaudeCodeHooks | Self::ClaudeCodeOtel | Self::CursorHooks
@@ -49,22 +49,22 @@ impl IntegrationComponent {
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(default)]
-pub struct IntegrationPreferences {
+pub(crate) struct IntegrationPreferences {
     pub enabled: BTreeSet<IntegrationComponent>,
 }
 
 #[derive(Debug, Default)]
-pub struct InstallReport {
+pub(crate) struct InstallReport {
     pub warnings: Vec<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum InstallState {
+pub(crate) enum InstallState {
     Installed,
     NotInstalled,
 }
 
-pub fn cmd_integrations(action: crate::IntegrationAction) -> Result<()> {
+pub(crate) fn cmd_integrations(action: crate::IntegrationAction) -> Result<()> {
     let cfg = crate::client::DaemonClient::load_config();
     match action {
         crate::IntegrationAction::List => {
@@ -157,7 +157,7 @@ pub fn cmd_integrations(action: crate::IntegrationAction) -> Result<()> {
     }
 }
 
-pub fn default_recommended_components() -> BTreeSet<IntegrationComponent> {
+pub(crate) fn default_recommended_components() -> BTreeSet<IntegrationComponent> {
     [
         IntegrationComponent::ClaudeCodeStatusline,
         IntegrationComponent::ClaudeCodeBudiSkill,
@@ -167,7 +167,7 @@ pub fn default_recommended_components() -> BTreeSet<IntegrationComponent> {
     .collect()
 }
 
-pub fn all_components() -> BTreeSet<IntegrationComponent> {
+pub(crate) fn all_components() -> BTreeSet<IntegrationComponent> {
     [
         IntegrationComponent::ClaudeCodeStatusline,
         IntegrationComponent::ClaudeCodeBudiSkill,
@@ -177,11 +177,11 @@ pub fn all_components() -> BTreeSet<IntegrationComponent> {
     .collect()
 }
 
-pub fn integrations_config_path() -> Result<PathBuf> {
+pub(crate) fn integrations_config_path() -> Result<PathBuf> {
     Ok(config::budi_config_dir()?.join("integrations.toml"))
 }
 
-pub fn load_preferences() -> IntegrationPreferences {
+pub(crate) fn load_preferences() -> IntegrationPreferences {
     let path = match integrations_config_path() {
         Ok(p) => p,
         Err(_) => return IntegrationPreferences::default(),
@@ -196,7 +196,7 @@ pub fn load_preferences() -> IntegrationPreferences {
     toml::from_str::<IntegrationPreferences>(&raw).unwrap_or_default()
 }
 
-pub fn save_preferences(prefs: &IntegrationPreferences) -> Result<()> {
+pub(crate) fn save_preferences(prefs: &IntegrationPreferences) -> Result<()> {
     let path = integrations_config_path()?;
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)
@@ -207,7 +207,7 @@ pub fn save_preferences(prefs: &IntegrationPreferences) -> Result<()> {
     Ok(())
 }
 
-pub fn detect_component_state(
+pub(crate) fn detect_component_state(
     config: &config::BudiConfig,
     component: IntegrationComponent,
 ) -> InstallState {
@@ -226,7 +226,7 @@ pub fn detect_component_state(
     }
 }
 
-pub fn infer_preferences_from_system(config: &config::BudiConfig) -> IntegrationPreferences {
+pub(crate) fn infer_preferences_from_system(config: &config::BudiConfig) -> IntegrationPreferences {
     let mut prefs = IntegrationPreferences::default();
     for component in all_components() {
         if matches!(
@@ -239,7 +239,7 @@ pub fn infer_preferences_from_system(config: &config::BudiConfig) -> Integration
     prefs
 }
 
-pub fn install_selected(
+pub(crate) fn install_selected(
     config: &config::BudiConfig,
     selected: &BTreeSet<IntegrationComponent>,
 ) -> InstallReport {
@@ -322,7 +322,7 @@ fn drop_removed_surfaces(selected: &mut BTreeSet<IntegrationComponent>) -> Vec<S
     warnings
 }
 
-pub fn refresh_enabled_integrations(config: &config::BudiConfig) -> InstallReport {
+pub(crate) fn refresh_enabled_integrations(config: &config::BudiConfig) -> InstallReport {
     let mut prefs = load_preferences();
     if prefs.enabled.is_empty() {
         prefs = infer_preferences_from_system(config);
@@ -712,7 +712,7 @@ fn install_cursor_extension(warnings: &mut Vec<String>) {
 }
 
 /// Check if the `cursor` CLI is on PATH (or at the well-known macOS location).
-pub fn find_cursor_cli() -> Option<String> {
+pub(crate) fn find_cursor_cli() -> Option<String> {
     let candidates = if cfg!(target_os = "macos") {
         vec![
             "cursor".to_string(),
@@ -735,7 +735,7 @@ pub fn find_cursor_cli() -> Option<String> {
 }
 
 /// Check if the budi Cursor extension is installed.
-pub fn is_cursor_extension_installed() -> bool {
+pub(crate) fn is_cursor_extension_installed() -> bool {
     match find_cursor_cli() {
         Some(cli) => Command::new(cli)
             .arg("--list-extensions")
@@ -753,7 +753,7 @@ pub fn is_cursor_extension_installed() -> bool {
 }
 
 /// Path to the auto-installed `/budi` Claude Code skill file.
-pub fn claude_budi_skill_path() -> Result<PathBuf> {
+pub(crate) fn claude_budi_skill_path() -> Result<PathBuf> {
     let home = budi_core::config::home_dir()?;
     Ok(home
         .join(".claude")
@@ -766,7 +766,7 @@ pub fn claude_budi_skill_path() -> Result<PathBuf> {
 /// constant so the install path and the e2e regression guard agree on
 /// the byte-for-byte contents (idempotent re-install must leave a
 /// pre-existing file with these bytes untouched).
-pub const BUDI_SKILL_CONTENTS: &str = "---\n\
+pub(crate) const BUDI_SKILL_CONTENTS: &str = "---\n\
 name: budi\n\
 description: \"Show live session vitals — context bloat, cache hit rate, retry loops, cost acceleration — for the current Claude Code session. Buddy is back, but now it's budi.\"\n\
 ---\n\
@@ -818,14 +818,14 @@ fn install_claude_budi_skill() -> Result<BudiSkillApply> {
     Ok(BudiSkillApply::Created)
 }
 
-pub fn claude_budi_skill_installed() -> bool {
+pub(crate) fn claude_budi_skill_installed() -> bool {
     let Ok(path) = claude_budi_skill_path() else {
         return false;
     };
     path.is_file()
 }
 
-pub fn claude_statusline_installed() -> bool {
+pub(crate) fn claude_statusline_installed() -> bool {
     let Some(settings) = read_claude_settings() else {
         return false;
     };
@@ -836,21 +836,21 @@ pub fn claude_statusline_installed() -> bool {
         .is_some_and(super::statusline::statusline_has_budi)
 }
 
-pub fn claude_hooks_installed() -> bool {
+pub(crate) fn claude_hooks_installed() -> bool {
     let Some(settings) = read_claude_settings() else {
         return false;
     };
     budi_core::integrations::validate_cc_hooks(&settings).0
 }
 
-pub fn claude_otel_installed(config: &config::BudiConfig) -> bool {
+pub(crate) fn claude_otel_installed(config: &config::BudiConfig) -> bool {
     let Some(settings) = read_claude_settings() else {
         return false;
     };
     budi_core::integrations::check_otel_config(&settings, config.daemon_port)
 }
 
-pub fn cursor_hooks_installed() -> bool {
+pub(crate) fn cursor_hooks_installed() -> bool {
     let home = match budi_core::config::home_dir() {
         Ok(h) => h,
         Err(_) => return false,

--- a/crates/budi-cli/src/commands/mod.rs
+++ b/crates/budi-cli/src/commands/mod.rs
@@ -6,26 +6,26 @@ use budi_core::config;
 use serde::Serialize;
 use serde_json::Value;
 
-pub mod autostart;
-pub mod cloud;
-pub mod db;
-pub mod doctor;
-pub mod import;
-pub mod init;
-pub mod integrations;
-pub mod pricing;
-pub mod sessions;
-pub mod stats;
-pub mod status;
-pub mod statusline;
-pub mod uninstall;
-pub mod update;
+pub(crate) mod autostart;
+pub(crate) mod cloud;
+pub(crate) mod db;
+pub(crate) mod doctor;
+pub(crate) mod import;
+pub(crate) mod init;
+pub(crate) mod integrations;
+pub(crate) mod pricing;
+pub(crate) mod sessions;
+pub(crate) mod stats;
+pub(crate) mod status;
+pub(crate) mod statusline;
+pub(crate) mod uninstall;
+pub(crate) mod update;
 
 // ---------------------------------------------------------------------------
 // Hook event constants and detection helpers — re-exported from budi-core
 // ---------------------------------------------------------------------------
 
-pub use budi_core::integrations::{
+pub(crate) use budi_core::integrations::{
     CC_HOOK_EVENTS, CURSOR_HOOK_EVENTS, is_budi_cc_hook_entry, is_budi_cursor_hook_entry,
 };
 
@@ -34,7 +34,7 @@ pub use budi_core::integrations::{
 // ---------------------------------------------------------------------------
 
 /// Read a JSON file, returning an empty object if missing or invalid.
-pub fn read_json_or_default(path: &Path) -> Result<Value> {
+pub(crate) fn read_json_or_default(path: &Path) -> Result<Value> {
     if !path.exists() {
         return Ok(serde_json::json!({}));
     }
@@ -52,7 +52,7 @@ pub fn read_json_or_default(path: &Path) -> Result<Value> {
 ///
 /// If the file does not exist, returns `{}`. If parsing fails (or the root is not an
 /// object), creates a backup next to the file and returns an error.
-pub fn read_json_object_strict(path: &Path) -> Result<Value> {
+pub(crate) fn read_json_object_strict(path: &Path) -> Result<Value> {
     if !path.exists() {
         return Ok(serde_json::json!({}));
     }
@@ -106,7 +106,7 @@ fn backup_invalid_json(path: &Path) -> Result<PathBuf> {
 ///    rename, permissions, etc.), we fall back to a non-atomic
 ///    in-place write through the symlink and emit a warning so
 ///    dotfile managers don't desync silently.
-pub fn atomic_write_json(path: &Path, value: &Value) -> Result<()> {
+pub(crate) fn atomic_write_json(path: &Path, value: &Value) -> Result<()> {
     let out = serde_json::to_string_pretty(value)?;
 
     // If `path` is a symlink, write to its canonical target so the
@@ -210,17 +210,17 @@ pub fn atomic_write_json(path: &Path, value: &Value) -> Result<()> {
 // ---------------------------------------------------------------------------
 
 /// Returns true if color output should be used (NO_COLOR env var is not set).
-pub fn use_color() -> bool {
+pub(crate) fn use_color() -> bool {
     std::env::var("NO_COLOR").is_err()
 }
 
 /// Returns the ANSI escape code if color is enabled, otherwise empty string.
-pub fn ansi(code: &str) -> &str {
+pub(crate) fn ansi(code: &str) -> &str {
     if use_color() { code } else { "" }
 }
 
 /// Try to resolve a repo root, but return None if not in a git repository.
-pub fn try_resolve_repo_root(candidate: Option<PathBuf>) -> Option<PathBuf> {
+pub(crate) fn try_resolve_repo_root(candidate: Option<PathBuf>) -> Option<PathBuf> {
     if let Some(path) = candidate {
         return Some(path);
     }
@@ -249,7 +249,7 @@ pub fn try_resolve_repo_root(candidate: Option<PathBuf>) -> Option<PathBuf> {
 /// Walk `value` in place and round every numeric field whose key ends
 /// in `_cents` to an integer. Non-numeric values at those keys are
 /// left unchanged. Returns the mutated reference for chaining.
-pub fn round_cents_to_integer(value: &mut Value) -> &mut Value {
+pub(crate) fn round_cents_to_integer(value: &mut Value) -> &mut Value {
     match value {
         Value::Object(map) => {
             for (k, v) in map.iter_mut() {
@@ -280,7 +280,7 @@ fn is_cents_key(key: &str) -> bool {
 /// CLI cents normalisation applied. All `budi` commands that emit
 /// `--format json` should route through this helper so the contract
 /// stays consistent.
-pub fn print_json<T: Serialize>(value: &T) -> Result<()> {
+pub(crate) fn print_json<T: Serialize>(value: &T) -> Result<()> {
     let mut v = serde_json::to_value(value).context("serialise to JSON value")?;
     round_cents_to_integer(&mut v);
     let out = serde_json::to_string_pretty(&v).context("serialise JSON value to string")?;
@@ -293,7 +293,7 @@ pub fn print_json<T: Serialize>(value: &T) -> Result<()> {
 /// (Cursor extension, cloud dashboard, user's starship prompt)
 /// expects a single-line payload but still benefits from the cents
 /// normalisation.
-pub fn print_json_compact<T: Serialize>(value: &T) -> Result<()> {
+pub(crate) fn print_json_compact<T: Serialize>(value: &T) -> Result<()> {
     let mut v = serde_json::to_value(value).context("serialise to JSON value")?;
     round_cents_to_integer(&mut v);
     let out = serde_json::to_string(&v).context("serialise JSON value to string")?;
@@ -302,7 +302,7 @@ pub fn print_json_compact<T: Serialize>(value: &T) -> Result<()> {
 }
 
 /// Format a cost value in dollars: $1.2K, $123, $12.50, $0.42, $0.00
-pub fn format_cost(dollars: f64) -> String {
+pub(crate) fn format_cost(dollars: f64) -> String {
     if dollars >= 1000.0 {
         format!("${:.1}K", dollars / 1000.0)
     } else if dollars >= 100.0 {
@@ -322,7 +322,7 @@ pub fn format_cost(dollars: f64) -> String {
 /// the canonical form used in SQLite. Prompt-style commands that want to
 /// stay quiet on a typo can map this error to a soft fallback themselves
 /// (#615).
-pub fn normalize_provider(input: &str) -> Result<String> {
+pub(crate) fn normalize_provider(input: &str) -> Result<String> {
     const KNOWN_PROVIDERS: &[&str] = &[
         "claude_code",
         "cursor",
@@ -361,7 +361,7 @@ pub fn normalize_provider(input: &str) -> Result<String> {
 /// silently returning empty results. Surfaces are canonical-only at first
 /// (no `code` → `vscode` alias yet) per the #702 ticket's "Out of scope".
 /// Accepts mixed-case input — `--surface VSCode` lowercases to `vscode`.
-pub fn normalize_surface(input: &str) -> Result<String> {
+pub(crate) fn normalize_surface(input: &str) -> Result<String> {
     const KNOWN_SURFACES: &[&str] = &[
         budi_core::surface::VSCODE,
         budi_core::surface::CURSOR,

--- a/crates/budi-cli/src/commands/pricing.rs
+++ b/crates/budi-cli/src/commands/pricing.rs
@@ -28,7 +28,7 @@ use crate::client::DaemonClient;
 use super::{ansi, format_cost};
 
 /// `budi pricing` (bare) and `budi pricing status` — read-only manifest state.
-pub fn cmd_pricing_status(format: StatsFormat) -> Result<()> {
+pub(crate) fn cmd_pricing_status(format: StatsFormat) -> Result<()> {
     let client = DaemonClient::connect()?;
     let status = client.pricing_status()?;
 
@@ -56,7 +56,7 @@ pub fn cmd_pricing_status(format: StatsFormat) -> Result<()> {
 /// for the hourly worker tick. `--force` skips the `list_version`
 /// short-circuit so the recompute runs even when the list is unchanged.
 /// #732.
-pub fn cmd_pricing_recompute(format: StatsFormat, force: bool) -> Result<()> {
+pub(crate) fn cmd_pricing_recompute(format: StatsFormat, force: bool) -> Result<()> {
     let client = DaemonClient::connect()?;
     let body = client.pricing_recompute(force)?;
     let status = client.pricing_status()?;
@@ -82,7 +82,7 @@ pub fn cmd_pricing_recompute(format: StatsFormat, force: bool) -> Result<()> {
 /// own subcommand, matching the `cloud sync` shape. Exit code is `2` on
 /// refresh failure so CI scripts can branch on status without parsing the
 /// body.
-pub fn cmd_pricing_sync(format: StatsFormat) -> Result<()> {
+pub(crate) fn cmd_pricing_sync(format: StatsFormat) -> Result<()> {
     let client = DaemonClient::connect()?;
     let refresh_body = client.pricing_refresh()?;
     let status = client.pricing_status()?;

--- a/crates/budi-cli/src/commands/sessions.rs
+++ b/crates/budi-cli/src/commands/sessions.rs
@@ -32,7 +32,7 @@ const MODEL_COL_WIDTH: usize = 28;
 use budi_core::analytics::SHORT_ID_LEN;
 
 #[allow(clippy::too_many_arguments)]
-pub fn cmd_sessions(
+pub(crate) fn cmd_sessions(
     period: StatsPeriod,
     search: Option<&str>,
     provider: Option<&str>,
@@ -200,7 +200,7 @@ pub fn cmd_sessions(
     Ok(())
 }
 
-pub fn cmd_session_detail(session_id: &str, json_output: bool) -> Result<()> {
+pub(crate) fn cmd_session_detail(session_id: &str, json_output: bool) -> Result<()> {
     let client = DaemonClient::connect().context(
         "Could not reach budi daemon. Run `budi init` to set up, or `budi doctor` to diagnose.",
     )?;

--- a/crates/budi-cli/src/commands/stats/mod.rs
+++ b/crates/budi-cli/src/commands/stats/mod.rs
@@ -269,7 +269,7 @@ fn format_breakdown_row_text(
     }
 }
 
-pub fn period_label(period: StatsPeriod) -> String {
+pub(crate) fn period_label(period: StatsPeriod) -> String {
     match period {
         StatsPeriod::Today => "Today".to_string(),
         StatsPeriod::Week => "Last 7 days".to_string(),
@@ -284,7 +284,7 @@ pub fn period_label(period: StatsPeriod) -> String {
     }
 }
 
-pub fn period_key(period: StatsPeriod) -> String {
+pub(crate) fn period_key(period: StatsPeriod) -> String {
     match period {
         StatsPeriod::Today => "today".to_string(),
         StatsPeriod::Week => "week".to_string(),
@@ -343,14 +343,14 @@ pub(crate) fn period_since_date(today: NaiveDate, period: StatsPeriod) -> Option
     }
 }
 
-pub fn period_date_range(period: StatsPeriod) -> (Option<String>, Option<String>) {
+pub(crate) fn period_date_range(period: StatsPeriod) -> (Option<String>, Option<String>) {
     let today = Local::now().date_naive();
     let since = period_since_date(today, period).map(local_midnight_to_utc);
     (since, None)
 }
 
 #[allow(clippy::too_many_arguments)]
-pub fn cmd_stats(
+pub(crate) fn cmd_stats(
     period: StatsPeriod,
     projects: bool,
     branches: bool,
@@ -2684,7 +2684,7 @@ fn format_breakdown_footer<T>(
 
 // ─── Formatting Utilities ────────────────────────────────────────────────────
 
-pub fn format_tokens(n: u64) -> String {
+pub(crate) fn format_tokens(n: u64) -> String {
     if n >= 1_000_000_000 {
         format!("{:.1}B", n as f64 / 1_000_000_000.0)
     } else if n >= 1_000_000 {
@@ -2696,9 +2696,9 @@ pub fn format_tokens(n: u64) -> String {
     }
 }
 
-pub use super::format_cost;
+pub(crate) use super::format_cost;
 
-pub fn format_cost_cents(cents: f64) -> String {
+pub(crate) fn format_cost_cents(cents: f64) -> String {
     format_cost(cents / 100.0)
 }
 
@@ -2708,7 +2708,7 @@ pub fn format_cost_cents(cents: f64) -> String {
 /// the #450 acceptance for "Single currency format per column type" —
 /// the summary view keeps the humanized `$1.2K` form via
 /// [`format_cost_cents`]; breakdowns use this one.
-pub fn format_cost_cents_fixed(cents: f64) -> String {
+pub(crate) fn format_cost_cents_fixed(cents: f64) -> String {
     let dollars = cents / 100.0;
     let sign = if dollars < 0.0 { "-" } else { "" };
     let magnitude = dollars.abs();

--- a/crates/budi-cli/src/commands/status.rs
+++ b/crates/budi-cli/src/commands/status.rs
@@ -9,7 +9,7 @@ use crate::{StatsFormat, commands};
 use super::ansi;
 
 /// Quick operational overview: daemon and today's cost.
-pub fn cmd_status(format: StatsFormat) -> Result<()> {
+pub(crate) fn cmd_status(format: StatsFormat) -> Result<()> {
     if matches!(format, StatsFormat::Json) {
         return cmd_status_json();
     }

--- a/crates/budi-cli/src/commands/statusline.rs
+++ b/crates/budi-cli/src/commands/statusline.rs
@@ -13,7 +13,7 @@ use serde_json::{Value, json};
 use crate::StatuslineFormat;
 use crate::daemon::daemon_client_with_timeout;
 
-pub const CLAUDE_USER_SETTINGS: &str = ".claude/settings.json";
+pub(crate) const CLAUDE_USER_SETTINGS: &str = ".claude/settings.json";
 
 use super::format_cost as fmt_cost;
 use super::normalize_provider;
@@ -298,7 +298,7 @@ fn parse_slots_arg(raw: &str) -> Vec<String> {
         .collect()
 }
 
-pub fn cmd_statusline(
+pub(crate) fn cmd_statusline(
     format: StatuslineFormat,
     provider: Option<String>,
     slots: Option<String>,
@@ -582,7 +582,7 @@ pub(crate) fn statusline_has_budi(cmd: &str) -> bool {
     cmd.contains("budi statusline") || cmd.contains("budi_out=$(budi")
 }
 
-pub fn cmd_statusline_install() -> Result<()> {
+pub(crate) fn cmd_statusline_install() -> Result<()> {
     let home = budi_core::config::home_dir()?;
     let settings_path = home.join(CLAUDE_USER_SETTINGS);
     if let Some(parent) = settings_path.parent() {
@@ -619,7 +619,7 @@ pub fn cmd_statusline_install() -> Result<()> {
 /// Remove legacy budi hooks from ~/.claude/settings.json.
 /// Old budi versions installed hooks that call `budi hook <subcommand>` (with arguments).
 /// Preserves new-style hooks that use just `budi hook` (no arguments).
-pub fn remove_legacy_hooks() {
+pub(crate) fn remove_legacy_hooks() {
     let Ok(home) = budi_core::config::home_dir() else {
         return;
     };

--- a/crates/budi-cli/src/commands/uninstall.rs
+++ b/crates/budi-cli/src/commands/uninstall.rs
@@ -10,7 +10,7 @@ use serde_json::Value;
 
 use super::statusline::CLAUDE_USER_SETTINGS;
 
-pub fn cmd_uninstall(keep_data: bool, yes: bool) -> Result<()> {
+pub(crate) fn cmd_uninstall(keep_data: bool, yes: bool) -> Result<()> {
     let green = super::ansi("\x1b[32m");
     let yellow = super::ansi("\x1b[33m");
     let reset = super::ansi("\x1b[0m");

--- a/crates/budi-cli/src/commands/update.rs
+++ b/crates/budi-cli/src/commands/update.rs
@@ -35,7 +35,7 @@ struct BackupEntry {
     backup: Option<PathBuf>,
 }
 
-pub fn cmd_update(yes: bool, version: Option<String>) -> Result<()> {
+pub(crate) fn cmd_update(yes: bool, version: Option<String>) -> Result<()> {
     let is_brew = is_homebrew_install();
 
     let current = env!("CARGO_PKG_VERSION");

--- a/crates/budi-cli/src/daemon.rs
+++ b/crates/budi-cli/src/daemon.rs
@@ -12,18 +12,18 @@ use reqwest::blocking::Client;
 
 use crate::HEALTH_TIMEOUT_SECS;
 
-pub fn daemon_client_with_timeout(timeout: Duration) -> Result<Client> {
+pub(crate) fn daemon_client_with_timeout(timeout: Duration) -> Result<Client> {
     Client::builder()
         .timeout(timeout)
         .build()
         .context("Failed to construct HTTP client")
 }
 
-pub fn daemon_health(config: &BudiConfig) -> bool {
+pub(crate) fn daemon_health(config: &BudiConfig) -> bool {
     daemon_health_with_timeout(config, Duration::from_secs(HEALTH_TIMEOUT_SECS))
 }
 
-pub fn daemon_health_with_timeout(config: &BudiConfig, timeout: Duration) -> bool {
+pub(crate) fn daemon_health_with_timeout(config: &BudiConfig, timeout: Duration) -> bool {
     let Ok(client) = daemon_client_with_timeout(timeout) else {
         return false;
     };
@@ -49,11 +49,11 @@ fn startup_timeout_retries() -> usize {
         .unwrap_or(80) // default: 80 retries * ~650ms = ~52s
 }
 
-pub fn ensure_daemon_running(repo_root: Option<&Path>, config: &BudiConfig) -> Result<()> {
+pub(crate) fn ensure_daemon_running(repo_root: Option<&Path>, config: &BudiConfig) -> Result<()> {
     ensure_daemon_running_with_binary(repo_root, config, None)
 }
 
-pub fn ensure_daemon_running_with_binary(
+pub(crate) fn ensure_daemon_running_with_binary(
     repo_root: Option<&Path>,
     config: &BudiConfig,
     daemon_bin_override: Option<&Path>,
@@ -187,7 +187,7 @@ fn daemon_version_equals(config: &BudiConfig, expected: &str) -> bool {
 ///
 /// No-op when the daemon already reports the expected version (the brew /
 /// launchd respawn already picked up the new binary on its own).
-pub fn restart_daemon_for_version_upgrade(
+pub(crate) fn restart_daemon_for_version_upgrade(
     repo_root: Option<&Path>,
     config: &BudiConfig,
     daemon_bin_override: Option<&Path>,
@@ -437,7 +437,7 @@ fn daemon_process_command(pid: u32) -> Option<String> {
     }
 }
 
-pub fn is_budi_daemon_command_for_port(command: &str, port: u16) -> bool {
+pub(crate) fn is_budi_daemon_command_for_port(command: &str, port: u16) -> bool {
     let spaced = format!("--port {port}");
     let inline = format!("--port={port}");
     command.contains("budi-daemon")

--- a/crates/budi-core/src/legacy_proxy.rs
+++ b/crates/budi-core/src/legacy_proxy.rs
@@ -166,6 +166,9 @@ impl EnvContext {
     }
 }
 
+// Variants are constructed via cfg-gated branches in `current_platform`; on any
+// single target some variants appear dead to the lint but are required for tests
+// that drive scans for the other platforms.
 #[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum PlatformFamily {

--- a/crates/budi-core/src/pipeline/mod.rs
+++ b/crates/budi-core/src/pipeline/mod.rs
@@ -902,7 +902,7 @@ mod tests {
         );
     }
 
-    pub fn test_msg() -> ParsedMessage {
+    pub(super) fn test_msg() -> ParsedMessage {
         ParsedMessage {
             uuid: "test".to_string(),
             session_id: None,

--- a/crates/budi-core/src/providers/copilot_chat/jetbrains.rs
+++ b/crates/budi-core/src/providers/copilot_chat/jetbrains.rs
@@ -1107,7 +1107,6 @@ pub(super) fn empty_fixture_dir() -> PathBuf {
 }
 
 #[cfg(test)]
-#[allow(dead_code)]
 pub(super) fn parse_session_dir_for_tests(
     session_dir: &Path,
 ) -> anyhow::Result<Vec<ParsedMessage>> {

--- a/crates/budi-daemon/src/routes/analytics.rs
+++ b/crates/budi-daemon/src/routes/analytics.rs
@@ -24,7 +24,7 @@ impl Drop for BusyFlagGuard {
 }
 
 #[derive(serde::Deserialize)]
-pub struct DimensionParams {
+pub(crate) struct DimensionParams {
     #[serde(alias = "agent", alias = "providers")]
     pub agents: Option<String>,
     #[serde(alias = "model")]
@@ -65,7 +65,7 @@ fn parse_dimension_filters(params: &DimensionParams) -> analytics::DimensionFilt
 }
 
 #[derive(serde::Deserialize)]
-pub struct DateRangeParams {
+pub(crate) struct DateRangeParams {
     pub since: Option<String>,
     pub until: Option<String>,
     #[serde(flatten)]
@@ -73,14 +73,14 @@ pub struct DateRangeParams {
 }
 
 #[derive(serde::Deserialize)]
-pub struct BranchDetailParams {
+pub(crate) struct BranchDetailParams {
     pub since: Option<String>,
     pub until: Option<String>,
     pub repo_id: Option<String>,
 }
 
 #[derive(serde::Deserialize)]
-pub struct SummaryParams {
+pub(crate) struct SummaryParams {
     pub since: Option<String>,
     pub until: Option<String>,
     pub provider: Option<String>,
@@ -88,7 +88,7 @@ pub struct SummaryParams {
     pub filters: DimensionParams,
 }
 
-pub async fn analytics_summary(
+pub(crate) async fn analytics_summary(
     Query(params): Query<SummaryParams>,
 ) -> Result<Json<analytics::UsageSummary>, (StatusCode, Json<serde_json::Value>)> {
     let filters = parse_dimension_filters(&params.filters);
@@ -111,7 +111,7 @@ pub async fn analytics_summary(
 }
 
 #[derive(serde::Deserialize)]
-pub struct MessagesParams {
+pub(crate) struct MessagesParams {
     pub since: Option<String>,
     pub until: Option<String>,
     pub search: Option<String>,
@@ -155,7 +155,7 @@ const VALID_SESSION_SORT_BY: &[&str] = &[
 
 const VALID_ACTIVITY_GRANULARITY: &[&str] = &["hour", "day", "week", "month"];
 
-pub async fn analytics_messages(
+pub(crate) async fn analytics_messages(
     Query(params): Query<MessagesParams>,
 ) -> Result<Json<analytics::PaginatedMessages>, (StatusCode, Json<serde_json::Value>)> {
     if let Some(ref sort) = params.sort_by
@@ -194,7 +194,7 @@ pub async fn analytics_messages(
 }
 
 #[derive(serde::Deserialize)]
-pub struct ListParams {
+pub(crate) struct ListParams {
     pub since: Option<String>,
     pub until: Option<String>,
     pub limit: Option<usize>,
@@ -209,7 +209,7 @@ fn resolve_breakdown_limit(requested: Option<usize>) -> usize {
     if raw == 0 { 0 } else { raw.min(100_000) }
 }
 
-pub async fn analytics_projects(
+pub(crate) async fn analytics_projects(
     Query(params): Query<ListParams>,
 ) -> Result<
     Json<analytics::BreakdownPage<analytics::RepoUsage>>,
@@ -239,7 +239,7 @@ pub async fn analytics_projects(
 /// `repo_id` is NULL. Returned as a flat `Vec<RepoUsage>` (no paginated
 /// `(other)` bucket) because the expected cardinality is small — any
 /// single user's non-repo scratch-dir set tops out in the low dozens.
-pub async fn analytics_non_repo(
+pub(crate) async fn analytics_non_repo(
     Query(params): Query<ListParams>,
 ) -> Result<Json<Vec<analytics::RepoUsage>>, (StatusCode, Json<serde_json::Value>)> {
     let limit = resolve_breakdown_limit(params.limit);
@@ -260,7 +260,7 @@ pub async fn analytics_non_repo(
     Ok(Json(result))
 }
 
-pub async fn analytics_models(
+pub(crate) async fn analytics_models(
     Query(params): Query<ListParams>,
 ) -> Result<
     Json<analytics::BreakdownPage<analytics::ModelUsage>>,
@@ -286,7 +286,7 @@ pub async fn analytics_models(
     Ok(Json(analytics::paginate_breakdown(result, limit)))
 }
 
-pub async fn analytics_branches(
+pub(crate) async fn analytics_branches(
     Query(params): Query<ListParams>,
 ) -> Result<
     Json<analytics::BreakdownPage<analytics::BranchCost>>,
@@ -312,7 +312,7 @@ pub async fn analytics_branches(
     Ok(Json(analytics::paginate_breakdown(result, limit)))
 }
 
-pub async fn analytics_cost(
+pub(crate) async fn analytics_cost(
     Query(params): Query<SummaryParams>,
 ) -> Result<Json<cost::CostEstimate>, (StatusCode, Json<serde_json::Value>)> {
     let filters = parse_dimension_filters(&params.filters);
@@ -336,7 +336,7 @@ pub async fn analytics_cost(
 
 /// `GET /analytics/status_snapshot` — summary + cost + providers from one
 /// connection so `budi status` sees a single consistent snapshot (#619).
-pub async fn analytics_status_snapshot(
+pub(crate) async fn analytics_status_snapshot(
     Query(params): Query<SummaryParams>,
 ) -> Result<Json<analytics::StatusSnapshot>, (StatusCode, Json<serde_json::Value>)> {
     let result = tokio::task::spawn_blocking(move || {
@@ -357,7 +357,7 @@ pub async fn analytics_status_snapshot(
 }
 
 #[derive(serde::Deserialize)]
-pub struct ActivityChartParams {
+pub(crate) struct ActivityChartParams {
     pub since: Option<String>,
     pub until: Option<String>,
     pub granularity: Option<String>,
@@ -366,7 +366,7 @@ pub struct ActivityChartParams {
     pub filters: DimensionParams,
 }
 
-pub async fn analytics_activity(
+pub(crate) async fn analytics_activity(
     Query(params): Query<ActivityChartParams>,
 ) -> Result<Json<Vec<analytics::ActivityBucket>>, (StatusCode, Json<serde_json::Value>)> {
     let granularity = params.granularity.unwrap_or_else(|| "day".to_string());
@@ -397,7 +397,7 @@ pub async fn analytics_activity(
     Ok(Json(result))
 }
 
-pub async fn analytics_providers(
+pub(crate) async fn analytics_providers(
     Query(params): Query<DateRangeParams>,
 ) -> Result<Json<Vec<analytics::ProviderStats>>, (StatusCode, Json<serde_json::Value>)> {
     let filters = parse_dimension_filters(&params.filters);
@@ -423,7 +423,7 @@ pub async fn analytics_providers(
 /// (`vscode` / `cursor` / `jetbrains` / `terminal` / `unknown`). Empty
 /// surfaces (no rows in window) are excluded so a single-host install
 /// never sees three empty rows.
-pub async fn analytics_surfaces(
+pub(crate) async fn analytics_surfaces(
     Query(params): Query<DateRangeParams>,
 ) -> Result<Json<Vec<analytics::SurfaceStats>>, (StatusCode, Json<serde_json::Value>)> {
     let filters = parse_dimension_filters(&params.filters);
@@ -451,7 +451,7 @@ pub(crate) struct ProviderInfo {
 }
 
 #[derive(serde::Serialize)]
-pub struct SchemaVersionResponse {
+pub(crate) struct SchemaVersionResponse {
     pub current: u32,
     pub target: u32,
     pub exists: bool,
@@ -460,7 +460,7 @@ pub struct SchemaVersionResponse {
 }
 
 #[derive(serde::Serialize)]
-pub struct RepairResponse {
+pub(crate) struct RepairResponse {
     pub from_version: u32,
     pub to_version: u32,
     pub migrated: bool,
@@ -471,7 +471,7 @@ pub struct RepairResponse {
 }
 
 #[derive(serde::Serialize)]
-pub struct IntegrationsResponse {
+pub(crate) struct IntegrationsResponse {
     pub cursor_extension: bool,
     pub statusline: bool,
     pub database: DatabaseStats,
@@ -479,21 +479,21 @@ pub struct IntegrationsResponse {
 }
 
 #[derive(serde::Serialize)]
-pub struct DatabaseStats {
+pub(crate) struct DatabaseStats {
     pub size_mb: f64,
     pub records: i64,
     pub first_record: Option<String>,
 }
 
 #[derive(serde::Serialize)]
-pub struct IntegrationPaths {
+pub(crate) struct IntegrationPaths {
     pub database: String,
     pub config: String,
     pub claude_settings: String,
 }
 
 #[derive(serde::Serialize)]
-pub struct CheckUpdateResponse {
+pub(crate) struct CheckUpdateResponse {
     pub current: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub latest: Option<String>,
@@ -503,7 +503,7 @@ pub struct CheckUpdateResponse {
     pub error: Option<String>,
 }
 
-pub async fn analytics_registered_providers()
+pub(crate) async fn analytics_registered_providers()
 -> Result<Json<Vec<ProviderInfo>>, (StatusCode, Json<serde_json::Value>)> {
     let providers = budi_core::provider::all_providers();
     let list: Vec<ProviderInfo> = providers
@@ -516,7 +516,7 @@ pub async fn analytics_registered_providers()
     Ok(Json(list))
 }
 
-pub async fn analytics_statusline(
+pub(crate) async fn analytics_statusline(
     Query(params): Query<analytics::StatuslineParams>,
 ) -> Result<Json<analytics::StatuslineStats>, (StatusCode, Json<serde_json::Value>)> {
     let result = tokio::task::spawn_blocking(move || {
@@ -540,7 +540,7 @@ pub async fn analytics_statusline(
 }
 
 #[derive(serde::Deserialize)]
-pub struct TagParams {
+pub(crate) struct TagParams {
     pub since: Option<String>,
     pub until: Option<String>,
     pub key: Option<String>,
@@ -549,7 +549,7 @@ pub struct TagParams {
     pub filters: DimensionParams,
 }
 
-pub async fn analytics_tags(
+pub(crate) async fn analytics_tags(
     Query(params): Query<TagParams>,
 ) -> Result<Json<analytics::BreakdownPage<analytics::TagCost>>, (StatusCode, Json<serde_json::Value>)>
 {
@@ -573,7 +573,7 @@ pub async fn analytics_tags(
     Ok(Json(analytics::paginate_breakdown(result, limit)))
 }
 
-pub async fn analytics_branch_detail(
+pub(crate) async fn analytics_branch_detail(
     Path(branch): Path<String>,
     Query(params): Query<BranchDetailParams>,
 ) -> Result<Json<analytics::BranchCost>, (StatusCode, Json<serde_json::Value>)> {
@@ -606,7 +606,7 @@ pub async fn analytics_branch_detail(
 /// `--provider`/`--model`/`--repo` slicing offered by `--branches` is also
 /// available for `--tickets`.
 #[derive(serde::Deserialize)]
-pub struct TicketListParams {
+pub(crate) struct TicketListParams {
     pub since: Option<String>,
     pub until: Option<String>,
     pub limit: Option<usize>,
@@ -615,13 +615,13 @@ pub struct TicketListParams {
 }
 
 #[derive(serde::Deserialize)]
-pub struct TicketDetailParams {
+pub(crate) struct TicketDetailParams {
     pub since: Option<String>,
     pub until: Option<String>,
     pub repo_id: Option<String>,
 }
 
-pub async fn analytics_tickets(
+pub(crate) async fn analytics_tickets(
     Query(params): Query<TicketListParams>,
 ) -> Result<
     Json<analytics::BreakdownPage<analytics::TicketCost>>,
@@ -647,7 +647,7 @@ pub async fn analytics_tickets(
     Ok(Json(analytics::paginate_breakdown(result, limit)))
 }
 
-pub async fn analytics_ticket_detail(
+pub(crate) async fn analytics_ticket_detail(
     Path(ticket_id): Path<String>,
     Query(params): Query<TicketDetailParams>,
 ) -> Result<Json<analytics::TicketCostDetail>, (StatusCode, Json<serde_json::Value>)> {
@@ -683,7 +683,7 @@ pub async fn analytics_ticket_detail(
 
 /// `GET /analytics/activities` query params. Mirrors `TicketListParams`.
 #[derive(serde::Deserialize)]
-pub struct ActivityListParams {
+pub(crate) struct ActivityListParams {
     pub since: Option<String>,
     pub until: Option<String>,
     pub limit: Option<usize>,
@@ -692,13 +692,13 @@ pub struct ActivityListParams {
 }
 
 #[derive(serde::Deserialize)]
-pub struct ActivityDetailParams {
+pub(crate) struct ActivityDetailParams {
     pub since: Option<String>,
     pub until: Option<String>,
     pub repo_id: Option<String>,
 }
 
-pub async fn analytics_activities(
+pub(crate) async fn analytics_activities(
     Query(params): Query<ActivityListParams>,
 ) -> Result<
     Json<analytics::BreakdownPage<analytics::ActivityCost>>,
@@ -724,7 +724,7 @@ pub async fn analytics_activities(
     Ok(Json(analytics::paginate_breakdown(result, limit)))
 }
 
-pub async fn analytics_activity_detail(
+pub(crate) async fn analytics_activity_detail(
     Path(activity): Path<String>,
     Query(params): Query<ActivityDetailParams>,
 ) -> Result<Json<analytics::ActivityCostDetail>, (StatusCode, Json<serde_json::Value>)> {
@@ -762,7 +762,7 @@ pub async fn analytics_activity_detail(
 // ---------------------------------------------------------------------------
 
 #[derive(serde::Deserialize)]
-pub struct FileListParams {
+pub(crate) struct FileListParams {
     pub since: Option<String>,
     pub until: Option<String>,
     pub limit: Option<usize>,
@@ -771,13 +771,13 @@ pub struct FileListParams {
 }
 
 #[derive(serde::Deserialize)]
-pub struct FileDetailParams {
+pub(crate) struct FileDetailParams {
     pub since: Option<String>,
     pub until: Option<String>,
     pub repo_id: Option<String>,
 }
 
-pub async fn analytics_files(
+pub(crate) async fn analytics_files(
     Query(params): Query<FileListParams>,
 ) -> Result<
     Json<analytics::BreakdownPage<analytics::FileCost>>,
@@ -803,7 +803,7 @@ pub async fn analytics_files(
     Ok(Json(analytics::paginate_breakdown(result, limit)))
 }
 
-pub async fn analytics_file_detail(
+pub(crate) async fn analytics_file_detail(
     Path(file_path): Path<String>,
     Query(params): Query<FileDetailParams>,
 ) -> Result<Json<analytics::FileCostDetail>, (StatusCode, Json<serde_json::Value>)> {
@@ -844,7 +844,7 @@ pub async fn analytics_file_detail(
     }
 }
 
-pub async fn analytics_schema_version()
+pub(crate) async fn analytics_schema_version()
 -> Result<Json<SchemaVersionResponse>, (StatusCode, Json<serde_json::Value>)> {
     let result = tokio::task::spawn_blocking(move || -> anyhow::Result<SchemaVersionResponse> {
         let db_path = analytics::db_path()?;
@@ -872,7 +872,7 @@ pub async fn analytics_schema_version()
     Ok(Json(result))
 }
 
-pub async fn analytics_cache_efficiency(
+pub(crate) async fn analytics_cache_efficiency(
     Query(params): Query<DateRangeParams>,
 ) -> Result<Json<analytics::CacheEfficiency>, (StatusCode, Json<serde_json::Value>)> {
     let filters = parse_dimension_filters(&params.filters);
@@ -892,7 +892,7 @@ pub async fn analytics_cache_efficiency(
     Ok(Json(result))
 }
 
-pub async fn analytics_session_cost_curve(
+pub(crate) async fn analytics_session_cost_curve(
     Query(params): Query<DateRangeParams>,
 ) -> Result<Json<Vec<analytics::SessionCostBucket>>, (StatusCode, Json<serde_json::Value>)> {
     let filters = parse_dimension_filters(&params.filters);
@@ -912,7 +912,7 @@ pub async fn analytics_session_cost_curve(
     Ok(Json(result))
 }
 
-pub async fn analytics_cost_confidence(
+pub(crate) async fn analytics_cost_confidence(
     Query(params): Query<DateRangeParams>,
 ) -> Result<Json<Vec<analytics::CostConfidenceStat>>, (StatusCode, Json<serde_json::Value>)> {
     let filters = parse_dimension_filters(&params.filters);
@@ -932,7 +932,7 @@ pub async fn analytics_cost_confidence(
     Ok(Json(result))
 }
 
-pub async fn analytics_subagent_cost(
+pub(crate) async fn analytics_subagent_cost(
     Query(params): Query<DateRangeParams>,
 ) -> Result<Json<Vec<analytics::SubagentCostStat>>, (StatusCode, Json<serde_json::Value>)> {
     let filters = parse_dimension_filters(&params.filters);
@@ -953,11 +953,11 @@ pub async fn analytics_subagent_cost(
 }
 
 #[derive(serde::Deserialize)]
-pub struct FilterOptionsParams {
+pub(crate) struct FilterOptionsParams {
     pub limit: Option<usize>,
 }
 
-pub async fn analytics_filter_options(
+pub(crate) async fn analytics_filter_options(
     Query(params): Query<FilterOptionsParams>,
 ) -> Result<Json<analytics::FilterOptions>, (StatusCode, Json<serde_json::Value>)> {
     let limit = params.limit.map(|value| value.min(5000));
@@ -973,7 +973,7 @@ pub async fn analytics_filter_options(
 }
 
 #[derive(serde::Deserialize)]
-pub struct SessionsQueryParams {
+pub(crate) struct SessionsQueryParams {
     pub since: Option<String>,
     pub until: Option<String>,
     pub search: Option<String>,
@@ -992,7 +992,7 @@ pub struct SessionsQueryParams {
     pub filters: DimensionParams,
 }
 
-pub async fn analytics_sessions(
+pub(crate) async fn analytics_sessions(
     Query(params): Query<SessionsQueryParams>,
 ) -> Result<Json<analytics::PaginatedSessions>, (StatusCode, Json<serde_json::Value>)> {
     if let Some(ref sort) = params.sort_by
@@ -1044,7 +1044,7 @@ pub async fn analytics_sessions(
 /// Code's `~/.claude/projects/<encoded>/` form and walk for the
 /// most-recent transcript.
 #[derive(serde::Deserialize)]
-pub struct ResolveSessionParams {
+pub(crate) struct ResolveSessionParams {
     pub token: String,
     pub cwd: Option<String>,
 }
@@ -1070,7 +1070,7 @@ pub struct ResolveSessionParams {
 /// - `token=latest` returns the newest session id from the DB.
 /// - Any other token → 400 Bad Request.
 /// - Empty workspace (no sessions at all anywhere) → 404 Not Found.
-pub async fn analytics_resolve_session(
+pub(crate) async fn analytics_resolve_session(
     Query(params): Query<ResolveSessionParams>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
     let token = params.token.trim().to_lowercase();
@@ -1194,7 +1194,7 @@ async fn resolve_sid(prefix: String) -> Result<String, (StatusCode, Json<serde_j
     }
 }
 
-pub async fn analytics_session_detail(
+pub(crate) async fn analytics_session_detail(
     Path(session_id): Path<String>,
 ) -> Result<Json<analytics::SessionListEntry>, (StatusCode, Json<serde_json::Value>)> {
     let sid = resolve_sid(session_id.clone()).await?;
@@ -1213,7 +1213,7 @@ pub async fn analytics_session_detail(
     }
 }
 
-pub async fn analytics_session_tags(
+pub(crate) async fn analytics_session_tags(
     Path(session_id): Path<String>,
 ) -> Result<Json<Vec<analytics::SessionTag>>, (StatusCode, Json<serde_json::Value>)> {
     let sid = resolve_sid(session_id).await?;
@@ -1233,7 +1233,7 @@ pub async fn analytics_session_tags(
     Ok(Json(result))
 }
 
-pub async fn analytics_session_messages(
+pub(crate) async fn analytics_session_messages(
     Path(session_id): Path<String>,
     Query(params): Query<SessionMessagesQueryParams>,
 ) -> Result<Json<analytics::PaginatedMessages>, (StatusCode, Json<serde_json::Value>)> {
@@ -1274,7 +1274,7 @@ pub async fn analytics_session_messages(
     Ok(Json(result))
 }
 
-pub async fn analytics_session_message_curve(
+pub(crate) async fn analytics_session_message_curve(
     Path(session_id): Path<String>,
 ) -> Result<Json<Vec<analytics::SessionMessageCurvePoint>>, (StatusCode, Json<serde_json::Value>)> {
     let sid = resolve_sid(session_id).await?;
@@ -1290,7 +1290,7 @@ pub async fn analytics_session_message_curve(
 }
 
 #[derive(serde::Deserialize)]
-pub struct SessionMessagesQueryParams {
+pub(crate) struct SessionMessagesQueryParams {
     pub roles: Option<String>,
     pub sort_by: Option<String>,
     pub sort_asc: Option<bool>,
@@ -1298,7 +1298,7 @@ pub struct SessionMessagesQueryParams {
     pub offset: Option<usize>,
 }
 
-pub async fn analytics_message_detail(
+pub(crate) async fn analytics_message_detail(
     Path(message_uuid): Path<String>,
 ) -> Result<Json<analytics::MessageDetail>, (StatusCode, Json<serde_json::Value>)> {
     let lookup_uuid = message_uuid.clone();
@@ -1317,11 +1317,11 @@ pub async fn analytics_message_detail(
 }
 
 #[derive(serde::Deserialize)]
-pub struct SessionHealthParams {
+pub(crate) struct SessionHealthParams {
     pub session_id: Option<String>,
 }
 
-pub async fn analytics_session_health(
+pub(crate) async fn analytics_session_health(
     Query(params): Query<SessionHealthParams>,
 ) -> Result<Json<analytics::SessionHealth>, (StatusCode, Json<serde_json::Value>)> {
     // #496 (D-3): resolve an 8-char session prefix (or any prefix) the
@@ -1344,8 +1344,8 @@ pub async fn analytics_session_health(
     Ok(Json(result))
 }
 
-pub async fn analytics_check() -> Result<Json<RepairResponse>, (StatusCode, Json<serde_json::Value>)>
-{
+pub(crate) async fn analytics_check()
+-> Result<Json<RepairResponse>, (StatusCode, Json<serde_json::Value>)> {
     // Read-only diagnostic: opens the DB, asks `migration::check` what
     // would change, and returns the same `RepairResponse` shape as
     // `/admin/repair` so the CLI can render either with one renderer.
@@ -1374,7 +1374,7 @@ pub async fn analytics_check() -> Result<Json<RepairResponse>, (StatusCode, Json
     Ok(Json(result))
 }
 
-pub async fn analytics_repair(
+pub(crate) async fn analytics_repair(
     State(state): State<AppState>,
 ) -> Result<Json<RepairResponse>, (StatusCode, Json<serde_json::Value>)> {
     if state
@@ -1418,7 +1418,7 @@ pub async fn analytics_repair(
     Ok(Json(result))
 }
 
-pub async fn analytics_session_audit()
+pub(crate) async fn analytics_session_audit()
 -> Result<Json<analytics::SessionAudit>, (StatusCode, Json<serde_json::Value>)> {
     let result = tokio::task::spawn_blocking(move || {
         let db_path = analytics::db_path()?;

--- a/crates/budi-daemon/src/routes/cloud.rs
+++ b/crates/budi-daemon/src/routes/cloud.rs
@@ -36,7 +36,7 @@ const RESULT_DISABLED: &str = "disabled";
 
 /// `GET /cloud/status` — report cloud sync readiness and freshness.
 /// No network call; reads `cloud.toml` and the local watermarks.
-pub async fn cloud_status() -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+pub(crate) async fn cloud_status() -> Result<Json<Value>, (StatusCode, Json<Value>)> {
     let snapshot = tokio::task::spawn_blocking(read_status_snapshot)
         .await
         .map_err(|e| super::internal_error(anyhow::anyhow!("cloud status task panicked: {e}")))?;
@@ -55,7 +55,7 @@ fn read_status_snapshot() -> budi_core::cloud_sync::CloudSyncStatus {
 ///
 /// Returns 409 if another cloud sync is already running (either from the
 /// background worker or a prior CLI invocation).
-pub async fn cloud_sync(
+pub(crate) async fn cloud_sync(
     State(state): State<AppState>,
 ) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
     let cfg = config::load_cloud_config();
@@ -130,7 +130,7 @@ pub async fn cloud_sync(
 /// re-push everything anyway. Holding the flag keeps the sequencing
 /// honest. Returns 409 when the worker (or another `cloud sync`) is
 /// already running so the operator can re-run after it finishes.
-pub async fn cloud_reset(
+pub(crate) async fn cloud_reset(
     State(state): State<AppState>,
 ) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
     if state

--- a/crates/budi-daemon/src/routes/hooks.rs
+++ b/crates/budi-daemon/src/routes/hooks.rs
@@ -11,7 +11,7 @@ use super::{internal_error, schema_unavailable};
 use crate::AppState;
 
 #[derive(serde::Serialize)]
-pub struct HealthResponse {
+pub(crate) struct HealthResponse {
     pub ok: bool,
     pub version: &'static str,
     /// Daemon management API version.  The Cursor extension checks this field
@@ -27,7 +27,7 @@ pub struct HealthResponse {
 }
 
 #[derive(serde::Serialize)]
-pub struct SyncResponse {
+pub(crate) struct SyncResponse {
     pub files_synced: usize,
     pub messages_ingested: usize,
     pub warnings: Vec<String>,
@@ -40,7 +40,7 @@ pub struct SyncResponse {
 }
 
 #[derive(serde::Serialize)]
-pub struct SyncStatusResponse {
+pub(crate) struct SyncStatusResponse {
     pub syncing: bool,
     pub last_sync_completed_at: Option<String>,
     pub newest_data_at: Option<String>,
@@ -59,7 +59,7 @@ pub struct SyncStatusResponse {
 
 #[derive(Debug, Clone, Copy, serde::Deserialize)]
 #[serde(rename_all = "kebab-case")]
-pub enum IntegrationInstallComponent {
+pub(crate) enum IntegrationInstallComponent {
     ClaudeCodeHooks,
     ClaudeCodeMcp,
     ClaudeCodeOtel,
@@ -84,13 +84,13 @@ impl IntegrationInstallComponent {
 }
 
 #[derive(Debug, serde::Deserialize)]
-pub struct InstallIntegrationsRequest {
+pub(crate) struct InstallIntegrationsRequest {
     #[serde(default)]
     pub components: Vec<IntegrationInstallComponent>,
 }
 
 #[derive(Debug, serde::Serialize)]
-pub struct InstallIntegrationsResponse {
+pub(crate) struct InstallIntegrationsResponse {
     pub ok: bool,
     pub command: String,
     #[serde(skip_serializing_if = "String::is_empty")]
@@ -240,7 +240,7 @@ fn is_cursor_extension_installed(home: &str) -> bool {
         || cursor_extension_installed_via_filesystem(home)
 }
 
-pub async fn favicon() -> impl IntoResponse {
+pub(crate) async fn favicon() -> impl IntoResponse {
     let svg = "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>&#x1f4ca;</text></svg>";
     (
         [
@@ -266,7 +266,7 @@ pub async fn favicon() -> impl IntoResponse {
 /// they can fall back to the all-rows view when talking to an older
 /// daemon. Sibling ticket adds the HTTP + CLI filter; this PR ships the
 /// data layer and the `surface` field shows up in returned rows.
-pub const API_VERSION: u32 = 3;
+pub(crate) const API_VERSION: u32 = 3;
 
 /// Canonical surface values advertised on `/health` (#701). Mirrors
 /// `budi_core::surface`'s `VSCODE` / `CURSOR` / `JETBRAINS` / `TERMINAL`
@@ -275,7 +275,7 @@ pub const API_VERSION: u32 = 3;
 /// format stays a deliberate snapshot rather than a transitive view.
 const SURFACES: &[&str] = &["vscode", "cursor", "jetbrains", "terminal", "unknown"];
 
-pub async fn health() -> Json<HealthResponse> {
+pub(crate) async fn health() -> Json<HealthResponse> {
     Json(HealthResponse {
         ok: true,
         version: env!("CARGO_PKG_VERSION"),
@@ -293,19 +293,19 @@ pub async fn health() -> Json<HealthResponse> {
 /// consume the unfiltered form yet, but the contract is documented
 /// here so future hosts can rely on it.
 #[derive(Debug, serde::Deserialize)]
-pub struct HealthSourcesParams {
+pub(crate) struct HealthSourcesParams {
     pub surface: Option<String>,
 }
 
 #[derive(Debug, serde::Serialize)]
-pub struct HealthSourcesByGroup {
+pub(crate) struct HealthSourcesByGroup {
     pub surface: String,
     pub paths: Vec<String>,
 }
 
 #[derive(Debug, serde::Serialize)]
 #[serde(untagged)]
-pub enum HealthSourcesResponse {
+pub(crate) enum HealthSourcesResponse {
     Filtered { surface: String, paths: Vec<String> },
     Grouped { surfaces: Vec<HealthSourcesByGroup> },
 }
@@ -328,7 +328,7 @@ pub enum HealthSourcesResponse {
 /// `copilot_chat` (whose watch roots span VS Code, Cursor, and
 /// JetBrains storage) gets [`budi_core::surface::infer_copilot_chat_surface`]
 /// per path so each root is bucketed correctly.
-pub async fn health_sources(
+pub(crate) async fn health_sources(
     axum::extract::Query(params): axum::extract::Query<HealthSourcesParams>,
 ) -> Result<Json<HealthSourcesResponse>, (StatusCode, Json<serde_json::Value>)> {
     let result = tokio::task::spawn_blocking(move || collect_health_sources(params.surface))
@@ -411,7 +411,7 @@ fn collect_health_sources(surface_filter: Option<String>) -> HealthSourcesRespon
     HealthSourcesResponse::Grouped { surfaces }
 }
 
-pub async fn health_check_update()
+pub(crate) async fn health_check_update()
 -> Result<Json<super::analytics::CheckUpdateResponse>, (StatusCode, Json<serde_json::Value>)> {
     use super::analytics::CheckUpdateResponse;
 
@@ -494,7 +494,7 @@ pub async fn health_check_update()
     Ok(Json(result))
 }
 
-pub async fn admin_install_integrations(
+pub(crate) async fn admin_install_integrations(
     State(state): State<AppState>,
     Json(req): Json<InstallIntegrationsRequest>,
 ) -> Result<Json<InstallIntegrationsResponse>, (StatusCode, Json<serde_json::Value>)> {
@@ -575,7 +575,7 @@ pub async fn admin_install_integrations(
     }))
 }
 
-pub async fn health_integrations()
+pub(crate) async fn health_integrations()
 -> Result<Json<super::analytics::IntegrationsResponse>, (StatusCode, Json<serde_json::Value>)> {
     use super::analytics::{DatabaseStats, IntegrationPaths, IntegrationsResponse};
 
@@ -662,7 +662,7 @@ pub async fn health_integrations()
     Ok(Json(result))
 }
 
-pub async fn sync_status(State(state): State<AppState>) -> Json<SyncStatusResponse> {
+pub(crate) async fn sync_status(State(state): State<AppState>) -> Json<SyncStatusResponse> {
     let syncing = state.syncing.load(std::sync::atomic::Ordering::Acquire);
     // Only return a progress snapshot when we actually hold the busy flag;
     // a leftover `Some(..)` from a previous run (cleared by `BusyFlagGuard`
@@ -1345,7 +1345,7 @@ mod tests {
 }
 
 #[derive(serde::Deserialize, Default)]
-pub struct SyncParams {
+pub(crate) struct SyncParams {
     #[serde(default)]
     pub migrate: bool,
 }
@@ -1367,7 +1367,7 @@ fn progress_publisher(
     }
 }
 
-pub async fn analytics_sync(
+pub(crate) async fn analytics_sync(
     State(state): State<AppState>,
     body: Option<Json<SyncParams>>,
 ) -> Result<Json<SyncResponse>, (StatusCode, Json<serde_json::Value>)> {
@@ -1433,7 +1433,7 @@ pub async fn analytics_sync(
     }
 }
 
-pub async fn analytics_sync_reset(
+pub(crate) async fn analytics_sync_reset(
     State(state): State<AppState>,
 ) -> Result<Json<SyncResponse>, (StatusCode, Json<serde_json::Value>)> {
     if state
@@ -1478,7 +1478,7 @@ pub async fn analytics_sync_reset(
     Ok(Json(result))
 }
 
-pub async fn analytics_history(
+pub(crate) async fn analytics_history(
     State(state): State<AppState>,
 ) -> Result<Json<SyncResponse>, (StatusCode, Json<serde_json::Value>)> {
     if state

--- a/crates/budi-daemon/src/routes/mod.rs
+++ b/crates/budi-daemon/src/routes/mod.rs
@@ -1,7 +1,7 @@
-pub mod analytics;
-pub mod cloud;
-pub mod hooks;
-pub mod pricing;
+pub(crate) mod analytics;
+pub(crate) mod cloud;
+pub(crate) mod hooks;
+pub(crate) mod pricing;
 
 use std::collections::HashSet;
 use std::net::SocketAddr;
@@ -14,7 +14,7 @@ use axum::http::header;
 use axum::middleware::Next;
 use axum::response::Response;
 
-pub fn internal_error(err: anyhow::Error) -> (StatusCode, Json<serde_json::Value>) {
+pub(crate) fn internal_error(err: anyhow::Error) -> (StatusCode, Json<serde_json::Value>) {
     // Log the full `anyhow` chain (with `{:#}`) so `daemon.log` captures the
     // root cause for ops, even though the HTTP response stays opaque on
     // purpose (no stack frames leaked to loopback consumers).
@@ -53,7 +53,10 @@ pub fn internal_error(err: anyhow::Error) -> (StatusCode, Json<serde_json::Value
 /// handler, and any future endpoints emit byte-identical bodies — which
 /// the CLI in `budi-cli::client::check_response` then pattern-matches on
 /// to render an actionable error instead of "Daemon returned 500".
-pub fn schema_unavailable(current: u32, target: u32) -> (StatusCode, Json<serde_json::Value>) {
+pub(crate) fn schema_unavailable(
+    current: u32,
+    target: u32,
+) -> (StatusCode, Json<serde_json::Value>) {
     (
         StatusCode::SERVICE_UNAVAILABLE,
         Json(serde_json::json!({
@@ -78,7 +81,7 @@ pub fn schema_unavailable(current: u32, target: u32) -> (StatusCode, Json<serde_
 /// reads (setenv across threads is unsound on macOS, which previously
 /// caused flaky CI — see #366 PR history).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum SchemaStatus {
+pub(crate) enum SchemaStatus {
     /// DB is absent, unreadable, or at exactly the expected version — let
     /// the request proceed.  A missing file is normal on first boot; the
     /// daemon's `open_db_with_migration` at startup is what materializes
@@ -98,7 +101,7 @@ pub enum SchemaStatus {
 /// Pure function that inspects the SQLite DB at `db_path` and classifies
 /// the schema state.  No env-var reads, no global state — tests drive
 /// this directly with a tempdir path.
-pub fn schema_status_for(db_path: &std::path::Path) -> SchemaStatus {
+pub(crate) fn schema_status_for(db_path: &std::path::Path) -> SchemaStatus {
     if !db_path.exists() {
         return SchemaStatus::Proceed;
     }
@@ -123,7 +126,7 @@ pub fn schema_status_for(db_path: &std::path::Path) -> SchemaStatus {
 ///
 /// Thin wrapper over [`schema_status_for`]: resolves `db_path()` from env,
 /// runs the pure classifier, maps to an HTTP response.
-pub async fn require_current_schema(
+pub(crate) async fn require_current_schema(
     req: Request,
     next: Next,
 ) -> Result<Response, (StatusCode, Json<serde_json::Value>)> {
@@ -155,21 +158,21 @@ pub async fn require_current_schema(
     }
 }
 
-pub fn bad_request(msg: impl std::fmt::Display) -> (StatusCode, Json<serde_json::Value>) {
+pub(crate) fn bad_request(msg: impl std::fmt::Display) -> (StatusCode, Json<serde_json::Value>) {
     (
         StatusCode::BAD_REQUEST,
         Json(serde_json::json!({ "ok": false, "error": format!("{msg}") })),
     )
 }
 
-pub fn not_found(msg: impl std::fmt::Display) -> (StatusCode, Json<serde_json::Value>) {
+pub(crate) fn not_found(msg: impl std::fmt::Display) -> (StatusCode, Json<serde_json::Value>) {
     (
         StatusCode::NOT_FOUND,
         Json(serde_json::json!({ "ok": false, "error": format!("{msg}") })),
     )
 }
 
-pub fn forbidden(msg: impl std::fmt::Display) -> (StatusCode, Json<serde_json::Value>) {
+pub(crate) fn forbidden(msg: impl std::fmt::Display) -> (StatusCode, Json<serde_json::Value>) {
     (
         StatusCode::FORBIDDEN,
         Json(serde_json::json!({ "ok": false, "error": format!("{msg}") })),
@@ -198,12 +201,12 @@ pub fn forbidden(msg: impl std::fmt::Display) -> (StatusCode, Json<serde_json::V
 /// Anything else returns `403` with `invalid Host header` and a
 /// `tracing::warn!` line for ops visibility.
 #[derive(Clone, Debug)]
-pub struct HostAllowlist {
+pub(crate) struct HostAllowlist {
     hosts: Arc<HashSet<String>>,
 }
 
 impl HostAllowlist {
-    pub fn new(configured_host: &str, port: u16) -> Self {
+    pub(crate) fn new(configured_host: &str, port: u16) -> Self {
         let mut hosts = HashSet::new();
         let bases = ["127.0.0.1", "[::1]", "localhost", configured_host];
         for base in bases {
@@ -226,11 +229,11 @@ impl HostAllowlist {
     /// are router-level unit tests where the Host header is unset.
     /// Production callers always go through `HostAllowlist::new`.
     #[cfg(test)]
-    pub fn for_tests() -> Self {
+    pub(crate) fn for_tests() -> Self {
         Self::new("127.0.0.1", 0)
     }
 
-    pub fn allows(&self, host: &str) -> bool {
+    pub(crate) fn allows(&self, host: &str) -> bool {
         self.hosts.contains(host)
     }
 }
@@ -239,7 +242,7 @@ impl HostAllowlist {
 /// allowlist.  Layered onto every route (public and protected) to defend
 /// against DNS-rebinding (#695) — the peer IP is loopback in that
 /// scenario, so `require_loopback` alone is insufficient.
-pub async fn require_local_host(
+pub(crate) async fn require_local_host(
     State(allowlist): State<HostAllowlist>,
     req: Request,
     next: Next,
@@ -272,7 +275,7 @@ pub async fn require_local_host(
     }
 }
 
-pub async fn require_loopback(
+pub(crate) async fn require_loopback(
     req: Request,
     next: Next,
 ) -> Result<Response, (StatusCode, Json<serde_json::Value>)> {

--- a/crates/budi-daemon/src/routes/pricing.rs
+++ b/crates/budi-daemon/src/routes/pricing.rs
@@ -31,7 +31,7 @@ use crate::workers::team_pricing;
 /// `team_pricing` is always present so JSON consumers can probe a
 /// single key — `team_pricing.active == false` means "not in use", same
 /// shape as the inactive path.
-pub async fn pricing_status() -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+pub(crate) async fn pricing_status() -> Result<Json<Value>, (StatusCode, Json<Value>)> {
     let result = tokio::task::spawn_blocking(|| -> anyhow::Result<Value> {
         let state = pricing::current_state();
         let mut body = serde_json::to_value(state)?;
@@ -75,7 +75,7 @@ pub async fn pricing_status() -> Result<Json<Value>, (StatusCode, Json<Value>)> 
 }
 
 #[derive(Debug, Deserialize)]
-pub struct RecomputeQuery {
+pub(crate) struct RecomputeQuery {
     #[serde(default)]
     pub force: bool,
 }
@@ -125,7 +125,7 @@ fn recompute_outcome_body(outcome: team_pricing::CliTickOutcome) -> Value {
 /// the version check and always runs a recompute pass against the
 /// currently-installed list. Returns the resulting `RecomputeSummary`
 /// (or `{ok: true, skipped: true}` for the short-circuit path).
-pub async fn pricing_recompute(
+pub(crate) async fn pricing_recompute(
     Query(q): Query<RecomputeQuery>,
 ) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
     let force = q.force;
@@ -169,7 +169,7 @@ fn refresh_report_body(report: &pricing_refresh::RefreshReport) -> Value {
 }
 
 /// `POST /pricing/refresh` — loopback-only; fire a manual refresh tick.
-pub async fn pricing_refresh() -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+pub(crate) async fn pricing_refresh() -> Result<Json<Value>, (StatusCode, Json<Value>)> {
     let result =
         tokio::task::spawn_blocking(|| -> anyhow::Result<pricing_refresh::RefreshReport> {
             let db_path = analytics::db_path()?;

--- a/crates/budi-daemon/src/workers/cloud_sync.rs
+++ b/crates/budi-daemon/src/workers/cloud_sync.rs
@@ -25,7 +25,11 @@ use budi_core::config::CloudConfig;
 /// every iteration so an api_key rotation (`budi cloud init --force`,
 /// cross-org switch per #559, manager-driven rotation) lands on the next
 /// sync without a daemon restart (#560).
-pub async fn run(db_path: PathBuf, initial_config: CloudConfig, cloud_syncing: Arc<AtomicBool>) {
+pub(crate) async fn run(
+    db_path: PathBuf,
+    initial_config: CloudConfig,
+    cloud_syncing: Arc<AtomicBool>,
+) {
     let mut config = initial_config;
     let mut consecutive_failures: u32 = 0;
     let mut auth_failed = false;

--- a/crates/budi-daemon/src/workers/mod.rs
+++ b/crates/budi-daemon/src/workers/mod.rs
@@ -1,4 +1,4 @@
-pub mod cloud_sync;
-pub mod pricing_refresh;
-pub mod tailer;
-pub mod team_pricing;
+pub(crate) mod cloud_sync;
+pub(crate) mod pricing_refresh;
+pub(crate) mod tailer;
+pub(crate) mod team_pricing;

--- a/crates/budi-daemon/src/workers/pricing_refresh.rs
+++ b/crates/budi-daemon/src/workers/pricing_refresh.rs
@@ -49,7 +49,7 @@ pub(crate) const DISABLE_ENV_VAR: &str = "BUDI_PRICING_REFRESH";
 /// the tailer. Stops when `shutdown` is set; shutdown is checked between
 /// ticks and during the 24 h sleep via a poll loop so clean exits don't
 /// wait 24 h.
-pub async fn run(db_path: PathBuf, shutdown: Arc<AtomicBool>) {
+pub(crate) async fn run(db_path: PathBuf, shutdown: Arc<AtomicBool>) {
     // Warm-load the on-disk cache if present — the daemon may have been
     // restarted between refreshes and the embedded baseline in `pricing`
     // would otherwise serve until the next tick.
@@ -238,7 +238,7 @@ async fn tick(db_path: &std::path::Path) {
 /// by the row-level sanity partition. Pre-8.3.1 the same rows would
 /// have whole-payload-rejected the refresh (ADR-0091 §2 amendment).
 #[derive(Debug, serde::Serialize)]
-pub struct RefreshReport {
+pub(crate) struct RefreshReport {
     pub version: u32,
     pub known_model_count: usize,
     pub backfilled_rows: usize,
@@ -255,7 +255,7 @@ pub struct RefreshReport {
 /// written to the cache, and the rejected rows are returned via
 /// `RefreshReport.rejected_upstream_rows` + surfaced on
 /// `GET /pricing/status`.
-pub fn run_tick(db_path: &std::path::Path) -> anyhow::Result<RefreshReport> {
+pub(crate) fn run_tick(db_path: &std::path::Path) -> anyhow::Result<RefreshReport> {
     let bytes = fetch_upstream()?;
     let entries = pricing::parse_entries(&bytes)?;
     let now = chrono::Utc::now().to_rfc3339();

--- a/crates/budi-daemon/src/workers/tailer.rs
+++ b/crates/budi-daemon/src/workers/tailer.rs
@@ -107,7 +107,7 @@ const MAX_TAIL_BYTES: usize = 32 * 1024 * 1024;
 /// rechecks filesystem-level availability, not config flags). If the
 /// snapshot has no enabled providers at all, the worker exits
 /// immediately because no later event could give it work.
-pub async fn run(db_path: PathBuf, shutdown: Arc<AtomicBool>) {
+pub(crate) async fn run(db_path: PathBuf, shutdown: Arc<AtomicBool>) {
     let agents_config = budi_core::config::load_agents_config();
     let providers: Vec<Box<dyn Provider>> = match &agents_config {
         Some(cfg) => budi_core::provider::all_providers()
@@ -137,7 +137,7 @@ pub async fn run(db_path: PathBuf, shutdown: Arc<AtomicBool>) {
 /// do not re-filter the set by `is_available()` — a provider whose home
 /// directory appears mid-run should start producing routes on the very
 /// next backstop tick without any daemon restart.
-pub fn run_blocking(
+pub(crate) fn run_blocking(
     db_path: PathBuf,
     providers: Vec<Box<dyn Provider>>,
     shutdown: Arc<AtomicBool>,

--- a/crates/budi-daemon/src/workers/team_pricing.rs
+++ b/crates/budi-daemon/src/workers/team_pricing.rs
@@ -47,7 +47,7 @@ const ENDPOINT_PATH: &str = "/v1/pricing/active";
 /// HTTP timeout per poll, matching the cloud-sync 30 s budget.
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 
-pub async fn run(db_path: PathBuf, shutdown: Arc<AtomicBool>) {
+pub(crate) async fn run(db_path: PathBuf, shutdown: Arc<AtomicBool>) {
     // Warm-load any cached price list so the very first `budi pricing
     // status` call after a daemon restart still has the team layer
     // populated. Cheap — a single JSON read off disk.
@@ -210,7 +210,7 @@ enum TickOutcome {
 /// can distinguish "the list version was unchanged but we ran anyway"
 /// from "we installed a new list".
 #[derive(Debug)]
-pub enum CliTickOutcome {
+pub(crate) enum CliTickOutcome {
     Updated(RecomputeSummary),
     Cleared(RecomputeSummary),
     ForcedRecompute(RecomputeSummary),
@@ -223,7 +223,7 @@ pub enum CliTickOutcome {
 /// fetch and re-run `recompute_messages` against the currently-
 /// installed list anyway — useful for support cases where the operator
 /// suspects a cost number drifted.
-pub fn run_tick_for_cli(force: bool) -> anyhow::Result<CliTickOutcome> {
+pub(crate) fn run_tick_for_cli(force: bool) -> anyhow::Result<CliTickOutcome> {
     let db_path = budi_core::analytics::db_path()?;
     let outcome = run_tick(&db_path)?;
     match outcome {


### PR DESCRIPTION
Closes #806. **Alternative approach to #812.**

## Summary

End-of-release hygiene per #806 acceptance criteria. Same audit results as #812, different remediation strategy for the `unreachable_pub` warnings: mechanically narrow each site to `pub(crate)` via `clippy --fix` rather than blanketing the binary crates with `#![allow(unreachable_pub)]`.

## Audit results

- `cargo machete`: clean.
- `cargo +nightly udeps --workspace --all-targets`: clean.
- `cargo clippy --workspace --all-targets -- -W dead_code -W unreachable_pub`: clean.
- `#[deprecated]` items in tree: none.
- `#[cfg(feature = "...")]` items in tree: none.

## Changes

- 255 `unreachable_pub` hits mechanically narrowed via `cargo clippy --fix -- -W unreachable_pub`. Safe because neither `budi-cli` nor `budi-daemon` exposes a public API and `budi-core` is a workspace-private path dependency.
- `crates/budi-core/src/legacy_proxy.rs` — added one-line comment on `PlatformFamily`'s `#[allow(dead_code)]` (variants constructed via cfg-gated branches that look dead per-target but are required for cross-platform tests).
- `crates/budi-core/src/providers/copilot_chat/jetbrains.rs` — dropped the redundant `#[allow(dead_code)]` on `parse_session_dir_for_tests`; it's exercised from the sibling test module.

## Trade-off vs. #812

- **#812** keeps the existing `pub` annotations and silences the lint at the crate root with a rationale comment. Smaller diff (6 files), no churn on individual sites.
- **This PR** narrows the actual visibility on each item. Larger diff (31 files), but each item's visibility is now mechanically accurate so future `pub` additions stand out as intentional rather than habitual.

Either is defensible — picking one closes #806.

## Test plan

- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo clippy --workspace --all-targets -- -W dead_code -W unreachable_pub\` clean
- [x] \`cargo machete\` clean
- [x] \`cargo +nightly udeps --workspace --all-targets\` clean
- [x] \`cargo test --workspace\` — one flaky tailer test (\`run_blocking_exits_when_shutdown_flag_is_set\`) timed out under full-suite parallelism, passes when run alone; unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)